### PR TITLE
feat: add passthrough_env config to whitelist env vars through scrub

### DIFF
--- a/examples/circle_packing/helix.toml
+++ b/examples/circle_packing/helix.toml
@@ -1,6 +1,10 @@
 [project]
 objective = "Maximize the sum of radii of 26 non-overlapping circles packed in a unit square. Higher total radius sum = better packing."
 
+# Uncomment to pass specific env vars through the scrub into evaluator
+# and Claude Code subprocesses (e.g. GPU selection, cache dirs):
+# passthrough_env = ["CUDA_VISIBLE_DEVICES", "MUJOCO_GL", "HF_HOME"]
+
 [evaluator]
 command = "python3 evaluate.py"
 score_parser = "json_score"

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -304,6 +304,14 @@ class HelixConfig(BaseModel):
     objective: str
     seed: str = "."
     rng_seed: int = 0  # GEPA parity: deterministic RNG for selection
+    passthrough_env: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Environment variable names to pass through the env scrub into "
+            "evaluator and Claude Code subprocesses (e.g. "
+            '["CUDA_VISIBLE_DEVICES", "MUJOCO_GL", "HF_HOME"]).'
+        ),
+    )
     evaluator: EvaluatorConfig
     dataset: DatasetConfig = Field(default_factory=DatasetConfig)
     seedless: SeedlessConfig = Field(default_factory=SeedlessConfig)

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -89,14 +89,21 @@ def _validate_and_split_command(cmd: str) -> list[str]:
 
 
 def _scrub_environment(
-    split: str,
+    split: str | None = None,
     instance_ids: list[str] | None = None,
     passthrough_env: list[str] | None = None,
 ) -> dict[str, str]:
     """Create a scrubbed environment with only allowed variables.
 
+    This is the single source of truth for env-scrubbing across HELIX.
+    Both the evaluator subprocess (via :func:`run_evaluator`) and the
+    Claude Code subprocess (via :func:`~helix.mutator.invoke_claude_code`)
+    call this function.
+
     Args:
-        split: Dataset split name to pass as HELIX_SPLIT.
+        split: Dataset split name to pass as HELIX_SPLIT.  When *None*
+            (the default), HELIX_SPLIT is not added — useful for
+            non-evaluator subprocesses like Claude Code.
         instance_ids: Optional list of example IDs to evaluate on. Passed
             to the evaluator as HELIX_INSTANCE_IDS (comma-separated).
             Evaluators that honor it restrict to these; others ignore it
@@ -105,7 +112,7 @@ def _scrub_environment(
             from the parent process (e.g. CUDA_VISIBLE_DEVICES, HF_HOME).
 
     Returns:
-        Dict containing only PATH, HOME, HELIX_SPLIT, HELIX_* variables,
+        Dict containing only PATH, HOME, HELIX_* variables,
         and any explicitly listed passthrough_env keys.
     """
     scrubbed: dict[str, str] = {}
@@ -116,8 +123,9 @@ def _scrub_environment(
     if "HOME" in os.environ:
         scrubbed["HOME"] = os.environ["HOME"]
 
-    # Add HELIX_SPLIT
-    scrubbed["HELIX_SPLIT"] = split
+    # Add HELIX_SPLIT when running evaluators.
+    if split is not None:
+        scrubbed["HELIX_SPLIT"] = split
 
     # Add HELIX_INSTANCE_IDS when a minibatch subset is requested.
     if instance_ids is not None:

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -89,7 +89,9 @@ def _validate_and_split_command(cmd: str) -> list[str]:
 
 
 def _scrub_environment(
-    split: str, instance_ids: list[str] | None = None
+    split: str,
+    instance_ids: list[str] | None = None,
+    passthrough_env: list[str] | None = None,
 ) -> dict[str, str]:
     """Create a scrubbed environment with only allowed variables.
 
@@ -99,9 +101,12 @@ def _scrub_environment(
             to the evaluator as HELIX_INSTANCE_IDS (comma-separated).
             Evaluators that honor it restrict to these; others ignore it
             and HELIX post-filters the returned instance_scores.
+        passthrough_env: Optional list of extra env var names to preserve
+            from the parent process (e.g. CUDA_VISIBLE_DEVICES, HF_HOME).
 
     Returns:
-        Dict containing only PATH, HOME, HELIX_SPLIT, and HELIX_* variables.
+        Dict containing only PATH, HOME, HELIX_SPLIT, HELIX_* variables,
+        and any explicitly listed passthrough_env keys.
     """
     scrubbed: dict[str, str] = {}
 
@@ -126,6 +131,11 @@ def _scrub_environment(
             and key != "HELIX_INSTANCE_IDS"
         ):
             scrubbed[key] = value
+
+    # Include user-specified passthrough variables
+    for key in passthrough_env or []:
+        if key in os.environ:
+            scrubbed[key] = os.environ[key]
 
     return scrubbed
 
@@ -213,7 +223,7 @@ def run_evaluator(
     evaluator = config.evaluator
 
     # Run main evaluation command
-    env = _scrub_environment(split, instance_ids=instance_ids)
+    env = _scrub_environment(split, instance_ids=instance_ids, passthrough_env=config.passthrough_env)
     cmd_tokens = _validate_and_split_command(evaluator.command)
     result = subprocess.run(
         cmd_tokens,

--- a/src/helix/merger.py
+++ b/src/helix/merger.py
@@ -154,7 +154,7 @@ def merge(
     )
 
     try:
-        invoke_claude_code(child.worktree_path, prompt, config.claude)
+        invoke_claude_code(child.worktree_path, prompt, config.claude, passthrough_env=config.passthrough_env)
     except MutationError as exc:
         exc.operation = f"merge {new_id} ({candidate_a.id} + {candidate_b.id})"
         print_helix_error(exc)

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 logger = logging.getLogger(__name__)
 
+import os
+
 from helix.population import Candidate, EvalResult
 from helix.config import ClaudeConfig, HelixConfig
 from helix.exceptions import MutationError, RateLimitError, print_helix_error
@@ -188,7 +190,7 @@ def generate_seed(
     MutationError
         Propagated directly from :func:`invoke_claude_code` on failure.
     """
-    invoke_claude_code(worktree_path, prompt, config.claude)
+    invoke_claude_code(worktree_path, prompt, config.claude, passthrough_env=config.passthrough_env)
 
 
 def build_mutation_prompt(
@@ -303,6 +305,7 @@ def invoke_claude_code(
     worktree_path: str,
     prompt: str,
     config: ClaudeConfig,
+    passthrough_env: list[str] | None = None,
 ) -> dict[str, Any]:
     """Invoke Claude Code CLI in *worktree_path* and return the parsed JSON output.
 
@@ -314,6 +317,9 @@ def invoke_claude_code(
         The prompt to pass via ``-p``.
     config:
         Claude configuration (model, effort, allowed_tools).
+    passthrough_env:
+        Optional list of extra env var names to preserve from the parent
+        process through the env scrub (e.g. CUDA_VISIBLE_DEVICES).
 
     Returns
     -------
@@ -348,11 +354,26 @@ def invoke_claude_code(
 
     cmd_str = " ".join(args)
 
+    # Build a scrubbed env for the Claude Code subprocess, preserving only
+    # PATH, HOME, HELIX_*, and any user-specified passthrough vars.
+    cc_env: dict[str, str] = {}
+    if "PATH" in os.environ:
+        cc_env["PATH"] = os.environ["PATH"]
+    if "HOME" in os.environ:
+        cc_env["HOME"] = os.environ["HOME"]
+    for k, v in os.environ.items():
+        if k.startswith("HELIX_"):
+            cc_env[k] = v
+    for k in passthrough_env or []:
+        if k in os.environ:
+            cc_env[k] = os.environ[k]
+
     result = subprocess.run(
         args,
         cwd=worktree_path,
         capture_output=True,
         text=True,
+        env=cc_env,
     )
 
     if result.returncode != 0:
@@ -501,7 +522,7 @@ def mutate(
     )
 
     try:
-        invoke_claude_code(child.worktree_path, prompt, config.claude)
+        invoke_claude_code(child.worktree_path, prompt, config.claude, passthrough_env=config.passthrough_env)
     except MutationError as exc:
         exc.operation = f"mutate {new_id} (parent: {parent.id})"
         print_helix_error(exc)

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -4,18 +4,18 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-logger = logging.getLogger(__name__)
-
-import os
-
 from helix.population import Candidate, EvalResult
 from helix.config import ClaudeConfig, HelixConfig
 from helix.exceptions import MutationError, RateLimitError, print_helix_error
+from helix.executor import _scrub_environment
 from helix.worktree import clone_candidate, snapshot_candidate, remove_worktree
+
+logger = logging.getLogger(__name__)
 
 # Differential-testing hook: when set to a callable, ``invoke_claude_code``
 # bypasses the subprocess invocation and delegates to the override with
@@ -354,19 +354,8 @@ def invoke_claude_code(
 
     cmd_str = " ".join(args)
 
-    # Build a scrubbed env for the Claude Code subprocess, preserving only
-    # PATH, HOME, HELIX_*, and any user-specified passthrough vars.
-    cc_env: dict[str, str] = {}
-    if "PATH" in os.environ:
-        cc_env["PATH"] = os.environ["PATH"]
-    if "HOME" in os.environ:
-        cc_env["HOME"] = os.environ["HOME"]
-    for k, v in os.environ.items():
-        if k.startswith("HELIX_"):
-            cc_env[k] = v
-    for k in passthrough_env or []:
-        if k in os.environ:
-            cc_env[k] = os.environ[k]
+    # Reuse the shared scrub helper (no split/instance_ids for CC sessions).
+    cc_env = _scrub_environment(passthrough_env=passthrough_env)
 
     result = subprocess.run(
         args,

--- a/tests/unit/test_executor_security.py
+++ b/tests/unit/test_executor_security.py
@@ -234,6 +234,21 @@ class TestEnvironmentScrubbing:
         env_empty = _scrub_environment("val", passthrough_env=[])
         assert env_default == env_empty
 
+    def test_scrub_without_split_omits_helix_split(self, monkeypatch):
+        """When split is None (CC subprocess path), HELIX_SPLIT is not set."""
+        monkeypatch.delenv("HELIX_SPLIT", raising=False)
+        env = _scrub_environment(passthrough_env=["PATH"])
+        assert "HELIX_SPLIT" not in env
+        # PATH and HOME should still be present
+        assert "PATH" in env
+
+    def test_scrub_without_split_preserves_passthrough(self, monkeypatch):
+        """CC subprocess path (split=None) still honours passthrough_env."""
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2")
+        env = _scrub_environment(passthrough_env=["CUDA_VISIBLE_DEVICES"])
+        assert env["CUDA_VISIBLE_DEVICES"] == "2"
+        assert "HELIX_SPLIT" not in env
+
 
 # ---------------------------------------------------------------------------
 # Tests: Integration - run_evaluator with security

--- a/tests/unit/test_executor_security.py
+++ b/tests/unit/test_executor_security.py
@@ -211,6 +211,29 @@ class TestEnvironmentScrubbing:
         allowed_keys = {"PATH", "HOME", "HELIX_SPLIT", "HELIX_VAR"}
         assert set(env.keys()) == allowed_keys
 
+    def test_passthrough_env_preserves_listed_vars(self, monkeypatch):
+        """passthrough_env includes specified variables in the scrubbed env."""
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+        monkeypatch.setenv("HF_HOME", "/data/hf")
+        monkeypatch.setenv("SECRET_KEY", "should_not_appear")
+
+        env = _scrub_environment("val", passthrough_env=["CUDA_VISIBLE_DEVICES", "HF_HOME"])
+        assert env["CUDA_VISIBLE_DEVICES"] == "0,1"
+        assert env["HF_HOME"] == "/data/hf"
+        assert "SECRET_KEY" not in env
+
+    def test_passthrough_env_missing_var_is_ignored(self, monkeypatch):
+        """passthrough_env silently skips vars not present in os.environ."""
+        monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
+        env = _scrub_environment("val", passthrough_env=["NONEXISTENT_VAR"])
+        assert "NONEXISTENT_VAR" not in env
+
+    def test_passthrough_env_empty_list_no_change(self):
+        """Empty passthrough_env behaves identically to the default."""
+        env_default = _scrub_environment("val")
+        env_empty = _scrub_environment("val", passthrough_env=[])
+        assert env_default == env_empty
+
 
 # ---------------------------------------------------------------------------
 # Tests: Integration - run_evaluator with security


### PR DESCRIPTION
Adds a `passthrough_env` config option that preserves specified environment variables through HELIX env scrub for both evaluator commands and Claude Code mutation sessions.

**Problem:** `CUDA_VISIBLE_DEVICES` and other critical env vars were being stripped during env scrub, breaking GPU-dependent workloads.

**Solution:** New `passthrough_env` list in config that whitelists env vars to survive scrubbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)