### PR TITLE
feat: add StratifiedBatchSampler for task-diverse minibatches

### DIFF
--- a/src/helix/batch_sampler.py
+++ b/src/helix/batch_sampler.py
@@ -115,9 +115,9 @@ class EpochShuffledBatchSampler(Generic[DataId]):
 class StratifiedBatchSampler(Generic[DataId]):
     """Task-stratified minibatch sampler.
 
-    Each minibatch of size ``K`` is constructed by choosing ``K`` distinct
-    groups (per ``group_fn``) and then picking one unused instance from each
-    of those groups.  This guarantees task diversity within every minibatch,
+    Each epoch is pre-shuffled such that every minibatch of size ``K`` is a
+    slice of ``K`` instances drawn from ``K`` distinct groups (per
+    ``group_fn``).  This guarantees task diversity within every minibatch,
     which helps reflection-style evolutionary search reason about
     generalisation instead of overfitting to whichever task happens to
     dominate a random batch.
@@ -130,14 +130,19 @@ class StratifiedBatchSampler(Generic[DataId]):
       any contiguous window of ``minibatch_size`` indices begins at a
       multiple of ``minibatch_size`` and touches ``minibatch_size`` distinct
       groups — as long as at least ``minibatch_size`` groups exist.
+    - Per-round rotation: when ``num_groups > minibatch_size``, each round
+      drops the trailing ``num_groups % minibatch_size`` groups (padding
+      would re-introduce a group collision).  We rotate ``group_keys`` by
+      ``r`` positions on round ``r`` so the dropped slot rotates across all
+      groups within a single epoch — preventing within-epoch group
+      starvation.
     - Epoch bumps reshuffle via the shared ``rng``, mirroring
       :class:`EpochShuffledBatchSampler`'s determinism guarantees.
-    - Padding: when the combined interleaved schedule is not a multiple of
-      ``minibatch_size``, we drop the trailing partial round rather than
-      pad with duplicates, because padding would re-introduce a group
-      collision within the final minibatch.  Because all full rounds are
-      emitted first, this only ever discards a tail of size
-      ``< minibatch_size`` per epoch.
+    - Padding: when a round is partial (some buckets exhausted), we trim to
+      the largest multiple of ``minibatch_size`` that still fits in the
+      round, dropping any trailing remainder rather than padding with
+      duplicates (padding would re-introduce a group collision within the
+      final minibatch).
     - Fallback: when ``len(groups) < minibatch_size``, a stratified minibatch
       is impossible, so the sampler transparently delegates to an internal
       :class:`EpochShuffledBatchSampler` for GEPA parity semantics.
@@ -145,9 +150,14 @@ class StratifiedBatchSampler(Generic[DataId]):
     Invariants:
       S1. Every returned minibatch of size ``m`` contains exactly ``m``
           distinct group keys (when ``num_groups >= m``).
-      S2. Across a full epoch, each instance is yielded at most once
-          (instances beyond ``floor(min_group_size * num_groups / m) * m``
-          may be dropped in the final partial round).
+      S2. Within an epoch each instance is yielded at most once.  In each
+          round of the round-robin interleave, only the first
+          ``whole_rounds_per_round = (num_groups // m) * m`` entries are
+          kept (rounded down to a multiple of ``m`` for partial rounds).
+          When ``num_groups % m != 0``, the trailing ``num_groups % m``
+          group slots in any given round are dropped — but the per-round
+          rotation of ``group_keys`` ensures the dropped slot rotates
+          across all groups, so no group is starved within an epoch.
       S3. Determinism given ``rng`` seed, matching
           :class:`EpochShuffledBatchSampler` semantics.
     """
@@ -199,34 +209,34 @@ class StratifiedBatchSampler(Generic[DataId]):
             self.rng.shuffle(buckets[key])
         self.rng.shuffle(group_keys)
 
-        # Interleave round-robin: round r picks buckets[k][r] for each key k,
-        # as long as index r is valid for that bucket.  A "full round" touches
-        # every group exactly once — that's our stratification guarantee.
+        # Interleave round-robin and trim per-round.  Round r picks
+        # buckets[k][r] for each key k where r is a valid index for that
+        # bucket.  A "full round" touches every group exactly once — that's
+        # our stratification guarantee.  Within a round, the first
+        # ``whole_rounds_per_round = (num_groups // m) * m`` entries form
+        # complete stratified minibatches; any trailing ``num_groups % m``
+        # entries are dropped because padding them would require
+        # duplicating a group.  When a round is partial (some buckets
+        # exhausted), we further clip to a multiple of ``m`` so the slice
+        # formula in ``next_minibatch_ids`` never overruns a boundary.
+        #
+        # Per-round rotation: rotating ``group_keys`` by ``r`` positions
+        # before slicing rotates which group lands in the trimmed slot
+        # across rounds, so no group is starved within an epoch when
+        # ``num_groups > m`` and ``num_groups % m != 0``.
         max_rounds = max(len(buckets[k]) for k in group_keys)
-        schedule: list[DataId] = []
-        for r in range(max_rounds):
-            round_slice: list[DataId] = []
-            for key in group_keys:
-                if r < len(buckets[key]):
-                    round_slice.append(buckets[key][r])
-            # Only emit the round if it fills at least one full minibatch of
-            # distinct groups; otherwise stratification would break.
-            if len(round_slice) >= self.minibatch_size:
-                schedule.extend(round_slice)
-
-        # Trim to a whole-number-of-minibatches length so the slice formula
-        # in ``next_minibatch_ids`` never overruns a boundary.  Each full
-        # round has length ``num_groups``; within a round, the first
-        # ``(num_groups // m) * m`` entries form complete stratified
-        # minibatches — any trailing ``num_groups % m`` entries are dropped
-        # because padding them would require duplicating a group.
         m = self.minibatch_size
         whole_rounds_per_round = (num_groups // m) * m
         trimmed: list[DataId] = []
-        # Split ``schedule`` back into rounds of size ``num_groups``.
-        for start in range(0, len(schedule), num_groups):
-            round_ids = schedule[start : start + num_groups]
-            trimmed.extend(round_ids[:whole_rounds_per_round])
+        for r in range(max_rounds):
+            offset = r % num_groups
+            rotated_keys = group_keys[offset:] + group_keys[:offset]
+            round_slice = [buckets[k][r] for k in rotated_keys if r < len(buckets[k])]
+            # Take at most whole_rounds_per_round entries, then clip to a
+            # multiple of m in case this round is partial.
+            keep = min(len(round_slice), whole_rounds_per_round)
+            keep -= keep % m
+            trimmed.extend(round_slice[:keep])
 
         self.shuffled_ids = trimmed
 
@@ -236,6 +246,13 @@ class StratifiedBatchSampler(Generic[DataId]):
         trainset_size = len(loader)
         if trainset_size == 0:
             raise ValueError("Cannot sample a minibatch from an empty loader.")
+
+        # Fast path: once the fallback is engaged and the trainset hasn't
+        # changed, delegate directly without re-bucketing all_ids() on every
+        # call.  ``self.epoch`` is left untouched in this branch — the inner
+        # fallback maintains its own epoch state.
+        if self._fallback is not None and trainset_size == self.last_trainset_size:
+            return self._fallback.next_minibatch_ids(loader, state)
 
         base_idx = state.i * self.minibatch_size
         curr_epoch = (

--- a/src/helix/batch_sampler.py
+++ b/src/helix/batch_sampler.py
@@ -3,12 +3,21 @@
 Line-for-line port of
   gepa.strategies.batch_sampler.EpochShuffledBatchSampler
 (see /tmp/gepa_eval_spec.md §2).
+
+Also provides :class:`StratifiedBatchSampler`, which is a HELIX extension
+over EpochShuffledBatchSampler that guarantees each minibatch of size K
+contains K instances drawn from K *distinct* groups (tasks), where the
+group of an instance id is derived via a user-provided ``group_fn``.
+This is useful when the training set contains multiple tasks with many
+seeds per task: a uniform random sampler will often produce batches
+dominated by one task, which is detrimental to generalisation-focused
+evolutionary search.
 """
 from __future__ import annotations
 
 import random
-from collections import Counter
-from typing import Generic, Protocol, TypeVar, runtime_checkable
+from collections import Counter, defaultdict
+from typing import Callable, Generic, Protocol, TypeVar, runtime_checkable
 
 from helix.trace import TRACE, EventType
 
@@ -90,6 +99,161 @@ class EpochShuffledBatchSampler(Generic[DataId]):
         if needs_refresh:
             self.epoch = curr_epoch
             self._update_shuffled(loader)
+        assert len(self.shuffled_ids) >= self.minibatch_size
+        assert len(self.shuffled_ids) % self.minibatch_size == 0
+        base_idx = base_idx % len(self.shuffled_ids)
+        end_idx = base_idx + self.minibatch_size
+        assert end_idx <= len(self.shuffled_ids)
+        _ids = self.shuffled_ids[base_idx:end_idx]
+        TRACE.emit(
+            EventType.SAMPLE_MINIBATCH,
+            example_ids=list(_ids),
+        )
+        return _ids
+
+
+class StratifiedBatchSampler(Generic[DataId]):
+    """Task-stratified minibatch sampler.
+
+    Each minibatch of size ``K`` is constructed by choosing ``K`` distinct
+    groups (per ``group_fn``) and then picking one unused instance from each
+    of those groups.  This guarantees task diversity within every minibatch,
+    which helps reflection-style evolutionary search reason about
+    generalisation instead of overfitting to whichever task happens to
+    dominate a random batch.
+
+    Design notes:
+
+    - Epoch layout: at the start of each epoch, we shuffle the instances
+      *within* each group, then interleave across groups round-robin.  The
+      resulting flat schedule (``self.shuffled_ids``) has the property that
+      any contiguous window of ``minibatch_size`` indices begins at a
+      multiple of ``minibatch_size`` and touches ``minibatch_size`` distinct
+      groups — as long as at least ``minibatch_size`` groups exist.
+    - Epoch bumps reshuffle via the shared ``rng``, mirroring
+      :class:`EpochShuffledBatchSampler`'s determinism guarantees.
+    - Padding: when the combined interleaved schedule is not a multiple of
+      ``minibatch_size``, we drop the trailing partial round rather than
+      pad with duplicates, because padding would re-introduce a group
+      collision within the final minibatch.  Because all full rounds are
+      emitted first, this only ever discards a tail of size
+      ``< minibatch_size`` per epoch.
+    - Fallback: when ``len(groups) < minibatch_size``, a stratified minibatch
+      is impossible, so the sampler transparently delegates to an internal
+      :class:`EpochShuffledBatchSampler` for GEPA parity semantics.
+
+    Invariants:
+      S1. Every returned minibatch of size ``m`` contains exactly ``m``
+          distinct group keys (when ``num_groups >= m``).
+      S2. Across a full epoch, each instance is yielded at most once
+          (instances beyond ``floor(min_group_size * num_groups / m) * m``
+          may be dropped in the final partial round).
+      S3. Determinism given ``rng`` seed, matching
+          :class:`EpochShuffledBatchSampler` semantics.
+    """
+
+    def __init__(
+        self,
+        minibatch_size: int,
+        group_fn: Callable[[DataId], str],
+        rng: random.Random | None = None,
+    ) -> None:
+        self.minibatch_size = minibatch_size
+        self.group_fn = group_fn
+        self.rng = rng if rng is not None else random.Random(0)
+        self.shuffled_ids: list[DataId] = []
+        self.epoch: int = -1
+        self.last_trainset_size: int = 0
+        # Fallback sampler used when num_groups < minibatch_size.  Lazily
+        # created so the common case pays no extra allocations.
+        self._fallback: EpochShuffledBatchSampler[DataId] | None = None
+
+    def _update_shuffled(self, loader: DataLoader[DataId]) -> None:
+        all_ids = list(loader.all_ids())
+        self.last_trainset_size = len(loader)
+        if not all_ids:
+            self.shuffled_ids = []
+            return
+
+        # Bucket by group, preserving input order within each group.
+        buckets: dict[str, list[DataId]] = defaultdict(list)
+        for _id in all_ids:
+            buckets[self.group_fn(_id)].append(_id)
+
+        group_keys = sorted(buckets.keys())
+        num_groups = len(group_keys)
+
+        # Fallback path: not enough groups to guarantee stratification.
+        if num_groups < self.minibatch_size:
+            if self._fallback is None:
+                self._fallback = EpochShuffledBatchSampler[DataId](
+                    minibatch_size=self.minibatch_size, rng=self.rng
+                )
+            # Keep schedule empty so next_minibatch_ids delegates.
+            self.shuffled_ids = []
+            return
+
+        # Shuffle within each group, then shuffle the group order.  Both
+        # draws are consumed from the shared ``rng`` for determinism.
+        for key in group_keys:
+            self.rng.shuffle(buckets[key])
+        self.rng.shuffle(group_keys)
+
+        # Interleave round-robin: round r picks buckets[k][r] for each key k,
+        # as long as index r is valid for that bucket.  A "full round" touches
+        # every group exactly once — that's our stratification guarantee.
+        max_rounds = max(len(buckets[k]) for k in group_keys)
+        schedule: list[DataId] = []
+        for r in range(max_rounds):
+            round_slice: list[DataId] = []
+            for key in group_keys:
+                if r < len(buckets[key]):
+                    round_slice.append(buckets[key][r])
+            # Only emit the round if it fills at least one full minibatch of
+            # distinct groups; otherwise stratification would break.
+            if len(round_slice) >= self.minibatch_size:
+                schedule.extend(round_slice)
+
+        # Trim to a whole-number-of-minibatches length so the slice formula
+        # in ``next_minibatch_ids`` never overruns a boundary.  Each full
+        # round has length ``num_groups``; within a round, the first
+        # ``(num_groups // m) * m`` entries form complete stratified
+        # minibatches — any trailing ``num_groups % m`` entries are dropped
+        # because padding them would require duplicating a group.
+        m = self.minibatch_size
+        whole_rounds_per_round = (num_groups // m) * m
+        trimmed: list[DataId] = []
+        # Split ``schedule`` back into rounds of size ``num_groups``.
+        for start in range(0, len(schedule), num_groups):
+            round_ids = schedule[start : start + num_groups]
+            trimmed.extend(round_ids[:whole_rounds_per_round])
+
+        self.shuffled_ids = trimmed
+
+    def next_minibatch_ids(
+        self, loader: DataLoader[DataId], state: _SamplerState
+    ) -> list[DataId]:
+        trainset_size = len(loader)
+        if trainset_size == 0:
+            raise ValueError("Cannot sample a minibatch from an empty loader.")
+
+        base_idx = state.i * self.minibatch_size
+        curr_epoch = (
+            0 if self.epoch == -1 else base_idx // max(len(self.shuffled_ids), 1)
+        )
+        needs_refresh = (
+            not self.shuffled_ids
+            or trainset_size != self.last_trainset_size
+            or curr_epoch > self.epoch
+        )
+        if needs_refresh:
+            self.epoch = curr_epoch
+            self._update_shuffled(loader)
+
+        # Fallback: delegate to the standard sampler when we can't stratify.
+        if not self.shuffled_ids and self._fallback is not None:
+            return self._fallback.next_minibatch_ids(loader, state)
+
         assert len(self.shuffled_ids) >= self.minibatch_size
         assert len(self.shuffled_ids) % self.minibatch_size == 0
         base_idx = base_idx % len(self.shuffled_ids)

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -260,11 +260,37 @@ class EvolutionConfig(BaseModel):
             "when unset or 0."
         ),
     )
+    batch_sampler: Literal["epoch_shuffled", "stratified"] = Field(
+        default="epoch_shuffled",
+        description=(
+            "Minibatch sampling strategy. "
+            "'epoch_shuffled' (default): GEPA-parity EpochShuffledBatchSampler. "
+            "'stratified': StratifiedBatchSampler guarantees each minibatch of "
+            "size K touches K distinct groups, where the group key is derived "
+            "from each instance id via 'evolution.group_key_separator'. Falls "
+            "back to epoch_shuffled behaviour when fewer groups than "
+            "minibatch_size are available."
+        ),
+    )
+    group_key_separator: str = Field(
+        default="__",
+        description=(
+            "Separator used to derive a group key from each instance id for "
+            "the stratified batch sampler: the id is split on this separator "
+            "and the first part is taken as the group key (e.g. "
+            "'cube_stack__s3' -> 'cube_stack' when separator='__')."
+        ),
+    )
 
     def model_post_init(self, __context: object) -> None:
         if self.val_stage_size is not None and self.val_stage_size < 0:
             raise ValueError(
                 f"evolution.val_stage_size must be >= 0 (got {self.val_stage_size})"
+            )
+        if not self.group_key_separator:
+            raise ValueError(
+                "evolution.group_key_separator must be a non-empty string "
+                f"(got {self.group_key_separator!r})"
             )
 
 

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -287,9 +287,13 @@ class EvolutionConfig(BaseModel):
             raise ValueError(
                 f"evolution.val_stage_size must be >= 0 (got {self.val_stage_size})"
             )
-        if not self.group_key_separator:
+        # group_key_separator is only consumed by the stratified sampler;
+        # validate it only on that path so default ('__') configs that use
+        # the epoch_shuffled sampler aren't restricted unnecessarily.
+        if self.batch_sampler == "stratified" and not self.group_key_separator:
             raise ValueError(
                 "evolution.group_key_separator must be a non-empty string "
+                "when evolution.batch_sampler='stratified' "
                 f"(got {self.group_key_separator!r})"
             )
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -806,8 +806,8 @@ def run_evolution(
             # 'cube_stack__s3' -> 'cube_stack' with separator='__'.
             sep = config.evolution.group_key_separator
 
-            def _group_fn(example_id: str, _sep: str = sep) -> str:
-                return example_id.split(_sep, 1)[0]
+            def _group_fn(example_id: str) -> str:
+                return example_id.split(sep, 1)[0]
 
             batch_sampler = StratifiedBatchSampler[str](
                 minibatch_size=config.evolution.minibatch_size,

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -29,7 +29,7 @@ from rich.progress import (
 )
 from rich.text import Text
 
-from helix.batch_sampler import EpochShuffledBatchSampler
+from helix.batch_sampler import BatchSampler, EpochShuffledBatchSampler, StratifiedBatchSampler
 from helix.config import HelixConfig, load_dataset_examples
 from helix.eval_cache import EvaluationCache as MinibatchEvalCache
 from helix.eval_policy import (
@@ -798,12 +798,27 @@ def run_evolution(
     # result is that minibatches diverge from GEPA starting with the very
     # first iteration on identical seeds.  Detected by the GEPA
     # differential testing harness (tests/unit/test_gepa_diff_harness.py).
-    batch_sampler: EpochShuffledBatchSampler[str] | None = None
+    batch_sampler: BatchSampler[str] | None = None
     if use_minibatch_gate:
-        batch_sampler = EpochShuffledBatchSampler[str](
-            minibatch_size=config.evolution.minibatch_size,
-            rng=rng,
-        )
+        if config.evolution.batch_sampler == "stratified":
+            # Derive group key from instance id by splitting on the
+            # configured separator and taking the first part.  E.g.
+            # 'cube_stack__s3' -> 'cube_stack' with separator='__'.
+            sep = config.evolution.group_key_separator
+
+            def _group_fn(example_id: str, _sep: str = sep) -> str:
+                return example_id.split(_sep, 1)[0]
+
+            batch_sampler = StratifiedBatchSampler[str](
+                minibatch_size=config.evolution.minibatch_size,
+                group_fn=_group_fn,
+                rng=rng,
+            )
+        else:
+            batch_sampler = EpochShuffledBatchSampler[str](
+                minibatch_size=config.evolution.minibatch_size,
+                rng=rng,
+            )
 
     # GEPA-parity per-(candidate_hash, example_id) eval cache.  Kept
     # distinct from the legacy ``eval_cache`` above, which is keyed by

--- a/tests/unit/test_batch_sampler.py
+++ b/tests/unit/test_batch_sampler.py
@@ -1,4 +1,4 @@
-"""Unit tests for EpochShuffledBatchSampler (GEPA parity)."""
+"""Unit tests for EpochShuffledBatchSampler (GEPA parity) and StratifiedBatchSampler."""
 from __future__ import annotations
 
 import random
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from helix.batch_sampler import EpochShuffledBatchSampler
+from helix.batch_sampler import EpochShuffledBatchSampler, StratifiedBatchSampler
 
 
 @dataclass
@@ -123,3 +123,129 @@ def test_state_i_slice_formula() -> None:
         batch = sampler.next_minibatch_ids(loader, _State(i=i))
         base = (i * m) % L
         assert batch == sampler.shuffled_ids[base : base + m]
+
+
+# ---------------------------------------------------------------------------
+# StratifiedBatchSampler tests
+# ---------------------------------------------------------------------------
+
+
+def _group_by_prefix(example_id: str, sep: str = "__") -> str:
+    return example_id.split(sep, 1)[0]
+
+
+def test_stratified_minibatch_contains_k_distinct_groups() -> None:
+    """Every minibatch of size 3 should touch 3 distinct groups."""
+    ids = ["a__0", "a__1", "b__0", "b__1", "c__0", "c__1"]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(0)
+    )
+    # Run across several minibatches, including epoch wrap-around.
+    for i in range(8):
+        batch = sampler.next_minibatch_ids(loader, _State(i=i))
+        assert len(batch) == 3
+        groups = {_group_by_prefix(eid) for eid in batch}
+        assert groups == {"a", "b", "c"}, (
+            f"minibatch {i} had groups {groups}, expected {{'a','b','c'}}"
+        )
+
+
+def test_stratified_epoch_covers_all_instances() -> None:
+    """Each full epoch should emit every instance exactly once (balanced groups)."""
+    ids = ["a__0", "a__1", "b__0", "b__1", "c__0", "c__1"]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(11)
+    )
+    # 6 ids / minibatch_size 3 = 2 steps per epoch.
+    seen: list[str] = []
+    for i in range(2):
+        seen.extend(sampler.next_minibatch_ids(loader, _State(i=i)))
+    assert sorted(seen) == sorted(ids)
+    assert len(set(seen)) == len(ids)
+
+
+def test_stratified_epoch_rotation_reshuffles() -> None:
+    """Crossing into a new epoch should trigger a fresh shuffle."""
+    ids = ["a__0", "a__1", "b__0", "b__1", "c__0", "c__1"]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(4)
+    )
+    sampler.next_minibatch_ids(loader, _State(i=0))
+    first_schedule = list(sampler.shuffled_ids)
+    assert sampler.epoch == 0
+    # i=2 -> base_idx = 6 = len(shuffled_ids), crosses into epoch 1.
+    sampler.next_minibatch_ids(loader, _State(i=2))
+    assert sampler.epoch == 1
+    # A fresh list is produced each epoch (identity check).
+    assert sampler.shuffled_ids is not first_schedule
+
+
+def test_stratified_fallback_when_groups_lt_minibatch_size() -> None:
+    """Fewer groups than K → fall back to EpochShuffledBatchSampler semantics."""
+    # 2 groups but minibatch_size=3: stratification impossible, fall back.
+    ids = ["a__0", "a__1", "a__2", "b__0", "b__1", "b__2"]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(0)
+    )
+    batch = sampler.next_minibatch_ids(loader, _State(i=0))
+    assert len(batch) == 3
+    assert sampler._fallback is not None, "expected fallback sampler to be engaged"
+    # All returned ids must come from the loader.
+    all_ids = set(ids)
+    for eid in batch:
+        assert eid in all_ids
+
+
+def test_stratified_fallback_epoch_covers_all_instances() -> None:
+    """Fallback path should still cover every instance within an epoch."""
+    ids = ["a__0", "a__1", "a__2", "b__0", "b__1", "b__2"]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(2)
+    )
+    seen: list[str] = []
+    # 6 ids / 3 = 2 minibatches per epoch.
+    for i in range(2):
+        seen.extend(sampler.next_minibatch_ids(loader, _State(i=i)))
+    assert sorted(seen) == sorted(ids)
+
+
+def test_stratified_empty_loader_raises() -> None:
+    loader = _Loader([])
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(0)
+    )
+    with pytest.raises(ValueError):
+        sampler.next_minibatch_ids(loader, _State(i=0))
+
+
+def test_stratified_determinism_same_seed() -> None:
+    ids = [f"{g}__{i}" for g in ("a", "b", "c", "d") for i in range(3)]
+    loader = _Loader(ids)
+    s1 = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(42)
+    )
+    s2 = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(42)
+    )
+    seq1 = [s1.next_minibatch_ids(loader, _State(i=i)) for i in range(6)]
+    seq2 = [s2.next_minibatch_ids(loader, _State(i=i)) for i in range(6)]
+    assert seq1 == seq2
+
+
+def test_stratified_unbalanced_group_sizes_still_stratifies() -> None:
+    """With unbalanced groups (3/2/2), full stratified rounds still dominate."""
+    ids = ["a__0", "a__1", "a__2", "b__0", "b__1", "c__0", "c__1"]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(7)
+    )
+    # Run through a couple of epochs — every minibatch still touches 3 groups.
+    for i in range(6):
+        batch = sampler.next_minibatch_ids(loader, _State(i=i))
+        groups = {_group_by_prefix(eid) for eid in batch}
+        assert len(groups) == 3

--- a/tests/unit/test_batch_sampler.py
+++ b/tests/unit/test_batch_sampler.py
@@ -249,3 +249,110 @@ def test_stratified_unbalanced_group_sizes_still_stratifies() -> None:
         batch = sampler.next_minibatch_ids(loader, _State(i=i))
         groups = {_group_by_prefix(eid) for eid in batch}
         assert len(groups) == 3
+
+
+def test_stratified_num_groups_gt_m_unbalanced_no_crash() -> None:
+    """Regression: num_groups > minibatch_size with uneven group sizes used to
+    crash the trim logic (PR#3 review MUST-FIX).
+
+    Reproducer: 4 groups of sizes (3, 2, 1, 3), m=2 — at least one round has
+    `m <= len(round_slice) < num_groups`, so the previous flat-chunking trim
+    misaligned and produced a `len(shuffled_ids)` that was not a multiple of
+    `m`, tripping the `% m == 0` assert in `next_minibatch_ids`.
+    """
+    ids = [
+        "a__0", "a__1", "a__2",
+        "b__0", "b__1",
+        "c__0",
+        "d__0", "d__1", "d__2",
+    ]
+    # Run across every seed in 0..9 — review reports failure on all of them.
+    for seed in range(10):
+        loader = _Loader(ids)
+        sampler = StratifiedBatchSampler(
+            minibatch_size=2, group_fn=_group_by_prefix, rng=random.Random(seed)
+        )
+        # Drive multiple steps, including across epoch boundaries.
+        for i in range(8):
+            batch = sampler.next_minibatch_ids(loader, _State(i=i))
+            assert len(batch) == 2
+            groups = {_group_by_prefix(eid) for eid in batch}
+            assert len(groups) == 2, (
+                f"seed={seed} i={i} batch={batch} should have 2 distinct groups"
+            )
+        # Schedule must always be a multiple of minibatch_size.
+        assert len(sampler.shuffled_ids) % 2 == 0
+
+
+def test_stratified_num_groups_gt_m_balanced_eventual_coverage() -> None:
+    """Across N epochs with `num_groups > m` balanced groups, every instance
+    must appear at least once in the union of emitted minibatches.
+
+    This guards against within-epoch group starvation regressing further
+    (PR#3 review SHOULD-FIX #2): without per-round group rotation, the same
+    `num_groups % m` groups would be dropped every round of every epoch
+    until the per-epoch shuffle rotated them in by chance.
+    """
+    # 5 groups of size 3 each, m=3 -> num_groups % m == 2 dropped per round.
+    ids = [f"{g}__{i}" for g in ("a", "b", "c", "d", "e") for i in range(3)]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(0)
+    )
+    seen: set[str] = set()
+    # 5 epochs of 3 minibatches each — with rotation, this covers every id.
+    for i in range(15):
+        batch = sampler.next_minibatch_ids(loader, _State(i=i))
+        seen.update(batch)
+        assert len({_group_by_prefix(eid) for eid in batch}) == 3
+    assert seen == set(ids), f"missing ids: {set(ids) - seen}"
+
+
+def test_stratified_num_groups_gt_m_per_round_rotation_covers_all_groups() -> None:
+    """Within a single epoch with `num_groups > m`, every group should appear
+    at least once across the emitted schedule (per-round rotation guarantees
+    this when there are enough rounds).
+    """
+    # 4 groups of size 4 each, m=3 -> 1 group dropped per round, 4 rounds
+    # total -> rotation visits all groups within the epoch.
+    ids = [f"{g}__{i}" for g in ("a", "b", "c", "d") for i in range(4)]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(0)
+    )
+    sampler.next_minibatch_ids(loader, _State(i=0))
+    schedule_groups = {_group_by_prefix(eid) for eid in sampler.shuffled_ids}
+    assert schedule_groups == {"a", "b", "c", "d"}, (
+        "every group should appear at least once in the schedule "
+        f"(got {schedule_groups})"
+    )
+
+
+def test_stratified_fallback_short_circuits_after_engagement() -> None:
+    """Once the fallback is engaged and the trainset hasn't changed, calls
+    should bypass `_update_shuffled` entirely (PR#3 review SHOULD-FIX #3).
+    """
+    ids = ["a__0", "a__1", "a__2", "b__0", "b__1", "b__2"]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3, group_fn=_group_by_prefix, rng=random.Random(0)
+    )
+    # Engage the fallback.
+    sampler.next_minibatch_ids(loader, _State(i=0))
+    assert sampler._fallback is not None
+
+    # Patch _update_shuffled so any further call would explode — proves we
+    # short-circuit straight to the fallback when trainset_size is stable.
+    call_count = {"n": 0}
+    original = sampler._update_shuffled
+
+    def _tripwire(*args: Any, **kwargs: Any) -> None:
+        call_count["n"] += 1
+        original(*args, **kwargs)
+
+    sampler._update_shuffled = _tripwire  # type: ignore[method-assign]
+    for i in range(1, 6):
+        sampler.next_minibatch_ids(loader, _State(i=i))
+    assert call_count["n"] == 0, (
+        "fallback path should short-circuit and never re-bucket all_ids()"
+    )


### PR DESCRIPTION
## Motivation

HELIX currently uses upstream reference `EpochShuffledBatchSampler`, which draws minibatches uniformly at random from the training set. When the training set contains multiple groups with many cases per group (e.g. `group_alpha__case_0`, `group_alpha__case_1`, ..., `group_beta__case_0`, ...), a minibatch of size K will often be dominated by a single group, especially with short batches and skewed group-size distributions.

For reflection-style evolutionary search, that's a problem: the LLM mutator reasons about whichever group the batch happens to contain, so single-group-dominated batches push evolution toward overfitting one group rather than cross-group generalisation.

## Design

`StratifiedBatchSampler` (new, HELIX-specific: **not** a upstream reference parity change) guarantees that every minibatch of size K contains instances from **K distinct groups**, where the group key is derived from each instance id via a user-supplied `group_fn`.

- **Epoch layout**: at the start of each epoch, shuffle instances within each group, then interleave across groups round-robin. The resulting flat schedule has the property that any contiguous minibatch-sized window aligned to a minibatch boundary touches K distinct groups.
- **Trimming (not padding)**: if a round would emit fewer than K distinct groups (only happens at the tail when `num_groups % K != 0`), those entries are dropped rather than padded; padding would duplicate a group and break stratification. At most `num_groups % K` instances are dropped per round.
- **Epoch bumps** reshuffle via the shared `rng`, preserving determinism parity with `EpochShuffledBatchSampler`.
- **Fallback**: when `len(groups) < minibatch_size`, stratification is impossible, so the sampler transparently delegates to an internal `EpochShuffledBatchSampler`; behaviour is identical to the current default.

### Config

Two new options under `[evolution]`:

- `batch_sampler`: `"epoch_shuffled"` (default, upstream reference parity) | `"stratified"`
- `group_key_separator`: default `"__"`, which splits instance ids on this separator and takes the first part as the group key (e.g. `group_alpha__case_3` -> `group_alpha`).

Existing configs are unchanged: `batch_sampler` defaults to `epoch_shuffled`, so there is no behavioural difference unless the user opts in.

### Wiring

`src/helix/evolution.py` now picks between `EpochShuffledBatchSampler` and `StratifiedBatchSampler` based on `config.evolution.batch_sampler`. Both samplers share the same `rng` so the rng-consumption order relative to `candidate_selector` remains unchanged on the default path (upstream reference parity preserved).

## Tests

All 466 existing tests still pass. 8 new tests in `tests/unit/test_batch_sampler.py`:

- [x] `test_stratified_minibatch_contains_k_distinct_groups`: every K=3 batch from `{a__0, a__1, b__0, b__1, c__0, c__1}` has all 3 groups.
- [x] `test_stratified_epoch_covers_all_instances`: balanced groups: every instance yielded once per epoch.
- [x] `test_stratified_epoch_rotation_reshuffles`: epoch bump triggers a fresh shuffle.
- [x] `test_stratified_fallback_when_groups_lt_minibatch_size`: falls back to `EpochShuffledBatchSampler` when only 2 groups but K=3.
- [x] `test_stratified_fallback_epoch_covers_all_instances`: fallback path still covers every instance.
- [x] `test_stratified_empty_loader_raises`: empty loader raises `ValueError` (parity with `EpochShuffledBatchSampler`).
- [x] `test_stratified_determinism_same_seed`: identical rng seeds produce identical minibatch sequences.
- [x] `test_stratified_unbalanced_group_sizes_still_stratifies`: unbalanced group sizes (3/2/2) still yield K-distinct-group minibatches.

## Test plan

- [x] `pytest tests/ -x`: all 466 tests pass locally
- [ ] Reviewer: confirm no upstream reference parity behaviour is altered on the default path