### PR TITLE
Add helix_result score_parser for the upstream reference HELIX_RESULT= contract

### DIFF
--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -18,7 +18,9 @@ class EvaluatorConfig(BaseModel):
     results are parsed into scores.
     """
     command: str
-    score_parser: Literal["pytest", "exitcode", "json_accuracy", "json_score"] = "pytest"
+    score_parser: Literal[
+        "pytest", "exitcode", "json_accuracy", "json_score", "helix_result"
+    ] = "pytest"
     include_stdout: bool = True
     include_stderr: bool = True
     extra_commands: list[str] = Field(default_factory=list)

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -314,7 +314,7 @@ def run_evaluator(
 
     # If HELIX_RESULT= provided a score, override the parser-derived aggregate
     if helix_result_score is not None:
-        scores["success"] = helix_result_score
+        scores["success"] = 0.0 if returncode != 0 else helix_result_score
 
     # Post-filter instance_scores when a subset was requested: evaluators
     # that ignore HELIX_INSTANCE_IDS will still have returned the whole

--- a/src/helix/parsers/__init__.py
+++ b/src/helix/parsers/__init__.py
@@ -26,7 +26,8 @@ def get_parser(name: str) -> Callable[..., Any]:
     """Return the parse function for the given parser name.
 
     Args:
-        name: Parser name, one of "pytest" or "exitcode".
+        name: Parser name, one of "pytest", "exitcode", "json_accuracy",
+            "json_score", or "helix_result".
 
     Returns:
         A callable parse function.

--- a/src/helix/parsers/__init__.py
+++ b/src/helix/parsers/__init__.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from helix.parsers import exitcode, pytest as pytest_parser, json_accuracy, json_score
+from helix.parsers import (
+    exitcode,
+    pytest as pytest_parser,
+    json_accuracy,
+    json_score,
+    helix_result,
+)
 
 
 _PARSERS: dict[str, Callable[..., Any]] = {
@@ -12,6 +18,7 @@ _PARSERS: dict[str, Callable[..., Any]] = {
     "exitcode": exitcode.parse,
     "json_accuracy": json_accuracy.parse,
     "json_score": json_score.parse,
+    "helix_result": helix_result.parse,
 }
 
 

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -1,0 +1,124 @@
+"""Parse HELIX_RESULT= lines emitted by evaluators.
+
+This is the companion parser to the ``HELIX_RESULT=`` override handled
+inside :mod:`helix.executor` (see ``run_evaluator``). Evaluators that want
+to hand HELIX a scalar score *and* a diagnostics dictionary on the GEPA
+``(accuracy, side_info)`` contract emit exactly one line of the form::
+
+    HELIX_RESULT=[<score>, <side_info_dict>]
+
+as their last meaningful stdout line. The executor scans for that line,
+overrides ``scores["success"]`` with ``<score>``, and stashes
+``side_info`` on the :class:`EvalResult`.  This parser exists so the
+config's ``score_parser = "helix_result"`` is a valid selector and so the
+per-instance scores in ``side_info["scores"]`` (e.g. ``task__metric`` →
+float) flow into HELIX's minibatch-gate via ``instance_scores``.
+
+Fallbacks mirror ``exitcode``/``json_score`` semantics so a missing or
+malformed ``HELIX_RESULT=`` line does not crash the evolve loop.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+
+def parse(
+    returncode: int, stdout: str, stderr: str
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Parse ``HELIX_RESULT=[score, side_info]`` from evaluator stdout.
+
+    Behaviour:
+        * Scan stdout lines in reverse for the last line starting with
+          ``HELIX_RESULT=``. Strip the prefix, ``json.loads`` the payload.
+        * When the payload is well-formed ``[float, dict]``:
+              - ``scores = {"success": float(payload[0])}``; if
+                ``side_info`` carries a numeric ``"accuracy"`` field, also
+                set ``scores["accuracy"]`` for readability.
+              - ``instance_scores`` is populated from
+                ``side_info.get("scores", {})`` when that value is a
+                ``dict`` of ``str`` → number; otherwise empty.
+              - If ``returncode != 0``, coerce ``scores["success"] = 0.0``
+                to match ``json_score``'s failure semantics.
+        * When the line is missing or malformed, fall back to
+          ``exitcode`` semantics (``success = 1.0 if returncode == 0 else
+          0.0``) so the evolve loop still runs.
+
+    Note:
+        The executor independently scans for ``HELIX_RESULT=`` and
+        overrides ``scores["success"]`` from the same payload; this
+        parser duplicates the scan so it remains useful on its own
+        (tests, non-executor code paths) and so it can populate
+        ``instance_scores`` from ``side_info["scores"]``.
+    """
+    fallback_success = 1.0 if returncode == 0 else 0.0
+
+    # Find the last HELIX_RESULT= line (matches executor's reverse-scan order).
+    result_line: str | None = None
+    for line in reversed(stdout.splitlines()):
+        if line.startswith("HELIX_RESULT="):
+            result_line = line
+            break
+
+    if result_line is None:
+        return (
+            {"success": fallback_success},
+            {"success": fallback_success},
+        )
+
+    try:
+        payload: Any = json.loads(result_line[len("HELIX_RESULT="):])
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return (
+            {"success": fallback_success},
+            {"success": fallback_success},
+        )
+
+    if not (isinstance(payload, list) and len(payload) == 2):
+        return (
+            {"success": fallback_success},
+            {"success": fallback_success},
+        )
+
+    raw_score, raw_side_info = payload
+
+    try:
+        score_value = float(raw_score)
+    except (TypeError, ValueError):
+        return (
+            {"success": fallback_success},
+            {"success": fallback_success},
+        )
+
+    if not math.isfinite(score_value):
+        return (
+            {"success": fallback_success},
+            {"success": fallback_success},
+        )
+
+    if returncode != 0:
+        score_value = 0.0
+
+    scores: dict[str, float] = {"success": score_value}
+
+    side_info: dict[str, Any] = raw_side_info if isinstance(raw_side_info, dict) else {}
+
+    # Cosmetic: surface accuracy alongside success when the evaluator reports it.
+    raw_accuracy = side_info.get("accuracy")
+    if isinstance(raw_accuracy, (int, float)) and not isinstance(raw_accuracy, bool):
+        scores["accuracy"] = float(raw_accuracy)
+
+    instance_scores: dict[str, float] = {}
+    raw_instances = side_info.get("scores", {})
+    if isinstance(raw_instances, dict):
+        for k, v in raw_instances.items():
+            if isinstance(v, bool):
+                # bool is a subclass of int; treat as numeric 0/1.
+                instance_scores[str(k)] = float(v)
+                continue
+            if isinstance(v, (int, float)) and math.isfinite(float(v)):
+                instance_scores[str(k)] = float(v)
+
+    return scores, instance_scores

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -69,7 +69,7 @@ def parse(
         )
 
     try:
-        payload: Any = json.loads(result_line[len("HELIX_RESULT="):])
+        payload: Any = json.loads(result_line.removeprefix("HELIX_RESULT="))
     except (json.JSONDecodeError, ValueError, TypeError):
         return (
             {"success": fallback_success},
@@ -114,10 +114,6 @@ def parse(
     raw_instances = side_info.get("scores", {})
     if isinstance(raw_instances, dict):
         for k, v in raw_instances.items():
-            if isinstance(v, bool):
-                # bool is a subclass of int; treat as numeric 0/1.
-                instance_scores[str(k)] = float(v)
-                continue
             if isinstance(v, (int, float)) and math.isfinite(float(v)):
                 instance_scores[str(k)] = float(v)
 

--- a/tests/unit/test_parser_helix_result.py
+++ b/tests/unit/test_parser_helix_result.py
@@ -71,6 +71,52 @@ class TestHelixResultWellFormed:
         assert "accuracy" not in scores
         assert scores["success"] == 0.5
 
+    def test_bool_top_level_score_true(self):
+        # bool is a subclass of int; float(True) == 1.0.
+        side_info = {"scores": {"a__m": 1.0}}
+        line = f"HELIX_RESULT={json.dumps([True, side_info])}"
+
+        scores, instance_scores = helix_result_parse(0, line + "\n", "")
+
+        assert scores["success"] == 1.0
+        assert instance_scores == {"a__m": 1.0}
+
+    def test_bool_top_level_score_false(self):
+        side_info = {"scores": {"a__m": 0.0}}
+        line = f"HELIX_RESULT={json.dumps([False, side_info])}"
+
+        scores, instance_scores = helix_result_parse(0, line + "\n", "")
+
+        assert scores["success"] == 0.0
+        assert instance_scores == {"a__m": 0.0}
+
+    def test_int_top_level_score(self):
+        side_info = {"scores": {"a__m": 1.0}}
+        line = f"HELIX_RESULT={json.dumps([1, side_info])}"
+
+        scores, instance_scores = helix_result_parse(0, line + "\n", "")
+
+        assert scores["success"] == 1.0
+        assert instance_scores == {"a__m": 1.0}
+
+    def test_empty_scores_dict_yields_empty_instance_scores(self):
+        side_info = {"scores": {}}
+        line = f"HELIX_RESULT={json.dumps([0.5, side_info])}"
+
+        _scores, instance_scores = helix_result_parse(0, line + "\n", "")
+
+        assert instance_scores == {}
+
+    def test_non_dict_scores_value_yields_empty_instance_scores(self):
+        # side_info["scores"] is a string rather than a dict — must not crash.
+        side_info = {"scores": "not-a-dict"}
+        line = f"HELIX_RESULT={json.dumps([0.5, side_info])}"
+
+        scores, instance_scores = helix_result_parse(0, line + "\n", "")
+
+        assert scores["success"] == 0.5
+        assert instance_scores == {}
+
 
 # ---------------------------------------------------------------------------
 # Fallback paths (missing / malformed / shape errors)

--- a/tests/unit/test_parser_helix_result.py
+++ b/tests/unit/test_parser_helix_result.py
@@ -1,0 +1,171 @@
+"""Unit tests for the ``helix_result`` score parser.
+
+The parser is the companion to the ``HELIX_RESULT=`` override in
+``helix.executor`` and must tolerate missing / malformed evaluator output
+while still populating ``instance_scores`` from ``side_info["scores"]``
+when the payload is well-formed.
+"""
+
+from __future__ import annotations
+
+import json
+
+from helix.parsers import get_parser
+from helix.parsers.helix_result import parse as helix_result_parse
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHelixResultWellFormed:
+    def test_scores_and_instance_scores_populated(self):
+        side_info = {
+            "accuracy": 0.42,
+            "scores": {
+                "cube_lifting__success": 1.0,
+                "cube_stack__success": 0.0,
+                "nut_assembly__success": 0.5,
+            },
+        }
+        line = f"HELIX_RESULT={json.dumps([0.42, side_info])}"
+        stdout = f"preamble\n{line}\ntrailing log\n"
+
+        scores, instance_scores = helix_result_parse(0, stdout, "")
+
+        assert scores["success"] == 0.42
+        assert scores["accuracy"] == 0.42
+        assert instance_scores == {
+            "cube_lifting__success": 1.0,
+            "cube_stack__success": 0.0,
+            "nut_assembly__success": 0.5,
+        }
+
+    def test_last_helix_result_line_wins(self):
+        # Mirrors executor's reverse-scan behaviour: the last line wins.
+        line1 = f"HELIX_RESULT={json.dumps([0.1, {'scores': {'a__m': 0.1}}])}"
+        line2 = f"HELIX_RESULT={json.dumps([0.9, {'scores': {'b__m': 0.9}}])}"
+        stdout = f"{line1}\n{line2}\n"
+
+        scores, instance_scores = helix_result_parse(0, stdout, "")
+
+        assert scores["success"] == 0.9
+        assert instance_scores == {"b__m": 0.9}
+
+    def test_non_numeric_instance_values_are_dropped(self):
+        side_info = {"scores": {"good__m": 0.75, "bad__m": "nope", "none__m": None}}
+        line = f"HELIX_RESULT={json.dumps([0.75, side_info])}"
+        stdout = f"{line}\n"
+
+        _scores, instance_scores = helix_result_parse(0, stdout, "")
+
+        assert instance_scores == {"good__m": 0.75}
+
+    def test_accuracy_omitted_when_missing(self):
+        side_info = {"scores": {"a__m": 1.0}}
+        line = f"HELIX_RESULT={json.dumps([0.5, side_info])}"
+
+        scores, _ = helix_result_parse(0, line + "\n", "")
+
+        assert "accuracy" not in scores
+        assert scores["success"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Fallback paths (missing / malformed / shape errors)
+# ---------------------------------------------------------------------------
+
+
+class TestHelixResultFallbacks:
+    def test_missing_line_falls_back_to_exitcode_success(self):
+        scores, instance_scores = helix_result_parse(0, "arbitrary log\n", "")
+        assert scores == {"success": 1.0}
+        assert instance_scores == {"success": 1.0}
+
+    def test_missing_line_falls_back_to_exitcode_failure(self):
+        scores, instance_scores = helix_result_parse(1, "crashed\n", "some err")
+        assert scores == {"success": 0.0}
+        assert instance_scores == {"success": 0.0}
+
+    def test_malformed_json_falls_back(self):
+        stdout = "HELIX_RESULT=not-valid-json\ntrailing\n"
+        scores, instance_scores = helix_result_parse(0, stdout, "")
+        assert scores == {"success": 1.0}
+        assert instance_scores == {"success": 1.0}
+
+    def test_wrong_shape_falls_back(self):
+        # Not a 2-element list.
+        stdout = f"HELIX_RESULT={json.dumps({'score': 0.5})}\n"
+        scores, instance_scores = helix_result_parse(0, stdout, "")
+        assert scores == {"success": 1.0}
+        assert instance_scores == {"success": 1.0}
+
+    def test_non_dict_side_info_yields_empty_instance_scores(self):
+        # Score is still honoured, but instance_scores is empty.
+        stdout = f"HELIX_RESULT={json.dumps([0.8, 'just a string'])}\n"
+        scores, instance_scores = helix_result_parse(0, stdout, "")
+        assert scores == {"success": 0.8}
+        assert instance_scores == {}
+
+    def test_nan_and_inf_are_rejected(self):
+        # Sanity-check: json.loads accepts NaN/Infinity by default, so the
+        # parser actually sees non-finite floats post-decode.
+        decoded = json.loads(
+            '[NaN, {"scores": {"a": 1.0, "b": NaN, "c": Infinity, "d": -Infinity}}]'
+        )
+        top_score, side_info = decoded
+        import math as _math
+
+        assert _math.isnan(top_score)
+        assert _math.isnan(side_info["scores"]["b"])
+        assert _math.isinf(side_info["scores"]["c"])
+        assert _math.isinf(side_info["scores"]["d"])
+
+        # NaN top-level score -> full fallback (both dicts == {'success': 1.0}).
+        stdout = (
+            'HELIX_RESULT=[NaN, {"scores": {"a": 1.0, "b": NaN, '
+            '"c": Infinity, "d": -Infinity}}]\n'
+        )
+        scores, instance_scores = helix_result_parse(0, stdout, "")
+        assert scores == {"success": 1.0}
+        assert instance_scores == {"success": 1.0}
+
+    def test_finite_score_drops_non_finite_instance_values(self):
+        # When the top-level score is finite, the parser keeps the good
+        # instance scores and silently drops NaN/+Inf/-Inf entries, matching
+        # how non-numeric values are dropped today.
+        stdout = (
+            'HELIX_RESULT=[0.5, {"scores": {"a": 1.0, "b": NaN, '
+            '"c": Infinity, "d": -Infinity}}]\n'
+        )
+        scores, instance_scores = helix_result_parse(0, stdout, "")
+        assert scores["success"] == 0.5
+        assert instance_scores == {"a": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# Returncode semantics
+# ---------------------------------------------------------------------------
+
+
+class TestHelixResultReturncode:
+    def test_nonzero_returncode_zeros_success(self):
+        side_info = {"scores": {"t__m": 1.0}}
+        line = f"HELIX_RESULT={json.dumps([0.9, side_info])}"
+        scores, instance_scores = helix_result_parse(1, line + "\n", "")
+
+        assert scores["success"] == 0.0
+        # instance_scores still reflect evaluator's per-instance reports.
+        assert instance_scores == {"t__m": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryWiring:
+    def test_get_parser_returns_helix_result(self):
+        parser = get_parser("helix_result")
+        assert parser is helix_result_parse


### PR DESCRIPTION
## Summary
Adds a real `helix_result` score parser for the upstream reference `HELIX_RESULT=[accuracy, side_info]` stdout contract, with stratified-sampling support via `instance_scores`, NaN/±inf rejection at both aggregation levels, and a returncode-honoring aggregate in the executor.

Previously, evaluators following this contract had to select one of the pre-existing parsers (`pytest`/`exitcode`/`json_accuracy`/`json_score`) and rely on `executor.py`'s hidden `HELIX_RESULT=` override to get the right aggregate score. That override only set `scores["success"]`; it never populated `instance_scores`, which quietly disabled the stratified batch sampler. Additionally, a non-zero evaluator exit would still produce a non-zero success score from a valid payload, contradicting `json_score`-style failure semantics.

**What changes:**
- New parser `src/helix/parsers/helix_result.py`:
  - Reverse-scans stdout for the last `HELIX_RESULT=` line (uses `str.removeprefix`).
  - Well-formed payload: `scores = {"success": accuracy}`; lifts `side_info["scores"]` into `instance_scores` (str-coerced keys; `(int|float)` values; NaN/±inf dropped).
  - Malformed / missing: falls back to `{"success": 1.0 if rc==0 else 0.0}`.
- Executor change (`src/helix/executor.py` around line 315): the `HELIX_RESULT=`-derived success score is now zeroed when the evaluator exits non-zero. Brings executor-pipeline semantics into agreement with the parser's docstring ("match `json_score`'s failure semantics").
- `EvaluatorConfig.score_parser` Literal widened to include `"helix_result"`.
- Registry entry in `parsers/__init__.py`; stale two-parser docstring updated to list all five parsers.
- Collapses a redundant `isinstance(v, bool)` branch in the instance-scores loop (bool is a subclass of int; `math.isfinite(float(True))` is True).

## Test plan
- [x] `tests/unit/test_parser_helix_result.py` — 18 tests: well-formed parsing, last-line-wins ordering, non-dict/non-numeric `side_info`, fallback paths, returncode semantics, registry wiring, NaN/inf rejection at both aggregate and per-instance levels, bool/int top-level score handling, empty scores dict, non-dict scores value.
- [x] Full helix unit suite: 488 passed (3.11 + 3.12 via GitHub Actions).
- [x] `mypy --strict src/helix/`: Success on 24 source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)