### PR TITLE
fix helix_result parser so users don't need to specify example ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validation errors, pointing users at likely typos or misplaced keys.
 
 ### Changed
+- **BREAKING**: `score_parser = "helix_result"` now takes a **per-example**
+  `HELIX_RESULT=[[score_0, side_info_0], [score_1, side_info_1], ...]`
+  payload — one `[score, side_info]` pair per id in `helix_batch.json`.
+  HELIX zips it into `instance_scores` and stores `side_info_i` on
+  `EvalResult.per_example_side_info` for the reflection prompt.  GEPA
+  `optimize_anything` parity (`src/gepa/optimize_anything.py:387-438`).
+  The previous scalar-plus-id-keyed-dict contract is removed — it
+  silently failed the minibatch gate whenever the evaluator keyed its
+  dict by aggregate metric names (`task__metric`) instead of per-example
+  ids (`task__trialN`).  Migration: replace
+  `HELIX_RESULT=[mean, {"scores": {id_i: v_i, ...}, ...}]` with
+  `HELIX_RESULT=[[v_0, {"info": "..."}], [v_1, {...}], ...]`.
+- `helix.executor.run_evaluator` now emits a `WARNING` log line when the
+  post-filter zero-fills any requested id (naming the count and a sample
+  of up to five).  Non-breaking — behaviour is unchanged, only
+  observability improves.  Catches parser / id-keying mismatches on
+  parsers other than `helix_result` (e.g. `exitcode` plus `instance_ids`).
 - **BREAKING**: `seedless` is now a section (`[seedless]` with `enabled = …`),
   not a top-level boolean.
 - **BREAKING**: `dataset.train_path` / `dataset.val_path` have moved to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Multi-axis Pareto frontier (GEPA `FrontierType` parity,
+  `src/gepa/core/state.py:22-23`).  New
+  `evolution.frontier_type: Literal["instance", "objective", "hybrid",
+  "cartesian"]` with default `"hybrid"` — matches GEPA's own
+  `optimize_anything` default (`src/gepa/optimize_anything.py:476`).
+  `ParetoFrontier` now tracks per-objective-name and per-`(val_id,
+  objective_name)` best sets alongside the existing per-example-id
+  tracking, and `get_non_dominated()` / `select_parent()` dispatch on
+  `frontier_type`.  The acceptance gate stays positional on
+  `scores_list` unchanged.
+- `EvalResult.per_example_side_info: list[dict[str, Any]] | None` —
+  per-example diagnostic dicts from the new `helix_result` contract,
+  positional to `instance_scores` by `helix_batch.json` id order.
+  GEPA analogue: `EvaluationBatch.trajectories`
+  (`src/gepa/core/adapter.py:25`).
+- `EvalResult.objective_scores: list[dict[str, float]] | None` —
+  per-example objective-axis harvest from `side_info["scores"]`.  GEPA
+  analogue: `EvaluationBatch.objective_scores`
+  (`src/gepa/core/adapter.py:26`).  Feeds `frontier_type ∈ {"objective",
+  "hybrid", "cartesian"}`; harmless on the `"instance"` path.
 - `DatasetConfig.train_size` / `val_size` — cardinality-only fields that drive
   the minibatch sampler when the evaluator owns the dataset (Architecture A
   example-id handoff).  HELIX writes sampled example ids to

--- a/README.md
+++ b/README.md
@@ -241,7 +241,12 @@ rng_seed = 0
 
 [evaluator]
 command = "uv run python evaluate.py"
-# Available parsers: "pytest" | "exitcode" | "json_accuracy" | "json_score"
+# Available parsers: "pytest" | "exitcode" | "json_accuracy" | "json_score" | "helix_result"
+# "helix_result" takes a per-example list of [score, side_info] pairs — the
+# evaluator emits `HELIX_RESULT=[[s_0, si_0], [s_1, si_1], ...]` positional
+# to `helix_batch.json`. HELIX zips it into id-keyed `instance_scores` and
+# stores the side_info list for the reflection prompt. GEPA `optimize_anything`
+# parity; use for minibatch runs (`dataset.train_size` set).
 score_parser = "json_score"
 include_stdout = true
 include_stderr = true

--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ minibatch_size = 3               # train-set minibatch gate size
 cache_evaluation = true          # reuse per-instance evaluator results
 acceptance_criterion = "strict_improvement"
 val_stage_size = 0               # optional first-N val gate before full val
+frontier_type = "hybrid"         # Pareto dimensionality (GEPA FrontierType parity):
+                                 # "instance" | "objective" | "hybrid" | "cartesian".
+                                 # Default "hybrid" matches GEPA optimize_anything.
+                                 # Non-instance axes require score_parser="helix_result"
+                                 # emitting per-example side_info["scores"] dicts.
 
 [claude]
 model = "sonnet"                 # or "opus", "haiku", full model name

--- a/README.md
+++ b/README.md
@@ -242,11 +242,15 @@ rng_seed = 0
 [evaluator]
 command = "uv run python evaluate.py"
 # Available parsers: "pytest" | "exitcode" | "json_accuracy" | "json_score" | "helix_result"
-# "helix_result" takes a per-example list of [score, side_info] pairs — the
-# evaluator emits `HELIX_RESULT=[[s_0, si_0], [s_1, si_1], ...]` positional
-# to `helix_batch.json`. HELIX zips it into id-keyed `instance_scores` and
-# stores the side_info list for the reflection prompt. GEPA `optimize_anything`
-# parity; use for minibatch runs (`dataset.train_size` set).
+# "helix_result" takes a per-example list matching GEPA optimize_anything's
+# `tuple[float, SideInfo] | float` union — each entry is either a bare
+# score or a [score, side_info] pair, mixed allowed:
+#   HELIX_RESULT=[s_0, s_1, ...]                        # all bare
+#   HELIX_RESULT=[[s_0, si_0], [s_1, si_1], ...]        # all rich
+#   HELIX_RESULT=[s_0, [s_1, si_1], s_2, ...]           # mixed
+# Positional to `helix_batch.json`. HELIX zips it into id-keyed
+# `instance_scores` and stores the side_info list for the reflection
+# prompt. Use for minibatch runs (`dataset.train_size` set).
 score_parser = "json_score"
 include_stdout = true
 include_stderr = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helix-evo"
-version = "0.1.2"
+version = "0.1.3"
 description = "Hierarchical Evolution via LLM-Informed eXploration"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -26,7 +26,7 @@ from helix.display import (
 )
 from helix.exceptions import RateLimitError
 from helix.lineage import load_lineage
-from helix.population import EvalResult, ParetoFrontier, Candidate
+from helix.population import EvalResult, FrontierType, ParetoFrontier, Candidate
 from helix.state import load_state, save_state
 from helix.worktree import remove_worktree
 
@@ -204,8 +204,26 @@ def _load_all_evaluations(base_dir: Path) -> tuple[dict[str, EvalResult], dict[s
 def _reconstruct_frontier(
     base_dir: Path, state: Any
 ) -> tuple[ParetoFrontier, dict[str, Candidate], list[str]]:
-    """Rebuild in-memory ParetoFrontier from persisted state and evaluations."""
-    frontier = ParetoFrontier()
+    """Rebuild in-memory ``ParetoFrontier`` from persisted state + evaluations.
+
+    The frontier is constructed with ``state.frontier_type`` rather
+    than the class default ``"instance"`` — so read-only display
+    commands (``helix frontier``, ``helix best``) show the frontier
+    with the SAME axis the evolution run used.  Legacy states (no
+    persisted ``frontier_type``) default to ``"instance"`` via
+    ``EvolutionState.frontier_type``'s field default, preserving the
+    pre-multi-axis display behaviour.
+    """
+    # ``frontier_type`` is part of ``EvolutionState`` after commit Q;
+    # getattr + whitelist narrowing keeps us defensive against an
+    # ad-hoc test that passes a mock state without the attribute
+    # (or a hand-crafted state.json with a bogus literal).
+    _raw_ft = getattr(state, "frontier_type", "instance")
+    _valid: tuple[FrontierType, ...] = (
+        "instance", "objective", "hybrid", "cartesian",
+    )
+    frontier_type: FrontierType = _raw_ft if _raw_ft in _valid else "instance"
+    frontier = ParetoFrontier(frontier_type=frontier_type)
     candidates: dict[str, Candidate] = {}
     skipped: list[str] = []
     worktrees_dir = base_dir / "worktrees"

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -317,6 +317,35 @@ class EvolutionConfig(BaseModel):
             "'cube_stack__s3' -> 'cube_stack' when separator='__')."
         ),
     )
+    frontier_type: Literal["instance", "objective", "hybrid", "cartesian"] = Field(
+        default="hybrid",
+        description=(
+            "Pareto frontier dimensionality.  Mirrors GEPA's "
+            "``FrontierType`` at ``src/gepa/core/state.py:22-23``.  Default "
+            "is ``\"hybrid\"`` to match GEPA ``optimize_anything``'s own "
+            "default at ``src/gepa/optimize_anything.py:476`` — O.A. is the "
+            "right parent for HELIX, not the base ``api.py`` path whose "
+            "default is ``\"instance\"``.\n\n"
+            "- ``\"instance\"``: one frontier key per example-id.  Matches "
+            "HELIX's historical behaviour and GEPA's ``frontier_type="
+            "\"instance\"``.\n"
+            "- ``\"objective\"``: one frontier key per objective-name, "
+            "score = mean of that objective across the valset.  Harvested "
+            "from ``side_info[\"scores\"]`` via ``helix_result``.\n"
+            "- ``\"hybrid\"``: both instance and objective frontiers "
+            "maintained; a candidate is retained if it survives on either.\n"
+            "- ``\"cartesian\"``: one frontier key per (val_id, "
+            "objective_name) pair.  Mirrors GEPA "
+            "``_update_pareto_front_for_cartesian``.\n\n"
+            "The acceptance gate stays positional on ``scores_list`` "
+            "regardless of ``frontier_type`` (GEPA ``acceptance.py:39-48``); "
+            "only the Pareto retention / parent-selection decision is "
+            "multi-axis.  Non-``instance`` paths require ``helix_result`` "
+            "to emit per-example ``side_info[\"scores\"]`` dicts — without "
+            "them the objective / cartesian frontiers stay empty and "
+            "behaviour degenerates to the instance path."
+        ),
+    )
 
     def model_post_init(self, __context: object) -> None:
         # GEPA parity: resolve ``num_parallel_proposals="auto"`` to

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -26,11 +26,21 @@ class EvaluatorConfig(BaseModel):
     ``helix_batch.json`` pre-invocation.  Pick ``"helix_result"`` to
     hand HELIX a list of per-example ``[score, side_info]`` pairs
     (GEPA ``optimize_anything`` evaluator parity) — HELIX owns the
-    id-keying so the evaluator never types a HELIX-internal id.  The
-    other parsers (``"pytest"``, ``"exitcode"``, ``"json_accuracy"``,
+    id-keying so the evaluator never types a HELIX-internal id.
+
+    ``helix_result`` is the only parser that populates the new
+    :attr:`helix.population.EvalResult.per_example_side_info` and
+    :attr:`~helix.population.EvalResult.objective_scores` fields: the
+    former from ``side_info_i`` verbatim (reflection), the latter from
+    the reserved ``side_info_i["scores"]`` sub-dict (multi-axis Pareto
+    frontier — see :attr:`EvolutionConfig.frontier_type`).
+
+    The other parsers (``"pytest"``, ``"exitcode"``, ``"json_accuracy"``,
     ``"json_score"``) aggregate to a single score and do NOT produce
     id-keyed per-instance scores; combining them with ``instance_ids``
-    triggers the zero-fill warning in :mod:`helix.executor`.
+    triggers the zero-fill warning in :mod:`helix.executor`.  They also
+    leave ``objective_scores`` empty, so the multi-axis frontier
+    degenerates to the instance path when they're selected.
     """
     model_config = ConfigDict(extra="forbid")
 

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -15,8 +15,22 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 class EvaluatorConfig(BaseModel):
     """Configuration for candidate evaluation.
 
-    Defines how candidates are evaluated via shell commands and how their
-    results are parsed into scores.
+    Defines how candidates are evaluated via shell commands and how
+    their results are parsed into scores.
+
+    ``score_parser`` selects how HELIX turns evaluator output into
+    ``(scores, instance_scores)``.  For the minibatch-gate at
+    :func:`helix.evolution._minibatch_gate_accept` the **per-id keys**
+    in ``instance_scores`` matter: the gate looks up
+    ``instance_scores[eid]`` where ``eid`` is whatever HELIX wrote to
+    ``helix_batch.json`` pre-invocation.  Pick ``"helix_result"`` to
+    hand HELIX a list of per-example ``[score, side_info]`` pairs
+    (GEPA ``optimize_anything`` evaluator parity) — HELIX owns the
+    id-keying so the evaluator never types a HELIX-internal id.  The
+    other parsers (``"pytest"``, ``"exitcode"``, ``"json_accuracy"``,
+    ``"json_score"``) aggregate to a single score and do NOT produce
+    id-keyed per-instance scores; combining them with ``instance_ids``
+    triggers the zero-fill warning in :mod:`helix.executor`.
     """
     model_config = ConfigDict(extra="forbid")
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -12,7 +12,7 @@ import shlex
 import threading
 import traceback
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 
@@ -703,6 +703,15 @@ def _cached_evaluate_batch(
     # itself (helix.eval_cache.EvaluationCache.evaluate_with_cache_full,
     # which is a line-for-line port of GEPA state.py:94-130).
 
+    # Closure side-channel: the cache stores ``(output, score, objective_scores)``
+    # per id but has no slot for freeform ``side_info``.  Collect fresh
+    # per-example side_info in a closure dict so we can attach it to the
+    # merged ``EvalResult`` below.  Cache-hit ids (not in this dict) get
+    # ``{}`` as their per_example_side_info slot — their prior side_info
+    # was consumed by the reflection prompt at their original eval time
+    # and is not round-tripped through the cache.
+    fresh_side_info_by_id: dict[str, dict[str, Any]] = {}
+
     def _fetcher(ids: list[str]) -> list[str]:
         # HELIX evaluators read batches off disk via helix_batch.json;
         # the "batch" handed to the evaluator callable is just the list
@@ -740,10 +749,35 @@ def _cached_evaluate_batch(
             f"{sorted(missing)}"
         )
         scores = [float(fresh.instance_scores[eid]) for eid in batch]
-        return outputs, scores, None
+        # Thread per-example objective_scores through the cache: GEPA
+        # ``EvaluationBatch.objective_scores`` parity
+        # (``src/gepa/core/adapter.py:26``).  Feeds the multi-axis
+        # Pareto frontier when ``evolution.frontier_type`` is
+        # ``"objective"``, ``"hybrid"``, or ``"cartesian"``.  The
+        # underlying ``EvaluationCache`` already has a slot for this
+        # (``put_batch(..., objective_scores_list=...)``); previously
+        # ``_evaluator`` returned ``None`` here and the multi-axis data
+        # was dropped on the cached path.
+        obj_list: list[dict[str, float]] | None = None
+        if (
+            fresh.objective_scores is not None
+            and len(fresh.objective_scores) == len(batch)
+        ):
+            obj_list = [fresh.objective_scores[i] for i in range(len(batch))]
+        # Capture per-example side_info for the outer merge.  Only
+        # freshly-evaluated ids populate this; cache hits remain ``{}``.
+        if (
+            fresh.per_example_side_info is not None
+            and len(fresh.per_example_side_info) == len(batch)
+        ):
+            for i, eid in enumerate(batch):
+                fresh_side_info_by_id[eid] = fresh.per_example_side_info[i]
+        return outputs, scores, obj_list
 
-    _, scores_by_id, _, num_actual_evals = cache.evaluate_with_cache_full(
-        cand_dict, example_ids, _fetcher, _evaluator,
+    _, scores_by_id, objective_by_id, num_actual_evals = (
+        cache.evaluate_with_cache_full(
+            cand_dict, example_ids, _fetcher, _evaluator,
+        )
     )
 
     # Merge hits + fresh into a single EvalResult.  ``scores_by_id``
@@ -751,11 +785,31 @@ def _cached_evaluate_batch(
     # ``scores`` (aggregate dict) and ``asi`` (metadata) are not carried
     # on cached paths: the minibatch gate and frontier update logic only
     # read ``instance_scores``.
+    #
+    # Per-example ``objective_scores`` and ``per_example_side_info`` ARE
+    # attached when any data was produced (freshly-evaluated) or cached
+    # for any id in this batch — the multi-axis frontier and reflection
+    # paths both depend on them.  Missing entries get ``{}`` placeholders
+    # so the list length always equals ``len(example_ids)`` (positional
+    # alignment is the whole point of the per-example contract).
+    objective_scores_list: list[dict[str, float]] | None = None
+    if objective_by_id is not None:
+        objective_scores_list = [
+            objective_by_id.get(eid, {}) for eid in example_ids
+        ]
+    per_example_side_info_list: list[dict[str, Any]] | None = None
+    if fresh_side_info_by_id:
+        per_example_side_info_list = [
+            fresh_side_info_by_id.get(eid, {}) for eid in example_ids
+        ]
+
     merged = EvalResult(
         candidate_id=candidate.id,
         scores={},
         asi={},
         instance_scores={eid: scores_by_id[eid] for eid in example_ids},
+        per_example_side_info=per_example_side_info_list,
+        objective_scores=objective_scores_list,
     )
     return merged, num_actual_evals
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1040,10 +1040,22 @@ def run_evolution(
             instance_scores={},
             budget=BudgetState(),
             config_hash=cfg_hash,
+            # Pin the frontier dimensionality to whatever the evolve
+            # run uses so ``helix frontier`` / ``helix best`` display
+            # with the SAME axis later — even if ``helix.toml``'s
+            # ``evolution.frontier_type`` is edited between runs.
+            frontier_type=config.evolution.frontier_type,
         )
         needs_seed = True
     else:
         needs_seed = False
+        # Keep ``state.frontier_type`` pinned to whatever was stored;
+        # it already matches the frontier that was built.  On a legacy
+        # state with no persisted field (defaulted to "instance" by
+        # ``load_state``) a config change to e.g. "hybrid" does NOT
+        # retroactively rebuild the frontier — display stays on
+        # "instance" for legacy runs.  A fresh run picks up the new
+        # type via the branch above.
         if state.config_hash != cfg_hash:
             print_warning(
                 "Config hash differs from the saved state; resuming with the current "

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -760,12 +760,33 @@ def _cached_evaluate_batch(
     return merged, num_actual_evals
 
 
-def _full_val_example_ids(config: HelixConfig) -> list[str]:
-    """Return deterministic full validation ids for the cardinality-only dataset."""
+def _full_val_example_ids(
+    config: HelixConfig,
+    val_loader: "HelixDataLoader | _RangeDataLoader | None" = None,
+) -> list[str]:
+    """Return deterministic full validation ids.
+
+    Priority (first non-empty wins):
+
+    1. ``dataset.val_size`` — stringified range ids ``"0".."N-1"``
+       (Architecture A cardinality-only path).
+    2. ``val_loader.all_ids()`` — ids from the configured
+       :class:`HelixDataLoader` over ``seedless.val_path`` (or
+       ``seedless.train_path`` when val_path is unset).  File-stem
+       ids for a directory layout, stringified indices otherwise.
+       This is what lets the seed-eval and full-val paths write
+       ``helix_batch.json`` for evaluators (like capx-solver) that
+       use ``helix_result`` and need the positional id handoff — the
+       strict ``helix_result`` parser requires the batch file to be
+       present on every evaluator invocation.
+    3. Empty list — legacy single-task path (no example-id handoff).
+    """
     val_size = config.dataset.val_size
-    if val_size is None or val_size <= 0:
-        return []
-    return [str(i) for i in range(val_size)]
+    if val_size is not None and val_size > 0:
+        return [str(i) for i in range(val_size)]
+    if val_loader is not None and len(val_loader) > 0:
+        return list(val_loader.all_ids())
+    return []
 
 
 def _stage_val_example_ids(config: HelixConfig, full_example_ids: list[str]) -> list[str]:
@@ -934,7 +955,7 @@ def run_evolution(
     # Full-eval policy (GEPA §4.2) — kept for parity and future policy-based
     # val scheduling refactors.
     _full_eval_policy = FullEvaluationPolicy()
-    full_val_example_ids = _full_val_example_ids(config)
+    full_val_example_ids = _full_val_example_ids(config, val_loader)
     stage_val_example_ids = _stage_val_example_ids(config, full_val_example_ids)
 
     # ------------------------------------------------------------------

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -208,16 +208,20 @@ def init_base_dir(base_dir: Path, config: HelixConfig) -> None:
 
 
 def _save_evaluation(base_dir: Path, result: EvalResult) -> None:
-    """Persist an EvalResult to evaluations/<candidate_id>.json."""
+    """Persist an EvalResult to evaluations/<candidate_id>.json.
+
+    Uses ``EvalResult.to_dict()`` so every field — including the newer
+    ``side_info`` / ``per_example_side_info`` / ``objective_scores``
+    optionals — round-trips through the on-disk JSON.  Optional fields
+    are omitted by ``to_dict`` when ``None`` so evaluations from
+    single-task / non-helix_result paths stay byte-identical to their
+    pre-multi-axis shape.
+    """
     eval_dir = base_dir / "evaluations"
     eval_dir.mkdir(parents=True, exist_ok=True)
-    data = {
-        "candidate_id": result.candidate_id,
-        "scores": result.scores,
-        "instance_scores": result.instance_scores,
-        "asi": result.asi,
-    }
-    (eval_dir / f"{result.candidate_id}.json").write_text(json.dumps(data, indent=2))
+    (eval_dir / f"{result.candidate_id}.json").write_text(
+        json.dumps(result.to_dict(), indent=2)
+    )
 
 
 def _load_evaluation(base_dir: Path, candidate_id: str) -> EvalResult | None:

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -827,7 +827,7 @@ def run_evolution(
     # In-memory candidate registry and frontier
     candidates: dict[str, Candidate] = {}
     rng = _random.Random(config.rng_seed)
-    frontier = ParetoFrontier(rng=rng)
+    frontier = ParetoFrontier(rng=rng, frontier_type=config.evolution.frontier_type)
 
     # GEPA parity (Fix 11): evaluation cache — skip re-evaluation of
     # identical (candidate_id, split) pairs.

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -345,9 +345,11 @@ def run_evaluator(
         # ``per_example_side_info`` replaces it for the reflection path.
         per_example_side_info=per_example_side_info,
         # ``objective_scores`` — per-example ``side_info["scores"]``
-        # harvest.  Feeds the multi-axis Pareto frontier; currently
-        # pass-through on EvalResult until the frontier config + state
-        # land (follow-up commits in this branch).
+        # harvest.  Feeds the multi-axis Pareto frontier
+        # (``ParetoFrontier._update_objective`` /
+        # ``_update_cartesian``) when
+        # ``config.evolution.frontier_type`` is ``"objective"``,
+        # ``"hybrid"``, or ``"cartesian"``.
         objective_scores=objective_scores,
     )
     TRACE.emit(

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -244,9 +244,12 @@ def run_evaluator(
     asi = _collect_asi(stdout, stderr, extra_outputs, config)
 
     # Guard: at most one HELIX_RESULT= line is expected.  Multiple is an
-    # evaluator bug (race or accidental double-emit).  The ``helix_result``
-    # parser does its own reverse-scan; this pre-check surfaces the
-    # "multiple lines" case as an explicit error across all parser paths
+    # evaluator-contract violation (race or accidental double-emit).
+    # Surface as ``EvaluatorError`` so upstream HelixError handlers in
+    # ``evolution.py`` can route it uniformly with the rest of the
+    # evaluator-contract failures the parser raises (length mismatch,
+    # missing batch file, etc.).  The ``helix_result`` parser does its
+    # own reverse-scan; this pre-check fires across all parser paths
     # before any parser runs.  Payload shape is parser-specific —
     # ``helix_result`` takes a list of per-example [score, side_info]
     # pairs; other parsers ignore this line entirely.
@@ -255,9 +258,15 @@ def run_evaluator(
         if line.startswith("HELIX_RESULT="):
             result_line_count += 1
             if result_line_count > 1:
-                raise RuntimeError(
+                raise EvaluatorError(
                     "Multiple HELIX_RESULT= lines found in evaluator output. "
-                    "Expected exactly one."
+                    "Expected exactly one.",
+                    operation="run_evaluator",
+                    command=evaluator.command,
+                    cwd=str(candidate.worktree_path),
+                    stdout=stdout,
+                    stderr=stderr,
+                    exit_code=returncode,
                 )
 
     # Parse scores.  ``helix_result`` returns a 4-tuple with per-example

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -260,12 +260,14 @@ def run_evaluator(
                     "Expected exactly one."
                 )
 
-    # Parse scores.  ``helix_result`` returns a 3-tuple including
-    # ``per_example_side_info`` (GEPA O.A. evaluator contract: one
-    # ``(score, side_info)`` pair per example).  All other parsers
-    # return the 2-tuple ``(scores, instance_scores)``.
+    # Parse scores.  ``helix_result`` returns a 4-tuple with per-example
+    # side_info (GEPA O.A. evaluator contract: one ``(score, side_info)``
+    # pair per example) and the per-example ``objective_scores`` harvest
+    # from ``side_info["scores"]``.  All other parsers return the
+    # 2-tuple ``(scores, instance_scores)``.
     parser = get_parser(evaluator.score_parser)
     per_example_side_info: list[dict[str, Any]] | None = None
+    objective_scores: list[dict[str, float]] | None = None
 
     if evaluator.score_parser == "pytest":
         scores, instance_scores = parser(stdout, stderr)
@@ -273,9 +275,12 @@ def run_evaluator(
         # helix_result reads ``{worktree}/helix_batch.json`` to recover
         # the id list HELIX wrote pre-invocation and zips it with the
         # per-example ``[score, side_info]`` payload on stdout.
-        scores, instance_scores, per_example_side_info = parser(
-            returncode, stdout, stderr, candidate.worktree_path,
-        )
+        (
+            scores,
+            instance_scores,
+            per_example_side_info,
+            objective_scores,
+        ) = parser(returncode, stdout, stderr, candidate.worktree_path)
     else:
         # exitcode, json_accuracy, and other parsers take (returncode, stdout, stderr)
         scores, instance_scores = parser(returncode, stdout, stderr)
@@ -330,6 +335,11 @@ def run_evaluator(
         # by the executor.  The per-example list in
         # ``per_example_side_info`` replaces it for the reflection path.
         per_example_side_info=per_example_side_info,
+        # ``objective_scores`` — per-example ``side_info["scores"]``
+        # harvest.  Feeds the multi-axis Pareto frontier; currently
+        # pass-through on EvalResult until the frontier config + state
+        # land (follow-up commits in this branch).
+        objective_scores=objective_scores,
     )
     TRACE.emit(
         EventType.EVAL_END,

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import shlex
 import subprocess
+from typing import Any
 
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig, EvaluatorConfig
@@ -243,47 +243,49 @@ def run_evaluator(
     # Collect ASI
     asi = _collect_asi(stdout, stderr, extra_outputs, config)
 
-    # Check for HELIX_RESULT= line (GEPA OA contract: [score, side_info_dict])
-    # Exactly zero or one HELIX_RESULT= line is expected; multiple is an evaluator bug.
-    helix_result_score = None
-    side_info = None
-    result_line = None
+    # Guard: at most one HELIX_RESULT= line is expected.  Multiple is an
+    # evaluator bug (race or accidental double-emit).  The ``helix_result``
+    # parser does its own reverse-scan; this pre-check surfaces the
+    # "multiple lines" case as an explicit error across all parser paths
+    # before any parser runs.  Payload shape is parser-specific —
+    # ``helix_result`` takes a list of per-example [score, side_info]
+    # pairs; other parsers ignore this line entirely.
+    result_line_count = 0
     for line in reversed(stdout.splitlines()):
         if line.startswith("HELIX_RESULT="):
-            if result_line is not None:
+            result_line_count += 1
+            if result_line_count > 1:
                 raise RuntimeError(
                     "Multiple HELIX_RESULT= lines found in evaluator output. "
                     "Expected exactly one."
                 )
-            result_line = line
-    if result_line is not None:
-        line = result_line
-        try:
-            payload = json.loads(line[len("HELIX_RESULT="):])
-            if isinstance(payload, list) and len(payload) == 2:
-                helix_result_score = float(payload[0])
-                if isinstance(payload[1], dict):
-                    side_info = payload[1]
-        except (json.JSONDecodeError, ValueError, TypeError):
-            logger.warning("Failed to parse HELIX_RESULT= line: %s", line)
 
-    # Parse scores (fallback path, always runs for instance_scores)
+    # Parse scores.  ``helix_result`` returns a 3-tuple including
+    # ``per_example_side_info`` (GEPA O.A. evaluator contract: one
+    # ``(score, side_info)`` pair per example).  All other parsers
+    # return the 2-tuple ``(scores, instance_scores)``.
     parser = get_parser(evaluator.score_parser)
+    per_example_side_info: list[dict[str, Any]] | None = None
+
     if evaluator.score_parser == "pytest":
         scores, instance_scores = parser(stdout, stderr)
+    elif evaluator.score_parser == "helix_result":
+        # helix_result reads ``{worktree}/helix_batch.json`` to recover
+        # the id list HELIX wrote pre-invocation and zips it with the
+        # per-example ``[score, side_info]`` payload on stdout.
+        scores, instance_scores, per_example_side_info = parser(
+            returncode, stdout, stderr, candidate.worktree_path,
+        )
     else:
         # exitcode, json_accuracy, and other parsers take (returncode, stdout, stderr)
         scores, instance_scores = parser(returncode, stdout, stderr)
-
-    # If HELIX_RESULT= provided a score, override the parser-derived aggregate
-    if helix_result_score is not None:
-        scores["success"] = 0.0 if returncode != 0 else helix_result_score
 
     # Post-filter instance_scores when a subset was requested: evaluators
     # that ignore HELIX_INSTANCE_IDS will still have returned the whole
     # split, but the minibatch gate only looks at the requested subset.
     if instance_ids is not None:
         filtered: dict[str, float] = {}
+        missing: list[str] = []
         for eid in instance_ids:
             eid_s = str(eid)
             if eid_s in instance_scores:
@@ -291,6 +293,32 @@ def run_evaluator(
             else:
                 # Evaluator produced no result for this id → 0.0
                 filtered[eid_s] = 0.0
+                missing.append(eid_s)
+        if missing:
+            # Diagnostic: the silent zero-fill above used to hide evaluator
+            # bugs — most infamously an ``instance_scores`` dict keyed by
+            # aggregate metric names (``task__metric``) instead of the
+            # per-example ids HELIX writes to ``helix_batch.json``
+            # (``task__trialN``).  That mismatch made strict-improvement
+            # acceptance compare ``0.0 vs 0.0`` for 113 straight generations
+            # in one real run.  The per-example ``helix_result`` contract
+            # removes that class of bug at the parser level, but this
+            # warning is still useful defense in depth: e.g. when a user
+            # picks ``score_parser="exitcode"`` and then asks for a
+            # minibatch subset, every requested id lands here.
+            sample = missing[:5]
+            logger.warning(
+                "evaluator returned %d/%d missing instance_scores for "
+                "requested ids (sample: %r%s); these were filled with 0.0. "
+                "If you need per-id scores for the minibatch gate, use "
+                "score_parser='helix_result' (per-example contract — "
+                "HELIX reads helix_batch.json and zips it with your list "
+                "of [score, side_info] pairs).",
+                len(missing),
+                len(instance_ids),
+                sample,
+                "" if len(missing) <= len(sample) else f" ... +{len(missing) - len(sample)} more",
+            )
         instance_scores = filtered
 
     _result = EvalResult(
@@ -298,7 +326,10 @@ def run_evaluator(
         scores=scores,
         asi=asi,
         instance_scores=instance_scores,
-        side_info=side_info,
+        # ``side_info`` (legacy batch-level dict) is no longer populated
+        # by the executor.  The per-example list in
+        # ``per_example_side_info`` replaces it for the reflection path.
+        per_example_side_info=per_example_side_info,
     )
     TRACE.emit(
         EventType.EVAL_END,

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -383,6 +383,65 @@ def _looks_like_rate_limit(text: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Rendered-mutation-prompt artifact
+# ---------------------------------------------------------------------------
+
+
+#: Filename of the post-hoc mutation-prompt artifact persisted in each
+#: candidate's worktree root alongside ``helix_batch.json``.  The leading
+#: dot + per-worktree ``.gitignore`` entry keep it out of the candidate
+#: git tree.
+MUTATION_PROMPT_ARTIFACT_NAME = ".helix_mutation_prompt.md"
+
+
+def _ignore_helix_artifacts(worktree_path: Path) -> None:
+    """Append HELIX artifact names to ``<worktree>/.gitignore``.
+
+    The candidate worktree is a real git tree; anything committed there
+    bakes into the candidate's evolutionary history.  HELIX writes
+    a handful of per-invocation metadata files (``helix_batch.json``,
+    ``.helix_mutation_prompt.md``) that must NOT flow into those
+    diffs — otherwise the next generation's mutator sees the prior
+    artifact as part of the codebase and the lineage grows a
+    meaningless file-rename trail.
+
+    Idempotent: only appends patterns that aren't already present.
+    Creates the ``.gitignore`` file if missing.
+    """
+    gitignore = worktree_path / ".gitignore"
+    patterns = [
+        "# HELIX per-invocation artifacts (never commit to candidate tree)",
+        MUTATION_PROMPT_ARTIFACT_NAME,
+        "helix_batch.json",
+    ]
+    existing = gitignore.read_text() if gitignore.exists() else ""
+    to_append = [p for p in patterns if p not in existing]
+    if not to_append:
+        return
+    sep = "" if existing.endswith("\n") or not existing else "\n"
+    gitignore.write_text(existing + sep + "\n".join(to_append) + "\n")
+
+
+def _write_mutation_prompt_artifact(worktree_path: str, prompt: str) -> None:
+    """Persist the rendered mutation prompt to the worktree for post-hoc inspection.
+
+    Writes to ``<worktree>/.helix_mutation_prompt.md`` and ensures the
+    per-worktree ``.gitignore`` excludes the file.  Best-effort: any I/O
+    exception is logged at DEBUG and swallowed — a missing artifact is
+    not worth failing a mutation over.
+    """
+    try:
+        wt = Path(worktree_path)
+        _ignore_helix_artifacts(wt)
+        (wt / MUTATION_PROMPT_ARTIFACT_NAME).write_text(prompt)
+    except OSError as e:
+        logger.debug(
+            "failed to write mutation-prompt artifact to %s: %s",
+            worktree_path, e,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Claude Code invocation
 # ---------------------------------------------------------------------------
 
@@ -595,6 +654,15 @@ def mutate(
     prompt = build_mutation_prompt(
         config.objective, eval_result, background, config.claude.max_turns,
     )
+
+    # Persist the rendered prompt to the worktree for post-hoc inspection:
+    # what did the mutator actually see on this generation?  Sits next to
+    # ``helix_batch.json`` in the worktree root.  The leading dot and the
+    # per-worktree ``.gitignore`` entry (see ``_ignore_helix_artifacts``)
+    # keep it out of the candidate git tree — otherwise it'd leak into
+    # every subsequent mutation's diff and the mutator would see its own
+    # prior prompt file as part of the codebase.
+    _write_mutation_prompt_artifact(child.worktree_path, prompt)
 
     try:
         invoke_claude_code(child.worktree_path, prompt, config.claude, passthrough_env=config.passthrough_env)

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -193,23 +193,80 @@ def generate_seed(
     invoke_claude_code(worktree_path, prompt, config.claude, passthrough_env=config.passthrough_env)
 
 
+_MAX_MARKDOWN_HEADER_LEVEL = 6
+
+
+def _render_side_info_value(value: Any, level: int) -> str:
+    """Render a single side_info value as markdown.
+
+    Line-for-line port of GEPA's ``render_value`` closure inside
+    ``format_samples`` at
+    ``src/gepa/strategies/instruction_proposal.py:63-85``:
+
+      * ``dict`` → ``{'#' * level} {key}`` for each item, recursing
+        at ``level + 1`` (capped at ``#_MAX_MARKDOWN_HEADER_LEVEL``
+        to stay inside valid markdown depth).
+      * ``list`` / ``tuple`` → ``{'#' * level} Item N`` headers,
+        recursing at ``level + 1``.
+      * primitive → ``str(value).strip() + "\n\n"``.
+
+    Empty containers still emit a trailing blank line so surrounding
+    headers don't collapse against the next block.
+    """
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for k, v in value.items():
+            parts.append(f"{'#' * level} {k}")
+            parts.append(
+                _render_side_info_value(
+                    v, min(level + 1, _MAX_MARKDOWN_HEADER_LEVEL),
+                )
+            )
+        if not value:
+            parts.append("")
+        return "\n".join(parts)
+    if isinstance(value, (list, tuple)):
+        parts = []
+        for i, item in enumerate(value):
+            parts.append(f"{'#' * level} Item {i + 1}")
+            parts.append(
+                _render_side_info_value(
+                    item, min(level + 1, _MAX_MARKDOWN_HEADER_LEVEL),
+                )
+            )
+        if not value:
+            parts.append("")
+        return "\n".join(parts)
+    # Primitive — GEPA renders with ``str(...).strip() + "\n\n"``.
+    return str(value).strip() + "\n\n"
+
+
 def _render_per_example_diagnostics(
     example_ids: list[str],
     per_example_side_info: list[dict[str, Any]],
+    example_header_level: int = 1,
+    key_header_level: int = 2,
 ) -> str:
     """Render per-example side_info as the mutation-prompt Diagnostics section.
 
-    Mirrors GEPA's ``format_samples`` at
-    ``src/gepa/strategies/instruction_proposal.py:54-95``:
+    Mirrors GEPA's ``OptimizeAnythingAdapter.make_reflective_dataset`` +
+    ``format_samples`` at
+    ``src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py:524-553``
+    and ``src/gepa/strategies/instruction_proposal.py:54-95``:
 
-      * each example gets a ``# Example <id>`` header (id from
-        ``helix_batch.json`` via ``eval_result.instance_scores.keys()``);
-      * the reserved ``scores`` key is renamed to
-        ``## Scores (Higher is Better)`` and its per-objective values
-        are listed as ``<name>: <value>`` (same rename GEPA does at
-        ``optimize_anything_adapter.py:524-553``);
-      * any other side_info key is rendered as ``## <key>`` with its
-        value verbatim (``json.dumps`` for non-scalars).
+      * each example gets an ``{'#' * example_header_level} Example <id>``
+        header (id recovered from ``helix_batch.json`` via
+        ``eval_result.instance_scores.keys()``);
+      * the reserved ``scores`` key renames to
+        ``Scores (Higher is Better)`` at ``key_header_level``;
+      * any other side_info key renders as a ``{'#' * key_header_level}``
+        header with a recursive :func:`_render_side_info_value` body
+        (nested dicts bump to ``key_header_level + 1``, lists become
+        ``### Item N`` sub-headers, primitives render as plain text).
+
+    ``example_header_level`` / ``key_header_level`` are parameterised
+    so the surrounding Diagnostics section's own level (``## Diagnostics``)
+    can drive a monotonic hierarchy from the outside.
 
     Length mismatch between ``example_ids`` and ``per_example_side_info``
     is tolerated by iterating over ``zip`` — the parser enforces
@@ -224,31 +281,28 @@ def _render_per_example_diagnostics(
     if not per_example_side_info:
         return ""
 
+    example_hashes = "#" * example_header_level
+    key_hashes = "#" * key_header_level
+    nested_level = min(key_header_level + 1, _MAX_MARKDOWN_HEADER_LEVEL)
+
     lines: list[str] = ["## Diagnostics"]
     for eid, side_info in zip(example_ids, per_example_side_info):
         lines.append("")
-        lines.append(f"# Example {eid}")
+        lines.append(f"{example_hashes} Example {eid}")
         if not side_info:
             lines.append("(no per-example side_info)")
             continue
         for key, value in sorted(side_info.items()):
             if key == "scores":
-                # GEPA parity: the reserved ``scores`` sub-dict renders
-                # under a friendly header.
-                lines.append("## Scores (Higher is Better)")
-                if isinstance(value, dict):
-                    for k in sorted(value.keys()):
-                        lines.append(f"  {k}: {value[k]}")
-                else:
-                    lines.append(f"  {value}")
+                # GEPA parity: the reserved ``scores`` sub-dict renames
+                # to "Scores (Higher is Better)" and still renders
+                # recursively underneath.
+                lines.append(f"{key_hashes} Scores (Higher is Better)")
             else:
-                lines.append(f"## {key}")
-                if isinstance(value, (dict, list)):
-                    # Keep structured values legible as JSON rather
-                    # than Python repr.
-                    lines.append(json.dumps(value, ensure_ascii=False))
-                else:
-                    lines.append(str(value))
+                lines.append(f"{key_hashes} {key}")
+            body = _render_side_info_value(value, nested_level).rstrip("\n")
+            if body:
+                lines.append(body)
     lines.append("")  # trailing blank line before the next section
     return "\n".join(lines) + "\n"
 

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -351,9 +351,17 @@ def build_mutation_prompt(
     #   3. No diagnostics section otherwise.
     diagnostics_section = ""
     if eval_result.per_example_side_info is not None:
+        # Monotonic markdown hierarchy under the surrounding
+        # ``## Diagnostics`` (h2): each example is ``### Example <id>``
+        # (h3), each side_info key is ``#### {key}`` (h4), nested
+        # values bump further.  Before this the Example header was
+        # ``#`` (h1), which inverted the hierarchy and confused
+        # markdown-aware tooling / LLM markdown parsers.
         diagnostics_section = _render_per_example_diagnostics(
             example_ids=list(eval_result.instance_scores.keys()),
             per_example_side_info=eval_result.per_example_side_info,
+            example_header_level=3,
+            key_header_level=4,
         )
     elif eval_result.side_info is not None:
         diag_lines = "\n".join(

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -193,6 +193,66 @@ def generate_seed(
     invoke_claude_code(worktree_path, prompt, config.claude, passthrough_env=config.passthrough_env)
 
 
+def _render_per_example_diagnostics(
+    example_ids: list[str],
+    per_example_side_info: list[dict[str, Any]],
+) -> str:
+    """Render per-example side_info as the mutation-prompt Diagnostics section.
+
+    Mirrors GEPA's ``format_samples`` at
+    ``src/gepa/strategies/instruction_proposal.py:54-95``:
+
+      * each example gets a ``# Example <id>`` header (id from
+        ``helix_batch.json`` via ``eval_result.instance_scores.keys()``);
+      * the reserved ``scores`` key is renamed to
+        ``## Scores (Higher is Better)`` and its per-objective values
+        are listed as ``<name>: <value>`` (same rename GEPA does at
+        ``optimize_anything_adapter.py:524-553``);
+      * any other side_info key is rendered as ``## <key>`` with its
+        value verbatim (``json.dumps`` for non-scalars).
+
+    Length mismatch between ``example_ids`` and ``per_example_side_info``
+    is tolerated by iterating over ``zip`` — the parser enforces
+    equality on the helix_result path; other paths should never hit
+    this function.
+
+    Empty per-example side_info (every slot is ``{}``) still produces
+    the section header + per-example headers, so the mutator can see
+    that the evaluator had no reflection data rather than silently
+    dropping the section.
+    """
+    if not per_example_side_info:
+        return ""
+
+    lines: list[str] = ["## Diagnostics"]
+    for eid, side_info in zip(example_ids, per_example_side_info):
+        lines.append("")
+        lines.append(f"# Example {eid}")
+        if not side_info:
+            lines.append("(no per-example side_info)")
+            continue
+        for key, value in sorted(side_info.items()):
+            if key == "scores":
+                # GEPA parity: the reserved ``scores`` sub-dict renders
+                # under a friendly header.
+                lines.append("## Scores (Higher is Better)")
+                if isinstance(value, dict):
+                    for k in sorted(value.keys()):
+                        lines.append(f"  {k}: {value[k]}")
+                else:
+                    lines.append(f"  {value}")
+            else:
+                lines.append(f"## {key}")
+                if isinstance(value, (dict, list)):
+                    # Keep structured values legible as JSON rather
+                    # than Python repr.
+                    lines.append(json.dumps(value, ensure_ascii=False))
+                else:
+                    lines.append(str(value))
+    lines.append("")  # trailing blank line before the next section
+    return "\n".join(lines) + "\n"
+
+
 def build_mutation_prompt(
     objective: str,
     eval_result: EvalResult,
@@ -222,9 +282,26 @@ def build_mutation_prompt(
     else:
         extra_asi_section = ""
 
-    # Render side_info diagnostics section (GEPA OA contract)
+    # Render side_info diagnostics.  Precedence:
+    #   1. ``eval_result.per_example_side_info`` (new per-example GEPA
+    #      O.A. contract — list of dicts positional to instance_scores
+    #      ids) when populated; mirrors GEPA's
+    #      ``OptimizeAnythingAdapter.make_reflective_dataset`` at
+    #      ``optimize_anything_adapter.py:524-553`` combined with
+    #      ``format_samples`` at
+    #      ``gepa/strategies/instruction_proposal.py:54-95``.
+    #   2. ``eval_result.side_info`` (legacy batch-level dict) when
+    #      ``per_example_side_info`` is absent — unchanged rendering
+    #      for non-``helix_result`` paths that still populate the
+    #      legacy field.
+    #   3. No diagnostics section otherwise.
     diagnostics_section = ""
-    if eval_result.side_info is not None:
+    if eval_result.per_example_side_info is not None:
+        diagnostics_section = _render_per_example_diagnostics(
+            example_ids=list(eval_result.instance_scores.keys()),
+            per_example_side_info=eval_result.per_example_side_info,
+        )
+    elif eval_result.side_info is not None:
         diag_lines = "\n".join(
             f"  {k}: {v}" for k, v in sorted(eval_result.side_info.items())
         )

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -38,6 +38,19 @@ observability).  The executor stores the full list on
 reflection prompt (actual wiring into the mutation prompt is a
 follow-up PR).
 
+Reserved key: ``side_info_i["scores"]``
+---------------------------------------
+Mirrors GEPA's ``OptimizeAnythingAdapter._process_side_info``
+(``optimize_anything_adapter.py:260-272``).  When a per-example
+``side_info_i["scores"]`` is a dict of ``{objective_name: float}``,
+HELIX harvests it into the corresponding slot of
+:attr:`helix.population.EvalResult.objective_scores`
+(``list[dict[str, float]]`` positional to the ids).  That axis feeds
+the multi-axis Pareto frontier when ``evolution.frontier_type`` is
+``"objective"``, ``"hybrid"``, or ``"cartesian"`` (wired in a later
+commit).  No consumer in this commit; the harvest is strictly pass-
+through on :class:`EvalResult`.
+
 Aggregate
 ---------
 * ``instance_scores = dict(zip(ids, [p[0] for p in payload]))`` —
@@ -115,6 +128,34 @@ def _extract_helix_result_line(stdout: str) -> str | None:
     return None
 
 
+def _harvest_objective_scores(side_info: dict[str, Any]) -> dict[str, float]:
+    """Extract ``side_info["scores"]`` into a ``dict[str, float]``.
+
+    Mirrors GEPA's ``OptimizeAnythingAdapter._process_side_info``
+    (``optimize_anything_adapter.py:260-272``): the reserved
+    ``"scores"`` key carries a dict of ``{objective_name: float}`` that
+    becomes the per-example ``objective_scores`` slot feeding the
+    multi-axis Pareto frontier.  Non-dict values and non-numeric /
+    non-finite entries are silently dropped so evaluators can stuff
+    arbitrary diagnostics under ``"scores"`` without the parser
+    rejecting well-formed payloads elsewhere (the primary per-example
+    score is what the minibatch gate depends on; the objective axis
+    is best-effort).
+    """
+    raw = side_info.get("scores")
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, float] = {}
+    for k, v in raw.items():
+        if not isinstance(k, str):
+            continue
+        if isinstance(v, bool):
+            out[k] = 1.0 if v else 0.0
+        elif isinstance(v, (int, float)) and math.isfinite(float(v)):
+            out[k] = float(v)
+    return out
+
+
 def _coerce_score(
     raw_val: Any,
     eid: str,
@@ -156,6 +197,7 @@ def parse(
     dict[str, float],
     dict[str, float],
     list[dict[str, Any]],
+    list[dict[str, float]],
 ]:
     """Parse per-example ``[score, side_info]`` pairs from ``HELIX_RESULT=``.
 
@@ -175,7 +217,7 @@ def parse(
     Returns
     -------
     tuple
-        Three elements, positionally aligned to the id list from
+        Four elements, positionally aligned to the id list from
         ``helix_batch.json``:
 
         * ``scores: dict[str, float]`` — top-level aggregate
@@ -188,6 +230,13 @@ def parse(
           freeform side_info dict for each example, in id order.
           Stored on :class:`helix.population.EvalResult` for the
           reflection prompt.
+        * ``objective_scores: list[dict[str, float]]`` — the
+          ``side_info_i["scores"]`` harvest for each example, in id
+          order.  GEPA analogue:
+          :attr:`gepa.core.adapter.EvaluationBatch.objective_scores`
+          (``src/gepa/core/adapter.py:26``).  Feeds the multi-axis
+          Pareto frontier; stored on
+          :attr:`helix.population.EvalResult.objective_scores`.
 
     Raises
     ------
@@ -290,6 +339,7 @@ def parse(
 
     instance_scores: dict[str, float] = {}
     per_example_side_info: list[dict[str, Any]] = []
+    objective_scores: list[dict[str, float]] = []
 
     for eid, entry in zip(ids, payload):
         if not isinstance(entry, list) or len(entry) != 2:
@@ -322,6 +372,7 @@ def parse(
 
         instance_scores[eid] = score_val
         per_example_side_info.append(side_info)
+        objective_scores.append(_harvest_objective_scores(side_info))
 
     if returncode != 0 or not instance_scores:
         success = 0.0
@@ -329,4 +380,4 @@ def parse(
         success = sum(instance_scores.values()) / len(instance_scores)
 
     scores: dict[str, float] = {"success": success}
-    return scores, instance_scores, per_example_side_info
+    return scores, instance_scores, per_example_side_info, objective_scores

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -40,9 +40,11 @@ a 2-element ``[score: float, side_info: dict]`` list.
 
 Per-example side_info is a freeform dict (evaluator's own
 observability).  The executor stores the full list on
-:class:`helix.population.EvalResult.per_example_side_info` for the
-reflection prompt (actual wiring into the mutation prompt is a
-follow-up PR).
+:class:`helix.population.EvalResult.per_example_side_info`;
+:func:`helix.mutator._render_per_example_diagnostics` renders it into
+the mutation prompt's ``## Diagnostics`` section (GEPA
+``format_samples`` parity at
+``src/gepa/strategies/instruction_proposal.py:54-95``).
 
 Reserved key: ``side_info_i["scores"]``
 ---------------------------------------
@@ -95,9 +97,9 @@ def _read_helix_batch(worktree_path: str | Path) -> list[str]:
     batch_file = Path(worktree_path) / "helix_batch.json"
     if not batch_file.exists():
         raise EvaluatorError(
-            "helix_result parser requires {worktree}/helix_batch.json "
-            "to be present (HELIX writes it before every evaluator "
-            "invocation).  Make sure the evaluator runs with "
+            f"helix_result parser requires {batch_file} to be present "
+            "(HELIX writes it before every evaluator invocation).  "
+            "Make sure the evaluator runs with "
             "cwd=candidate.worktree_path.",
             operation="parse_helix_result",
             cwd=str(worktree_path),
@@ -279,11 +281,11 @@ def parse(
     if not isinstance(payload, list):
         raise EvaluatorError(
             "HELIX_RESULT= payload must be a list of per-example "
-            "[score, side_info] pairs; "
-            f"got {type(payload).__name__}.  See the "
-            "helix.parsers.helix_result module docstring for the "
-            "BREAKING change from the previous [score, side_info_dict] "
-            "shape.",
+            "entries (bare score or [score, side_info] pair, one per "
+            "id in helix_batch.json); "
+            f"got {type(payload).__name__}.  If you're migrating from "
+            "the previous ``[score: float, side_info: dict]`` contract, "
+            "see helix.parsers.helix_result for the reshape guidance.",
             operation="parse_helix_result",
             stdout=stdout,
             stderr=stderr,
@@ -357,15 +359,12 @@ def parse(
         # float to ``(score, None, {})`` — HELIX does the same here,
         # materialising ``side_info = {}`` for bare entries so the
         # downstream objective harvest is a no-op rather than a crash.
-        # Mixed bare / rich within one payload is allowed.
-        #
-        # Note on precedence: ``bool`` is a subclass of ``int`` but we
-        # only see it at this layer when an evaluator emits
-        # ``true`` / ``false`` as a bare score; route through the
-        # numeric branch below (``_coerce_score`` handles the bool
-        # ⇒ 1.0 / 0.0 coercion consistently).
+        # Mixed bare / rich within one payload is allowed.  ``bool`` is
+        # a subclass of ``int`` in Python so it already flows through
+        # the ``(int, float)`` numeric branch; ``_coerce_score`` then
+        # handles the ``True/False`` ⇒ ``1.0/0.0`` coercion.
         raw_side_info: Any
-        if isinstance(entry, bool) or isinstance(entry, (int, float)):
+        if isinstance(entry, (int, float)):
             # Bare score — empty per-example side_info.
             raw_score = entry
             raw_side_info = None

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -1,120 +1,332 @@
-"""Parse HELIX_RESULT= lines emitted by evaluators.
+"""Parse ``HELIX_RESULT=<per-example [score, side_info] pairs>``.
 
-This is the companion parser to the ``HELIX_RESULT=`` override handled
-inside :mod:`helix.executor` (see ``run_evaluator``). Evaluators that want
-to hand HELIX a scalar score *and* a diagnostics dictionary on the GEPA
-``(accuracy, side_info)`` contract emit exactly one line of the form::
+GEPA ``optimize_anything`` evaluator-contract parity.  GEPA's O.A.
+evaluator returns ``(score: float, side_info: dict)`` **per example**
+(``src/gepa/optimize_anything.py:387-438``); the O.A. adapter then wraps
+that per-example stream into ``EvaluationBatch(scores=list[float],
+trajectories=list[SideInfo], ...)``
+(``optimize_anything_adapter.py:218-292``).  This parser hands HELIX
+the same per-example stream.
 
-    HELIX_RESULT=[<score>, <side_info_dict>]
+**BREAKING (pre-1.0):** ``helix_result`` previously accepted
+``[score: float, side_info: dict]`` with an id-keyed
+``side_info["scores"]`` sub-dict.  That contract silently failed the
+minibatch gate whenever the evaluator keyed its dict by aggregate
+metric names (``task__metric``) instead of the per-example ids HELIX
+wrote to ``helix_batch.json`` (``task__trialN``): 113 generations of
+evolution were once wasted on exactly that zero-vs-zero footgun.
+See ``/tmp/gepa_audit_report.md`` for the full audit.
 
-as their last meaningful stdout line. The executor scans for that line,
-overrides ``scores["success"]`` with ``<score>``, and stashes
-``side_info`` on the :class:`EvalResult`.  This parser exists so the
-config's ``score_parser = "helix_result"`` is a valid selector and so the
-per-instance scores in ``side_info["scores"]`` (e.g. ``task__metric`` →
-float) flow into HELIX's minibatch-gate via ``instance_scores``.
+Contract
+--------
+The evaluator (run with ``cwd=candidate.worktree_path``) emits exactly
+one line on stdout of the form::
 
-Fallbacks mirror ``exitcode``/``json_score`` semantics so a missing or
-malformed ``HELIX_RESULT=`` line does not crash the evolve loop.
+    HELIX_RESULT=[[s_0, side_info_0], [s_1, side_info_1], ..., [s_{N-1}, side_info_{N-1}]]
+
+where element ``i`` corresponds to the id at position ``i`` in the
+``helix_batch.json`` HELIX wrote pre-invocation (see
+:func:`helix.evolution._write_helix_batch`).  Each inner pair is
+``[score_i: float, side_info_i: dict]`` — matching GEPA O.A.'s
+per-example return.
+
+``len(payload) == len(ids)`` is required.
+
+Per-example side_info is a freeform dict (evaluator's own
+observability).  The executor stores the full list on
+:class:`helix.population.EvalResult.per_example_side_info` for the
+reflection prompt (actual wiring into the mutation prompt is a
+follow-up PR).
+
+Aggregate
+---------
+* ``instance_scores = dict(zip(ids, [p[0] for p in payload]))`` —
+  feeds the minibatch gate at ``evolution.py:1920-1939`` as before.
+* ``scores["success"] = mean([p[0] for p in payload])`` — or 0.0 when
+  ``returncode != 0`` or the payload is empty.
+
+Strictness
+----------
+The parser raises :class:`helix.exceptions.EvaluatorError` on any
+deviation from the contract — missing ``helix_batch.json``, missing /
+malformed ``HELIX_RESULT=`` line, wrong outer shape, per-example
+element not a 2-tuple, non-numeric / non-finite score, or length
+mismatch.  Silent fallback would reintroduce the exact footgun this
+rewrite exists to close.
 """
 
 from __future__ import annotations
 
 import json
 import math
+from pathlib import Path
 from typing import Any
+
+from helix.exceptions import EvaluatorError
+
+
+def _read_helix_batch(worktree_path: str | Path) -> list[str]:
+    """Read the id list HELIX wrote to ``{worktree}/helix_batch.json``.
+
+    Raises
+    ------
+    EvaluatorError
+        If the file is missing or not a JSON list of strings.
+    """
+    batch_file = Path(worktree_path) / "helix_batch.json"
+    if not batch_file.exists():
+        raise EvaluatorError(
+            "helix_result parser requires {worktree}/helix_batch.json "
+            "to be present (HELIX writes it before every evaluator "
+            "invocation).  Make sure the evaluator runs with "
+            "cwd=candidate.worktree_path.",
+            operation="parse_helix_result",
+            cwd=str(worktree_path),
+        )
+    try:
+        raw = batch_file.read_text()
+        ids_any: Any = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as e:
+        raise EvaluatorError(
+            f"Failed to read helix_batch.json: {e}",
+            operation="parse_helix_result",
+            cwd=str(worktree_path),
+        ) from e
+    if not isinstance(ids_any, list) or not all(isinstance(x, str) for x in ids_any):
+        raise EvaluatorError(
+            "helix_batch.json must contain a JSON list[str] of example ids "
+            f"(got {type(ids_any).__name__})",
+            operation="parse_helix_result",
+            cwd=str(worktree_path),
+        )
+    return [str(x) for x in ids_any]
+
+
+def _extract_helix_result_line(stdout: str) -> str | None:
+    """Return the last ``HELIX_RESULT=``-prefixed line, or ``None``.
+
+    Matches :func:`helix.executor.run_evaluator`'s reverse-scan order
+    so the two agree on "which line wins" when (buggy) evaluators emit
+    more than one.
+    """
+    for line in reversed(stdout.splitlines()):
+        if line.startswith("HELIX_RESULT="):
+            return line
+    return None
+
+
+def _coerce_score(
+    raw_val: Any,
+    eid: str,
+    ctx_stdout: str,
+    ctx_stderr: str,
+    returncode: int,
+) -> float:
+    """Coerce a per-example raw score to a finite float or raise."""
+    if isinstance(raw_val, bool):
+        val = 1.0 if raw_val else 0.0
+    elif isinstance(raw_val, (int, float)):
+        val = float(raw_val)
+    else:
+        raise EvaluatorError(
+            f"helix_result score for id {eid!r} is not numeric "
+            f"(got {type(raw_val).__name__}: {raw_val!r}).",
+            operation="parse_helix_result",
+            stdout=ctx_stdout,
+            stderr=ctx_stderr,
+            exit_code=returncode,
+        )
+    if not math.isfinite(val):
+        raise EvaluatorError(
+            f"helix_result score for id {eid!r} is non-finite ({val!r}).",
+            operation="parse_helix_result",
+            stdout=ctx_stdout,
+            stderr=ctx_stderr,
+            exit_code=returncode,
+        )
+    return val
 
 
 def parse(
-    returncode: int, stdout: str, stderr: str
-) -> tuple[dict[str, float], dict[str, float]]:
-    """Parse ``HELIX_RESULT=[score, side_info]`` from evaluator stdout.
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    worktree_path: str | Path,
+) -> tuple[
+    dict[str, float],
+    dict[str, float],
+    list[dict[str, Any]],
+]:
+    """Parse per-example ``[score, side_info]`` pairs from ``HELIX_RESULT=``.
 
-    Behaviour:
-        * Scan stdout lines in reverse for the last line starting with
-          ``HELIX_RESULT=``. Strip the prefix, ``json.loads`` the payload.
-        * When the payload is well-formed ``[float, dict]``:
-              - ``scores = {"success": float(payload[0])}``; if
-                ``side_info`` carries a numeric ``"accuracy"`` field, also
-                set ``scores["accuracy"]`` for readability.
-              - ``instance_scores`` is populated from
-                ``side_info.get("scores", {})`` when that value is a
-                ``dict`` of ``str`` → number; otherwise empty.
-              - If ``returncode != 0``, coerce ``scores["success"] = 0.0``
-                to match ``json_score``'s failure semantics.
-        * When the line is missing or malformed, fall back to
-          ``exitcode`` semantics (``success = 1.0 if returncode == 0 else
-          0.0``) so the evolve loop still runs.
+    Parameters
+    ----------
+    returncode:
+        Evaluator subprocess exit code.  Non-zero zeroes the aggregate
+        ``success`` score but leaves per-example data intact so
+        reflection / diagnostics remain informative.
+    stdout, stderr:
+        Captured evaluator output.  ``stderr`` is unused by the parser
+        but kept in the signature for registry-contract uniformity.
+    worktree_path:
+        Evaluator cwd — the directory HELIX wrote ``helix_batch.json``
+        to before invoking the evaluator.
 
-    Note:
-        The executor independently scans for ``HELIX_RESULT=`` and
-        overrides ``scores["success"]`` from the same payload; this
-        parser duplicates the scan so it remains useful on its own
-        (tests, non-executor code paths) and so it can populate
-        ``instance_scores`` from ``side_info["scores"]``.
+    Returns
+    -------
+    tuple
+        Three elements, positionally aligned to the id list from
+        ``helix_batch.json``:
+
+        * ``scores: dict[str, float]`` — top-level aggregate
+          (``scores["success"] = mean(per-example scores)``,
+          0.0 on non-zero exit or empty list).
+        * ``instance_scores: dict[str, float]`` —
+          ``dict(zip(ids, per_example_scores))``.  Feeds the minibatch
+          gate at :func:`helix.evolution._minibatch_gate_accept`.
+        * ``per_example_side_info: list[dict[str, Any]]`` — the raw
+          freeform side_info dict for each example, in id order.
+          Stored on :class:`helix.population.EvalResult` for the
+          reflection prompt.
+
+    Raises
+    ------
+    EvaluatorError
+        On any contract violation (see module docstring).
     """
-    fallback_success = 1.0 if returncode == 0 else 0.0
+    ids = _read_helix_batch(worktree_path)
 
-    # Find the last HELIX_RESULT= line (matches executor's reverse-scan order).
-    result_line: str | None = None
-    for line in reversed(stdout.splitlines()):
-        if line.startswith("HELIX_RESULT="):
-            result_line = line
-            break
-
+    result_line = _extract_helix_result_line(stdout)
     if result_line is None:
-        return (
-            {"success": fallback_success},
-            {"success": fallback_success},
+        raise EvaluatorError(
+            "helix_result parser found no HELIX_RESULT= line on stdout. "
+            "Emit exactly one line of shape "
+            "HELIX_RESULT=[[score_0, side_info_0], [score_1, side_info_1], ...] "
+            "with one [score, side_info] pair per id in helix_batch.json.",
+            operation="parse_helix_result",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
         )
 
     try:
         payload: Any = json.loads(result_line.removeprefix("HELIX_RESULT="))
-    except (json.JSONDecodeError, ValueError, TypeError):
-        return (
-            {"success": fallback_success},
-            {"success": fallback_success},
+    except (json.JSONDecodeError, ValueError) as e:
+        raise EvaluatorError(
+            f"Failed to JSON-decode HELIX_RESULT= payload: {e}",
+            operation="parse_helix_result",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
+        ) from e
+
+    if not isinstance(payload, list):
+        raise EvaluatorError(
+            "HELIX_RESULT= payload must be a list of per-example "
+            "[score, side_info] pairs; "
+            f"got {type(payload).__name__}.  See the "
+            "helix.parsers.helix_result module docstring for the "
+            "BREAKING change from the previous [score, side_info_dict] "
+            "shape.",
+            operation="parse_helix_result",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
         )
 
-    if not (isinstance(payload, list) and len(payload) == 2):
-        return (
-            {"success": fallback_success},
-            {"success": fallback_success},
+    # Guard the two legacy scalar-plus-dict shapes with explicit error
+    # messages so migrators get a pointer instead of a cryptic
+    # "element is not a list" further down.
+    if (
+        len(payload) == 2
+        and isinstance(payload[0], (int, float))
+        and not isinstance(payload[0], bool)
+        and isinstance(payload[1], dict)
+    ):
+        raise EvaluatorError(
+            "HELIX_RESULT= looks like the removed legacy shape "
+            "[score: float, side_info: dict].  The new contract is a "
+            "list of per-example [score, side_info] pairs, one per id "
+            "in helix_batch.json.  See helix.parsers.helix_result for "
+            "migration guidance.",
+            operation="parse_helix_result",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
+        )
+    if (
+        len(payload) == 2
+        and isinstance(payload[0], list)
+        and isinstance(payload[1], dict)
+        and all(
+            isinstance(x, (int, float)) and not isinstance(x, bool)
+            for x in payload[0]
+        )
+    ):
+        raise EvaluatorError(
+            "HELIX_RESULT= looks like the intermediate shape "
+            "[scores_list, side_info_dict] (one batch-level side_info). "
+            "The contract is now a list of per-example [score, side_info] "
+            "pairs — one side_info per example, not one per batch.  "
+            "Zip your scores with per-example side_info dicts before "
+            "emitting.",
+            operation="parse_helix_result",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
         )
 
-    raw_score, raw_side_info = payload
-
-    try:
-        score_value = float(raw_score)
-    except (TypeError, ValueError):
-        return (
-            {"success": fallback_success},
-            {"success": fallback_success},
+    if len(payload) != len(ids):
+        raise EvaluatorError(
+            f"helix_result length mismatch: payload has {len(payload)} "
+            f"per-example entries but helix_batch.json has {len(ids)} ids. "
+            "The evaluator must emit exactly one [score, side_info] pair "
+            "per id, in the same order.",
+            operation="parse_helix_result",
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
         )
-
-    if not math.isfinite(score_value):
-        return (
-            {"success": fallback_success},
-            {"success": fallback_success},
-        )
-
-    if returncode != 0:
-        score_value = 0.0
-
-    scores: dict[str, float] = {"success": score_value}
-
-    side_info: dict[str, Any] = raw_side_info if isinstance(raw_side_info, dict) else {}
-
-    # Cosmetic: surface accuracy alongside success when the evaluator reports it.
-    raw_accuracy = side_info.get("accuracy")
-    if isinstance(raw_accuracy, (int, float)) and not isinstance(raw_accuracy, bool):
-        scores["accuracy"] = float(raw_accuracy)
 
     instance_scores: dict[str, float] = {}
-    raw_instances = side_info.get("scores", {})
-    if isinstance(raw_instances, dict):
-        for k, v in raw_instances.items():
-            if isinstance(v, (int, float)) and math.isfinite(float(v)):
-                instance_scores[str(k)] = float(v)
+    per_example_side_info: list[dict[str, Any]] = []
 
-    return scores, instance_scores
+    for eid, entry in zip(ids, payload):
+        if not isinstance(entry, list) or len(entry) != 2:
+            raise EvaluatorError(
+                f"helix_result per-example entry for id {eid!r} must be "
+                f"a 2-element [score, side_info] list; got "
+                f"{type(entry).__name__}"
+                + (f" (len={len(entry)})" if isinstance(entry, list) else "")
+                + ".",
+                operation="parse_helix_result",
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=returncode,
+            )
+        raw_score, raw_side_info = entry
+        score_val = _coerce_score(raw_score, eid, stdout, stderr, returncode)
+        if raw_side_info is None:
+            side_info: dict[str, Any] = {}
+        elif isinstance(raw_side_info, dict):
+            side_info = raw_side_info
+        else:
+            raise EvaluatorError(
+                f"helix_result side_info for id {eid!r} must be a dict "
+                f"(or null); got {type(raw_side_info).__name__}.",
+                operation="parse_helix_result",
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=returncode,
+            )
+
+        instance_scores[eid] = score_val
+        per_example_side_info.append(side_info)
+
+    if returncode != 0 or not instance_scores:
+        success = 0.0
+    else:
+        success = sum(instance_scores.values()) / len(instance_scores)
+
+    scores: dict[str, float] = {"success": success}
+    return scores, instance_scores, per_example_side_info

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -20,15 +20,21 @@ See ``/tmp/gepa_audit_report.md`` for the full audit.
 Contract
 --------
 The evaluator (run with ``cwd=candidate.worktree_path``) emits exactly
-one line on stdout of the form::
+one line on stdout.  Each per-example entry matches GEPA O.A.'s
+``tuple[float, SideInfo] | float`` union — either the rich pair or a
+bare score::
 
-    HELIX_RESULT=[[s_0, side_info_0], [s_1, side_info_1], ..., [s_{N-1}, side_info_{N-1}]]
+    HELIX_RESULT=[s_0, s_1, ..., s_{N-1}]                         # all bare
+    HELIX_RESULT=[[s_0, si_0], [s_1, si_1], ..., [s_{N-1}, si_{N-1}]]  # all rich
+    HELIX_RESULT=[s_0, [s_1, si_1], s_2, ...]                     # mixed — allowed
 
-where element ``i`` corresponds to the id at position ``i`` in the
+Element ``i`` corresponds to the id at position ``i`` in the
 ``helix_batch.json`` HELIX wrote pre-invocation (see
-:func:`helix.evolution._write_helix_batch`).  Each inner pair is
-``[score_i: float, side_info_i: dict]`` — matching GEPA O.A.'s
-per-example return.
+:func:`helix.evolution._write_helix_batch`).  A bare ``float`` is
+normalised to ``(score, {})`` — matching GEPA O.A.'s
+``EvaluatorWrapper`` at ``src/gepa/optimize_anything.py:971`` which
+auto-wraps a bare score to ``(score, None, {})``.  Rich entries are
+a 2-element ``[score: float, side_info: dict]`` list.
 
 ``len(payload) == len(ids)`` is required.
 
@@ -249,9 +255,10 @@ def parse(
     if result_line is None:
         raise EvaluatorError(
             "helix_result parser found no HELIX_RESULT= line on stdout. "
-            "Emit exactly one line of shape "
-            "HELIX_RESULT=[[score_0, side_info_0], [score_1, side_info_1], ...] "
-            "with one [score, side_info] pair per id in helix_batch.json.",
+            "Emit exactly one line of the per-example shape "
+            "HELIX_RESULT=[entry_0, entry_1, ...] where each entry is "
+            "either a bare score (int|float) or a 2-element "
+            "[score, side_info] list, positional to helix_batch.json.",
             operation="parse_helix_result",
             stdout=stdout,
             stderr=stderr,
@@ -327,10 +334,11 @@ def parse(
 
     if len(payload) != len(ids):
         raise EvaluatorError(
-            f"helix_result length mismatch: payload has {len(payload)} "
-            f"per-example entries but helix_batch.json has {len(ids)} ids. "
-            "The evaluator must emit exactly one [score, side_info] pair "
-            "per id, in the same order.",
+            f"helix_result length mismatch: per-example payload has "
+            f"{len(payload)} entries but helix_batch.json has {len(ids)} "
+            "ids.  The evaluator must emit exactly one entry per id, in "
+            "the same order.  Each entry is either a bare score "
+            "(int|float) or a 2-element [score, side_info] list.",
             operation="parse_helix_result",
             stdout=stdout,
             stderr=stderr,
@@ -342,11 +350,33 @@ def parse(
     objective_scores: list[dict[str, float]] = []
 
     for eid, entry in zip(ids, payload):
-        if not isinstance(entry, list) or len(entry) != 2:
+        # GEPA optimize_anything union parity: per-example entry is
+        # either a bare score or a ``[score, side_info]`` pair.  The
+        # O.A. ``EvaluatorWrapper`` at
+        # ``src/gepa/optimize_anything.py:971`` auto-normalizes a bare
+        # float to ``(score, None, {})`` — HELIX does the same here,
+        # materialising ``side_info = {}`` for bare entries so the
+        # downstream objective harvest is a no-op rather than a crash.
+        # Mixed bare / rich within one payload is allowed.
+        #
+        # Note on precedence: ``bool`` is a subclass of ``int`` but we
+        # only see it at this layer when an evaluator emits
+        # ``true`` / ``false`` as a bare score; route through the
+        # numeric branch below (``_coerce_score`` handles the bool
+        # ⇒ 1.0 / 0.0 coercion consistently).
+        raw_side_info: Any
+        if isinstance(entry, bool) or isinstance(entry, (int, float)):
+            # Bare score — empty per-example side_info.
+            raw_score = entry
+            raw_side_info = None
+        elif isinstance(entry, list) and len(entry) == 2:
+            # Rich [score, side_info] pair.
+            raw_score, raw_side_info = entry
+        else:
             raise EvaluatorError(
                 f"helix_result per-example entry for id {eid!r} must be "
-                f"a 2-element [score, side_info] list; got "
-                f"{type(entry).__name__}"
+                "either a bare score (int|float) or a 2-element "
+                f"[score, side_info] list; got {type(entry).__name__}"
                 + (f" (len={len(entry)})" if isinstance(entry, list) else "")
                 + ".",
                 operation="parse_helix_result",
@@ -354,7 +384,6 @@ def parse(
                 stderr=stderr,
                 exit_code=returncode,
             )
-        raw_score, raw_side_info = entry
         score_val = _coerce_score(raw_score, eid, stdout, stderr, returncode)
         if raw_side_info is None:
             side_info: dict[str, Any] = {}

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -64,6 +64,14 @@ class EvalResult:
     # ``instance_scores`` by helix_batch.json id order.  Consumed by
     # the reflection prompt in a follow-up PR.
     per_example_side_info: list[dict[str, Any]] | None = None
+    # Per-example objective-axis harvest: each slot is
+    # ``side_info_i.get("scores", {})`` filtered down to
+    # ``{str: float}`` entries.  GEPA analogue:
+    # :attr:`gepa.core.adapter.EvaluationBatch.objective_scores`
+    # (``src/gepa/core/adapter.py:26``).  Feeds the multi-axis Pareto
+    # frontier when ``evolution.frontier_type`` ∈ {"objective",
+    # "hybrid", "cartesian"}; harmless on the default "instance" path.
+    objective_scores: list[dict[str, float]] | None = None
 
     def aggregate_score(self) -> float:
         """Return mean of instance scores, or 0.0 if none."""
@@ -91,6 +99,8 @@ class EvalResult:
             d["side_info"] = self.side_info
         if self.per_example_side_info is not None:
             d["per_example_side_info"] = self.per_example_side_info
+        if self.objective_scores is not None:
+            d["objective_scores"] = self.objective_scores
         return d
 
     @classmethod
@@ -103,6 +113,7 @@ class EvalResult:
             asi=data.get("asi", {}),
             side_info=data.get("side_info"),
             per_example_side_info=data.get("per_example_side_info"),
+            objective_scores=data.get("objective_scores"),
         )
 
 

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -33,14 +33,37 @@ class Candidate:
 class EvalResult:
     """Evaluation results for a candidate.
 
-    Stores aggregate scores, per-instance scores, and arbitrary
-    metadata returned by the evaluator.
+    Mirrors GEPA's :class:`gepa.core.adapter.EvaluationBatch` where it
+    can.  Key invariants:
+
+    - ``instance_scores`` is keyed **only** by HELIX's internal example
+      ids — the same strings HELIX writes to
+      ``{worktree}/helix_batch.json`` pre-invocation.  Never aggregate
+      metric names.  Previously this was the footgun: an evaluator
+      keying by ``task__metric`` instead of ``task__trialN`` silently
+      zero-filled every requested id in the minibatch gate.  The
+      per-example ``helix_result`` parser owns the id-keying now so
+      evaluators never type a HELIX-internal id.
+    - ``per_example_side_info`` is positional to ``instance_scores``
+      by id order (same order as ``helix_batch.json``).  GEPA analogue:
+      ``EvaluationBatch.trajectories`` (``src/gepa/core/adapter.py:25``).
+      Carries freeform per-example diagnostics for the reflection
+      prompt (prompt wiring lands in a follow-up PR).
     """
     candidate_id: str
     scores: dict[str, float]          # aggregate/summary scores
     asi: dict[str, str]               # arbitrary string info (metadata)
-    instance_scores: dict[str, float] # per-instance scores
-    side_info: dict[str, Any] | None = None  # optional diagnostics from HELIX_RESULT (reflection only)
+    instance_scores: dict[str, float] # per-instance scores, keyed by HELIX example-id
+    # Legacy batch-level diagnostics dict.  No longer populated by the
+    # ``helix_result`` parser (which uses ``per_example_side_info``);
+    # kept for back-compat with any other path that still sets it and
+    # for the mutation prompt's existing Diagnostics section.
+    side_info: dict[str, Any] | None = None
+    # Per-example freeform side_info (GEPA O.A. evaluator contract:
+    # ``(score, side_info)`` per example).  Positional to
+    # ``instance_scores`` by helix_batch.json id order.  Consumed by
+    # the reflection prompt in a follow-up PR.
+    per_example_side_info: list[dict[str, Any]] | None = None
 
     def aggregate_score(self) -> float:
         """Return mean of instance scores, or 0.0 if none."""
@@ -53,7 +76,11 @@ class EvalResult:
         return sum(self.instance_scores.values())
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to a JSON-compatible dict."""
+        """Serialize to a JSON-compatible dict.
+
+        Optional fields are omitted when ``None`` so on-disk evaluations
+        stay byte-identical when they don't carry the newer data.
+        """
         d: dict[str, Any] = {
             "candidate_id": self.candidate_id,
             "scores": self.scores,
@@ -62,6 +89,8 @@ class EvalResult:
         }
         if self.side_info is not None:
             d["side_info"] = self.side_info
+        if self.per_example_side_info is not None:
+            d["per_example_side_info"] = self.per_example_side_info
         return d
 
     @classmethod
@@ -73,6 +102,7 @@ class EvalResult:
             instance_scores=data.get("instance_scores", {}),
             asi=data.get("asi", {}),
             side_info=data.get("side_info"),
+            per_example_side_info=data.get("per_example_side_info"),
         )
 
 

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -8,9 +8,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import random
 from dataclasses import dataclass, field
 from typing import Any, Literal
+
+
+logger = logging.getLogger(__name__)
 
 
 FrontierType = Literal["instance", "objective", "hybrid", "cartesian"]
@@ -50,8 +54,11 @@ class EvalResult:
     - ``per_example_side_info`` is positional to ``instance_scores``
       by id order (same order as ``helix_batch.json``).  GEPA analogue:
       ``EvaluationBatch.trajectories`` (``src/gepa/core/adapter.py:25``).
-      Carries freeform per-example diagnostics for the reflection
-      prompt (prompt wiring lands in a follow-up PR).
+      Carries freeform per-example diagnostics; rendered into the
+      mutation prompt's Diagnostics section by
+      :func:`helix.mutator._render_per_example_diagnostics` (GEPA
+      ``format_samples`` parity at
+      ``src/gepa/strategies/instruction_proposal.py:54-95``).
     """
     candidate_id: str
     scores: dict[str, float]          # aggregate/summary scores
@@ -64,8 +71,9 @@ class EvalResult:
     side_info: dict[str, Any] | None = None
     # Per-example freeform side_info (GEPA O.A. evaluator contract:
     # ``(score, side_info)`` per example).  Positional to
-    # ``instance_scores`` by helix_batch.json id order.  Consumed by
-    # the reflection prompt in a follow-up PR.
+    # ``instance_scores`` by helix_batch.json id order.  Rendered into
+    # the mutation prompt's Diagnostics section by
+    # :func:`helix.mutator._render_per_example_diagnostics`.
     per_example_side_info: list[dict[str, Any]] | None = None
     # Per-example objective-axis harvest: each slot is
     # ``side_info_i.get("scores", {})`` filtered down to
@@ -281,7 +289,14 @@ class ParetoFrontier:
         if len(val_ids) != len(result.objective_scores):
             # Defensive: skip cartesian updates when lengths disagree
             # (should not happen on the helix_result path but could on
-            # hand-constructed EvalResults in tests).
+            # hand-constructed EvalResults in tests).  Log at DEBUG so
+            # the skip is traceable without polluting the default log.
+            logger.debug(
+                "ParetoFrontier._update_cartesian: skipping cid=%r — "
+                "objective_scores length %d does not match "
+                "instance_scores length %d",
+                cid, len(result.objective_scores), len(val_ids),
+            )
             return
         for val_id, slot in zip(val_ids, result.objective_scores):
             for obj_name, score in slot.items():
@@ -296,14 +311,16 @@ class ParetoFrontier:
     def update_scores(self, result: EvalResult) -> None:
         """Update the evaluation result for an existing candidate and rebuild tracking."""
         self._results[result.candidate_id] = result
-        self._rebuild_per_key()
+        self._rebuild_axes()
 
-    def _rebuild_per_key(self) -> None:
+    def _rebuild_axes(self) -> None:
         """Rebuild all per-axis best tracking from scratch.
 
         Called after a score update rewrites one candidate's
-        ``EvalResult``.  Rebuilds every axis so a single consistent
-        snapshot is preserved.
+        ``EvalResult``.  Rebuilds every axis (instance, objective,
+        cartesian) so a single consistent snapshot is preserved —
+        hence the name; the original ``_rebuild_per_key`` pre-dated
+        the multi-axis frontier and only touched ``_per_key_best``.
         """
         self._per_key_best.clear()
         self._per_key_best_score.clear()

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -10,7 +10,10 @@ import hashlib
 import json
 import random
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
+
+
+FrontierType = Literal["instance", "objective", "hybrid", "cartesian"]
 
 
 @dataclass
@@ -134,18 +137,75 @@ class ParetoFrontier:
     4. **Parent selection** — ``select_program_candidate_from_pareto_front()``
        calls ``remove_dominated_programs()``, counts per-key frequency of
        surviving programs, builds a flat sampling list, picks uniformly.
+
+    Multi-axis frontier (GEPA ``FrontierType`` parity)
+    ---------------------------------------------------
+    The ``frontier_type`` constructor arg mirrors GEPA's literal at
+    ``src/gepa/core/state.py:22-23``:
+
+    - ``"instance"`` (default): per-example-id keyspace, built from
+      ``EvalResult.instance_scores``.  Matches HELIX's historical
+      behaviour and GEPA's ``frontier_type="instance"`` path.
+    - ``"objective"``: per-objective-name keyspace, values = mean of
+      that objective across the valset, built from
+      ``EvalResult.objective_scores``.  GEPA
+      ``_update_objective_pareto_front`` (``state.py:474-484``).
+    - ``"hybrid"``: union of the instance and objective keyspaces.
+      A candidate survives if it's non-dominated on the combined
+      keyset.  This is GEPA ``optimize_anything``'s default
+      (``optimize_anything.py:476``) and HELIX's default
+      (``evolution.frontier_type``).
+    - ``"cartesian"``: per ``(val_id, objective_name)`` keyspace.
+      GEPA ``_update_pareto_front_for_cartesian``
+      (``state.py:512-525``).
+
+    The **acceptance gate stays positional** on ``scores_list``
+    regardless of ``frontier_type`` (GEPA ``acceptance.py:39-48``);
+    only the Pareto retention / parent-selection decision is
+    multi-axis.
+
+    Implementation: each axis has its own ``_..._best`` /
+    ``_..._best_score`` dict, populated on ``add()``.
+    :meth:`_active_frontier` returns the merged keyspace for the
+    currently selected ``frontier_type``; dominance / selection run
+    against that merged dict via the existing
+    :func:`_remove_dominated_programs` helper.
     """
 
-    def __init__(self, rng: random.Random | None = None) -> None:
+    def __init__(
+        self,
+        rng: random.Random | None = None,
+        frontier_type: FrontierType = "instance",
+    ) -> None:
         # GEPA parity: seeded RNG for deterministic parent selection.
         self._rng = rng if rng is not None else random.Random(0)
+        self._frontier_type: FrontierType = frontier_type
         # Append-only storage (never pruned) — mirrors GEPA's program_candidates list
         self._candidates: dict[str, Candidate] = {}
         self._results: dict[str, EvalResult] = {}
-        # Mirrors GEPAState.program_at_pareto_front_valset: val_id → {candidate IDs with best score}
+        # ``"instance"`` axis — mirrors GEPAState.program_at_pareto_front_valset
+        # (val_id → {candidate IDs with best score}) and pareto_front_valset
+        # (val_id → best score).
         self._per_key_best: dict[str, set[str]] = {}
-        # Mirrors GEPAState.pareto_front_valset: val_id → best score
         self._per_key_best_score: dict[str, float] = {}
+        # ``"objective"`` axis — mirrors GEPAState.program_at_objective_pareto_front
+        # (objective_name → {candidates tied for best mean-across-valset})
+        # and ``objective_pareto_front`` (objective_name → best mean).
+        self._objective_best: dict[str, set[str]] = {}
+        self._objective_best_score: dict[str, float] = {}
+        # ``"cartesian"`` axis — mirrors
+        # GEPAState.program_at_pareto_front_cartesian / pareto_front_cartesian
+        # ((val_id, objective_name) → best).  Keys are encoded as
+        # ``f"{val_id}::{objective_name}"`` so the existing
+        # ``_remove_dominated_programs`` helper (which takes
+        # ``dict[str, set[str]]``) works unmodified.
+        self._cartesian_best: dict[str, set[str]] = {}
+        self._cartesian_best_score: dict[str, float] = {}
+
+    @property
+    def frontier_type(self) -> FrontierType:
+        """Selected Pareto dimensionality (GEPA parity)."""
+        return self._frontier_type
 
     # ------------------------------------------------------------------
     # Mutation helpers — mirrors GEPAState._update_pareto_front_for_val_id
@@ -156,6 +216,11 @@ class ParetoFrontier:
         self._candidates[candidate.id] = candidate
         self._results[candidate.id] = result
         self._update_per_key(candidate.id, result)
+        # Multi-axis updates are no-ops when the frontier_type doesn't
+        # use them, but always populating keeps diagnostics useful and
+        # lets a caller inspect any axis post-hoc.
+        self._update_objective(candidate.id, result)
+        self._update_cartesian(candidate.id, result)
 
     def _update_per_key(self, cid: str, result: EvalResult) -> None:
         """Incrementally update per-key best tracking for a single candidate.
@@ -171,17 +236,115 @@ class ParetoFrontier:
                 front = self._per_key_best.setdefault(key, set())
                 front.add(cid)
 
+    def _update_objective(self, cid: str, result: EvalResult) -> None:
+        """Update the per-objective frontier using mean-across-valset.
+
+        Mirrors GEPA's ``_update_objective_pareto_front``
+        (``state.py:474-484``) with its ``_per_prog_mean_objective_scores``
+        helper (``state.py:462-472``): for each objective name present
+        in any per-example slot, take the mean of that objective's
+        scores across the entire ``objective_scores`` list.
+        """
+        if result.objective_scores is None or not result.objective_scores:
+            return
+        aggregated: dict[str, list[float]] = {}
+        for slot in result.objective_scores:
+            for name, score in slot.items():
+                aggregated.setdefault(name, []).append(float(score))
+        for name, vals in aggregated.items():
+            if not vals:
+                continue
+            mean = sum(vals) / len(vals)
+            prev = self._objective_best_score.get(name, float("-inf"))
+            if mean > prev:
+                self._objective_best[name] = {cid}
+                self._objective_best_score[name] = mean
+            elif mean == prev:
+                self._objective_best.setdefault(name, set()).add(cid)
+
+    def _update_cartesian(self, cid: str, result: EvalResult) -> None:
+        """Update the (val_id, objective_name) frontier.
+
+        Mirrors GEPA's ``_update_pareto_front_for_cartesian``
+        (``state.py:512-525``): each per-example ``objective_scores[i]``
+        slot is combined with the corresponding ``val_id`` (from
+        ``instance_scores``' ordered keys) to form a tuple key.  We
+        encode the tuple as ``f"{val_id}::{objective_name}"`` so the
+        existing ``dict[str, set[str]]`` dominance helper works.
+        """
+        if result.objective_scores is None:
+            return
+        # ``instance_scores`` preserves helix_batch.json id order by
+        # construction in ``helix_result.parse``; ``objective_scores``
+        # is positional to the same id list.  Zip together.
+        val_ids = list(result.instance_scores.keys())
+        if len(val_ids) != len(result.objective_scores):
+            # Defensive: skip cartesian updates when lengths disagree
+            # (should not happen on the helix_result path but could on
+            # hand-constructed EvalResults in tests).
+            return
+        for val_id, slot in zip(val_ids, result.objective_scores):
+            for obj_name, score in slot.items():
+                key = f"{val_id}::{obj_name}"
+                prev = self._cartesian_best_score.get(key, float("-inf"))
+                if float(score) > prev:
+                    self._cartesian_best[key] = {cid}
+                    self._cartesian_best_score[key] = float(score)
+                elif float(score) == prev:
+                    self._cartesian_best.setdefault(key, set()).add(cid)
+
     def update_scores(self, result: EvalResult) -> None:
         """Update the evaluation result for an existing candidate and rebuild tracking."""
         self._results[result.candidate_id] = result
         self._rebuild_per_key()
 
     def _rebuild_per_key(self) -> None:
-        """Rebuild per-key best tracking from scratch (after score updates)."""
+        """Rebuild all per-axis best tracking from scratch.
+
+        Called after a score update rewrites one candidate's
+        ``EvalResult``.  Rebuilds every axis so a single consistent
+        snapshot is preserved.
+        """
         self._per_key_best.clear()
         self._per_key_best_score.clear()
+        self._objective_best.clear()
+        self._objective_best_score.clear()
+        self._cartesian_best.clear()
+        self._cartesian_best_score.clear()
         for cid, result in self._results.items():
             self._update_per_key(cid, result)
+            self._update_objective(cid, result)
+            self._update_cartesian(cid, result)
+
+    # ------------------------------------------------------------------
+    # Active frontier — merged keyspace per ``frontier_type``
+    # ------------------------------------------------------------------
+
+    def _active_frontier(self) -> dict[str, set[str]]:
+        """Return the merged per-key-best dict for the active axis.
+
+        Key collisions are avoided by prefixing per-axis keys when the
+        hybrid path unions multiple keyspaces.  Consumers treat the
+        returned dict opaquely via :func:`_remove_dominated_programs`,
+        so the prefix is internal implementation detail.
+        """
+        if self._frontier_type == "instance":
+            # Back-compat: return the raw instance dict so existing
+            # tests asserting on ``_per_key_best`` keys (``"i1"``,
+            # ``"i2"``, etc.) keep working through the same object.
+            return self._per_key_best
+        if self._frontier_type == "objective":
+            return self._objective_best
+        if self._frontier_type == "cartesian":
+            return self._cartesian_best
+        # "hybrid": union of instance ∪ objective keyspaces (GEPA O.A.
+        # default — see src/gepa/optimize_anything.py:476).
+        merged: dict[str, set[str]] = {}
+        for k, v in self._per_key_best.items():
+            merged[f"inst::{k}"] = v
+        for k, v in self._objective_best.items():
+            merged[f"obj::{k}"] = v
+        return merged
 
     # ------------------------------------------------------------------
     # GEPA coverage-based dominance
@@ -268,15 +431,19 @@ class ParetoFrontier:
     def get_non_dominated(self) -> set[str]:
         """Return the non-dominated set via GEPA's iterative fixed-point elimination.
 
-        Uses each candidate's ``sum_score()`` as the tiebreaker
-        (lower-scoring candidates are eliminated first, matching GEPA's
+        Dominance is computed against :meth:`_active_frontier`, which
+        dispatches on ``frontier_type``.  Uses each candidate's
+        ``sum_score()`` as the tiebreaker (lower-scoring candidates are
+        eliminated first, matching GEPA's
         ``train_val_weighted_agg_scores_for_all_programs``).
 
         GEPA parity (W1): use sum_score() to match GEPA semantics, which
         diverges from aggregate_score() when candidates have different instance counts.
         """
         scores = {cid: r.sum_score() for cid, r in self._results.items()}
-        dominators, _ = self._remove_dominated_programs(self._per_key_best, scores)
+        dominators, _ = self._remove_dominated_programs(
+            self._active_frontier(), scores,
+        )
         return dominators
 
     def is_dominated(self, candidate_id: str) -> bool:
@@ -296,10 +463,16 @@ class ParetoFrontier:
     # ------------------------------------------------------------------
 
     def _instance_wins(self) -> dict[str, set[str]]:
-        """Transpose of ``_per_key_best``: candidate → set of keys where it
-        appears in the best set."""
+        """Transpose of the active frontier: candidate → set of keys
+        where it appears in the best set.
+
+        Used by :meth:`select_complementary_pair` to find pairs with
+        minimal overlap in best-key coverage.  Name retained for
+        back-compat; now reflects the active frontier type.
+        """
+        active = self._active_frontier()
         wins: dict[str, set[str]] = {cid: set() for cid in self._candidates}
-        for key, front in self._per_key_best.items():
+        for key, front in active.items():
             for cid in front:
                 if cid in wins:
                     wins[cid].add(key)
@@ -308,7 +481,8 @@ class ParetoFrontier:
     def select_parent(self) -> Candidate:
         """GEPA ``select_program_candidate_from_pareto_front()``.
 
-        1. Run ``remove_dominated_programs()`` with sum scores (GEPA parity W1).
+        1. Run ``remove_dominated_programs()`` over :meth:`_active_frontier`
+           with sum scores (GEPA parity W1).
         2. Count per-key frequency of surviving programs in the *cleaned*
            frontier (dominated programs stripped from every front).
         3. Build a flat sampling list where each program appears *freq* times.
@@ -320,7 +494,7 @@ class ParetoFrontier:
         # GEPA parity (W1): use sum_score() to match GEPA semantics.
         scores = {cid: r.sum_score() for cid, r in self._results.items()}
         _, cleaned_per_key_best = self._remove_dominated_programs(
-            self._per_key_best, scores,
+            self._active_frontier(), scores,
         )
 
         # Count frequency in cleaned frontier (GEPA: program_frequency_in_validation_pareto_front)

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -10,6 +10,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from helix.population import FrontierType
+
 
 # GEPA parity (audit-rng-state-persist D1):
 # GEPA core/state.py:153 declares ``_VALIDATION_SCHEMA_VERSION: ClassVar[int] = 5``
@@ -93,6 +95,15 @@ class EvolutionState:
     # the frontier.  Empty by default; populated at every accept site (seed,
     # mutation, merge) in evolution.py.
     num_metric_calls_by_discovery: dict[str, int] = field(default_factory=dict)
+    # Persisted ``evolution.frontier_type`` (GEPA ``FrontierType`` parity
+    # — ``src/gepa/core/state.py:22-23``).  Captured at evolve-time so
+    # read-only CLI commands (``helix frontier``, ``helix best``,
+    # ``helix log``) display the frontier with the SAME dimensionality
+    # the evolution run actually used — regardless of what
+    # ``helix.toml`` currently says.  Legacy states without the field
+    # fall back to ``"instance"`` (HELIX's historical single-axis
+    # default) in ``load_state``.
+    frontier_type: FrontierType = "instance"
     # GEPA parity (audit-rng-state-persist D1): persisted schema version.
     # Mirrors GEPA core/state.py:182 / class-var :153.  Bumped when the
     # serialized schema changes; ``load_state`` migrates older payloads by
@@ -141,6 +152,7 @@ def save_state(state: EvolutionState, base_dir: Path) -> None:
         "merge_description_triplets": state.merge_description_triplets,
         "i": state.i,
         "num_metric_calls_by_discovery": state.num_metric_calls_by_discovery,
+        "frontier_type": state.frontier_type,
     }
 
     # Atomic write: write to tmp file in same directory, then rename
@@ -183,6 +195,17 @@ def load_state(base_dir: Path) -> EvolutionState | None:
         evaluations=budget_data.get("evaluations", 0),
     )
 
+    # Migrate legacy frontier_type: default to "instance" (HELIX's
+    # historical single-axis behaviour) for states written before the
+    # field existed.  Narrow the str → FrontierType via a whitelist so
+    # a corrupted state.json can't produce an invalid literal.
+    raw_frontier_type = data.get("frontier_type", "instance")
+    frontier_type: FrontierType = (
+        raw_frontier_type
+        if raw_frontier_type in ("instance", "objective", "hybrid", "cartesian")
+        else "instance"
+    )
+
     return EvolutionState(
         generation=data["generation"],
         frontier=data["frontier"],
@@ -196,6 +219,7 @@ def load_state(base_dir: Path) -> EvolutionState | None:
         merge_description_triplets=data.get("merge_description_triplets", []),
         i=data.get("i", -1),
         num_metric_calls_by_discovery=data.get("num_metric_calls_by_discovery", {}),
+        frontier_type=frontier_type,
         schema_version=SCHEMA_VERSION,
     )
 

--- a/tests/unit/test_cli_frontier_type.py
+++ b/tests/unit/test_cli_frontier_type.py
@@ -1,0 +1,243 @@
+"""Tests for Commit Q: CLI display commands read ``frontier_type``
+from persisted state.json rather than defaulting to ``"instance"``.
+
+Motivation: the evolution run that produced ``.helix/state.json`` used
+some ``config.evolution.frontier_type`` (hybrid / objective /
+cartesian / instance).  ``helix frontier`` / ``helix best`` /
+``helix log`` must display the frontier with the SAME dimensionality
+the run actually used — regardless of whether the user has edited
+``helix.toml`` between the evolve call and the display call.
+
+The fix (persist + read back) keeps display consistent across:
+  * ``helix evolve`` with ``frontier_type="hybrid"``
+  * human edits ``helix.toml`` to ``frontier_type="instance"``
+  * ``helix best --dir <project>`` → still uses ``"hybrid"``
+    because the state.json is the source of truth for what the
+    existing frontier represents.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from helix.cli import _reconstruct_frontier
+from helix.population import Candidate, EvalResult
+from helix.state import BudgetState, EvolutionState, load_state, save_state
+
+
+def _write_evaluation(base_dir: Path, cid: str, result: EvalResult) -> None:
+    eval_dir = base_dir / ".helix" / "evaluations"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    (eval_dir / f"{cid}.json").write_text(json.dumps(result.to_dict(), indent=2))
+
+
+def _write_fake_worktree(base_dir: Path, cid: str) -> None:
+    wt = base_dir / ".helix" / "worktrees" / cid
+    wt.mkdir(parents=True, exist_ok=True)
+
+
+class TestFrontierTypePersistence:
+    def test_state_round_trip_preserves_frontier_type(self, tmp_path: Path) -> None:
+        state = EvolutionState(
+            generation=3,
+            frontier=["g0-s0", "g1-s1"],
+            instance_scores={},
+            budget=BudgetState(),
+            config_hash="abc",
+            frontier_type="hybrid",
+        )
+        save_state(state, tmp_path)
+        loaded = load_state(tmp_path)
+        assert loaded is not None
+        assert loaded.frontier_type == "hybrid"
+
+    @pytest.mark.parametrize(
+        "variant", ["instance", "objective", "hybrid", "cartesian"],
+    )
+    def test_state_round_trip_all_variants(
+        self, tmp_path: Path, variant: str,
+    ) -> None:
+        state = EvolutionState(
+            generation=1,
+            frontier=[],
+            instance_scores={},
+            budget=BudgetState(),
+            config_hash="h",
+            frontier_type=variant,  # type: ignore[arg-type]
+        )
+        save_state(state, tmp_path)
+        loaded = load_state(tmp_path)
+        assert loaded is not None
+        assert loaded.frontier_type == variant
+
+    def test_legacy_state_without_field_defaults_to_instance(
+        self, tmp_path: Path,
+    ) -> None:
+        """state.json from a pre-multi-axis HELIX run has no
+        ``frontier_type`` key; load_state must default to
+        ``"instance"`` (HELIX's historical single-axis behaviour)
+        rather than raising or leaking ``None``."""
+        helix_dir = tmp_path / ".helix"
+        helix_dir.mkdir()
+        legacy = {
+            "schema_version": 1,
+            "generation": 0,
+            "frontier": [],
+            "instance_scores": {},
+            "budget": {"evaluations": 0},
+            "config_hash": "x",
+            "mutation_counter": 0,
+            "merge_counter": 0,
+            "total_merge_invocations": 0,
+            "merge_attempted_pairs": [],
+            "merge_description_triplets": [],
+            "i": -1,
+            "num_metric_calls_by_discovery": {},
+            # frontier_type intentionally absent
+        }
+        (helix_dir / "state.json").write_text(json.dumps(legacy))
+        loaded = load_state(tmp_path)
+        assert loaded is not None
+        assert loaded.frontier_type == "instance"
+
+    def test_corrupt_frontier_type_defaults_to_instance(
+        self, tmp_path: Path,
+    ) -> None:
+        """A state.json with a bogus frontier_type literal (e.g. from
+        a hand-edit) should not crash — narrow to ``"instance"``."""
+        helix_dir = tmp_path / ".helix"
+        helix_dir.mkdir()
+        corrupt = {
+            "schema_version": 1,
+            "generation": 0,
+            "frontier": [],
+            "instance_scores": {},
+            "budget": {"evaluations": 0},
+            "config_hash": "x",
+            "frontier_type": "not-a-real-literal",
+        }
+        (helix_dir / "state.json").write_text(json.dumps(corrupt))
+        loaded = load_state(tmp_path)
+        assert loaded is not None
+        assert loaded.frontier_type == "instance"
+
+
+class TestReconstructFrontierUsesPersistedType:
+    """``_reconstruct_frontier`` builds the display ``ParetoFrontier``
+    with ``state.frontier_type``, NOT the ``ParetoFrontier.__init__``
+    default (``"instance"``).  Guarantees display-path consistency
+    after a post-evolve helix.toml edit."""
+
+    def _build_state(
+        self, tmp_path: Path, frontier_type: str = "hybrid",
+    ) -> EvolutionState:
+        # Seed a minimal on-disk artifact set so _reconstruct_frontier
+        # picks up the single frontier member.
+        base_dir = tmp_path / ".helix"
+        _write_fake_worktree(tmp_path, "g0-s0")
+        er = EvalResult(
+            candidate_id="g0-s0",
+            scores={},
+            asi={},
+            instance_scores={"a": 1.0, "b": 0.0},
+            objective_scores=[{"obj_a": 0.9}, {"obj_a": 0.1}],
+        )
+        _write_evaluation(tmp_path, "g0-s0", er)
+        state = EvolutionState(
+            generation=0,
+            frontier=["g0-s0"],
+            instance_scores={"g0-s0": er.instance_scores},
+            budget=BudgetState(),
+            config_hash="h",
+            frontier_type=frontier_type,  # type: ignore[arg-type]
+        )
+        save_state(state, tmp_path)
+        return state
+
+    def test_reconstruct_uses_hybrid_when_state_says_hybrid(
+        self, tmp_path: Path,
+    ) -> None:
+        state = self._build_state(tmp_path, frontier_type="hybrid")
+        base_dir = tmp_path / ".helix"
+        frontier, _cands, _skipped = _reconstruct_frontier(base_dir, state)
+        # ParetoFrontier exposes the active type via its property.
+        assert frontier.frontier_type == "hybrid"
+
+    def test_reconstruct_uses_objective_when_state_says_objective(
+        self, tmp_path: Path,
+    ) -> None:
+        state = self._build_state(tmp_path, frontier_type="objective")
+        base_dir = tmp_path / ".helix"
+        frontier, _c, _s = _reconstruct_frontier(base_dir, state)
+        assert frontier.frontier_type == "objective"
+
+    def test_reconstruct_defaults_to_instance_without_attr(
+        self, tmp_path: Path,
+    ) -> None:
+        """A state-like object lacking ``frontier_type`` (e.g. an
+        ad-hoc test fixture) falls back to ``"instance"`` — the
+        pre-Q display default, preserved."""
+        _write_fake_worktree(tmp_path, "g0-s0")
+        er = EvalResult(
+            candidate_id="g0-s0",
+            scores={},
+            asi={},
+            instance_scores={"a": 1.0},
+        )
+        _write_evaluation(tmp_path, "g0-s0", er)
+
+        class _LegacyState:
+            generation = 0
+            frontier = ["g0-s0"]
+            instance_scores: dict[str, dict[str, float]] = {"g0-s0": {"a": 1.0}}
+
+        base_dir = tmp_path / ".helix"
+        frontier, _c, _s = _reconstruct_frontier(base_dir, _LegacyState())
+        assert frontier.frontier_type == "instance"
+
+
+class TestDisplayIgnoresCurrentConfig:
+    """End-to-end mock: state.json was written with ``frontier_type="hybrid"``;
+    a subsequent display call must use ``"hybrid"`` for its frontier,
+    even if the current helix.toml config says something else.
+
+    This is the core L7 guarantee — display is driven by the PERSISTED
+    run, not the live config.
+    """
+
+    def test_display_uses_state_type_not_config(self, tmp_path: Path) -> None:
+        # Persist a "hybrid" frontier to state.json.
+        _write_fake_worktree(tmp_path, "g0-s0")
+        er = EvalResult(
+            candidate_id="g0-s0",
+            scores={},
+            asi={},
+            instance_scores={"a": 1.0, "b": 0.5},
+            objective_scores=[{"obj_a": 0.9}, {"obj_a": 0.1}],
+        )
+        _write_evaluation(tmp_path, "g0-s0", er)
+        state = EvolutionState(
+            generation=0,
+            frontier=["g0-s0"],
+            instance_scores={"g0-s0": er.instance_scores},
+            budget=BudgetState(),
+            config_hash="h",
+            frontier_type="hybrid",
+        )
+        save_state(state, tmp_path)
+
+        # Reload state (simulating a fresh CLI invocation) and build
+        # the display frontier — must still be "hybrid" even though
+        # nothing about the current config has been consulted.
+        reloaded = load_state(tmp_path)
+        assert reloaded is not None
+        base_dir = tmp_path / ".helix"
+        frontier, _c, _s = _reconstruct_frontier(base_dir, reloaded)
+        assert frontier.frontier_type == "hybrid", (
+            "helix frontier / helix best must use the state.json axis, "
+            "not whatever helix.toml currently says"
+        )

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -160,6 +160,79 @@ class TestEvolutionConfigNewFields:
 
 
 # ---------------------------------------------------------------------------
+# evolution.frontier_type — GEPA multi-axis Pareto dimensionality
+# ---------------------------------------------------------------------------
+
+
+class TestEvolutionFrontierType:
+    """``evolution.frontier_type`` mirrors GEPA's ``FrontierType``
+    literal (``src/gepa/core/state.py:22-23``).  HELIX's default is
+    ``"hybrid"`` because O.A. is the right parent for HELIX — GEPA's
+    O.A. defaults to ``"hybrid"`` at
+    ``src/gepa/optimize_anything.py:476``.  The base ``api.py`` default
+    is ``"instance"`` but that's not the right baseline for HELIX.
+    """
+
+    def test_default_is_hybrid(self):
+        cfg = EvolutionConfig()
+        assert cfg.frontier_type == "hybrid"
+
+    @pytest.mark.parametrize(
+        "variant", ["instance", "objective", "hybrid", "cartesian"],
+    )
+    def test_all_literal_variants_accepted(self, variant):
+        cfg = EvolutionConfig(frontier_type=variant)
+        assert cfg.frontier_type == variant
+
+    def test_invalid_variant_rejected(self):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(frontier_type="instance_plus_one")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "variant", ["instance", "objective", "hybrid", "cartesian"],
+    )
+    def test_toml_round_trip_variant(self, tmp_path, variant):
+        toml = tmp_path / "helix.toml"
+        toml.write_text(textwrap.dedent(f"""
+            objective = "Test"
+
+            [evaluator]
+            command = "pytest"
+
+            [evolution]
+            frontier_type = "{variant}"
+        """))
+        cfg = load_config(toml)
+        assert cfg.evolution.frontier_type == variant
+
+    def test_toml_default_when_omitted(self, tmp_path):
+        toml = tmp_path / "helix.toml"
+        toml.write_text(textwrap.dedent("""
+            objective = "Test"
+
+            [evaluator]
+            command = "pytest"
+        """))
+        cfg = load_config(toml)
+        assert cfg.evolution.frontier_type == "hybrid"
+
+    def test_toml_invalid_literal_rejected_at_load(self, tmp_path):
+        toml = tmp_path / "helix.toml"
+        toml.write_text(textwrap.dedent("""
+            objective = "Test"
+
+            [evaluator]
+            command = "pytest"
+
+            [evolution]
+            frontier_type = "not-a-real-type"
+        """))
+        with pytest.raises(SystemExit):
+            # load_config prints + sys.exit(1) on validation errors.
+            load_config(toml)
+
+
+# ---------------------------------------------------------------------------
 # Round-trip TOML loading
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_e2e_multi_axis.py
+++ b/tests/unit/test_e2e_multi_axis.py
@@ -1,0 +1,269 @@
+"""End-to-end: toy evaluator → helix_result parser → EvalResult → ParetoFrontier.
+
+Exercises the full pipeline for this branch's feature set:
+
+  1. An evaluator emits a ``HELIX_RESULT=[[score, {"scores": {obj: v}}], ...]``
+     per-example payload (the shape introduced by the ``helix_result``
+     reshape in commit A).
+  2. :func:`helix.executor.run_evaluator` parses it, populates
+     :attr:`helix.population.EvalResult.instance_scores`,
+     :attr:`EvalResult.per_example_side_info`, and the new
+     :attr:`EvalResult.objective_scores` harvest.
+  3. A :class:`helix.population.ParetoFrontier` constructed with each
+     ``frontier_type`` variant tracks the expected per-axis state when
+     the ``EvalResult`` is added.
+
+The acceptance gate is **not** exercised here — it remains positional
+on ``scores_list`` regardless of ``frontier_type``, and the e2e story
+is about the multi-axis retention path.
+
+GEPA cross-references:
+  * Evaluator contract — per-example ``(score, side_info)``:
+    ``src/gepa/optimize_anything.py:387-438``.
+  * ``side_info["scores"]`` → ``objective_scores`` harvest:
+    ``optimize_anything_adapter.py:260-272``.
+  * ``FrontierType`` literal:
+    ``src/gepa/core/state.py:22-23``.
+  * O.A. default ``"hybrid"``:
+    ``src/gepa/optimize_anything.py:476``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helix.config import EvaluatorConfig, HelixConfig
+from helix.executor import run_evaluator
+from helix.population import Candidate, ParetoFrontier
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(cid: str, worktree_path: Path) -> Candidate:
+    return Candidate(
+        id=cid,
+        worktree_path=str(worktree_path),
+        branch_name=f"branch-{cid}",
+        generation=0,
+        parent_id=None,
+        parent_ids=[],
+        operation="mutation",
+    )
+
+
+def _make_config() -> HelixConfig:
+    return HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(
+            command="python eval.py",
+            score_parser="helix_result",
+            include_stdout=True,
+            include_stderr=True,
+            extra_commands=[],
+        ),
+    )
+
+
+def _mock_subprocess(stdout: str, returncode: int = 0) -> MagicMock:
+    m = MagicMock()
+    m.stdout = stdout
+    m.stderr = ""
+    m.returncode = returncode
+    return m
+
+
+def _write_batch(worktree: Path, ids: list[str]) -> None:
+    (worktree / "helix_batch.json").write_text(json.dumps(ids))
+
+
+def _toy_helix_result(
+    scores: list[float], objective_dicts: list[dict[str, float]] | None = None
+) -> str:
+    """Build a per-example ``HELIX_RESULT=`` line.
+
+    Each inner pair is ``[score_i, {"scores": objective_dicts[i]}]`` —
+    the GEPA O.A. user-facing evaluator shape.
+    """
+    if objective_dicts is None:
+        objective_dicts = [{} for _ in scores]
+    assert len(scores) == len(objective_dicts)
+    payload = [
+        [s, {"scores": obj} if obj else {}]
+        for s, obj in zip(scores, objective_dicts)
+    ]
+    return "HELIX_RESULT=" + json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# E2E: each frontier_type tracks the expected state
+# ---------------------------------------------------------------------------
+
+
+class TestE2EMultiAxisFrontier:
+    """A toy evaluator emits per-example ``[score, {"scores": {obj: v}}]``
+    pairs for three candidates with complementary strengths.  We then
+    check each ``frontier_type`` path tracks the expected state.
+    """
+
+    def _setup_candidates(
+        self, tmp_path: Path, mocker
+    ) -> dict[str, Any]:  # type: ignore[valid-type]
+        """Build three candidates (a, b, c) each evaluated on the same
+        2-example valset.
+
+        Scores:
+          a — instance [1.0, 0.0], obj_fast={1.0, 0.0}, obj_safe={0.0, 1.0}
+          b — instance [0.0, 1.0], obj_fast={0.0, 1.0}, obj_safe={1.0, 0.0}
+          c — instance [0.5, 0.5], obj_fast={0.3, 0.3}, obj_safe={0.5, 0.5}
+
+        Per-axis winners:
+          * instance i0 → a (1.0); instance i1 → b (1.0) — c is dominated
+            on instance axis.
+          * obj_fast mean: a=0.5, b=0.5, c=0.3 — a and b tie.
+          * obj_safe mean: a=0.5, b=0.5, c=0.5 — all three tie.
+
+        Returns a dict of ``{cid: EvalResult}`` with
+        ``objective_scores`` populated by the parser via
+        ``side_info["scores"]`` harvest.
+        """
+        ids = ["i0", "i1"]
+        _write_batch(tmp_path, ids)
+
+        def _eval_for(
+            scores_list: list[float],
+            fast: list[float],
+            safe: list[float],
+        ):
+            obj_dicts = [
+                {"obj_fast": f, "obj_safe": s} for f, s in zip(fast, safe)
+            ]
+            return _toy_helix_result(scores_list, obj_dicts)
+
+        per_candidate: dict[str, str] = {
+            "a": _eval_for([1.0, 0.0], [1.0, 0.0], [0.0, 1.0]),
+            "b": _eval_for([0.0, 1.0], [0.0, 1.0], [1.0, 0.0]),
+            "c": _eval_for([0.5, 0.5], [0.3, 0.3], [0.5, 0.5]),
+        }
+
+        results: dict[str, Any] = {}  # type: ignore[valid-type]
+        for cid, stdout in per_candidate.items():
+            mocker.patch(
+                "helix.executor.subprocess.run",
+                return_value=_mock_subprocess(stdout, returncode=0),
+            )
+            cand = _make_candidate(cid, tmp_path)
+            results[cid] = run_evaluator(
+                cand, _make_config(), split="val",
+            )
+        return results
+
+    def test_instance_path_tracks_per_example_winners(
+        self, tmp_path: Path, mocker
+    ):
+        results = self._setup_candidates(tmp_path, mocker)
+
+        frontier = ParetoFrontier(frontier_type="instance")
+        for cid, r in results.items():
+            frontier.add(_make_candidate(cid, tmp_path), r)
+
+        # i0 best = 1.0 (a); i1 best = 1.0 (b); c is dominated on instance.
+        assert frontier._per_key_best["i0"] == {"a"}
+        assert frontier._per_key_best["i1"] == {"b"}
+        assert frontier.get_non_dominated() == {"a", "b"}
+        assert frontier.is_dominated("c")
+
+    def test_objective_path_tracks_mean_across_valset(
+        self, tmp_path: Path, mocker
+    ):
+        results = self._setup_candidates(tmp_path, mocker)
+
+        frontier = ParetoFrontier(frontier_type="objective")
+        for cid, r in results.items():
+            frontier.add(_make_candidate(cid, tmp_path), r)
+
+        # obj_fast means: a=0.5, b=0.5, c=0.3 — a and b tie for best.
+        assert frontier._objective_best["obj_fast"] == {"a", "b"}
+        assert frontier._objective_best_score["obj_fast"] == pytest.approx(0.5)
+        # obj_safe means: all three at 0.5.
+        assert frontier._objective_best["obj_safe"] == {"a", "b", "c"}
+
+    def test_hybrid_path_unions_instance_and_objective(
+        self, tmp_path: Path, mocker
+    ):
+        results = self._setup_candidates(tmp_path, mocker)
+
+        frontier = ParetoFrontier(frontier_type="hybrid")
+        for cid, r in results.items():
+            frontier.add(_make_candidate(cid, tmp_path), r)
+
+        # Active frontier is the union with prefixed keys.
+        active = frontier._active_frontier()
+        assert "inst::i0" in active and "inst::i1" in active
+        assert "obj::obj_fast" in active and "obj::obj_safe" in active
+
+        # Coverage-based dominance: c appears only on ``obj::obj_safe``
+        # (tied with a and b).  Both a and b are also on that front, so
+        # ``{a, b}`` covers every front c participates in → c is
+        # dominated.  (Ties alone don't protect from coverage dominance
+        # when the tying dominators cover c's only front.)  Non-dominated
+        # set = {a, b}.  Under ``"instance"`` alone the result would be
+        # the same; hybrid adds the objective keys but doesn't rescue c
+        # here because a and b still cover every c-participating key.
+        non_dom = frontier.get_non_dominated()
+        assert non_dom == {"a", "b"}
+
+    def test_cartesian_path_tracks_per_cell_winners(
+        self, tmp_path: Path, mocker
+    ):
+        results = self._setup_candidates(tmp_path, mocker)
+
+        frontier = ParetoFrontier(frontier_type="cartesian")
+        for cid, r in results.items():
+            frontier.add(_make_candidate(cid, tmp_path), r)
+
+        # (i0, obj_fast): a=1.0, b=0.0, c=0.3 → a wins.
+        assert frontier._cartesian_best["i0::obj_fast"] == {"a"}
+        # (i1, obj_fast): a=0.0, b=1.0, c=0.3 → b wins.
+        assert frontier._cartesian_best["i1::obj_fast"] == {"b"}
+        # (i0, obj_safe): a=0.0, b=1.0, c=0.5 → b wins.
+        assert frontier._cartesian_best["i0::obj_safe"] == {"b"}
+        # (i1, obj_safe): a=1.0, b=0.0, c=0.5 → a wins.
+        assert frontier._cartesian_best["i1::obj_safe"] == {"a"}
+
+    def test_parser_wires_all_data_onto_eval_result(
+        self, tmp_path: Path, mocker
+    ):
+        """End-to-end sanity: per-example side_info dicts (full raw),
+        objective_scores harvest (just the "scores" sub-dict), and
+        instance_scores (positional-to-ids zip) are all populated on
+        the ``EvalResult`` returned by :func:`run_evaluator`."""
+        ids = ["i0", "i1"]
+        _write_batch(tmp_path, ids)
+        payload = [
+            [1.0, {"trajectory": "fast path", "scores": {"speed": 0.9, "cost": 0.1}}],
+            [0.5, {"trajectory": "slow path", "scores": {"speed": 0.3, "cost": 0.5}}],
+        ]
+        mocker.patch(
+            "helix.executor.subprocess.run",
+            return_value=_mock_subprocess("HELIX_RESULT=" + json.dumps(payload)),
+        )
+        result = run_evaluator(
+            _make_candidate("a", tmp_path), _make_config(), split="val",
+        )
+
+        assert result.instance_scores == {"i0": 1.0, "i1": 0.5}
+        assert result.per_example_side_info == [
+            {"trajectory": "fast path", "scores": {"speed": 0.9, "cost": 0.1}},
+            {"trajectory": "slow path", "scores": {"speed": 0.3, "cost": 0.5}},
+        ]
+        assert result.objective_scores == [
+            {"speed": 0.9, "cost": 0.1},
+            {"speed": 0.3, "cost": 0.5},
+        ]

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -744,6 +744,101 @@ class TestCachedEvaluateBatch:
         # Merged scores cover ALL requested ids: cached 0/2 + fresh 1.
         assert result.instance_scores == {"0": 0.11, "1": 0.22, "2": 0.33}
 
+    def test_partial_cache_hit_per_example_fields_merge(self, mocker: Any) -> None:
+        """Partial-cache-hit merge of ``per_example_side_info`` and
+        ``objective_scores``.  Pins the closure side-channel design
+        from commit H (``_cached_evaluate_batch``):
+
+          * cache-hit positions get ``{}`` for per_example_side_info
+            (the cache has no slot for freeform side_info so the merge
+            can't round-trip it — their prior side_info was consumed
+            by the reflection prompt at their original eval time);
+          * fresh miss positions get the per_example_side_info dict
+            from the fresh EvalResult, zipped by id;
+          * ``objective_scores`` IS round-tripped through the cache
+            (it has a dedicated slot — see
+            ``eval_cache.CachedEvaluation.objective_scores``), so
+            cache-hit positions get back the previously-stored dict
+            and miss positions get the freshly-harvested dict.
+        """
+        from helix.eval_cache import EvaluationCache as MBCache
+        from helix.evolution import _cached_evaluate_batch
+
+        cache: MBCache[object, str] = MBCache[object, str]()
+        cand = self._make_cand("cand-pcfm")
+        cand_dict = {"id": cand.id, "split": "train"}
+        # Pre-populate ids "0" and "2" with both score AND
+        # objective_scores (the cache stores these natively).
+        cache.put_batch(
+            cand_dict,
+            ["0", "2"],
+            [None, None],
+            [0.11, 0.33],
+            objective_scores_list=[
+                {"obj_alpha": 0.11, "obj_beta": 0.8},
+                {"obj_alpha": 0.33, "obj_beta": 0.1},
+            ],
+        )
+        # "1" is uncached — the evaluator is invoked with it only, and
+        # must return an ``EvalResult`` that carries per_example_side_info
+        # + objective_scores for the merge path to thread through.
+
+        def fake_run(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            # Produce one fresh entry for each requested uncached id.
+            ids = list(instance_ids or [])
+            return EvalResult(
+                candidate_id=candidate.id,
+                scores={},
+                asi={},
+                instance_scores={eid: 0.22 for eid in ids},
+                per_example_side_info=[
+                    {"trajectory": f"fresh_trace_{eid}", "rollout_id": f"fresh__{eid}"}
+                    for eid in ids
+                ],
+                objective_scores=[
+                    {"obj_alpha": 0.22, "obj_beta": 0.5}
+                    for _ in ids
+                ],
+            )
+
+        mocker.patch("helix.evolution.run_evaluator", side_effect=fake_run)
+        mocker.patch("helix.evolution._write_helix_batch")
+
+        result, num_actual = _cached_evaluate_batch(
+            cand, ["0", "1", "2"], cache, self._trivial_config(), "train",
+        )
+
+        # instance_scores merge: cached 0/2 + fresh 1 (established
+        # earlier by ``test_partial_cache_hit``).
+        assert result.instance_scores == {"0": 0.11, "1": 0.22, "2": 0.33}
+        assert num_actual == 1
+
+        # objective_scores round-trip fully through the cache (dedicated
+        # slot in ``CachedEvaluation``).  Each slot positional to
+        # ``example_ids``:
+        assert result.objective_scores is not None
+        assert result.objective_scores == [
+            {"obj_alpha": 0.11, "obj_beta": 0.8},     # cached id "0"
+            {"obj_alpha": 0.22, "obj_beta": 0.5},     # fresh id "1"
+            {"obj_alpha": 0.33, "obj_beta": 0.1},     # cached id "2"
+        ]
+
+        # per_example_side_info: cache has no slot, so cache-hit
+        # positions get ``{}`` placeholder; the fresh miss position
+        # gets the dict we returned from fake_run.
+        assert result.per_example_side_info is not None
+        assert result.per_example_side_info == [
+            {},                                                               # cached "0" → {}
+            {"trajectory": "fresh_trace_1", "rollout_id": "fresh__1"},         # fresh "1"
+            {},                                                               # cached "2" → {}
+        ]
+
     def test_cache_populates_after_fresh_eval(self, mocker: Any) -> None:
         """After a fresh eval, a second call with the same ids is a full hit."""
         from helix.eval_cache import EvaluationCache as MBCache

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -185,8 +185,10 @@ class TestMinibatchGateIntegration:
         mutated = _make_candidate("g1-s1")
         all_mocks["mutate"].return_value = mutated
 
-        # instance_ids should be set on parent/child gating calls
-        seen_instance_ids: list[list[str] | None] = []
+        # Filter to minibatch (train-split) calls only — seed-eval and
+        # child full-val are both on "val" split with explicit ids now
+        # (helix_result requires helix_batch.json on every invocation).
+        train_minibatch_calls: list[list[str]] = []
 
         def run_eval(
             candidate: Candidate,
@@ -195,13 +197,14 @@ class TestMinibatchGateIntegration:
             instance_ids: list[str] | None = None,
             **kwargs: Any,
         ) -> EvalResult:
-            seen_instance_ids.append(instance_ids)
+            if split == "train" and instance_ids is not None:
+                train_minibatch_calls.append(list(instance_ids))
             if instance_ids is not None:
-                # minibatch eval: return small per-id scores
+                # minibatch / explicit-id eval: return small per-id scores
                 if candidate.id == seed.id:
                     return _make_result(candidate.id, {i: 0.3 for i in instance_ids})
                 return _make_result(candidate.id, {i: 0.9 for i in instance_ids})
-            # full val eval: moderate scores
+            # full val eval (legacy path, single-task mode): moderate scores
             return _make_result(candidate.id, {"v1": 0.5, "v2": 0.5})
 
         all_mocks["run_evaluator"].side_effect = run_eval
@@ -212,14 +215,14 @@ class TestMinibatchGateIntegration:
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
         # Parent minibatch call + child minibatch call both carry instance_ids.
-        minibatch_calls = [x for x in seen_instance_ids if x is not None]
-        assert len(minibatch_calls) >= 2, (
-            f"Expected at least parent+child minibatch eval calls, got {seen_instance_ids}"
+        assert len(train_minibatch_calls) >= 2, (
+            "Expected at least parent+child minibatch eval calls on train split, "
+            f"got {train_minibatch_calls}"
         )
         # Parent and child minibatches should be the SAME subsample.
-        assert minibatch_calls[0] == minibatch_calls[1]
+        assert train_minibatch_calls[0] == train_minibatch_calls[1]
         # minibatch_size=2 → two ids.
-        assert len(minibatch_calls[0]) == 2
+        assert len(train_minibatch_calls[0]) == 2
 
     def test_rejected_proposal_skips_full_val_eval(
         self, tmp_path: Path, all_mocks: dict[str, Any]
@@ -273,7 +276,10 @@ class TestMinibatchGateIntegration:
         all_mocks["create_seed_worktree"].return_value = seed
         all_mocks["mutate"].return_value = _make_candidate("g1-s1")
 
-        child_val_calls: list[list[str] | None] = []
+        # Full-val evals now always carry explicit instance_ids when a
+        # loader is configured (helix_result requires helix_batch.json).
+        # Distinguish child full-val from child minibatch by split="val".
+        child_val_calls: list[list[str]] = []
 
         def run_eval(
             candidate: Candidate,
@@ -282,8 +288,12 @@ class TestMinibatchGateIntegration:
             instance_ids: list[str] | None = None,
             **kwargs: Any,
         ) -> EvalResult:
-            if candidate.id == "g1-s1" and instance_ids is None:
-                child_val_calls.append(instance_ids)
+            if (
+                candidate.id == "g1-s1"
+                and split == "val"
+                and instance_ids is not None
+            ):
+                child_val_calls.append(list(instance_ids))
             if instance_ids is not None:
                 if candidate.id == seed.id:
                     return _make_result(candidate.id, {i: 0.1 for i in instance_ids})
@@ -467,7 +477,15 @@ class TestMinibatchGateIntegration:
             instance_ids: list[str] | None = None,
             **kwargs: Any,
         ) -> EvalResult:
-            if candidate.id == seed.id and instance_ids is not None:
+            # Parent minibatch evals run on split="train"; the seed
+            # full-val eval runs on split="val" with explicit ids too
+            # (helix_result requires helix_batch.json on every
+            # invocation), so gate on split to avoid counting it.
+            if (
+                candidate.id == seed.id
+                and split == "train"
+                and instance_ids is not None
+            ):
                 parent_minibatches.append(list(instance_ids))
             if instance_ids is not None:
                 # Child scores slightly worse so all get rejected -- keeps
@@ -938,15 +956,23 @@ class TestParentMinibatchParallelism:
             instance_ids: list[str] | None = None,
             **kwargs: Any,
         ) -> EvalResult:
-            if candidate.id == seed.id and instance_ids is not None:
-                # Parent-minibatch eval site.  Small sleep guarantees the
-                # first eval is still in flight when the second submit
-                # fires, so the ThreadPoolExecutor spawns a second worker
-                # thread (rather than reusing W1 after an instant task).
-                # The per-worktree lock (see ``_worktree_lock``) serialises
-                # the subsequent lock acquisition, but both tasks still
-                # execute on DIFFERENT worker threads — our concurrency
-                # signal.
+            # Parent-minibatch eval site — gated on split="train" to
+            # exclude the seed full-val eval (which now also runs with
+            # explicit ids on split="val" because helix_result needs
+            # helix_batch.json on every invocation).
+            if (
+                candidate.id == seed.id
+                and split == "train"
+                and instance_ids is not None
+            ):
+                # Small sleep guarantees the first eval is still in
+                # flight when the second submit fires, so the
+                # ThreadPoolExecutor spawns a second worker thread
+                # (rather than reusing W1 after an instant task).
+                # The per-worktree lock (see ``_worktree_lock``)
+                # serialises the subsequent lock acquisition, but both
+                # tasks still execute on DIFFERENT worker threads —
+                # our concurrency signal.
                 parent_eval_threads.add(threading.get_ident())
                 parent_minibatches.append(list(instance_ids))
                 time.sleep(0.05)
@@ -1071,7 +1097,16 @@ class TestParentEvalExceptionDoesNotAbortGeneration:
             instance_ids: list[str] | None = None,
             **kwargs: Any,
         ) -> EvalResult:
-            if candidate.id == seed.id and instance_ids is not None:
+            # Parent-minibatch eval — gated on split="train" so the seed
+            # full-val eval (now also explicit-ids on "val" because
+            # helix_result needs helix_batch.json) doesn't inflate the
+            # count.  Without this filter the seed eval would be
+            # indistinguishable from a parent minibatch eval.
+            if (
+                candidate.id == seed.id
+                and split == "train"
+                and instance_ids is not None
+            ):
                 parent_eval_attempts.append(True)
                 # Raise on the second parent-eval only (stable because
                 # ``parent_eval_attempts`` is append-ordered).

--- a/tests/unit/test_executor_zero_fill_warning.py
+++ b/tests/unit/test_executor_zero_fill_warning.py
@@ -1,0 +1,184 @@
+"""Tests for the zero-fill warning emitted by :func:`helix.executor.run_evaluator`.
+
+When HELIX asks the evaluator for per-example scores via ``instance_ids``
+but the parser's ``instance_scores`` does not cover every requested id,
+the executor silently fills the missing ids with ``0.0`` so the
+minibatch gate can complete.  Historically that silence hid the
+id-key-mismatch footgun — 113 generations of evolution once failed
+silently because the old ``helix_result`` contract required an id-keyed
+``side_info["scores"]`` dict and the evaluator keyed it by aggregate
+metric names instead.
+
+The new per-example ``helix_result`` contract eliminates that specific
+footgun at the parser level (it raises on length mismatch), but the
+warning still has value as defense in depth for every other parser —
+e.g. ``score_parser="exitcode"`` combined with a minibatch
+``instance_ids`` subset, which can't produce per-id scores by
+construction and so zero-fills every requested id.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from helix.config import EvaluatorConfig, HelixConfig
+from helix.executor import run_evaluator
+from helix.population import Candidate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(worktree_path: Path) -> Candidate:
+    return Candidate(
+        id="cand-zfw",
+        worktree_path=str(worktree_path),
+        branch_name="helix/cand-zfw",
+        generation=1,
+        parent_id=None,
+        parent_ids=[],
+        operation="mutate",
+    )
+
+
+def _make_config(score_parser: str = "exitcode") -> HelixConfig:
+    return HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(
+            command="python eval.py",
+            score_parser=score_parser,
+            include_stdout=True,
+            include_stderr=True,
+            extra_commands=[],
+        ),
+    )
+
+
+def _mock_subprocess(stdout: str, returncode: int = 0, stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.stdout = stdout
+    m.stderr = stderr
+    m.returncode = returncode
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestZeroFillWarning:
+    def test_warns_when_exitcode_parser_cannot_produce_per_id_scores(
+        self, tmp_path: Path, mocker, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # ``exitcode`` parser returns ``{"success": 1.0}`` (single key) —
+        # not one entry per requested id.  The post-filter will zero-fill
+        # every requested id, and the warning must surface that.
+        mocker.patch(
+            "helix.executor.subprocess.run",
+            return_value=_mock_subprocess("ok\n", returncode=0),
+        )
+
+        candidate = _make_candidate(tmp_path)
+        instance_ids = [f"task__{i}" for i in range(4)]
+
+        with caplog.at_level(logging.WARNING, logger="helix.executor"):
+            result = run_evaluator(
+                candidate,
+                _make_config(score_parser="exitcode"),
+                split="train",
+                instance_ids=instance_ids,
+            )
+
+        # All requested ids present in the post-filtered dict, all zero-filled.
+        assert set(result.instance_scores.keys()) == set(instance_ids)
+        assert all(v == 0.0 for v in result.instance_scores.values())
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "missing instance_scores" in r.getMessage()
+        ]
+        assert warnings, (
+            "Expected a 'missing instance_scores' warning when the parser "
+            "cannot produce id-keyed scores but a minibatch subset was requested"
+        )
+        msg = warnings[0].getMessage()
+        assert "4/4" in msg
+        # Sample of up to 5 ids appears in the log body.
+        assert "task__0" in msg
+        # Log nudges the user toward the fix.
+        assert "helix_result" in msg
+
+    def test_no_warning_when_parser_covers_all_ids(
+        self, tmp_path: Path, mocker, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        ids = ["task__0", "task__1", "task__2"]
+        (tmp_path / "helix_batch.json").write_text(json.dumps(ids))
+        # Per-example payload: one [score, side_info] pair per id.
+        payload = [[1.0, {}], [0.5, {}], [0.0, {}]]
+        helix_line = f"HELIX_RESULT={json.dumps(payload)}"
+        mocker.patch(
+            "helix.executor.subprocess.run",
+            return_value=_mock_subprocess(helix_line + "\n", returncode=0),
+        )
+
+        candidate = _make_candidate(tmp_path)
+
+        with caplog.at_level(logging.WARNING, logger="helix.executor"):
+            run_evaluator(
+                candidate,
+                _make_config(score_parser="helix_result"),
+                split="train",
+                instance_ids=ids,
+            )
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "missing instance_scores" in r.getMessage()
+        ]
+        assert not warnings, (
+            "No warning expected when every requested id is present in the "
+            f"parser's returned instance_scores; got: {[r.getMessage() for r in warnings]}"
+        )
+
+    def test_warning_sample_truncates_to_five(
+        self, tmp_path: Path, mocker, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # exitcode parser + many requested ids → all zero-filled; log
+        # must cap the sample list at 5 and surface the overflow count.
+        mocker.patch(
+            "helix.executor.subprocess.run",
+            return_value=_mock_subprocess("ok\n", returncode=0),
+        )
+
+        candidate = _make_candidate(tmp_path)
+        instance_ids = [f"task__{i}" for i in range(8)]
+
+        with caplog.at_level(logging.WARNING, logger="helix.executor"):
+            run_evaluator(
+                candidate,
+                _make_config(score_parser="exitcode"),
+                split="train",
+                instance_ids=instance_ids,
+            )
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "missing instance_scores" in r.getMessage()
+        ]
+        assert warnings
+        msg = warnings[0].getMessage()
+        assert "8/8" in msg
+        # First five ids shown (task__0..task__4), and "+3 more" overflow marker present.
+        assert "task__0" in msg and "task__4" in msg
+        assert "+3 more" in msg

--- a/tests/unit/test_helix_result.py
+++ b/tests/unit/test_helix_result.py
@@ -177,14 +177,19 @@ class TestHelixResultParsing:
     @patch("helix.executor.subprocess.run")
     def test_multiple_helix_result_lines_raises(self, mock_run, tmp_path: Path):
         """The executor guards against multiple ``HELIX_RESULT=`` lines
-        and raises before the parser runs."""
+        and raises ``EvaluatorError`` before the parser runs.  Using
+        ``EvaluatorError`` (not ``RuntimeError``) keeps this
+        evaluator-contract violation on the same error-handling path
+        as the parser's own contract violations (length mismatch,
+        missing helix_batch.json, etc.) — upstream ``HelixError``
+        handlers in ``evolution.py`` treat them uniformly."""
         _write_batch(tmp_path, ["task__0"])
         line1 = f"HELIX_RESULT={json.dumps(_pairs([0.9]))}"
         line2 = f"HELIX_RESULT={json.dumps(_pairs([0.1]))}"
         stdout = f"preamble\n{line1}\nmiddle\n{line2}\nend\n"
         mock_run.return_value = _mock_subprocess_result(stdout, returncode=0)
 
-        with pytest.raises(RuntimeError, match="Multiple HELIX_RESULT= lines found"):
+        with pytest.raises(EvaluatorError, match="Multiple HELIX_RESULT= lines found"):
             run_evaluator(make_candidate(tmp_path), make_config(), split="val")
 
     @patch("helix.executor.subprocess.run")

--- a/tests/unit/test_helix_result.py
+++ b/tests/unit/test_helix_result.py
@@ -1,14 +1,27 @@
-"""Tests for HELIX_RESULT= evaluator output support."""
+"""Executor-level tests for ``score_parser="helix_result"`` — now the
+GEPA-parity per-example contract.
+
+BREAKING (pre-1.0): ``helix_result`` previously accepted one
+``[score, side_info_dict]`` blob per batch; it now takes one
+``[score, side_info]`` pair **per example**, positional to the ids in
+``helix_batch.json``.  HELIX zips them into id-keyed
+``instance_scores`` (for the minibatch gate) and stores the raw
+per-example side_info list on ``EvalResult`` for the reflection
+prompt.  See :mod:`helix.parsers.helix_result` and
+``/tmp/gepa_audit_report.md``.
+"""
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig, EvaluatorConfig
+from helix.exceptions import EvaluatorError
 from helix.executor import run_evaluator
 from helix.mutator import build_mutation_prompt
 
@@ -18,10 +31,10 @@ from helix.mutator import build_mutation_prompt
 # ---------------------------------------------------------------------------
 
 
-def make_candidate(worktree_path: str = "/tmp/fake-worktree") -> Candidate:
+def make_candidate(worktree_path: str | Path = "/tmp/fake-worktree") -> Candidate:
     return Candidate(
         id="cand-001",
-        worktree_path=worktree_path,
+        worktree_path=str(worktree_path),
         branch_name="helix/cand-001",
         generation=1,
         parent_id=None,
@@ -32,7 +45,7 @@ def make_candidate(worktree_path: str = "/tmp/fake-worktree") -> Candidate:
 
 def make_config(
     command: str = "python eval.py",
-    score_parser: str = "exitcode",
+    score_parser: str = "helix_result",
 ) -> HelixConfig:
     evaluator = EvaluatorConfig(
         command=command,
@@ -53,112 +66,160 @@ def _mock_subprocess_result(stdout: str, stderr: str = "", returncode: int = 0):
     return result
 
 
+def _write_batch(worktree: Path, ids: list[str]) -> None:
+    (worktree / "helix_batch.json").write_text(json.dumps(ids))
+
+
+def _pairs(scores: list[float], side_infos: list[dict] | None = None) -> list[list]:
+    if side_infos is None:
+        side_infos = [{} for _ in scores]
+    return [[s, si] for s, si in zip(scores, side_infos)]
+
+
 # ---------------------------------------------------------------------------
-# Tests: HELIX_RESULT= parsing in executor
+# Tests: HELIX_RESULT= per-example parsing via run_evaluator
 # ---------------------------------------------------------------------------
 
 
 class TestHelixResultParsing:
-    """Test that HELIX_RESULT= lines are parsed from evaluator stdout."""
+    """End-to-end: helix_result parser dispatch + per-example side_info
+    plumbing onto ``EvalResult``."""
 
     @patch("helix.executor.subprocess.run")
-    def test_helix_result_parsed(self, mock_run):
-        """HELIX_RESULT=[score, side_info] should override parser score and set side_info."""
-        side_info = {"accuracy": 0.95, "loss": 0.12, "note": "converged fast"}
-        helix_line = f"HELIX_RESULT={json.dumps([0.95, side_info])}"
+    def test_per_example_pairs_become_id_keyed(self, mock_run, tmp_path: Path):
+        """Each ``[score, side_info]`` pair is positional to the id list
+        in ``helix_batch.json``.  HELIX zips them into
+        ``instance_scores`` and stores the side_info list on
+        ``EvalResult``."""
+        ids = ["task__0", "task__1", "task__2"]
+        _write_batch(tmp_path, ids)
+        side_infos = [
+            {"note": "example 0", "loss": 0.1},
+            {"note": "example 1", "loss": 0.2},
+            {"note": "example 2"},
+        ]
+        helix_line = f"HELIX_RESULT={json.dumps(_pairs([1.0, 0.0, 0.5], side_infos))}"
         stdout = f"Some evaluator output\n{helix_line}\nMore output\n"
         mock_run.return_value = _mock_subprocess_result(stdout, returncode=0)
 
-        config = make_config()
-        candidate = make_candidate()
-        result = run_evaluator(candidate, config, split="val")
+        result = run_evaluator(make_candidate(tmp_path), make_config(), split="val")
 
-        assert result.scores["success"] == 0.95
-        assert result.side_info == side_info
-
-    @patch("helix.executor.subprocess.run")
-    def test_no_helix_result_backward_compat(self, mock_run):
-        """Without HELIX_RESULT=, fallback to parser (backward compatible)."""
-        stdout = "Regular evaluator output\nNo special lines\n"
-        mock_run.return_value = _mock_subprocess_result(stdout, returncode=0)
-
-        config = make_config()
-        candidate = make_candidate()
-        result = run_evaluator(candidate, config, split="val")
-
-        # exitcode parser: returncode 0 -> success=1.0
-        assert result.scores["success"] == 1.0
+        assert result.instance_scores == {
+            "task__0": 1.0, "task__1": 0.0, "task__2": 0.5,
+        }
+        # Aggregate is mean(scores).
+        assert result.scores["success"] == pytest.approx(0.5)
+        # Per-example side_info captured in id order.
+        assert result.per_example_side_info == side_infos
+        # Legacy batch-level side_info is not populated by this parser.
         assert result.side_info is None
 
     @patch("helix.executor.subprocess.run")
-    def test_helix_result_malformed_json_falls_back(self, mock_run):
-        """Malformed HELIX_RESULT= line should not crash; side_info stays None."""
-        stdout = "HELIX_RESULT=not-valid-json\nOther output\n"
-        mock_run.return_value = _mock_subprocess_result(stdout, returncode=0)
+    def test_missing_helix_result_raises_evaluator_error(
+        self, mock_run, tmp_path: Path
+    ):
+        """No ``HELIX_RESULT=`` line on stdout → strict parser raises."""
+        _write_batch(tmp_path, ["task__0"])
+        mock_run.return_value = _mock_subprocess_result(
+            "Regular evaluator output\nNo special lines\n", returncode=0,
+        )
 
-        config = make_config()
-        candidate = make_candidate()
-        result = run_evaluator(candidate, config, split="val")
-
-        # Falls back to parser path
-        assert result.side_info is None
+        with pytest.raises(EvaluatorError, match="no HELIX_RESULT"):
+            run_evaluator(make_candidate(tmp_path), make_config(), split="val")
 
     @patch("helix.executor.subprocess.run")
-    def test_helix_result_multiple_lines_raises(self, mock_run):
-        """When multiple HELIX_RESULT= lines exist, a RuntimeError is raised."""
-        side_info_1 = {"source": "first"}
-        side_info_2 = {"source": "second"}
-        line1 = f"HELIX_RESULT={json.dumps([0.9, side_info_1])}"
-        line2 = f"HELIX_RESULT={json.dumps([0.1, side_info_2])}"
+    def test_malformed_helix_result_raises(self, mock_run, tmp_path: Path):
+        """Malformed ``HELIX_RESULT=`` line → strict parser raises rather
+        than falling back (the fallback was the old footgun)."""
+        _write_batch(tmp_path, ["task__0"])
+        mock_run.return_value = _mock_subprocess_result(
+            "HELIX_RESULT=not-valid-json\nOther output\n", returncode=0,
+        )
+
+        with pytest.raises(EvaluatorError, match="JSON-decode"):
+            run_evaluator(make_candidate(tmp_path), make_config(), split="val")
+
+    @patch("helix.executor.subprocess.run")
+    def test_multiple_helix_result_lines_raises(self, mock_run, tmp_path: Path):
+        """The executor guards against multiple ``HELIX_RESULT=`` lines
+        and raises before the parser runs."""
+        _write_batch(tmp_path, ["task__0"])
+        line1 = f"HELIX_RESULT={json.dumps(_pairs([0.9]))}"
+        line2 = f"HELIX_RESULT={json.dumps(_pairs([0.1]))}"
         stdout = f"preamble\n{line1}\nmiddle\n{line2}\nend\n"
         mock_run.return_value = _mock_subprocess_result(stdout, returncode=0)
 
-        config = make_config()
-        candidate = make_candidate()
         with pytest.raises(RuntimeError, match="Multiple HELIX_RESULT= lines found"):
-            run_evaluator(candidate, config, split="val")
+            run_evaluator(make_candidate(tmp_path), make_config(), split="val")
 
     @patch("helix.executor.subprocess.run")
-    def test_helix_result_non_dict_side_info_ignored(self, mock_run):
-        """When payload[1] is not a dict, score is used but side_info stays None."""
-        helix_line = f"HELIX_RESULT={json.dumps([0.75, 'just a string'])}"
-        stdout = f"output\n{helix_line}\n"
-        mock_run.return_value = _mock_subprocess_result(stdout, returncode=0)
-
-        config = make_config()
-        candidate = make_candidate()
-        result = run_evaluator(candidate, config, split="val")
-
-        assert result.scores["success"] == 0.75
-        assert result.side_info is None
-
-    @patch("helix.executor.subprocess.run")
-    def test_helix_result_stdout_still_in_asi(self, mock_run):
-        """Non-HELIX_RESULT stdout lines should still flow into ASI."""
-        side_info = {"metric": 42}
-        helix_line = f"HELIX_RESULT={json.dumps([0.8, side_info])}"
+    def test_stdout_still_in_asi(self, mock_run, tmp_path: Path):
+        """Non-``HELIX_RESULT=`` stdout lines still flow into ASI for
+        the mutation prompt."""
+        _write_batch(tmp_path, ["task__0"])
+        helix_line = f"HELIX_RESULT={json.dumps([[0.8, {'metric': 42}]])}"
         stdout = f"line1\n{helix_line}\nline2\n"
         mock_run.return_value = _mock_subprocess_result(stdout, returncode=0)
 
-        config = make_config()
-        candidate = make_candidate()
-        result = run_evaluator(candidate, config, split="val")
+        result = run_evaluator(make_candidate(tmp_path), make_config(), split="val")
 
-        # Full stdout (including HELIX_RESULT line) is in ASI
+        # Full stdout (including HELIX_RESULT line) is in ASI.
         assert "line1" in result.asi["stdout"]
         assert "line2" in result.asi["stdout"]
 
+    @patch("helix.executor.subprocess.run")
+    def test_instance_ids_subset_post_filter_matches_batch(
+        self, mock_run, tmp_path: Path
+    ):
+        """When HELIX requests a subset via ``instance_ids``, it writes
+        exactly those ids to ``helix_batch.json`` pre-invocation, so the
+        parser's output already matches and the post-filter is a no-op."""
+        ids = ["task__0", "task__1", "task__2"]
+        _write_batch(tmp_path, ids)
+        helix_line = f"HELIX_RESULT={json.dumps(_pairs([0.1, 0.2, 0.3]))}"
+        mock_run.return_value = _mock_subprocess_result(
+            helix_line + "\n", returncode=0,
+        )
+
+        result = run_evaluator(
+            make_candidate(tmp_path), make_config(), split="train", instance_ids=ids,
+        )
+
+        assert result.instance_scores == {"task__0": 0.1, "task__1": 0.2, "task__2": 0.3}
+
+    @patch("helix.executor.subprocess.run")
+    def test_nonzero_returncode_zeros_aggregate_keeps_instance_scores(
+        self, mock_run, tmp_path: Path
+    ):
+        """Non-zero exit: ``scores["success"]`` drops to 0.0 but per-id
+        scores are preserved for diagnostics."""
+        _write_batch(tmp_path, ["task__0", "task__1"])
+        helix_line = f"HELIX_RESULT={json.dumps(_pairs([1.0, 1.0]))}"
+        mock_run.return_value = _mock_subprocess_result(
+            helix_line + "\n", returncode=2,
+        )
+
+        result = run_evaluator(make_candidate(tmp_path), make_config(), split="val")
+
+        assert result.scores["success"] == 0.0
+        assert result.instance_scores == {"task__0": 1.0, "task__1": 1.0}
+
 
 # ---------------------------------------------------------------------------
-# Tests: side_info in mutation prompt
+# Tests: side_info in mutation prompt (legacy batch-level path — unchanged)
 # ---------------------------------------------------------------------------
 
 
 class TestSideInfoInMutationPrompt:
-    """Test that side_info appears as a Diagnostics section in the mutation prompt."""
+    """The legacy batch-level ``EvalResult.side_info`` dict still
+    renders as a Diagnostics section in the mutation prompt.  The new
+    ``per_example_side_info`` is NOT yet wired into the prompt — that's
+    a follow-up PR.  These tests pin the existing rendering so it keeps
+    working for any non-``helix_result`` path that populates the
+    legacy field.
+    """
 
     def test_diagnostics_section_present(self):
-        """When side_info is set, mutation prompt should have ## Diagnostics."""
         eval_result = EvalResult(
             candidate_id="cand-001",
             scores={"success": 0.8},
@@ -172,7 +233,6 @@ class TestSideInfoInMutationPrompt:
         assert "loss: 0.12" in prompt
 
     def test_no_diagnostics_without_side_info(self):
-        """When side_info is None, no Diagnostics section should appear."""
         eval_result = EvalResult(
             candidate_id="cand-001",
             scores={"success": 0.5},
@@ -183,7 +243,6 @@ class TestSideInfoInMutationPrompt:
         assert "## Diagnostics" not in prompt
 
     def test_diagnostics_separate_from_scores(self):
-        """Diagnostics section should be separate from Current Evaluation Scores."""
         eval_result = EvalResult(
             candidate_id="cand-001",
             scores={"success": 0.7},
@@ -198,12 +257,13 @@ class TestSideInfoInMutationPrompt:
 
 
 # ---------------------------------------------------------------------------
-# Tests: EvalResult serialization round-trip
+# Tests: EvalResult serialization round-trip (incl. new per-example fields)
 # ---------------------------------------------------------------------------
 
 
 class TestEvalResultSerialization:
-    """Test that side_info survives to_dict / from_dict round-trip."""
+    """side_info and the new per-example fields survive
+    to_dict / from_dict round-trip."""
 
     def test_round_trip_with_side_info(self):
         er = EvalResult(
@@ -227,5 +287,21 @@ class TestEvalResultSerialization:
         )
         d = er.to_dict()
         assert "side_info" not in d
+        # New per-example field is also omitted when None.
+        assert "per_example_side_info" not in d
         er2 = EvalResult.from_dict(d)
         assert er2.side_info is None
+        assert er2.per_example_side_info is None
+
+    def test_round_trip_with_per_example_side_info(self):
+        er = EvalResult(
+            candidate_id="c1",
+            scores={"success": 0.5},
+            asi={},
+            instance_scores={"a": 1.0, "b": 0.0},
+            per_example_side_info=[{"traj": "A"}, {"traj": "B"}],
+        )
+        d = er.to_dict()
+        assert d["per_example_side_info"] == [{"traj": "A"}, {"traj": "B"}]
+        er2 = EvalResult.from_dict(d)
+        assert er2.per_example_side_info == [{"traj": "A"}, {"traj": "B"}]

--- a/tests/unit/test_helix_result.py
+++ b/tests/unit/test_helix_result.py
@@ -111,8 +111,43 @@ class TestHelixResultParsing:
         assert result.scores["success"] == pytest.approx(0.5)
         # Per-example side_info captured in id order.
         assert result.per_example_side_info == side_infos
+        # No side_info["scores"] → empty objective harvest per example.
+        assert result.objective_scores == [{}, {}, {}]
         # Legacy batch-level side_info is not populated by this parser.
         assert result.side_info is None
+
+    @patch("helix.executor.subprocess.run")
+    def test_side_info_scores_harvested_into_objective_scores(
+        self, mock_run, tmp_path: Path
+    ):
+        """The reserved ``side_info["scores"]`` key is harvested
+        per-example into ``EvalResult.objective_scores`` — GEPA
+        ``EvaluationBatch.objective_scores`` parity.  No frontier
+        wiring this commit; just pass-through onto EvalResult."""
+        ids = ["task__0", "task__1"]
+        _write_batch(tmp_path, ids)
+        payload = [
+            [1.0, {"trajectory": "ok", "scores": {"latency_ms": 42.0, "cost": 0.01}}],
+            [0.5, {"trajectory": "slow", "scores": {"latency_ms": 120.0}}],
+        ]
+        helix_line = f"HELIX_RESULT={json.dumps(payload)}"
+        mock_run.return_value = _mock_subprocess_result(
+            helix_line + "\n", returncode=0,
+        )
+
+        result = run_evaluator(make_candidate(tmp_path), make_config(), split="val")
+
+        assert result.objective_scores == [
+            {"latency_ms": 42.0, "cost": 0.01},
+            {"latency_ms": 120.0},
+        ]
+        # Per-example side_info still carries the full raw dict —
+        # "scores" is harvested, not stripped.
+        assert result.per_example_side_info is not None
+        assert result.per_example_side_info[0]["trajectory"] == "ok"
+        assert result.per_example_side_info[0]["scores"] == {
+            "latency_ms": 42.0, "cost": 0.01,
+        }
 
     @patch("helix.executor.subprocess.run")
     def test_missing_helix_result_raises_evaluator_error(
@@ -287,21 +322,26 @@ class TestEvalResultSerialization:
         )
         d = er.to_dict()
         assert "side_info" not in d
-        # New per-example field is also omitted when None.
+        # New per-example fields are also omitted when None.
         assert "per_example_side_info" not in d
+        assert "objective_scores" not in d
         er2 = EvalResult.from_dict(d)
         assert er2.side_info is None
         assert er2.per_example_side_info is None
+        assert er2.objective_scores is None
 
-    def test_round_trip_with_per_example_side_info(self):
+    def test_round_trip_with_per_example_fields(self):
         er = EvalResult(
             candidate_id="c1",
             scores={"success": 0.5},
             asi={},
             instance_scores={"a": 1.0, "b": 0.0},
             per_example_side_info=[{"traj": "A"}, {"traj": "B"}],
+            objective_scores=[{"latency": 42.0}, {"latency": 99.0}],
         )
         d = er.to_dict()
         assert d["per_example_side_info"] == [{"traj": "A"}, {"traj": "B"}]
+        assert d["objective_scores"] == [{"latency": 42.0}, {"latency": 99.0}]
         er2 = EvalResult.from_dict(d)
         assert er2.per_example_side_info == [{"traj": "A"}, {"traj": "B"}]
+        assert er2.objective_scores == [{"latency": 42.0}, {"latency": 99.0}]

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -119,6 +119,129 @@ class TestBuildMutationPrompt:
         assert "no scores recorded" in prompt
 
 
+class TestPerExampleDiagnostics:
+    """``build_mutation_prompt`` renders ``eval_result.per_example_side_info``
+    as the Diagnostics section under the new GEPA O.A. contract
+    (``optimize_anything_adapter.py:524-553`` + ``format_samples``
+    at ``gepa/strategies/instruction_proposal.py:54-95``).  The legacy
+    batch-level ``side_info`` rendering is used only when
+    ``per_example_side_info`` is absent.
+    """
+
+    def _make(
+        self,
+        per_example_side_info: list[dict] | None,
+        side_info: dict | None = None,
+        instance_scores: dict | None = None,
+    ) -> EvalResult:
+        return EvalResult(
+            candidate_id="g0-s0",
+            scores={"pass_rate": 0.5},
+            asi={"stdout": "", "stderr": ""},
+            instance_scores=instance_scores or {"cube_lifting__0": 1.0, "cube_lifting__1": 0.0},
+            side_info=side_info,
+            per_example_side_info=per_example_side_info,
+        )
+
+    def test_renders_per_example_headers_from_instance_scores(self):
+        er = self._make(
+            per_example_side_info=[
+                {"trajectory": "fell over", "scores": {"success": 1.0, "affordance": 0.8}},
+                {"trajectory": "stuck", "scores": {"success": 0.0, "affordance": 0.2}},
+            ],
+            instance_scores={"cube_lifting__0": 1.0, "cube_lifting__1": 0.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        # Per-example ids from instance_scores become "# Example <id>" headers.
+        assert "# Example cube_lifting__0" in prompt
+        assert "# Example cube_lifting__1" in prompt
+
+    def test_reserved_scores_key_renamed_for_mutator(self):
+        er = self._make(
+            per_example_side_info=[
+                {"scores": {"success": 1.0, "affordance": 0.8}},
+            ],
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        # GEPA parity: the reserved "scores" key renders under a
+        # friendly header.  Raw "scores:" label should not appear.
+        assert "## Scores (Higher is Better)" in prompt
+        # Values are exposed with their axis names.
+        assert "success: 1.0" in prompt
+        assert "affordance: 0.8" in prompt
+
+    def test_other_side_info_keys_render_verbatim(self):
+        er = self._make(
+            per_example_side_info=[
+                {"trajectory": "unique_traj_marker", "loss": 0.42},
+            ],
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "## trajectory" in prompt
+        assert "unique_traj_marker" in prompt
+        assert "## loss" in prompt
+        assert "0.42" in prompt
+
+    def test_diagnostics_section_header_present(self):
+        er = self._make(
+            per_example_side_info=[{"scores": {"s": 1.0}}],
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "## Diagnostics" in prompt
+
+    def test_empty_per_example_slots_still_render_headers(self):
+        """When every per-example side_info is ``{}`` (bare-score
+        evaluator), the section still shows per-example headers so the
+        mutator knows the data was present but empty — rather than
+        silently dropping the section."""
+        er = self._make(
+            per_example_side_info=[{}, {}],
+            instance_scores={"ex_0": 1.0, "ex_1": 0.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "# Example ex_0" in prompt
+        assert "# Example ex_1" in prompt
+        assert "no per-example side_info" in prompt
+
+    def test_legacy_side_info_used_when_per_example_absent(self):
+        """Fallback: ``per_example_side_info=None`` + batch-level
+        ``side_info={...}`` keeps the legacy rendering (non-helix_result
+        paths that still populate the batch-level field)."""
+        er = self._make(
+            per_example_side_info=None,
+            side_info={"legacy_key": "legacy_val"},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "## Diagnostics" in prompt
+        assert "legacy_key" in prompt
+        assert "legacy_val" in prompt
+        # Per-example markers must NOT appear on the legacy path.
+        assert "# Example" not in prompt
+
+    def test_no_diagnostics_when_both_absent(self):
+        er = self._make(per_example_side_info=None, side_info=None)
+        prompt = build_mutation_prompt("goal", er)
+        assert "## Diagnostics" not in prompt
+
+    def test_per_example_takes_precedence_over_legacy(self):
+        """When both fields are populated (hybrid evaluator path),
+        per-example wins — the legacy batch-level dict is dropped
+        from the rendered prompt."""
+        er = self._make(
+            per_example_side_info=[{"per_example_marker": "YES"}],
+            side_info={"legacy_marker": "NO"},
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "per_example_marker" in prompt
+        assert "YES" in prompt
+        assert "legacy_marker" not in prompt
+        assert "NO" not in prompt
+
+
 # ---------------------------------------------------------------------------
 # Tests: invoke_claude_code
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -243,6 +243,107 @@ class TestPerExampleDiagnostics:
 
 
 # ---------------------------------------------------------------------------
+# Tests: mutation-prompt artifact persistence
+# ---------------------------------------------------------------------------
+
+
+class TestMutationPromptArtifact:
+    """``mutate()`` writes the rendered prompt to
+    ``<worktree>/.helix_mutation_prompt.md`` before invoking Claude Code
+    and adds the artifact + ``helix_batch.json`` to the worktree's
+    ``.gitignore`` so neither leaks into the candidate git tree."""
+
+    def _build(self, tmp_path, mocker):
+        parent = make_candidate("g0-s0", str(tmp_path / "parent"))
+        er = make_eval_result("g0-s0")
+        config = make_config()
+        wt = tmp_path / "g1-s0"
+        wt.mkdir()
+        child = make_candidate("g1-s0", str(wt))
+        mocker.patch("helix.mutator.clone_candidate", return_value=child)
+        mocker.patch("helix.mutator.invoke_claude_code", return_value={"result": "ok"})
+        mocker.patch("helix.mutator.snapshot_candidate", return_value="abc123")
+        mocker.patch("helix.mutator.remove_worktree")
+        return parent, er, config, wt
+
+    def test_artifact_written_before_claude_invocation(
+        self, tmp_path: Path, mocker
+    ):
+        """The prompt file must exist at the time ``invoke_claude_code``
+        is called so Claude can in principle read it during the session
+        and so post-hoc inspection works even on a crashed mutation."""
+        parent, er, config, wt = self._build(tmp_path, mocker)
+
+        # Capture whether the artifact exists at the moment
+        # invoke_claude_code is entered.
+        artifact_path = wt / ".helix_mutation_prompt.md"
+        exists_at_invoke: list[bool] = []
+
+        def fake_invoke(*_a, **_kw):
+            exists_at_invoke.append(artifact_path.exists())
+            return {"result": "ok"}
+
+        mocker.patch("helix.mutator.invoke_claude_code", side_effect=fake_invoke)
+        mutate(parent, er, "g1-s0", config, tmp_path)
+        assert exists_at_invoke == [True]
+
+    def test_artifact_contains_rendered_prompt(
+        self, tmp_path: Path, mocker
+    ):
+        parent, er, config, wt = self._build(tmp_path, mocker)
+        mutate(parent, er, "g1-s0", config, tmp_path)
+
+        content = (wt / ".helix_mutation_prompt.md").read_text()
+        # Objective + autonomous-rules block are both in the rendered
+        # prompt via build_mutation_prompt.
+        assert config.objective in content
+        assert "[MUTATION COMPLETE]" in content
+
+    def test_gitignore_excludes_helix_artifacts(
+        self, tmp_path: Path, mocker
+    ):
+        """``.gitignore`` in the worktree gains entries for the prompt
+        file AND ``helix_batch.json`` so neither file enters the
+        candidate diff on the next generation."""
+        parent, er, config, wt = self._build(tmp_path, mocker)
+        mutate(parent, er, "g1-s0", config, tmp_path)
+
+        gi = (wt / ".gitignore").read_text()
+        assert ".helix_mutation_prompt.md" in gi
+        assert "helix_batch.json" in gi
+
+    def test_gitignore_append_is_idempotent(
+        self, tmp_path: Path, mocker
+    ):
+        """A pre-existing ``.gitignore`` with HELIX patterns already
+        present must not grow duplicate entries on subsequent mutate()
+        calls — otherwise long runs balloon the gitignore."""
+        parent, er, config, wt = self._build(tmp_path, mocker)
+        # Seed a gitignore with the patterns already present + other lines.
+        (wt / ".gitignore").write_text(
+            "*.pyc\n"
+            "# HELIX per-invocation artifacts (never commit to candidate tree)\n"
+            ".helix_mutation_prompt.md\n"
+            "helix_batch.json\n"
+        )
+        mutate(parent, er, "g1-s0", config, tmp_path)
+
+        gi = (wt / ".gitignore").read_text()
+        assert gi.count(".helix_mutation_prompt.md") == 1
+        assert gi.count("helix_batch.json") == 1
+        assert "*.pyc" in gi  # existing content preserved
+
+    def test_gitignore_created_when_absent(
+        self, tmp_path: Path, mocker
+    ):
+        parent, er, config, wt = self._build(tmp_path, mocker)
+        # Ensure no pre-existing gitignore.
+        assert not (wt / ".gitignore").exists()
+        mutate(parent, er, "g1-s0", config, tmp_path)
+        assert (wt / ".gitignore").exists()
+
+
+# ---------------------------------------------------------------------------
 # Tests: invoke_claude_code
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -152,9 +152,12 @@ class TestPerExampleDiagnostics:
             instance_scores={"cube_lifting__0": 1.0, "cube_lifting__1": 0.0},
         )
         prompt = build_mutation_prompt("goal", er)
-        # Per-example ids from instance_scores become "# Example <id>" headers.
-        assert "# Example cube_lifting__0" in prompt
-        assert "# Example cube_lifting__1" in prompt
+        # Per-example ids render as ``### Example <id>`` (h3 under the
+        # surrounding ``## Diagnostics`` h2).  Line-anchored check —
+        # a substring match would also accept ``# Example`` or
+        # ``#### Example`` and miss the header-level change.
+        assert "\n### Example cube_lifting__0\n" in prompt
+        assert "\n### Example cube_lifting__1\n" in prompt
 
     def test_reserved_scores_key_renamed_for_mutator(self):
         er = self._make(
@@ -165,14 +168,14 @@ class TestPerExampleDiagnostics:
         )
         prompt = build_mutation_prompt("goal", er)
         # GEPA parity: the reserved "scores" key renders under a
-        # friendly header.  Raw "scores:" label should not appear.
-        assert "## Scores (Higher is Better)" in prompt
+        # friendly header at h4 (one level below the example).
+        assert "\n#### Scores (Higher is Better)\n" in prompt
         # Values render via GEPA's recursive format_samples — the
-        # objective-axis names become their own markdown sub-headers
+        # objective-axis names become their own h5 markdown sub-headers
         # with the primitive scalar on the next line.
-        assert "### success" in prompt
+        assert "\n##### success\n" in prompt
         assert "1.0" in prompt
-        assert "### affordance" in prompt
+        assert "\n##### affordance\n" in prompt
         assert "0.8" in prompt
 
     def test_other_side_info_keys_render_verbatim(self):
@@ -183,9 +186,10 @@ class TestPerExampleDiagnostics:
             instance_scores={"ex_0": 1.0},
         )
         prompt = build_mutation_prompt("goal", er)
-        assert "## trajectory" in prompt
+        # ``### Example`` (h3) → ``#### {key}`` (h4) → scalar body.
+        assert "\n#### trajectory\n" in prompt
         assert "unique_traj_marker" in prompt
-        assert "## loss" in prompt
+        assert "\n#### loss\n" in prompt
         assert "0.42" in prompt
 
     def test_diagnostics_section_header_present(self):
@@ -232,7 +236,12 @@ class TestPerExampleDiagnostics:
 
     def test_nested_dict_renders_via_recursive_headers(self):
         """GEPA ``render_value`` parity: a dict value inside side_info
-        renders its keys as bumped-level sub-headers, recursively."""
+        renders its keys as bumped-level sub-headers, recursively.
+
+        Header depths under the monotonic hierarchy:
+          ## Diagnostics (h2) → ### Example (h3) → #### key (h4)
+          → ##### subkey (h5) → ###### subsubkey (h6, capped).
+        """
         er = self._make(
             per_example_side_info=[
                 {
@@ -245,21 +254,22 @@ class TestPerExampleDiagnostics:
             instance_scores={"ex_0": 1.0},
         )
         prompt = build_mutation_prompt("goal", er)
-        # Top-level key is at the current key-level (##).
-        assert "## trajectory" in prompt
-        # First-level nested keys bump by one.
-        assert "### grasp" in prompt
-        assert "### place" in prompt
-        # Second-level nested keys bump again.
-        assert "#### success" in prompt
-        assert "#### pose" in prompt
+        # Top-level key at h4 (one below ### Example).
+        assert "\n#### trajectory\n" in prompt
+        # First-level nested keys at h5.
+        assert "\n##### grasp\n" in prompt
+        assert "\n##### place\n" in prompt
+        # Second-level nested keys at h6 (cap).
+        assert "\n###### success\n" in prompt
+        assert "\n###### pose\n" in prompt
         # Scalar leaves render as plain text (no further headers).
         assert "top-down" in prompt
         assert "centered" in prompt
 
     def test_list_values_render_as_item_headers(self):
         """GEPA ``render_value`` parity: a list value renders each
-        element under ``### Item N`` sub-headers."""
+        element under ``##### Item N`` sub-headers (h5 under the h4
+        key header)."""
         er = self._make(
             per_example_side_info=[
                 {"attempts": ["first_try_failed", "retry_succeeded"]},
@@ -267,9 +277,9 @@ class TestPerExampleDiagnostics:
             instance_scores={"ex_0": 1.0},
         )
         prompt = build_mutation_prompt("goal", er)
-        assert "## attempts" in prompt
-        assert "### Item 1" in prompt
-        assert "### Item 2" in prompt
+        assert "\n#### attempts\n" in prompt
+        assert "\n##### Item 1\n" in prompt
+        assert "\n##### Item 2\n" in prompt
         assert "first_try_failed" in prompt
         assert "retry_succeeded" in prompt
 
@@ -288,12 +298,12 @@ class TestPerExampleDiagnostics:
             instance_scores={"ex_0": 1.0},
         )
         prompt = build_mutation_prompt("goal", er)
-        assert "## steps" in prompt
-        assert "### Item 1" in prompt
-        assert "### Item 2" in prompt
-        # Dict keys inside each list element bump a further level.
-        assert "#### action" in prompt
-        assert "#### outcome" in prompt
+        assert "\n#### steps\n" in prompt
+        assert "\n##### Item 1\n" in prompt
+        assert "\n##### Item 2\n" in prompt
+        # Dict keys inside each list element bump to h6 (capped).
+        assert "\n###### action\n" in prompt
+        assert "\n###### outcome\n" in prompt
         assert "grasp" in prompt
         assert "dropped" in prompt
 
@@ -306,11 +316,57 @@ class TestPerExampleDiagnostics:
             instance_scores={"ex_0": 1.0},
         )
         prompt = build_mutation_prompt("goal", er)
-        assert "## loss" in prompt
+        assert "\n#### loss\n" in prompt
         # The scalar should be rendered as just "0.42" on its own
         # line, not '"0.42"' or "0.42\n" wrapped in JSON.
         assert "0.42" in prompt
         assert '"0.42"' not in prompt
+
+    def test_diagnostics_header_hierarchy_is_monotonic(self):
+        """The Diagnostics block's header levels never jump backwards
+        as the reader descends the tree.  Concretely: under
+        ``## Diagnostics`` (h2) the next header is at h3 or deeper, the
+        next is h3-or-deeper again, etc.  Bumps of +1 and decreases
+        (coming back up from a sub-branch) are fine; a jump from h2
+        straight to h1 would inverted the hierarchy and confuse
+        markdown tooling / the LLM's markdown parser."""
+        er = self._make(
+            per_example_side_info=[
+                {"trajectory": {"grasp": "ok"}, "scores": {"success": 1.0}},
+                {"trajectory": {"grasp": "dropped"}, "scores": {"success": 0.0}},
+            ],
+            instance_scores={"ex_0": 1.0, "ex_1": 0.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+
+        # Find the Diagnostics block.
+        diag_idx = prompt.index("## Diagnostics")
+        diag = prompt[diag_idx:]
+        # Next section (## ...) ends the block — slice up to there.
+        next_h2 = diag.find("\n## ", 1)
+        if next_h2 != -1:
+            diag = diag[:next_h2]
+
+        # Extract header lines + depths.
+        headers = []
+        for line in diag.splitlines():
+            s = line.lstrip("#")
+            depth = len(line) - len(s)
+            if depth >= 1 and s.startswith(" "):
+                headers.append((depth, line))
+        assert headers, "Diagnostics block has no headers at all"
+
+        # The first header must be ``## Diagnostics`` itself (h2).
+        assert headers[0][0] == 2
+
+        # No header is at depth 1 (h1) — they'd visually outrank the
+        # surrounding ``## Diagnostics``.
+        h1s = [h for d, h in headers if d == 1]
+        assert not h1s, f"Unexpected h1 headers inside Diagnostics: {h1s}"
+
+        # Every depth is <= 6 (markdown cap).
+        for d, h in headers:
+            assert d <= 6, f"{d}-hash header exceeds markdown h6 cap: {h!r}"
 
     def test_max_markdown_header_level_caps_at_six(self):
         """GEPA caps nested header depth at ``######`` (h6) — deeper

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -167,9 +167,13 @@ class TestPerExampleDiagnostics:
         # GEPA parity: the reserved "scores" key renders under a
         # friendly header.  Raw "scores:" label should not appear.
         assert "## Scores (Higher is Better)" in prompt
-        # Values are exposed with their axis names.
-        assert "success: 1.0" in prompt
-        assert "affordance: 0.8" in prompt
+        # Values render via GEPA's recursive format_samples — the
+        # objective-axis names become their own markdown sub-headers
+        # with the primitive scalar on the next line.
+        assert "### success" in prompt
+        assert "1.0" in prompt
+        assert "### affordance" in prompt
+        assert "0.8" in prompt
 
     def test_other_side_info_keys_render_verbatim(self):
         er = self._make(
@@ -225,6 +229,109 @@ class TestPerExampleDiagnostics:
         er = self._make(per_example_side_info=None, side_info=None)
         prompt = build_mutation_prompt("goal", er)
         assert "## Diagnostics" not in prompt
+
+    def test_nested_dict_renders_via_recursive_headers(self):
+        """GEPA ``render_value`` parity: a dict value inside side_info
+        renders its keys as bumped-level sub-headers, recursively."""
+        er = self._make(
+            per_example_side_info=[
+                {
+                    "trajectory": {
+                        "grasp": {"success": True, "pose": "top-down"},
+                        "place": "centered",
+                    },
+                },
+            ],
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        # Top-level key is at the current key-level (##).
+        assert "## trajectory" in prompt
+        # First-level nested keys bump by one.
+        assert "### grasp" in prompt
+        assert "### place" in prompt
+        # Second-level nested keys bump again.
+        assert "#### success" in prompt
+        assert "#### pose" in prompt
+        # Scalar leaves render as plain text (no further headers).
+        assert "top-down" in prompt
+        assert "centered" in prompt
+
+    def test_list_values_render_as_item_headers(self):
+        """GEPA ``render_value`` parity: a list value renders each
+        element under ``### Item N`` sub-headers."""
+        er = self._make(
+            per_example_side_info=[
+                {"attempts": ["first_try_failed", "retry_succeeded"]},
+            ],
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "## attempts" in prompt
+        assert "### Item 1" in prompt
+        assert "### Item 2" in prompt
+        assert "first_try_failed" in prompt
+        assert "retry_succeeded" in prompt
+
+    def test_mixed_nested_structure(self):
+        """List of dicts + dicts-of-lists render recursively, each
+        level bumping the header depth."""
+        er = self._make(
+            per_example_side_info=[
+                {
+                    "steps": [
+                        {"action": "grasp", "outcome": "ok"},
+                        {"action": "lift", "outcome": "dropped"},
+                    ],
+                },
+            ],
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "## steps" in prompt
+        assert "### Item 1" in prompt
+        assert "### Item 2" in prompt
+        # Dict keys inside each list element bump a further level.
+        assert "#### action" in prompt
+        assert "#### outcome" in prompt
+        assert "grasp" in prompt
+        assert "dropped" in prompt
+
+    def test_primitive_values_no_json_dumps(self):
+        """Port of GEPA's ``render_value`` scalar case: primitives
+        render as plain stripped ``str(value)``, NOT ``json.dumps``.
+        Check that a bare float doesn't get quoted or wrapped."""
+        er = self._make(
+            per_example_side_info=[{"loss": 0.42}],
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "## loss" in prompt
+        # The scalar should be rendered as just "0.42" on its own
+        # line, not '"0.42"' or "0.42\n" wrapped in JSON.
+        assert "0.42" in prompt
+        assert '"0.42"' not in prompt
+
+    def test_max_markdown_header_level_caps_at_six(self):
+        """GEPA caps nested header depth at ``######`` (h6) — deeper
+        nesting folds to the same level rather than emitting h7+
+        which is not valid markdown."""
+        deeply_nested: Any = "leaf"
+        # Build ~10 levels of nesting.
+        for i in range(10):
+            deeply_nested = {f"k{i}": deeply_nested}
+        er = self._make(
+            per_example_side_info=[{"root": deeply_nested}],
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        # No header with 7+ ``#``.
+        for line in prompt.splitlines():
+            stripped = line.lstrip("#")
+            prefix_len = len(line) - len(stripped)
+            assert prefix_len <= 6, (
+                f"Found a {prefix_len}-hash markdown header (>h6): {line!r}"
+            )
 
     def test_per_example_takes_precedence_over_legacy(self):
         """When both fields are populated (hybrid evaluator path),

--- a/tests/unit/test_parser_helix_result.py
+++ b/tests/unit/test_parser_helix_result.py
@@ -58,7 +58,9 @@ class TestHelixResultHappyPath:
         line = f"HELIX_RESULT={json.dumps(payload)}"
         stdout = f"preamble\n{line}\ntrailing\n"
 
-        scores, instance_scores, pesi = helix_result_parse(0, stdout, "", tmp_path)
+        scores, instance_scores, pesi, obj = helix_result_parse(
+            0, stdout, "", tmp_path
+        )
 
         assert instance_scores == {
             "cube_lifting__0": 1.0,
@@ -69,13 +71,15 @@ class TestHelixResultHappyPath:
         assert scores["success"] == pytest.approx(0.5)
         # Per-example side_info captured in id order (empty dicts here).
         assert pesi == [{}, {}, {}]
+        # No side_info["scores"] key → empty objective harvest per example.
+        assert obj == [{}, {}, {}]
 
     def test_success_is_mean_of_scores(self, tmp_path: Path) -> None:
         _write_batch(tmp_path, ["0", "1", "2", "3"])
         payload = _pairs([0.25, 0.5, 0.75, 1.0])
         line = f"HELIX_RESULT={json.dumps(payload)}"
 
-        scores, _is, _pesi = helix_result_parse(0, line + "\n", "", tmp_path)
+        scores, _is, _pesi, _obj = helix_result_parse(0, line + "\n", "", tmp_path)
 
         assert scores["success"] == pytest.approx(0.625)
 
@@ -85,7 +89,7 @@ class TestHelixResultHappyPath:
         payload = [[1, {}], [0, {}], [True, {}], [False, {}]]
         line = f"HELIX_RESULT={json.dumps(payload)}"
 
-        scores, instance_scores, _pesi = helix_result_parse(
+        scores, instance_scores, _pesi, _obj = helix_result_parse(
             0, line + "\n", "", tmp_path
         )
 
@@ -99,7 +103,9 @@ class TestHelixResultHappyPath:
         last = f"HELIX_RESULT={json.dumps(_pairs([0.9, 0.9]))}"
         stdout = f"{first}\n{last}\n"
 
-        scores, instance_scores, _pesi = helix_result_parse(0, stdout, "", tmp_path)
+        scores, instance_scores, _pesi, _obj = helix_result_parse(
+            0, stdout, "", tmp_path
+        )
 
         assert instance_scores == {"x": 0.9, "y": 0.9}
         assert scores["success"] == pytest.approx(0.9)
@@ -110,7 +116,7 @@ class TestHelixResultHappyPath:
         _write_batch(tmp_path, ["a", "b"])
         line = f"HELIX_RESULT={json.dumps(_pairs([1.0, 1.0]))}"
 
-        scores, instance_scores, _pesi = helix_result_parse(
+        scores, instance_scores, _pesi, _obj = helix_result_parse(
             1, line + "\n", "", tmp_path
         )
 
@@ -124,13 +130,14 @@ class TestHelixResultHappyPath:
         _write_batch(tmp_path, [])
         line = f"HELIX_RESULT={json.dumps([])}"
 
-        scores, instance_scores, pesi = helix_result_parse(
+        scores, instance_scores, pesi, obj = helix_result_parse(
             0, line + "\n", "", tmp_path
         )
 
         assert scores == {"success": 0.0}
         assert instance_scores == {}
         assert pesi == []
+        assert obj == []
 
     def test_per_example_side_info_passthrough(self, tmp_path: Path) -> None:
         """Each per-example ``side_info`` dict flows through verbatim,
@@ -142,7 +149,7 @@ class TestHelixResultHappyPath:
         payload = [[1.0, side_a], [0.0, side_b]]
         line = f"HELIX_RESULT={json.dumps(payload)}"
 
-        _s, _is, pesi = helix_result_parse(0, line + "\n", "", tmp_path)
+        _s, _is, pesi, _obj = helix_result_parse(0, line + "\n", "", tmp_path)
 
         assert pesi == [side_a, side_b]
 
@@ -154,9 +161,89 @@ class TestHelixResultHappyPath:
         # JSON null parses to Python None.
         line = 'HELIX_RESULT=[[1.0, null], [0.5, null]]'
 
-        _s, _is, pesi = helix_result_parse(0, line + "\n", "", tmp_path)
+        _s, _is, pesi, obj = helix_result_parse(0, line + "\n", "", tmp_path)
 
         assert pesi == [{}, {}]
+        assert obj == [{}, {}]
+
+
+# ---------------------------------------------------------------------------
+# Reserved side_info["scores"] → per-example objective_scores harvest
+# ---------------------------------------------------------------------------
+
+
+class TestObjectiveScoresHarvest:
+    """Mirrors GEPA's ``OptimizeAnythingAdapter._process_side_info``
+    (``optimize_anything_adapter.py:260-272``): each per-example
+    ``side_info["scores"]`` dict is harvested into the corresponding
+    slot of ``objective_scores``.  No frontier wiring yet (that's a
+    later commit in this branch); this test just pins the harvest.
+    """
+
+    def test_scores_key_harvested_per_example(self, tmp_path: Path) -> None:
+        ids = ["a", "b", "c"]
+        _write_batch(tmp_path, ids)
+        payload = [
+            [1.0, {"scores": {"obj_alpha": 0.9, "obj_beta": 0.1}}],
+            [0.5, {"scores": {"obj_alpha": 0.5}}],
+            [0.0, {"no": "scores key here"}],
+        ]
+        line = f"HELIX_RESULT={json.dumps(payload)}"
+
+        _s, _is, _pesi, obj = helix_result_parse(0, line + "\n", "", tmp_path)
+
+        assert obj == [
+            {"obj_alpha": 0.9, "obj_beta": 0.1},
+            {"obj_alpha": 0.5},
+            {},
+        ]
+
+    def test_scores_key_non_dict_ignored(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a"])
+        payload = [[1.0, {"scores": "not-a-dict"}]]
+        line = f"HELIX_RESULT={json.dumps(payload)}"
+
+        _s, _is, _pesi, obj = helix_result_parse(0, line + "\n", "", tmp_path)
+
+        assert obj == [{}]
+
+    def test_scores_drops_non_numeric_and_non_finite(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a"])
+        # Hand-rolled JSON to smuggle NaN / Infinity past json.dumps.
+        stdout = (
+            'HELIX_RESULT=[[1.0, {"scores": '
+            '{"good": 0.5, "bad_str": "nope", "nan": NaN, "inf": Infinity}}]]\n'
+        )
+
+        _s, _is, _pesi, obj = helix_result_parse(0, stdout, "", tmp_path)
+
+        assert obj == [{"good": 0.5}]
+
+    def test_scores_harvest_coerces_bool_and_int(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a"])
+        payload = [
+            [1.0, {"scores": {"bool_true": True, "bool_false": False, "int_one": 1}}]
+        ]
+        line = f"HELIX_RESULT={json.dumps(payload)}"
+
+        _s, _is, _pesi, obj = helix_result_parse(0, line + "\n", "", tmp_path)
+
+        assert obj == [{"bool_true": 1.0, "bool_false": 0.0, "int_one": 1.0}]
+
+    def test_side_info_scores_preserved_alongside_harvest(
+        self, tmp_path: Path
+    ) -> None:
+        """The harvest does not strip ``side_info["scores"]`` from the
+        per-example side_info — it still flows through for reflection."""
+        _write_batch(tmp_path, ["a"])
+        side_info = {"trajectory": "ok", "scores": {"latency_ms": 42.0}}
+        payload = [[1.0, side_info]]
+        line = f"HELIX_RESULT={json.dumps(payload)}"
+
+        _s, _is, pesi, obj = helix_result_parse(0, line + "\n", "", tmp_path)
+
+        assert pesi == [side_info]
+        assert obj == [{"latency_ms": 42.0}]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_parser_helix_result.py
+++ b/tests/unit/test_parser_helix_result.py
@@ -247,6 +247,97 @@ class TestObjectiveScoresHarvest:
 
 
 # ---------------------------------------------------------------------------
+# GEPA O.A. union parity — bare score / rich pair / mixed
+# ---------------------------------------------------------------------------
+
+
+class TestBareAndMixedForms:
+    """Per-example entry matches GEPA O.A.'s ``tuple[float, SideInfo] | float``
+    union (``src/gepa/optimize_anything.py:971``): either a bare score or a
+    ``[score, side_info]`` pair.  Mixed within one payload is allowed."""
+
+    def test_all_bare_scores_accepted(self, tmp_path: Path) -> None:
+        """``HELIX_RESULT=[s_0, s_1, s_2]`` — all bare floats."""
+        _write_batch(tmp_path, ["a", "b", "c"])
+        line = "HELIX_RESULT=[1.0, 0.5, 0.0]"
+
+        scores, instance_scores, pesi, obj = helix_result_parse(
+            0, line + "\n", "", tmp_path
+        )
+
+        assert instance_scores == {"a": 1.0, "b": 0.5, "c": 0.0}
+        assert scores["success"] == pytest.approx(0.5)
+        # Bare scores materialise empty per-example side_info + empty harvest.
+        assert pesi == [{}, {}, {}]
+        assert obj == [{}, {}, {}]
+
+    def test_mixed_bare_and_rich_accepted(self, tmp_path: Path) -> None:
+        """Mixed within one payload.  Bare entries get empty side_info;
+        rich entries flow through verbatim."""
+        _write_batch(tmp_path, ["a", "b", "c"])
+        line = (
+            "HELIX_RESULT="
+            + json.dumps(
+                [
+                    1.0,
+                    [0.5, {"note": "middle", "scores": {"obj": 0.5}}],
+                    0.0,
+                ]
+            )
+        )
+
+        scores, instance_scores, pesi, obj = helix_result_parse(
+            0, line + "\n", "", tmp_path
+        )
+
+        assert instance_scores == {"a": 1.0, "b": 0.5, "c": 0.0}
+        assert scores["success"] == pytest.approx(0.5)
+        assert pesi == [
+            {},
+            {"note": "middle", "scores": {"obj": 0.5}},
+            {},
+        ]
+        # Objective harvest: bare → {}, rich-with-scores → extracted.
+        assert obj == [{}, {"obj": 0.5}, {}]
+
+    def test_bare_int_and_bool_scores_coerced(self, tmp_path: Path) -> None:
+        """Bare ``int`` / ``bool`` values follow the same coercion as
+        scores inside rich pairs."""
+        _write_batch(tmp_path, ["a", "b", "c", "d"])
+        line = "HELIX_RESULT=[1, 0, true, false]"
+
+        scores, instance_scores, pesi, _obj = helix_result_parse(
+            0, line + "\n", "", tmp_path
+        )
+
+        assert instance_scores == {"a": 1.0, "b": 0.0, "c": 1.0, "d": 0.0}
+        assert scores["success"] == pytest.approx(0.5)
+        assert pesi == [{}, {}, {}, {}]
+
+    def test_nonzero_returncode_zeros_bare_aggregate(
+        self, tmp_path: Path
+    ) -> None:
+        """Bare-score payload respects the same returncode semantics
+        as the rich form."""
+        _write_batch(tmp_path, ["a", "b"])
+        line = "HELIX_RESULT=[1.0, 1.0]"
+
+        scores, instance_scores, _pesi, _obj = helix_result_parse(
+            1, line + "\n", "", tmp_path
+        )
+
+        assert scores["success"] == 0.0
+        assert instance_scores == {"a": 1.0, "b": 1.0}
+
+    def test_bare_non_finite_raises(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a"])
+        stdout = "HELIX_RESULT=[NaN]\n"
+
+        with pytest.raises(EvaluatorError, match="non-finite"):
+            helix_result_parse(0, stdout, "", tmp_path)
+
+
+# ---------------------------------------------------------------------------
 # Strict contract — mismatch raises EvaluatorError
 # ---------------------------------------------------------------------------
 
@@ -318,13 +409,31 @@ class TestHelixResultStrictness:
         with pytest.raises(EvaluatorError, match="per-example"):
             helix_result_parse(0, line + "\n", "", tmp_path)
 
-    def test_per_example_entry_not_a_pair_raises(self, tmp_path: Path) -> None:
-        """Each per-example entry must be a 2-element list."""
-        _write_batch(tmp_path, ["a", "b"])
-        # Second entry is a bare scalar instead of [score, side_info].
-        line = f"HELIX_RESULT={json.dumps([[1.0, {}], 0.5])}"
+    def test_per_example_entry_three_element_list_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """A 3-element list is neither a bare score nor a valid
+        [score, side_info] pair."""
+        _write_batch(tmp_path, ["a"])
+        line = f"HELIX_RESULT={json.dumps([[1.0, {}, 'extra']])}"
 
-        with pytest.raises(EvaluatorError, match="2-element"):
+        with pytest.raises(EvaluatorError, match="bare score.*2-element"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_per_example_entry_dict_rejected(self, tmp_path: Path) -> None:
+        """A bare dict is not a valid entry — must be bare score or
+        rich pair."""
+        _write_batch(tmp_path, ["a"])
+        line = f"HELIX_RESULT={json.dumps([{'looks': 'like a side_info'}])}"
+
+        with pytest.raises(EvaluatorError, match="bare score.*2-element"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_per_example_entry_string_rejected(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a"])
+        line = f"HELIX_RESULT={json.dumps(['not-a-score'])}"
+
+        with pytest.raises(EvaluatorError, match="bare score.*2-element"):
             helix_result_parse(0, line + "\n", "", tmp_path)
 
     def test_per_example_side_info_non_dict_raises(self, tmp_path: Path) -> None:

--- a/tests/unit/test_parser_helix_result.py
+++ b/tests/unit/test_parser_helix_result.py
@@ -1,17 +1,48 @@
 """Unit tests for the ``helix_result`` score parser.
 
-The parser is the companion to the ``HELIX_RESULT=`` override in
-``helix.executor`` and must tolerate missing / malformed evaluator output
-while still populating ``instance_scores`` from ``side_info["scores"]``
-when the payload is well-formed.
+BREAKING (pre-1.0): ``helix_result`` is now **per-example** — the
+evaluator emits a list of ``[score_i, side_info_i]`` pairs positional
+to the ids in ``helix_batch.json``.  HELIX zips them into the id-keyed
+``instance_scores`` the minibatch gate needs and stores the
+per-example side_info list on :class:`helix.population.EvalResult` for
+the reflection prompt.  See :mod:`helix.parsers.helix_result` and
+``/tmp/gepa_audit_report.md`` for the GEPA parity rationale.
+
+The parser is strict by design: any deviation from the contract raises
+:class:`EvaluatorError` rather than silently falling back.  The footgun
+it exists to eliminate is the silent zero-fill that hid id-mismatch
+bugs for 113 generations in a real run.
 """
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
+import pytest
+
+from helix.exceptions import EvaluatorError
 from helix.parsers import get_parser
 from helix.parsers.helix_result import parse as helix_result_parse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_batch(worktree: Path, ids: list[str]) -> None:
+    (worktree / "helix_batch.json").write_text(json.dumps(ids))
+
+
+def _pairs(
+    scores_list: list[float], side_infos: list[dict] | None = None
+) -> list[list]:
+    """Build a per-example ``[score, side_info]`` payload."""
+    if side_infos is None:
+        side_infos = [{} for _ in scores_list]
+    assert len(scores_list) == len(side_infos)
+    return [[s, si] for s, si in zip(scores_list, side_infos)]
 
 
 # ---------------------------------------------------------------------------
@@ -19,191 +50,226 @@ from helix.parsers.helix_result import parse as helix_result_parse
 # ---------------------------------------------------------------------------
 
 
-class TestHelixResultWellFormed:
-    def test_scores_and_instance_scores_populated(self):
-        side_info = {
-            "accuracy": 0.42,
-            "scores": {
-                "cube_lifting__success": 1.0,
-                "cube_stack__success": 0.0,
-                "nut_assembly__success": 0.5,
-            },
-        }
-        line = f"HELIX_RESULT={json.dumps([0.42, side_info])}"
-        stdout = f"preamble\n{line}\ntrailing log\n"
+class TestHelixResultHappyPath:
+    def test_zips_ids_with_per_example_scores(self, tmp_path: Path) -> None:
+        ids = ["cube_lifting__0", "cube_stack__1", "nut_assembly__2"]
+        _write_batch(tmp_path, ids)
+        payload = _pairs([1.0, 0.0, 0.5])
+        line = f"HELIX_RESULT={json.dumps(payload)}"
+        stdout = f"preamble\n{line}\ntrailing\n"
 
-        scores, instance_scores = helix_result_parse(0, stdout, "")
+        scores, instance_scores, pesi = helix_result_parse(0, stdout, "", tmp_path)
 
-        assert scores["success"] == 0.42
-        assert scores["accuracy"] == 0.42
         assert instance_scores == {
-            "cube_lifting__success": 1.0,
-            "cube_stack__success": 0.0,
-            "nut_assembly__success": 0.5,
+            "cube_lifting__0": 1.0,
+            "cube_stack__1": 0.0,
+            "nut_assembly__2": 0.5,
         }
+        # mean of [1.0, 0.0, 0.5] == 0.5
+        assert scores["success"] == pytest.approx(0.5)
+        # Per-example side_info captured in id order (empty dicts here).
+        assert pesi == [{}, {}, {}]
 
-    def test_last_helix_result_line_wins(self):
+    def test_success_is_mean_of_scores(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["0", "1", "2", "3"])
+        payload = _pairs([0.25, 0.5, 0.75, 1.0])
+        line = f"HELIX_RESULT={json.dumps(payload)}"
+
+        scores, _is, _pesi = helix_result_parse(0, line + "\n", "", tmp_path)
+
+        assert scores["success"] == pytest.approx(0.625)
+
+    def test_integer_and_bool_scores_coerced_to_float(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a", "b", "c", "d"])
+        # bool is a subclass of int; the parser accepts both.
+        payload = [[1, {}], [0, {}], [True, {}], [False, {}]]
+        line = f"HELIX_RESULT={json.dumps(payload)}"
+
+        scores, instance_scores, _pesi = helix_result_parse(
+            0, line + "\n", "", tmp_path
+        )
+
+        assert instance_scores == {"a": 1.0, "b": 0.0, "c": 1.0, "d": 0.0}
+        assert scores["success"] == pytest.approx(0.5)
+
+    def test_last_helix_result_line_wins(self, tmp_path: Path) -> None:
         # Mirrors executor's reverse-scan behaviour: the last line wins.
-        line1 = f"HELIX_RESULT={json.dumps([0.1, {'scores': {'a__m': 0.1}}])}"
-        line2 = f"HELIX_RESULT={json.dumps([0.9, {'scores': {'b__m': 0.9}}])}"
-        stdout = f"{line1}\n{line2}\n"
+        _write_batch(tmp_path, ["x", "y"])
+        first = f"HELIX_RESULT={json.dumps(_pairs([0.1, 0.1]))}"
+        last = f"HELIX_RESULT={json.dumps(_pairs([0.9, 0.9]))}"
+        stdout = f"{first}\n{last}\n"
 
-        scores, instance_scores = helix_result_parse(0, stdout, "")
+        scores, instance_scores, _pesi = helix_result_parse(0, stdout, "", tmp_path)
 
-        assert scores["success"] == 0.9
-        assert instance_scores == {"b__m": 0.9}
+        assert instance_scores == {"x": 0.9, "y": 0.9}
+        assert scores["success"] == pytest.approx(0.9)
 
-    def test_non_numeric_instance_values_are_dropped(self):
-        side_info = {"scores": {"good__m": 0.75, "bad__m": "nope", "none__m": None}}
-        line = f"HELIX_RESULT={json.dumps([0.75, side_info])}"
-        stdout = f"{line}\n"
+    def test_nonzero_returncode_zeros_success_keeps_instance_scores(
+        self, tmp_path: Path
+    ) -> None:
+        _write_batch(tmp_path, ["a", "b"])
+        line = f"HELIX_RESULT={json.dumps(_pairs([1.0, 1.0]))}"
 
-        _scores, instance_scores = helix_result_parse(0, stdout, "")
-
-        assert instance_scores == {"good__m": 0.75}
-
-    def test_accuracy_omitted_when_missing(self):
-        side_info = {"scores": {"a__m": 1.0}}
-        line = f"HELIX_RESULT={json.dumps([0.5, side_info])}"
-
-        scores, _ = helix_result_parse(0, line + "\n", "")
-
-        assert "accuracy" not in scores
-        assert scores["success"] == 0.5
-
-    def test_bool_top_level_score_true(self):
-        # bool is a subclass of int; float(True) == 1.0.
-        side_info = {"scores": {"a__m": 1.0}}
-        line = f"HELIX_RESULT={json.dumps([True, side_info])}"
-
-        scores, instance_scores = helix_result_parse(0, line + "\n", "")
-
-        assert scores["success"] == 1.0
-        assert instance_scores == {"a__m": 1.0}
-
-    def test_bool_top_level_score_false(self):
-        side_info = {"scores": {"a__m": 0.0}}
-        line = f"HELIX_RESULT={json.dumps([False, side_info])}"
-
-        scores, instance_scores = helix_result_parse(0, line + "\n", "")
+        scores, instance_scores, _pesi = helix_result_parse(
+            1, line + "\n", "", tmp_path
+        )
 
         assert scores["success"] == 0.0
-        assert instance_scores == {"a__m": 0.0}
+        # Per-instance scores are still surfaced — only the aggregate is zeroed.
+        assert instance_scores == {"a": 1.0, "b": 1.0}
 
-    def test_int_top_level_score(self):
-        side_info = {"scores": {"a__m": 1.0}}
-        line = f"HELIX_RESULT={json.dumps([1, side_info])}"
+    def test_empty_batch_and_empty_payload(self, tmp_path: Path) -> None:
+        # Degenerate but well-formed: HELIX asked for zero examples
+        # (e.g. a len-0 minibatch) and the evaluator emitted an empty list.
+        _write_batch(tmp_path, [])
+        line = f"HELIX_RESULT={json.dumps([])}"
 
-        scores, instance_scores = helix_result_parse(0, line + "\n", "")
+        scores, instance_scores, pesi = helix_result_parse(
+            0, line + "\n", "", tmp_path
+        )
 
-        assert scores["success"] == 1.0
-        assert instance_scores == {"a__m": 1.0}
-
-    def test_empty_scores_dict_yields_empty_instance_scores(self):
-        side_info = {"scores": {}}
-        line = f"HELIX_RESULT={json.dumps([0.5, side_info])}"
-
-        _scores, instance_scores = helix_result_parse(0, line + "\n", "")
-
-        assert instance_scores == {}
-
-    def test_non_dict_scores_value_yields_empty_instance_scores(self):
-        # side_info["scores"] is a string rather than a dict — must not crash.
-        side_info = {"scores": "not-a-dict"}
-        line = f"HELIX_RESULT={json.dumps([0.5, side_info])}"
-
-        scores, instance_scores = helix_result_parse(0, line + "\n", "")
-
-        assert scores["success"] == 0.5
-        assert instance_scores == {}
-
-
-# ---------------------------------------------------------------------------
-# Fallback paths (missing / malformed / shape errors)
-# ---------------------------------------------------------------------------
-
-
-class TestHelixResultFallbacks:
-    def test_missing_line_falls_back_to_exitcode_success(self):
-        scores, instance_scores = helix_result_parse(0, "arbitrary log\n", "")
-        assert scores == {"success": 1.0}
-        assert instance_scores == {"success": 1.0}
-
-    def test_missing_line_falls_back_to_exitcode_failure(self):
-        scores, instance_scores = helix_result_parse(1, "crashed\n", "some err")
         assert scores == {"success": 0.0}
-        assert instance_scores == {"success": 0.0}
-
-    def test_malformed_json_falls_back(self):
-        stdout = "HELIX_RESULT=not-valid-json\ntrailing\n"
-        scores, instance_scores = helix_result_parse(0, stdout, "")
-        assert scores == {"success": 1.0}
-        assert instance_scores == {"success": 1.0}
-
-    def test_wrong_shape_falls_back(self):
-        # Not a 2-element list.
-        stdout = f"HELIX_RESULT={json.dumps({'score': 0.5})}\n"
-        scores, instance_scores = helix_result_parse(0, stdout, "")
-        assert scores == {"success": 1.0}
-        assert instance_scores == {"success": 1.0}
-
-    def test_non_dict_side_info_yields_empty_instance_scores(self):
-        # Score is still honoured, but instance_scores is empty.
-        stdout = f"HELIX_RESULT={json.dumps([0.8, 'just a string'])}\n"
-        scores, instance_scores = helix_result_parse(0, stdout, "")
-        assert scores == {"success": 0.8}
         assert instance_scores == {}
+        assert pesi == []
 
-    def test_nan_and_inf_are_rejected(self):
-        # Sanity-check: json.loads accepts NaN/Infinity by default, so the
-        # parser actually sees non-finite floats post-decode.
-        decoded = json.loads(
-            '[NaN, {"scores": {"a": 1.0, "b": NaN, "c": Infinity, "d": -Infinity}}]'
-        )
-        top_score, side_info = decoded
-        import math as _math
+    def test_per_example_side_info_passthrough(self, tmp_path: Path) -> None:
+        """Each per-example ``side_info`` dict flows through verbatim,
+        positional to the ids, for the reflection prompt."""
+        ids = ["a", "b"]
+        _write_batch(tmp_path, ids)
+        side_a = {"trajectory": "tried X; fell over", "loss": 0.12}
+        side_b = {"trajectory": "tried Y; stuck", "loss": 0.9, "note": "retry?"}
+        payload = [[1.0, side_a], [0.0, side_b]]
+        line = f"HELIX_RESULT={json.dumps(payload)}"
 
-        assert _math.isnan(top_score)
-        assert _math.isnan(side_info["scores"]["b"])
-        assert _math.isinf(side_info["scores"]["c"])
-        assert _math.isinf(side_info["scores"]["d"])
+        _s, _is, pesi = helix_result_parse(0, line + "\n", "", tmp_path)
 
-        # NaN top-level score -> full fallback (both dicts == {'success': 1.0}).
-        stdout = (
-            'HELIX_RESULT=[NaN, {"scores": {"a": 1.0, "b": NaN, '
-            '"c": Infinity, "d": -Infinity}}]\n'
-        )
-        scores, instance_scores = helix_result_parse(0, stdout, "")
-        assert scores == {"success": 1.0}
-        assert instance_scores == {"success": 1.0}
+        assert pesi == [side_a, side_b]
 
-    def test_finite_score_drops_non_finite_instance_values(self):
-        # When the top-level score is finite, the parser keeps the good
-        # instance scores and silently drops NaN/+Inf/-Inf entries, matching
-        # how non-numeric values are dropped today.
-        stdout = (
-            'HELIX_RESULT=[0.5, {"scores": {"a": 1.0, "b": NaN, '
-            '"c": Infinity, "d": -Infinity}}]\n'
-        )
-        scores, instance_scores = helix_result_parse(0, stdout, "")
-        assert scores["success"] == 0.5
-        assert instance_scores == {"a": 1.0}
+    def test_null_per_example_side_info_becomes_empty_dict(
+        self, tmp_path: Path
+    ) -> None:
+        """``null`` in the side_info slot is lenient → stored as ``{}``."""
+        _write_batch(tmp_path, ["a", "b"])
+        # JSON null parses to Python None.
+        line = 'HELIX_RESULT=[[1.0, null], [0.5, null]]'
+
+        _s, _is, pesi = helix_result_parse(0, line + "\n", "", tmp_path)
+
+        assert pesi == [{}, {}]
 
 
 # ---------------------------------------------------------------------------
-# Returncode semantics
+# Strict contract — mismatch raises EvaluatorError
 # ---------------------------------------------------------------------------
 
 
-class TestHelixResultReturncode:
-    def test_nonzero_returncode_zeros_success(self):
-        side_info = {"scores": {"t__m": 1.0}}
-        line = f"HELIX_RESULT={json.dumps([0.9, side_info])}"
-        scores, instance_scores = helix_result_parse(1, line + "\n", "")
+class TestHelixResultStrictness:
+    def test_length_mismatch_too_short_raises(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a", "b", "c"])
+        line = f"HELIX_RESULT={json.dumps(_pairs([1.0, 0.0]))}"  # len 2, ids len 3
 
-        assert scores["success"] == 0.0
-        # instance_scores still reflect evaluator's per-instance reports.
-        assert instance_scores == {"t__m": 1.0}
+        with pytest.raises(EvaluatorError, match="length mismatch"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_length_mismatch_too_long_raises(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a"])
+        line = f"HELIX_RESULT={json.dumps(_pairs([1.0, 0.0, 0.5]))}"
+
+        with pytest.raises(EvaluatorError, match="length mismatch"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_missing_helix_batch_raises(self, tmp_path: Path) -> None:
+        # helix_batch.json intentionally absent.
+        line = f"HELIX_RESULT={json.dumps(_pairs([1.0]))}"
+
+        with pytest.raises(EvaluatorError, match="helix_batch.json"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_missing_helix_result_line_raises(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a", "b"])
+
+        with pytest.raises(EvaluatorError, match="no HELIX_RESULT"):
+            helix_result_parse(0, "boring stdout\nno result line\n", "", tmp_path)
+
+    def test_malformed_helix_result_json_raises(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a"])
+
+        with pytest.raises(EvaluatorError, match="JSON-decode"):
+            helix_result_parse(
+                0, "HELIX_RESULT=not-valid-json\n", "", tmp_path
+            )
+
+    def test_non_list_payload_raises(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a"])
+        line = f"HELIX_RESULT={json.dumps({'score': 1.0})}"  # dict, not list
+
+        with pytest.raises(EvaluatorError, match="list of per-example"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_legacy_scalar_plus_dict_shape_rejected_with_migration_hint(
+        self, tmp_path: Path
+    ) -> None:
+        """Old (removed) contract: ``[float, {"scores": {...}}]``.  The
+        new parser recognises that shape and rejects with a pointer to
+        the migration guide rather than silently misbehaving."""
+        _write_batch(tmp_path, ["a"])
+        line = f"HELIX_RESULT={json.dumps([0.5, {'scores': {'a': 0.5}}])}"
+
+        with pytest.raises(EvaluatorError, match="legacy shape"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_intermediate_batch_level_shape_rejected_with_hint(
+        self, tmp_path: Path
+    ) -> None:
+        """Intermediate shape ``[scores_list, side_info_dict]`` (one
+        batch-level side_info) is also rejected with a pointer to the
+        per-example fix."""
+        _write_batch(tmp_path, ["a", "b"])
+        line = f"HELIX_RESULT={json.dumps([[1.0, 0.5], {'note': 'batch'}])}"
+
+        with pytest.raises(EvaluatorError, match="per-example"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_per_example_entry_not_a_pair_raises(self, tmp_path: Path) -> None:
+        """Each per-example entry must be a 2-element list."""
+        _write_batch(tmp_path, ["a", "b"])
+        # Second entry is a bare scalar instead of [score, side_info].
+        line = f"HELIX_RESULT={json.dumps([[1.0, {}], 0.5])}"
+
+        with pytest.raises(EvaluatorError, match="2-element"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_per_example_side_info_non_dict_raises(self, tmp_path: Path) -> None:
+        """``side_info`` must be a dict (or null for leniency); a
+        non-dict, non-null payload is rejected."""
+        _write_batch(tmp_path, ["a"])
+        line = f"HELIX_RESULT={json.dumps([[1.0, 'not-a-dict']])}"
+
+        with pytest.raises(EvaluatorError, match="side_info"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_non_numeric_score_entry_raises(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a", "b"])
+        line = f"HELIX_RESULT={json.dumps([[1.0, {}], ['oops', {}]])}"
+
+        with pytest.raises(EvaluatorError, match="not numeric"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
+
+    def test_non_finite_score_entry_raises(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a", "b"])
+        # ``json.dumps`` rejects NaN unless we write it raw.
+        stdout = 'HELIX_RESULT=[[1.0, {}], [NaN, {}]]\n'
+
+        with pytest.raises(EvaluatorError, match="non-finite"):
+            helix_result_parse(0, stdout, "", tmp_path)
+
+    def test_helix_batch_not_a_list_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "helix_batch.json").write_text('{"not": "a list"}')
+        line = f"HELIX_RESULT={json.dumps(_pairs([1.0]))}"
+
+        with pytest.raises(EvaluatorError, match="list\\[str\\]"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -211,7 +277,6 @@ class TestHelixResultReturncode:
 # ---------------------------------------------------------------------------
 
 
-class TestRegistryWiring:
-    def test_get_parser_returns_helix_result(self):
-        parser = get_parser("helix_result")
-        assert parser is helix_result_parse
+class TestHelixResultRegistry:
+    def test_get_parser_returns_helix_result(self) -> None:
+        assert get_parser("helix_result") is helix_result_parse

--- a/tests/unit/test_population_multi_axis_frontier.py
+++ b/tests/unit/test_population_multi_axis_frontier.py
@@ -1,0 +1,380 @@
+"""Unit tests for the multi-axis ``ParetoFrontier`` — GEPA ``FrontierType`` parity.
+
+Pins the per-axis state accumulation (``_per_key_best``,
+``_objective_best``, ``_cartesian_best``) and the dispatch-on-
+``frontier_type`` behaviour of :meth:`ParetoFrontier._active_frontier`,
+:meth:`get_non_dominated`, and :meth:`select_parent`.
+
+Cross-references:
+  * GEPA ``FrontierType`` literal: ``src/gepa/core/state.py:22-23``.
+  * ``_update_objective_pareto_front``: ``state.py:474-484``.
+  * ``_update_pareto_front_for_cartesian``: ``state.py:512-525``.
+  * O.A. default ``frontier_type="hybrid"``:
+    ``src/gepa/optimize_anything.py:476`` — rationale for HELIX's own
+    default (``evolution.frontier_type``).
+
+The acceptance gate is **not** tested here: it remains positional on
+``scores_list`` regardless of ``frontier_type`` (GEPA
+``acceptance.py:39-48``).
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from helix.population import Candidate, EvalResult, ParetoFrontier
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(cid: str) -> Candidate:
+    return Candidate(
+        id=cid,
+        worktree_path=f"/tmp/{cid}",
+        branch_name=f"branch-{cid}",
+        generation=0,
+        parent_id=None,
+        parent_ids=[],
+        operation="mutation",
+    )
+
+
+def _make_result(
+    cid: str,
+    instance_scores: dict[str, float],
+    objective_scores: list[dict[str, float]] | None = None,
+) -> EvalResult:
+    return EvalResult(
+        candidate_id=cid,
+        scores={},
+        asi={},
+        instance_scores=instance_scores,
+        objective_scores=objective_scores,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default frontier_type back-compat
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultFrontierTypeBackCompat:
+    """The default ``ParetoFrontier(rng=...)`` path stays
+    ``frontier_type="instance"`` to preserve every existing test
+    exercising ``_per_key_best`` directly."""
+
+    def test_default_is_instance(self):
+        frontier = ParetoFrontier()
+        assert frontier.frontier_type == "instance"
+
+    def test_instance_active_frontier_is_per_key_best(self):
+        frontier = ParetoFrontier()
+        frontier.add(_make_candidate("a"), _make_result("a", {"i1": 1.0}))
+        # Active frontier for "instance" is the raw _per_key_best dict
+        # (same object), so legacy code reading _per_key_best keeps working.
+        assert frontier._active_frontier() is frontier._per_key_best
+
+
+# ---------------------------------------------------------------------------
+# Objective-axis accumulation + active frontier
+# ---------------------------------------------------------------------------
+
+
+class TestObjectiveFrontier:
+    def test_objective_best_tracks_mean_across_valset(self):
+        """``_objective_best_score[obj]`` = max over candidates of
+        mean(obj-score across valset), mirroring GEPA
+        ``_update_objective_pareto_front`` + ``_per_prog_mean_objective_scores``.
+        """
+        frontier = ParetoFrontier(frontier_type="objective")
+        # Candidate a: obj_alpha mean = (0.8+0.2)/2 = 0.5
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 1.0, "i1": 0.0},
+                objective_scores=[
+                    {"obj_alpha": 0.8}, {"obj_alpha": 0.2},
+                ],
+            ),
+        )
+        # Candidate b: obj_alpha mean = (0.7+0.7)/2 = 0.7 → beats a.
+        frontier.add(
+            _make_candidate("b"),
+            _make_result(
+                "b", {"i0": 0.5, "i1": 0.5},
+                objective_scores=[
+                    {"obj_alpha": 0.7}, {"obj_alpha": 0.7},
+                ],
+            ),
+        )
+
+        assert frontier._objective_best_score["obj_alpha"] == pytest.approx(0.7)
+        assert frontier._objective_best["obj_alpha"] == {"b"}
+
+    def test_objective_best_tie_expands_set(self):
+        frontier = ParetoFrontier(frontier_type="objective")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result("a", {"i0": 1.0}, objective_scores=[{"obj": 0.5}]),
+        )
+        frontier.add(
+            _make_candidate("b"),
+            _make_result("b", {"i0": 1.0}, objective_scores=[{"obj": 0.5}]),
+        )
+        assert frontier._objective_best["obj"] == {"a", "b"}
+
+    def test_multiple_objectives_tracked_independently(self):
+        frontier = ParetoFrontier(frontier_type="objective")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 1.0, "i1": 0.0},
+                objective_scores=[
+                    {"latency": 40.0, "accuracy": 0.9},
+                    {"latency": 60.0, "accuracy": 0.1},
+                ],
+            ),
+        )
+        frontier.add(
+            _make_candidate("b"),
+            _make_result(
+                "b", {"i0": 0.5, "i1": 0.5},
+                objective_scores=[
+                    {"latency": 20.0, "accuracy": 0.5},
+                    {"latency": 20.0, "accuracy": 0.5},
+                ],
+            ),
+        )
+        # All axes are higher-is-better (GEPA parity: the framework
+        # maximizes).  latency means: a=50, b=20 → a wins.
+        # accuracy means: a=0.5, b=0.5 → tie.
+        assert frontier._objective_best["latency"] == {"a"}
+        assert frontier._objective_best["accuracy"] == {"a", "b"}
+
+    def test_empty_objective_scores_is_noop(self):
+        frontier = ParetoFrontier(frontier_type="objective")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result("a", {"i0": 1.0}, objective_scores=None),
+        )
+        assert frontier._objective_best == {}
+
+    def test_active_frontier_is_objective_dict(self):
+        frontier = ParetoFrontier(frontier_type="objective")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result("a", {"i0": 1.0}, objective_scores=[{"obj": 0.5}]),
+        )
+        assert frontier._active_frontier() is frontier._objective_best
+
+    def test_get_non_dominated_uses_objective_axis(self):
+        """Candidate a dominates on obj_alpha only; candidate b on
+        obj_beta only; both survive under frontier_type='objective'."""
+        frontier = ParetoFrontier(frontier_type="objective", rng=random.Random(0))
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i": 1.0},
+                objective_scores=[{"obj_alpha": 1.0, "obj_beta": 0.0}],
+            ),
+        )
+        frontier.add(
+            _make_candidate("b"),
+            _make_result(
+                "b", {"i": 1.0},
+                objective_scores=[{"obj_alpha": 0.0, "obj_beta": 1.0}],
+            ),
+        )
+        non_dom = frontier.get_non_dominated()
+        assert non_dom == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# Cartesian-axis accumulation
+# ---------------------------------------------------------------------------
+
+
+class TestCartesianFrontier:
+    def test_cartesian_keys_encode_val_id_and_objective(self):
+        frontier = ParetoFrontier(frontier_type="cartesian")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 1.0, "i1": 0.5},
+                objective_scores=[
+                    {"obj_alpha": 0.8, "obj_beta": 0.1},
+                    {"obj_alpha": 0.2, "obj_beta": 0.9},
+                ],
+            ),
+        )
+        # Keys are "{val_id}::{obj_name}".
+        assert frontier._cartesian_best["i0::obj_alpha"] == {"a"}
+        assert frontier._cartesian_best["i0::obj_beta"] == {"a"}
+        assert frontier._cartesian_best["i1::obj_alpha"] == {"a"}
+        assert frontier._cartesian_best["i1::obj_beta"] == {"a"}
+        assert frontier._cartesian_best_score["i1::obj_beta"] == pytest.approx(0.9)
+
+    def test_cartesian_per_cell_winner(self):
+        """Different candidates can win different (val_id, obj) cells."""
+        frontier = ParetoFrontier(frontier_type="cartesian")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 1.0, "i1": 0.5},
+                objective_scores=[{"obj": 0.9}, {"obj": 0.1}],
+            ),
+        )
+        frontier.add(
+            _make_candidate("b"),
+            _make_result(
+                "b", {"i0": 0.5, "i1": 1.0},
+                objective_scores=[{"obj": 0.1}, {"obj": 0.9}],
+            ),
+        )
+        assert frontier._cartesian_best["i0::obj"] == {"a"}
+        assert frontier._cartesian_best["i1::obj"] == {"b"}
+
+    def test_length_mismatch_skips_cartesian_update(self):
+        """Defensive: if ``objective_scores`` length ≠ ``instance_scores``
+        length (should not happen on the helix_result path), skip."""
+        frontier = ParetoFrontier(frontier_type="cartesian")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 1.0, "i1": 0.0},
+                objective_scores=[{"obj": 0.5}],  # len 1 vs ids len 2
+            ),
+        )
+        assert frontier._cartesian_best == {}
+
+    def test_active_frontier_is_cartesian_dict(self):
+        frontier = ParetoFrontier(frontier_type="cartesian")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 1.0},
+                objective_scores=[{"obj": 0.5}],
+            ),
+        )
+        assert frontier._active_frontier() is frontier._cartesian_best
+
+
+# ---------------------------------------------------------------------------
+# Hybrid — union of instance ∪ objective keyspaces
+# ---------------------------------------------------------------------------
+
+
+class TestHybridFrontier:
+    def test_active_frontier_prefixes_both_keyspaces(self):
+        frontier = ParetoFrontier(frontier_type="hybrid")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 1.0, "i1": 0.5},
+                objective_scores=[{"obj": 0.8}, {"obj": 0.2}],
+            ),
+        )
+        merged = frontier._active_frontier()
+        # Instance keys are namespaced "inst::", objective keys "obj::".
+        assert "inst::i0" in merged
+        assert "inst::i1" in merged
+        assert "obj::obj" in merged
+
+    def test_hybrid_survives_on_either_axis(self):
+        """Candidate a wins an instance key but is dominated on objective;
+        candidate b wins an objective but is dominated on instance.  Under
+        frontier_type="hybrid" both survive — the union keyspace puts them
+        on different fronts."""
+        frontier = ParetoFrontier(frontier_type="hybrid", rng=random.Random(0))
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 1.0, "i1": 0.0},
+                objective_scores=[{"obj": 0.1}, {"obj": 0.1}],  # mean 0.1
+            ),
+        )
+        frontier.add(
+            _make_candidate("b"),
+            _make_result(
+                "b", {"i0": 0.0, "i1": 0.0},
+                objective_scores=[{"obj": 0.9}, {"obj": 0.9}],  # mean 0.9
+            ),
+        )
+        non_dom = frontier.get_non_dominated()
+        # a wins inst::i0, b wins obj::obj — both survive.
+        assert non_dom == {"a", "b"}
+
+    def test_hybrid_dominates_on_both_axes(self):
+        """A candidate that loses every instance key AND every objective
+        is eliminated under hybrid."""
+        frontier = ParetoFrontier(frontier_type="hybrid", rng=random.Random(0))
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 1.0, "i1": 1.0},
+                objective_scores=[{"obj": 1.0}, {"obj": 1.0}],
+            ),
+        )
+        frontier.add(
+            _make_candidate("b"),
+            _make_result(
+                "b", {"i0": 0.0, "i1": 0.0},
+                objective_scores=[{"obj": 0.0}, {"obj": 0.0}],
+            ),
+        )
+        assert frontier.get_non_dominated() == {"a"}
+        assert frontier.is_dominated("b")
+
+
+# ---------------------------------------------------------------------------
+# select_parent dispatches on frontier_type
+# ---------------------------------------------------------------------------
+
+
+class TestSelectParentRespectsFrontierType:
+    def test_objective_only_parent_pool(self):
+        """With frontier_type='objective' and no surviving instance
+        winners in the active frontier, ``select_parent`` picks from the
+        objective-axis winners rather than falling back to
+        instance-axis."""
+        frontier = ParetoFrontier(frontier_type="objective", rng=random.Random(0))
+        # Candidate a wins on instance but has no objective_scores.
+        frontier.add(
+            _make_candidate("a"),
+            _make_result("a", {"i0": 1.0}, objective_scores=None),
+        )
+        # Candidate b is the sole objective-axis winner.
+        frontier.add(
+            _make_candidate("b"),
+            _make_result(
+                "b", {"i0": 0.0},
+                objective_scores=[{"obj": 0.9}],
+            ),
+        )
+        parent = frontier.select_parent()
+        assert parent.id == "b"
+
+    def test_rebuild_preserves_all_axes(self):
+        """``update_scores`` triggers a rebuild that regenerates every
+        axis from the (possibly updated) results."""
+        frontier = ParetoFrontier(frontier_type="hybrid")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result(
+                "a", {"i0": 0.5},
+                objective_scores=[{"obj": 0.5}],
+            ),
+        )
+        # Update a's result — bump both instance and objective scores.
+        new_result = _make_result(
+            "a", {"i0": 1.0},
+            objective_scores=[{"obj": 1.0}],
+        )
+        frontier.update_scores(new_result)
+        assert frontier._per_key_best_score["i0"] == 1.0
+        assert frontier._objective_best_score["obj"] == 1.0

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -324,6 +324,7 @@ def test_state_json_keys_when_val_stage_disabled(tmp_path: Path) -> None:
         "merge_description_triplets",
         "i",
         "num_metric_calls_by_discovery",
+        "frontier_type",
     }
     assert set(raw.keys()) == expected_keys, (
         f"state.json keys diverged from schema_version={SCHEMA_VERSION} "

--- a/uv.lock
+++ b/uv.lock
@@ -162,7 +162,7 @@ wheels = [
 
 [[package]]
 name = "helix-evo"
-version = "0.1.0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -174,6 +174,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
@@ -189,6 +190,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "gitpython", specifier = ">=3.1" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pathspec", specifier = ">=0.12" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
Brings `helix_result` and the reflection loop into parity with upstream reference `optimize_anything`.

## What changed

1. **`helix_result` parser → per-example, positional.** Evaluators now emit one entry per id in `helix_batch.json`, matching upstream reference's `tuple[float, SideInfo] | float` union. HELIX zips into `instance_scores`, stores per-example `side_info` on `EvalResult`, and harvests `side_info["scores"]` into `objective_scores`.

2. **Multi-axis Pareto frontier.** New `evolution.frontier_type: Literal["instance", "objective", "hybrid", "cartesian"]`, default `"hybrid"` matching upstream reference Persisted in `state.json` so `helix frontier` / `helix best` display the axis the run actually used.

3. **Per-example reflection.** `build_mutation_prompt` renders `per_example_side_info` as a markdown block under `## Diagnostics` with recursive nested-dict rendering (capped at h6). Rendered prompt is persisted to `<worktree>/.helix_mutation_prompt.md` for post-hoc inspection.

## Why

Previously, an evaluator that emitted `HELIX_RESULT=[scalar, {"scores": {"task__metric": ...}}]` silently mismatched the `task__trialN` ids HELIX looked up in `instance_scores` — every post-filter zero-filled and strict-improvement saw `0.0 vs 0.0` forever. A run cost 113 generations and produced zero evolution before the mismatch was caught. This PR replaces that contract with upstream reference per-example shape, where the mismatch becomes an `EvaluatorError` at parse time.

## Contract diff (breaking)

**Before** — single aggregate entry, dict-keyed:
```text
HELIX_RESULT=[0.42, {"scores": {"task__0": 1.0, ...}}]
```

**After** — per-example, positional to `helix_batch.json`; any of:
```text
HELIX_RESULT=[1.0, 0.5, 0.0]                                 # all bare
HELIX_RESULT=[[1.0, {"scores": {"obj_a": 0.9}}], [0.5, {}]]  # all rich
HELIX_RESULT=[1.0, [0.5, {"note": "mid"}], 0.0]              # mixed
```

## Commits (17)

Parser + frontier + tests (A–E), upstream reference contract extensions (F, J, K, L, M), silent-failure fixes surfaced in dry runs (G, H, I), reviewer polish (N, O, P, Q). Each commit is green in isolation; see the commit log for per-commit scope.

## Migration

- `helix_result` evaluators must migrate to per-example shape — see contract diff. `payload[i]` must describe `helix_batch.json[i]` (reorder in the evaluator if its native iteration order differs).
- Other parsers unaffected; they leave `per_example_side_info` / `objective_scores` as `None` and the frontier degenerates to the instance path.
- `frontier_type` default is `"hybrid"`; existing instance-only runs should pin `evolution.frontier_type = "instance"` in config.

## Test plan

- [x] `uv run pytest tests/ -q` → 620 passed
- [x] `uv run mypy --strict src/helix/` → clean
- [x] Each commit green in isolation
- [x] One-generation live evolve dry run — exit 0, 70/70 positional alignment, Diagnostics artifact on disk, CLI reads persisted `frontier_type`

## Related

- #7 (`fix/effort-help-text`, cosmetic)
- #8 (`fix/strict-config-keys`, introduced `helix_batch.json` + `extra="forbid"`)
