### PR TITLE
[codex] support multiple mutation backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Evolutionary optimization for full codebases using agentic coding tools as the mutation engine and git worktrees as the population pool.**
 
-HELIX brings reflective Pareto evolution out of the single-artifact setting and into real software projects: entire repositories, multi-turn agentic mutation, tool use, web research, and verification loops, all inside a single evolutionary stage. Currently supports Claude Code, with support for OpenCode, Codex CLI, and Cursor CLI coming in the next release.
+HELIX brings reflective Pareto evolution out of the single-artifact setting and into real software projects: entire repositories, multi-turn agentic mutation, tool use, web research, and verification loops, all inside a single evolutionary stage. Supported mutation backends include Claude Code, Codex CLI, Cursor Agent, Gemini CLI, and OpenCode.
 
 <br>
 
@@ -65,7 +65,7 @@ This is why `solver/solution.py` on cap-x or a shrinkwrap of a ML kernel on GPT-
 | 🧬 | **Whole-codebase evolution** | The candidate is your repository, not a single file, prompt, or patch |
 | 📂 | **Multi-file editing** | Mutate entire directory trees — edit `auth.py:42` and `routes.py:18` in one coherent session |
 | 🔁 | **Multi-turn mutations** | A single mutation can inspect, edit, test, revise, and continue before being evaluated |
-| 🔧 | **Tool access during mutation** | Claude Code can read, grep, run tests, inspect the codebase, and use the web mid-mutation |
+| 🔧 | **Tool access during mutation** | The configured backend can read, grep, run tests, inspect the codebase, and use the web mid-mutation |
 | ✅ | **Self-verification** | Mutations verify themselves by running commands before committing |
 | 📊 | **Pareto frontier** | Instance-level Pareto selection across test cases — no single metric bottleneck |
 | ⚡ | **Parallel evaluation** | Worktrees are isolated → parallel proposals via `ThreadPoolExecutor` (GEPA parity, bounded by `evolution.max_workers`) |
@@ -97,8 +97,8 @@ This is why `solver/solution.py` on cap-x or a shrinkwrap of a ML kernel on GPT-
                            │                               │
                            ▼                               │
                ┌───────────────────────┐                   │
-               │  Mutate via Claude    │                   │
-               │  Code in Worktree     │                   │
+               │  Mutate via Agent     │                   │
+               │  Backend in Worktree  │                   │
                │                       │                   │
                │  • Read files         │                   │
                │  • Edit multi-file    │                   │
@@ -134,10 +134,10 @@ This is why `solver/solution.py` on cap-x or a shrinkwrap of a ML kernel on GPT-
 1. **Seed** — Your starting code is copied into a git worktree and evaluated
 2. **Evaluate** — Run your evaluator command; parse scores per test/instance
 3. **Select** — Pick a parent from the Pareto frontier (weighted by instance wins)
-4. **Mutate** — Spawn Claude Code in an isolated worktree with full tool access. It reads files, diagnoses failures, makes surgical multi-file edits, and runs commands to verify
+4. **Mutate** — Spawn the configured agent backend in an isolated worktree with full tool access. It reads files, diagnoses failures, makes surgical multi-file edits, and runs commands to verify
 5. **Gate** — Re-evaluate on the train set. Reject if the mutation caused regressions
 6. **Pareto Update** — Evaluate on the val set and update the Pareto frontier
-7. **Merge** — Periodically combine two complementary frontier candidates via Claude Code
+7. **Merge** — Periodically combine two complementary frontier candidates via the configured backend
 8. **Cleanup** — Remove dominated worktrees; persist state; repeat
 
 ---
@@ -167,20 +167,21 @@ This creates a `helix.toml` config file and a `.helix/` directory. Edit `helix.t
 
 ### Whole-repo-as-candidate Model
 
-HELIX treats your **entire working tree** as the candidate. There is no `target_file` — Claude Code may read, edit, create, or delete any file in the project tree during each mutation. A minimal project layout looks like:
+HELIX treats your **entire working tree** as the candidate. There is no `target_file` — the configured backend may read, edit, create, or delete any file in the project tree during each mutation. A minimal project layout looks like:
 
 ```
 my-project/
 ├── helix.toml       # HELIX config (run `helix init` to generate)
 ├── evaluate.py      # Your evaluator script (must output JSON with a "score" key)
-├── solve.py         # File(s) you want to evolve (Claude Code will find them)
+├── solve.py         # File(s) you want to evolve (the backend will find them)
 └── ...              # Any other files; HELIX will consider them too
 ```
 
-To restrict what Claude Code touches, set `claude.background` in `helix.toml`:
+To restrict what the backend touches, set `agent.background` in `helix.toml`:
 
 ```toml
-[claude]
+[agent]
+backend = "claude"
 background = "Only modify files under src/. Do not edit tests/ or config/."
 ```
 
@@ -298,8 +299,9 @@ frontier_type = "hybrid"         # Pareto dimensionality (GEPA FrontierType pari
                                  # Non-instance axes require score_parser="helix_result"
                                  # emitting per-example side_info["scores"] dicts.
 
-[claude]
-model = "sonnet"                 # or "opus", "haiku", full model name
+[agent]
+backend = "claude"               # "claude" | "codex" | "cursor" | "gemini" | "opencode"
+model = "sonnet"                 # backend-specific model name
 effort = "medium"                # optional: "low" | "medium" | "high" | "xhigh" | "max"
 max_turns = 20
 allowed_tools = ["Read", "Edit", "Write", "Bash", "Glob", "Grep"]
@@ -477,8 +479,8 @@ Pack 26 non-overlapping circles in a unit square, maximizing sum of radii.
 | `population.py` | `Candidate`, `EvalResult`, `ParetoFrontier` |
 | `worktree.py` | Git worktree lifecycle (create, clone, snapshot, remove) |
 | `executor.py` | Run evaluator commands |
-| `mutator.py` | Claude Code mutation invocation with autonomous system prompt |
-| `merger.py` | Claude Code merge/crossover between complementary candidates |
+| `mutator.py` | Backend mutation invocation with autonomous system prompt and HELIX usage artifacts |
+| `merger.py` | Backend merge/crossover between complementary candidates |
 | `lineage.py` | Ancestry graph tracking |
 | `state.py` | Atomic state persistence and resume |
 | `display.py` | Rich terminal UI with phase tracking |
@@ -509,7 +511,11 @@ BSD 3-Clause License. See [LICENSE](LICENSE) for details.
 HELIX's core evolutionary algorithm is based on **GEPA optimize_anything** by Agrawal, Lee, Ma, Elmaaroufi, Tan, Seshia, Sen, Klein, Stoica, Gonzalez, Khattab, Dimakis, and Zaharia. Their work on applying reflective Pareto evolution to any text made HELIX possible — we extended their algorithm to full codebases and agentic mutation but the foundation is theirs.
 
 - **[GEPA optimize_anything](https://gepa-ai.github.io/gepa/blog/2026/02/18/introducing-optimize-anything/)** — The algorithmic foundation: minibatch-gated Pareto evolution with reflective LLM mutation
-- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — The agentic coding tool powering HELIX's mutation and merge engine
+- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — Supported HELIX mutation backend
+- **[Codex CLI](https://developers.openai.com/codex/cli)** — Supported HELIX mutation backend
+- **[Cursor CLI](https://cursor.com/cli/)** — Supported HELIX mutation backend
+- **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — Supported HELIX mutation backend
+- **[OpenCode](https://opencode.ai/docs/cli/)** — Supported HELIX mutation backend
 - **[OMAR](http://omar.tech/)** — The multi-agent orchestration system used to build HELIX
 
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ To restrict what the backend touches, set `agent.background` in `helix.toml`:
 ```toml
 [agent]
 backend = "claude"
+# model = "sonnet"  # optional backend-specific model
 background = "Only modify files under src/. Do not edit tests/ or config/."
 ```
 
@@ -301,7 +302,7 @@ frontier_type = "hybrid"         # Pareto dimensionality (GEPA FrontierType pari
 
 [agent]
 backend = "claude"               # "claude" | "codex" | "cursor" | "gemini" | "opencode"
-model = "sonnet"                 # backend-specific model name
+# model = "sonnet"               # optional backend-specific model name
 effort = "medium"                # optional: "low" | "medium" | "high" | "xhigh" | "max"
 max_turns = 20
 allowed_tools = ["Read", "Edit", "Write", "Bash", "Glob", "Grep"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "helix-evo"
-version = "0.1.3"
+version = "0.2.0"
 description = "Hierarchical Evolution via LLM-Informed eXploration"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich.tree import Tree
 
 from helix import __version__
-from helix.config import load_config, HelixConfig
+from helix.config import load_config
 from helix.logging_config import setup_file_logging
 from helix.display import (
     console,
@@ -44,7 +44,8 @@ _HELIX_TOML_TEMPLATE = """\
 # HELIX evolves your whole repo. Each mutation may read, edit, create, or delete
 # any file in the project tree. There is no target_file setting.
 #
-# To restrict what Claude Code touches, describe constraints in claude.background.
+# To restrict what the mutation backend touches, describe constraints in
+# agent.background.
 
 # Describe what you want the code to do better.
 objective = "Describe the optimisation objective"
@@ -65,7 +66,8 @@ command = "uv run python evaluate.py"
 max_generations = 20
 merge_enabled = false
 
-[claude]
+[agent]
+backend = "claude"
 model = "sonnet"
 max_turns = 20
 # background = "Only modify files under src/. Do not touch tests/ or config/."
@@ -328,7 +330,7 @@ def init() -> None:
 @cli.command(
     help=(
         "Run the HELIX evolutionary loop on the current project. "
-        "HELIX evolves your WHOLE REPO — Claude Code may read, edit, create, or delete "
+        "HELIX evolves your WHOLE REPO — the configured agent backend may read, edit, create, or delete "
         "any file in the project tree in each mutation. "
         "There is no target_file; the candidate is your entire working tree at HEAD.\n\n"
         "Requires a helix.toml file in the project directory. "
@@ -346,10 +348,13 @@ def init() -> None:
               help="Override max_generations.")
 @click.option("--no-merge", "no_merge", is_flag=True, default=False,
               help="Disable merge operations.")
+@click.option("--backend", default=None,
+              type=click.Choice(["claude", "codex", "cursor", "gemini", "opencode"]),
+              help="Override the mutation backend.")
 @click.option("--model", default=None,
-              help="Override the Claude model (e.g. claude-haiku-4-5-20250514).")
+              help="Override the backend model.")
 @click.option("--effort", default=None,
-              help="Override Claude effort level (e.g. low, medium, high, xhigh, max).")
+              help="Override backend effort / reasoning level when supported.")
 def evolve(
     config_path: str,
     project_dir: Path | None,
@@ -357,6 +362,7 @@ def evolve(
     evaluator: str | None,
     generations: int | None,
     no_merge: bool,
+    backend: str | None,
     model: str | None,
     effort: str | None,
 ) -> None:
@@ -403,14 +409,16 @@ def evolve(
                 "evolution": config.evolution.model_copy(update={"merge_enabled": False})
             }
         )
-    if model is not None or effort is not None:
-        claude_updates: dict[str, Any] = {}
+    if backend is not None or model is not None or effort is not None:
+        agent_updates: dict[str, Any] = {}
+        if backend is not None:
+            agent_updates["backend"] = backend
         if model is not None:
-            claude_updates["model"] = model
+            agent_updates["model"] = model
         if effort is not None:
-            claude_updates["effort"] = effort
+            agent_updates["effort"] = effort
         config = config.model_copy(
-            update={"claude": config.claude.model_copy(update=claude_updates)}
+            update={"agent": config.agent.model_copy(update=agent_updates)}
         )
 
     base_dir = _helix_dir(project_root)

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -68,7 +68,7 @@ merge_enabled = false
 
 [agent]
 backend = "claude"
-model = "sonnet"
+# model = "sonnet"  # optional backend-specific model
 max_turns = 20
 # background = "Only modify files under src/. Do not touch tests/ or config/."
 """

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -398,7 +398,7 @@ class AgentConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     backend: Literal["claude", "codex", "cursor", "gemini", "opencode"] = "claude"
-    model: str = "sonnet"
+    model: str | None = None
     effort: str | None = None
     max_turns: int | None = None
     allowed_tools: list[str] = Field(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -392,14 +392,12 @@ class EvolutionConfig(BaseModel):
             )
 
 
-class ClaudeConfig(BaseModel):
-    """Configuration for Claude Code integration.
-
-    Specifies which Claude model to use, allowed tools, effort level,
-    and optional background context for mutation sessions.
+class AgentConfig(BaseModel):
+    """Configuration for the mutation backend integration.
     """
     model_config = ConfigDict(extra="forbid")
 
+    backend: Literal["claude", "codex", "cursor", "gemini", "opencode"] = "claude"
     model: str = "sonnet"
     effort: str | None = None
     max_turns: int | None = None
@@ -427,7 +425,7 @@ class HelixConfig(BaseModel):
     """Top-level HELIX configuration.
 
     Combines all configuration sections (objective, evaluator, dataset,
-    evolution, claude, worktree) and validates compatibility constraints.
+    evolution, agent, worktree) and validates compatibility constraints.
     """
     model_config = ConfigDict(extra="forbid")
 
@@ -438,7 +436,7 @@ class HelixConfig(BaseModel):
         default_factory=list,
         description=(
             "Environment variable names to pass through the env scrub into "
-            "evaluator and Claude Code subprocesses (e.g. "
+            "evaluator and agent subprocesses (e.g. "
             '["CUDA_VISIBLE_DEVICES", "MUJOCO_GL", "HF_HOME"]).'
         ),
     )
@@ -446,7 +444,7 @@ class HelixConfig(BaseModel):
     dataset: DatasetConfig = Field(default_factory=DatasetConfig)
     seedless: SeedlessConfig = Field(default_factory=SeedlessConfig)
     evolution: EvolutionConfig = Field(default_factory=EvolutionConfig)
-    claude: ClaudeConfig = Field(default_factory=ClaudeConfig)
+    agent: AgentConfig = Field(default_factory=AgentConfig)
     worktree: WorktreeConfig = Field(default_factory=WorktreeConfig)
 
     def model_post_init(self, __context: object) -> None:
@@ -503,6 +501,6 @@ def load_config(path: Path) -> HelixConfig:
                     file=sys.stderr,
                 )
             elif "type" in str(error["type"]):
-                print(f"   Hint: Check that the value is the correct type", file=sys.stderr)
+                print("   Hint: Check that the value is the correct type", file=sys.stderr)
             print(file=sys.stderr)
         sys.exit(1)

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1100,7 +1100,7 @@ def run_evolution(
                 _dataset_examples = load_dataset_examples(config.seedless.train_path)
             seed_prompt = build_seed_generation_prompt(
                 objective=config.objective,
-                background=config.claude.background,
+                background=config.agent.background,
                 evaluator_cmd=config.evaluator.command,
                 dataset_examples=_dataset_examples,
             )
@@ -1365,7 +1365,7 @@ def run_evolution(
                     new_id=merge_id,
                     config=config,
                     base_dir=worktrees_dir,
-                    background=config.claude.background,
+                    background=config.agent.background,
                     eval_result_a=era,
                     eval_result_b=erb,
                 )
@@ -1859,7 +1859,7 @@ def run_evolution(
                 new_id=_new_id,
                 config=config,
                 base_dir=worktrees_dir,
-                background=config.claude.background,
+                background=config.agent.background,
             )
 
         mutation_results: list[Candidate | None]

--- a/src/helix/merger.py
+++ b/src/helix/merger.py
@@ -9,7 +9,7 @@ from typing import Mapping
 
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig
-from helix.worktree import clone_candidate, snapshot_candidate, remove_worktree, get_diff
+from helix.worktree import clone_candidate, snapshot_candidate, remove_worktree, get_diff  # noqa: F401
 from helix.exceptions import MutationError, RateLimitError, print_helix_error
 from helix.mutator import invoke_claude_code, AUTONOMOUS_SYSTEM_PROMPT, _turn_budget_section
 
@@ -197,11 +197,11 @@ def merge(
         eval_result_b,
         diff,
         background,
-        config.claude.max_turns,
+        config.agent.max_turns,
     )
 
     try:
-        invoke_claude_code(child.worktree_path, prompt, config.claude, passthrough_env=config.passthrough_env)
+        invoke_claude_code(child.worktree_path, prompt, config.agent, passthrough_env=config.passthrough_env)
     except MutationError as exc:
         exc.operation = f"merge {new_id} ({candidate_a.id} + {candidate_b.id})"
         print_helix_error(exc)

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -593,7 +593,6 @@ def _build_backend_args(
             "run",
             "--format", "json",
             "--dangerously-skip-permissions",
-            "--dir", worktree_path,
         ]
         if config.model:
             args.extend(["--model", config.model])

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 import json
 import logging
-import os
+import shlex
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from helix.population import Candidate, EvalResult
-from helix.config import ClaudeConfig, HelixConfig
+from helix.config import AgentConfig, HelixConfig
 from helix.exceptions import MutationError, RateLimitError, print_helix_error
 from helix.executor import _scrub_environment
-from helix.worktree import clone_candidate, snapshot_candidate, remove_worktree
+from helix.worktree import clone_candidate, snapshot_candidate, remove_worktree  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ def build_seed_generation_prompt(
     evaluator_cmd: str | None = None,
     dataset_examples: list[str] | None = None,
 ) -> str:
-    """Construct the seed generation prompt for Claude Code.
+    """Construct the seed generation prompt for the configured backend.
 
     Mirrors GEPA's ``_build_seed_generation_prompt`` — a single structured
     prompt that gives the LLM everything it needs to write a first candidate
@@ -179,18 +179,18 @@ def generate_seed(
     Parameters
     ----------
     worktree_path:
-        Path to the (empty) seed worktree where Claude will write files.
+        Path to the (empty) seed worktree where the backend will write files.
     prompt:
         The seed-generation prompt built by :func:`build_seed_generation_prompt`.
     config:
-        Full HELIX config (``config.claude`` is used for the LLM invocation).
+        Full HELIX config (``config.agent`` is used for the backend invocation).
 
     Raises
     ------
     MutationError
         Propagated directly from :func:`invoke_claude_code` on failure.
     """
-    invoke_claude_code(worktree_path, prompt, config.claude, passthrough_env=config.passthrough_env)
+    invoke_claude_code(worktree_path, prompt, config.agent, passthrough_env=config.passthrough_env)
 
 
 _MAX_MARKDOWN_HEADER_LEVEL = 6
@@ -454,6 +454,9 @@ def _looks_like_rate_limit(text: str) -> bool:
 #: dot + per-worktree ``.gitignore`` entry keep it out of the candidate
 #: git tree.
 MUTATION_PROMPT_ARTIFACT_NAME = ".helix_mutation_prompt.md"
+BACKEND_RESULT_ARTIFACT_NAME = ".helix_backend_result.json"
+BACKEND_STDOUT_ARTIFACT_NAME = ".helix_backend_stdout.txt"
+BACKEND_STDERR_ARTIFACT_NAME = ".helix_backend_stderr.txt"
 
 
 def _ignore_helix_artifacts(worktree_path: Path) -> None:
@@ -474,6 +477,9 @@ def _ignore_helix_artifacts(worktree_path: Path) -> None:
     patterns = [
         "# HELIX per-invocation artifacts (never commit to candidate tree)",
         MUTATION_PROMPT_ARTIFACT_NAME,
+        BACKEND_RESULT_ARTIFACT_NAME,
+        BACKEND_STDOUT_ARTIFACT_NAME,
+        BACKEND_STDERR_ARTIFACT_NAME,
         "helix_batch.json",
     ]
     existing = gitignore.read_text() if gitignore.exists() else ""
@@ -504,26 +510,342 @@ def _write_mutation_prompt_artifact(worktree_path: str, prompt: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Claude Code invocation
+# Backend invocation
 # ---------------------------------------------------------------------------
+
+
+def _backend_display_name(backend: str) -> str:
+    return {
+        "claude": "Claude Code",
+        "codex": "Codex CLI",
+        "cursor": "Cursor Agent",
+        "gemini": "Gemini CLI",
+        "opencode": "OpenCode",
+    }.get(backend, backend)
+
+
+def _build_backend_args(
+    worktree_path: str,
+    prompt: str,
+    config: AgentConfig,
+) -> list[str]:
+    backend = config.backend
+    if backend == "claude":
+        tools_str = ",".join(config.allowed_tools)
+        args = [
+            "claude",
+            "--dangerously-skip-permissions",
+            "--print",
+            "--output-format", "json",
+            "--allowedTools", tools_str,
+        ]
+        if config.model:
+            args.extend(["--model", config.model])
+        if config.effort:
+            args.extend(["--effort", config.effort])
+        if config.max_turns is not None:
+            args.extend(["--max-turns", str(config.max_turns)])
+        args.extend(["-p", prompt])
+        return args
+
+    if backend == "codex":
+        args = [
+            "codex",
+            "exec",
+            "--json",
+            "--dangerously-bypass-approvals-and-sandbox",
+        ]
+        if config.model:
+            args.extend(["--model", config.model])
+        args.append(prompt)
+        return args
+
+    if backend == "cursor":
+        args = [
+            "cursor",
+            "agent",
+            "--print",
+            "--output-format", "stream-json",
+            "--yolo",
+            "--approve-mcps",
+            "--trust",
+            "--workspace", worktree_path,
+        ]
+        if config.model:
+            args.extend(["--model", config.model])
+        args.append(prompt)
+        return args
+
+    if backend == "gemini":
+        args = [
+            "gemini",
+            "--yolo",
+            "--prompt", prompt,
+            "--output-format", "stream-json",
+        ]
+        if config.model:
+            args.extend(["--model", config.model])
+        return args
+
+    if backend == "opencode":
+        args = [
+            "opencode",
+            "run",
+            "--format", "json",
+            "--dangerously-skip-permissions",
+            "--dir", worktree_path,
+        ]
+        if config.model:
+            args.extend(["--model", config.model])
+        if config.effort:
+            args.extend(["--variant", config.effort])
+        args.append(prompt)
+        return args
+
+    raise ValueError(f"Unsupported backend: {backend}")
+
+
+def _parse_json_object_output(
+    stdout: str,
+    *,
+    backend: str,
+    cmd_str: str,
+    worktree_path: str,
+    stderr: str,
+    exit_code: int,
+) -> dict[str, Any]:
+    if not stdout.strip():
+        return {}
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise MutationError(
+            f"Failed to parse {_backend_display_name(backend)} JSON output: {exc}",
+            operation=f"{_backend_display_name(backend)} invocation",
+            phase="JSON parsing",
+            command=cmd_str,
+            cwd=str(worktree_path),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+            suggestion=(
+                f"{_backend_display_name(backend)} returned non-JSON output. "
+                "Check stdout above for details."
+            ),
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise MutationError(
+            f"{_backend_display_name(backend)} returned non-object JSON "
+            f"(got {type(parsed).__name__})",
+            operation=f"{_backend_display_name(backend)} invocation",
+            phase="JSON parsing",
+            command=cmd_str,
+            cwd=str(worktree_path),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+            suggestion=(
+                f"{_backend_display_name(backend)} returned a non-object JSON "
+                "value. Expected a JSON object."
+            ),
+        )
+    return parsed
+
+
+def _parse_jsonl_output(
+    stdout: str,
+    *,
+    backend: str,
+    cmd_str: str,
+    worktree_path: str,
+    stderr: str,
+    exit_code: int,
+    strict: bool,
+) -> dict[str, Any]:
+    events: list[dict[str, Any]] = []
+    unparsable: list[str] = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            if strict:
+                # Gemini CLI may prepend advisory text such as MCP-health
+                # warnings before the JSON stream even when
+                # `--output-format stream-json` is requested.
+                if backend == "gemini":
+                    unparsable.append(line)
+                    continue
+                raise MutationError(
+                    f"Failed to parse {_backend_display_name(backend)} JSONL output line",
+                    operation=f"{_backend_display_name(backend)} invocation",
+                    phase="JSON parsing",
+                    command=cmd_str,
+                    cwd=str(worktree_path),
+                    stdout=stdout,
+                    stderr=stderr,
+                    exit_code=exit_code,
+                    suggestion=(
+                        f"{_backend_display_name(backend)} emitted a non-JSON line "
+                        "in structured output mode. Check stdout above for details."
+                    ),
+                )
+            unparsable.append(line)
+            continue
+        if isinstance(parsed, dict):
+            events.append(parsed)
+    return {
+        "events": events,
+        "unparsable_lines": unparsable,
+    }
+
+
+def _parse_backend_output(
+    backend: str,
+    result: subprocess.CompletedProcess[str],
+    *,
+    cmd_str: str,
+    worktree_path: str,
+) -> dict[str, Any]:
+    if backend == "claude":
+        return _parse_json_object_output(
+            result.stdout,
+            backend=backend,
+            cmd_str=cmd_str,
+            worktree_path=worktree_path,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+        )
+    if backend in {"codex", "cursor", "gemini", "opencode"}:
+        return _parse_jsonl_output(
+            result.stdout,
+            backend=backend,
+            cmd_str=cmd_str,
+            worktree_path=worktree_path,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+            strict=result.returncode == 0,
+        )
+    raise ValueError(f"Unsupported backend: {backend}")
+
+
+def _walk_json(obj: Any) -> list[dict[str, Any]]:
+    found: list[dict[str, Any]] = []
+    if isinstance(obj, dict):
+        found.append(obj)
+        for value in obj.values():
+            found.extend(_walk_json(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            found.extend(_walk_json(item))
+    return found
+
+
+def _coerce_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _normalise_usage_stats(parsed: dict[str, Any]) -> dict[str, Any]:
+    usage: dict[str, Any] = {}
+    tool_event_count = 0
+    for node in _walk_json(parsed):
+        node_type = str(node.get("type", "")).lower()
+        if "tool" in node_type:
+            tool_event_count += 1
+        for key, aliases in (
+            ("input_tokens", ("input_tokens", "inputTokens", "prompt_tokens", "promptTokens", "input")),
+            ("output_tokens", ("output_tokens", "outputTokens", "completion_tokens", "completionTokens", "output")),
+            ("cached_input_tokens", ("cached_input_tokens", "cachedTokens", "cacheReadInputTokens", "cacheRead", "cached")),
+            ("reasoning_tokens", ("reasoning_tokens", "reasoningTokens", "thoughts")),
+            ("cost_usd", ("cost_usd", "costUsd", "total_cost_usd", "totalCostUsd", "total")),
+        ):
+            if key in usage:
+                continue
+            for alias in aliases:
+                if alias in node:
+                    value = _coerce_number(node[alias])
+                    if value is not None:
+                        usage[key] = value
+                        break
+        if "session_id" not in usage:
+            for alias in ("session_id", "sessionId", "chat_id", "chatId", "thread_id", "threadId"):
+                value = node.get(alias)
+                if isinstance(value, str) and value:
+                    usage["session_id"] = value
+                    break
+            if "session_id" not in usage:
+                value = node.get("sessionID")
+                if isinstance(value, str) and value:
+                    usage["session_id"] = value
+        if "cost_usd" not in usage:
+            value = node.get("cost")
+            coerced = _coerce_number(value)
+            if coerced is not None:
+                usage["cost_usd"] = coerced
+    if tool_event_count:
+        usage["tool_event_count"] = tool_event_count
+    return usage
+
+
+def _write_backend_artifacts(
+    worktree_path: str,
+    *,
+    backend: str,
+    command: str,
+    result: subprocess.CompletedProcess[str],
+    parsed: dict[str, Any] | None,
+) -> None:
+    try:
+        wt = Path(worktree_path)
+        _ignore_helix_artifacts(wt)
+        (wt / BACKEND_STDOUT_ARTIFACT_NAME).write_text(result.stdout or "")
+        (wt / BACKEND_STDERR_ARTIFACT_NAME).write_text(result.stderr or "")
+        payload = {
+            "backend": backend,
+            "backend_display_name": _backend_display_name(backend),
+            "command": command,
+            "cwd": worktree_path,
+            "returncode": result.returncode,
+            "stdout_artifact": BACKEND_STDOUT_ARTIFACT_NAME,
+            "stderr_artifact": BACKEND_STDERR_ARTIFACT_NAME,
+            "usage": _normalise_usage_stats(parsed or {}),
+            "parsed": parsed,
+        }
+        (wt / BACKEND_RESULT_ARTIFACT_NAME).write_text(json.dumps(payload, indent=2))
+    except OSError as e:
+        logger.debug(
+            "failed to write backend artifacts to %s: %s",
+            worktree_path, e,
+        )
 
 
 def invoke_claude_code(
     worktree_path: str,
     prompt: str,
-    config: ClaudeConfig,
+    config: AgentConfig,
     passthrough_env: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Invoke Claude Code CLI in *worktree_path* and return the parsed JSON output.
+    """Invoke the configured backend CLI in *worktree_path*.
 
     Parameters
     ----------
     worktree_path:
-        Working directory for the Claude Code subprocess.
+        Working directory for the backend subprocess.
     prompt:
-        The prompt to pass via ``-p``.
+        Prompt / task instructions for the backend.
     config:
-        Claude configuration (model, effort, allowed_tools).
+        Backend configuration (backend selector, model, effort, tool policy).
     passthrough_env:
         Optional list of extra env var names to preserve from the parent
         process through the env scrub (e.g. CUDA_VISIBLE_DEVICES).
@@ -531,7 +853,7 @@ def invoke_claude_code(
     Returns
     -------
     dict
-        Parsed JSON from Claude Code's stdout.
+        Parsed structured output from the backend.
 
     Raises
     ------
@@ -542,47 +864,60 @@ def invoke_claude_code(
     """
     if _MUTATOR_OVERRIDE is not None:
         return _MUTATOR_OVERRIDE(worktree_path, prompt, config)
+    backend = config.backend
+    backend_name = _backend_display_name(backend)
+    args = _build_backend_args(worktree_path, prompt, config)
+    cmd_str = shlex.join(args)
 
-    tools_str = ",".join(config.allowed_tools)
-    args = [
-        "claude",
-        "--dangerously-skip-permissions",
-        "--print",
-        "--output-format", "json",
-        "--allowedTools", tools_str,
-    ]
-    if config.model:
-        args.extend(["--model", config.model])
-    if config.effort:
-        args.extend(["--effort", config.effort])
-    if config.max_turns is not None:
-        args.extend(["--max-turns", str(config.max_turns)])
-    args.extend(["-p", prompt])
-
-    cmd_str = " ".join(args)
-
-    # Reuse the shared scrub helper (no split/instance_ids for CC sessions).
-    cc_env = _scrub_environment(passthrough_env=passthrough_env)
-
+    backend_env = _scrub_environment(passthrough_env=passthrough_env)
     result = subprocess.run(
         args,
         cwd=worktree_path,
         capture_output=True,
         text=True,
-        env=cc_env,
+        env=backend_env,
     )
 
-    if result.returncode != 0:
-        # Check for rate-limit / overload before raising generic MutationError
-        if _looks_like_rate_limit(result.stderr) or _looks_like_rate_limit(result.stdout):
+    parsed: dict[str, Any] | None = None
+    try:
+        if result.returncode == 0:
+            parsed = _parse_backend_output(
+                backend,
+                result,
+                cmd_str=cmd_str,
+                worktree_path=worktree_path,
+            )
+            if backend == "claude":
+                error_text = str(parsed.get("error", ""))
+                if _looks_like_rate_limit(error_text):
+                    logger.error("Rate limit detected in JSON response: %s", error_text[:200])
+                    raise RateLimitError(
+                        f"{backend_name} returned a rate/usage limit error in JSON response",
+                        operation=f"{backend_name} invocation",
+                        phase="JSON parsing",
+                        command=cmd_str,
+                        cwd=str(worktree_path),
+                        stdout=result.stdout,
+                        stderr=result.stderr,
+                        exit_code=result.returncode,
+                        suggestion=(
+                            f"{backend_name} reported a rate limit. "
+                            "Retry after backoff or check your API quota."
+                        ),
+                    )
+            return parsed
+
+        rate_limit_source = result.stderr or result.stdout
+        if _looks_like_rate_limit(rate_limit_source):
             logger.error(
-                "Rate limit detected in subprocess exit (code %d): %s",
+                "Rate limit detected in subprocess exit for %s (code %d): %s",
+                backend_name,
                 result.returncode,
-                (result.stderr or result.stdout)[:200],
+                rate_limit_source[:200],
             )
             raise RateLimitError(
-                f"Claude Code hit a rate/usage limit (exit code {result.returncode})",
-                operation="Claude Code invocation",
+                f"{backend_name} hit a rate/usage limit (exit code {result.returncode})",
+                operation=f"{backend_name} invocation",
                 phase="subprocess exit",
                 command=cmd_str,
                 cwd=str(worktree_path),
@@ -590,27 +925,40 @@ def invoke_claude_code(
                 stderr=result.stderr,
                 exit_code=result.returncode,
                 suggestion=(
-                    "Claude Code reported a rate limit. "
-                    "Retry after backoff or check your API quota."
+                    f"{backend_name} reported a rate limit. "
+                    "Retry after backoff or check your quota."
                 ),
             )
 
-        # error_max_turns: Claude hit the turn limit but may have made useful changes.
-        # Parse stdout as JSON and return it as a partial success rather than discarding.
-        try:
-            parsed = json.loads(result.stdout)
-            if isinstance(parsed, dict) and parsed.get("subtype") == "error_max_turns":
-                logger.warning(
-                    "Claude Code reached max_turns limit (%s turns) — treating as partial success.",
-                    parsed.get("num_turns", "?"),
+        # Claude's max-turns exhaustion is intentionally treated as partial
+        # success because the subprocess may have already produced useful edits.
+        if backend == "claude":
+            try:
+                parsed = _parse_backend_output(
+                    backend,
+                    result,
+                    cmd_str=cmd_str,
+                    worktree_path=worktree_path,
                 )
-                return parsed
-        except json.JSONDecodeError:
-            pass
+                if parsed.get("subtype") == "error_max_turns":
+                    logger.warning(
+                        "Claude Code reached max_turns limit (%s turns) — treating as partial success.",
+                        parsed.get("num_turns", "?"),
+                    )
+                    return parsed
+            except MutationError:
+                parsed = None
+
+        parsed = _parse_backend_output(
+            backend,
+            result,
+            cmd_str=cmd_str,
+            worktree_path=worktree_path,
+        )
 
         raise MutationError(
-            f"Claude Code exited with code {result.returncode}",
-            operation="Claude Code invocation",
+            f"{backend_name} exited with code {result.returncode}",
+            operation=f"{backend_name} invocation",
             phase="subprocess exit",
             command=cmd_str,
             cwd=str(worktree_path),
@@ -619,57 +967,14 @@ def invoke_claude_code(
             exit_code=result.returncode,
             suggestion="Check stderr for rate limits, permission errors, or model availability.",
         )
-
-    try:
-        parsed = json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
-        raise MutationError(
-            f"Failed to parse Claude Code JSON output: {exc}",
-            operation="Claude Code invocation",
-            phase="JSON parsing",
+    finally:
+        _write_backend_artifacts(
+            worktree_path,
+            backend=backend,
             command=cmd_str,
-            cwd=str(worktree_path),
-            stdout=result.stdout,
-            stderr=result.stderr,
-            exit_code=result.returncode,
-            suggestion="Claude Code returned non-JSON output. Check stdout above for details.",
-        ) from exc
-
-    # Check for rate-limit indicators in successful JSON responses
-    if not isinstance(parsed, dict):
-        raise MutationError(
-            f"Claude Code returned non-object JSON (got {type(parsed).__name__})",
-            operation="Claude Code invocation",
-            phase="JSON parsing",
-            command=cmd_str,
-            cwd=str(worktree_path),
-            stdout=result.stdout,
-            stderr=result.stderr,
-            exit_code=result.returncode,
-            suggestion="Claude Code returned a non-object JSON value. Expected a JSON object.",
+            result=result,
+            parsed=parsed,
         )
-    error_text = str(parsed.get("error", ""))
-    if _looks_like_rate_limit(error_text):
-        logger.error(
-            "Rate limit detected in JSON response: %s",
-            error_text[:200],
-        )
-        raise RateLimitError(
-            "Claude Code returned a rate/usage limit error in JSON response",
-            operation="Claude Code invocation",
-            phase="JSON parsing",
-            command=cmd_str,
-            cwd=str(worktree_path),
-            stdout=result.stdout,
-            stderr=result.stderr,
-            exit_code=result.returncode,
-            suggestion=(
-                "Claude Code reported a rate limit. "
-                "Retry after backoff or check your API quota."
-            ),
-        )
-
-    return parsed
 
 
 # ---------------------------------------------------------------------------
@@ -685,9 +990,9 @@ def mutate(
     base_dir: Path,
     background: str | None = None,
 ) -> Candidate | None:
-    """Mutate *parent* using Claude Code and return the new candidate.
+    """Mutate *parent* using the configured backend and return the new candidate.
 
-    Clones the parent worktree, builds a mutation prompt, invokes Claude Code,
+    Clones the parent worktree, builds a mutation prompt, invokes the backend,
     then snapshots on success.  Returns ``None`` on any :class:`MutationError`.
 
     Parameters
@@ -699,7 +1004,7 @@ def mutate(
     new_id:
         Identifier for the mutated candidate.
     config:
-        Full HELIX config (``config.claude`` and ``config.objective`` are used).
+        Full HELIX config (``config.agent`` and ``config.objective`` are used).
     base_dir:
         Base directory for worktrees.
     background:
@@ -714,7 +1019,7 @@ def mutate(
     child.operation = "mutate"
 
     prompt = build_mutation_prompt(
-        config.objective, eval_result, background, config.claude.max_turns,
+        config.objective, eval_result, background, config.agent.max_turns,
     )
 
     # Persist the rendered prompt to the worktree for post-hoc inspection:
@@ -727,7 +1032,7 @@ def mutate(
     _write_mutation_prompt_artifact(child.worktree_path, prompt)
 
     try:
-        invoke_claude_code(child.worktree_path, prompt, config.claude, passthrough_env=config.passthrough_env)
+        invoke_claude_code(child.worktree_path, prompt, config.agent, passthrough_env=config.passthrough_env)
     except MutationError as exc:
         exc.operation = f"mutate {new_id} (parent: {parent.id})"
         print_helix_error(exc)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,7 +9,7 @@ import pytest
 from pydantic import ValidationError
 
 from helix.config import (
-    ClaudeConfig,
+    AgentConfig,
     DatasetConfig,
     EvaluatorConfig,
     EvolutionConfig,
@@ -74,7 +74,7 @@ class TestLoadConfig:
             merge_enabled = false
             max_merge_invocations = 2
 
-            [claude]
+            [agent]
             model = "claude-opus-4-5-20250514"
             allowed_tools = ["Read", "Write"]
             background = "You are a coding expert."
@@ -98,12 +98,29 @@ class TestLoadConfig:
         assert cfg.evolution.max_generations == 20
         assert cfg.evolution.merge_enabled is False
         assert cfg.evolution.max_merge_invocations == 2
-        assert cfg.claude.model == "claude-opus-4-5-20250514"
-        assert cfg.claude.allowed_tools == ["Read", "Write"]
-        assert cfg.claude.background == "You are a coding expert."
+        assert cfg.agent.model == "claude-opus-4-5-20250514"
+        assert cfg.agent.allowed_tools == ["Read", "Write"]
+        assert cfg.agent.background == "You are a coding expert."
 
         assert cfg.worktree.base_dir == "/tmp/worktrees"
         assert cfg.worktree.cleanup_dominated is False
+
+    def test_agent_section_loads(self, tmp_path):
+        toml = write_toml(tmp_path, """
+            objective = "Use a different backend"
+
+            [evaluator]
+            command = "pytest"
+
+            [agent]
+            backend = "codex"
+            model = "gpt-5"
+        """)
+
+        cfg = load_config(toml)
+
+        assert cfg.agent.backend == "codex"
+        assert cfg.agent.model == "gpt-5"
 
     def test_defaults_applied_for_nested_sections(self, tmp_path):
         """Omitted nested sections should use their default values."""
@@ -126,10 +143,11 @@ class TestLoadConfig:
         assert cfg.evolution.merge_enabled is False  # GEPA parity: off by default
         assert cfg.evolution.max_merge_invocations == 5
 
-        # ClaudeConfig defaults
-        assert cfg.claude.model == "sonnet"
-        assert "Read" in cfg.claude.allowed_tools
-        assert cfg.claude.background is None
+        # AgentConfig defaults
+        assert cfg.agent.backend == "claude"
+        assert cfg.agent.model == "sonnet"
+        assert "Read" in cfg.agent.allowed_tools
+        assert cfg.agent.background is None
 
         # WorktreeConfig defaults
         assert cfg.worktree.base_dir == ".helix/worktrees"
@@ -224,7 +242,7 @@ class TestDirectModelConstruction:
         )
 
     def test_claude_config_default_tools(self):
-        cfg = ClaudeConfig()
+        cfg = AgentConfig()
         assert "Read" in cfg.allowed_tools
         assert "Edit" in cfg.allowed_tools
         assert "Bash" in cfg.allowed_tools

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -145,7 +145,7 @@ class TestLoadConfig:
 
         # AgentConfig defaults
         assert cfg.agent.backend == "claude"
-        assert cfg.agent.model == "sonnet"
+        assert cfg.agent.model is None
         assert "Read" in cfg.agent.allowed_tools
         assert cfg.agent.background is None
 

--- a/tests/unit/test_config_errors.py
+++ b/tests/unit/test_config_errors.py
@@ -300,7 +300,7 @@ class TestValidTOMLStillWorks:
             [evolution]
             max_generations = 20
 
-            [claude]
+            [agent]
             model = "sonnet"
         """)
 

--- a/tests/unit/test_config_seedless.py
+++ b/tests/unit/test_config_seedless.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 import json
 
 from helix.config import (
-    DatasetConfig,
     EvaluatorConfig,
     HelixConfig,
     SeedlessConfig,
@@ -336,7 +335,7 @@ class TestBuildSeedGenerationPromptDatasetExamples:
             _dataset_examples = load_dataset_examples(config.seedless.train_path)
         prompt = build_seed_generation_prompt(
             objective=config.objective,
-            background=config.claude.background,
+            background=config.agent.background,
             evaluator_cmd=config.evaluator.command,
             dataset_examples=_dataset_examples,
         )
@@ -355,7 +354,7 @@ class TestBuildSeedGenerationPromptDatasetExamples:
             _dataset_examples = load_dataset_examples(config.seedless.train_path)
         prompt = build_seed_generation_prompt(
             objective=config.objective,
-            background=config.claude.background,
+            background=config.agent.background,
             evaluator_cmd=config.evaluator.command,
             dataset_examples=_dataset_examples,
         )

--- a/tests/unit/test_merger.py
+++ b/tests/unit/test_merger.py
@@ -4,15 +4,11 @@ from __future__ import annotations
 
 import random
 from pathlib import Path
-from unittest.mock import MagicMock
-
-import pytest
 
 from helix.population import Candidate, EvalResult
-from helix.config import ClaudeConfig, HelixConfig, EvaluatorConfig
+from helix.config import HelixConfig, EvaluatorConfig
 from helix.mutator import MutationError
 from helix.merger import (
-    MERGE_PROMPT_TEMPLATE,
     build_merge_prompt,
     merge,
     select_eval_subsample_for_merged_program,

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from helix.population import Candidate, EvalResult
-from helix.config import ClaudeConfig, HelixConfig, EvaluatorConfig
+from helix.config import AgentConfig, HelixConfig, EvaluatorConfig
 from helix.mutator import (
     MutationError,
-    AUTONOMOUS_SYSTEM_PROMPT,
-    MUTATION_PROMPT_TEMPLATE,
+    BACKEND_RESULT_ARTIFACT_NAME,
+    BACKEND_STDERR_ARTIFACT_NAME,
+    BACKEND_STDOUT_ARTIFACT_NAME,
     build_mutation_prompt,
     invoke_claude_code,
     mutate,
@@ -520,7 +522,7 @@ class TestInvokeClaudeCode:
             stderr="",
             returncode=0,
         )
-        config = ClaudeConfig()
+        config = AgentConfig()
         result = invoke_claude_code("/tmp/wt", "do something", config)
         assert result == payload
 
@@ -531,7 +533,7 @@ class TestInvokeClaudeCode:
             stderr="fatal error",
             returncode=1,
         )
-        config = ClaudeConfig()
+        config = AgentConfig()
         with pytest.raises(MutationError, match="exited with code 1"):
             invoke_claude_code("/tmp/wt", "do something", config)
 
@@ -542,14 +544,14 @@ class TestInvokeClaudeCode:
             stderr="",
             returncode=0,
         )
-        config = ClaudeConfig()
+        config = AgentConfig()
         with pytest.raises(MutationError, match="Failed to parse"):
             invoke_claude_code("/tmp/wt", "do something", config)
 
     def test_cli_args_include_required_flags(self, mocker):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
-        config = ClaudeConfig(allowed_tools=["Read", "Edit"])
+        config = AgentConfig(allowed_tools=["Read", "Edit"])
         invoke_claude_code("/tmp/wt", "the prompt", config)
 
         call_args = mock_run.call_args
@@ -569,7 +571,7 @@ class TestInvokeClaudeCode:
     def test_uses_correct_cwd(self, mocker):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
-        config = ClaudeConfig()
+        config = AgentConfig()
         invoke_claude_code("/specific/path", "prompt", config)
         assert mock_run.call_args[1]["cwd"] == "/specific/path"
 
@@ -577,9 +579,137 @@ class TestInvokeClaudeCode:
         """subprocess.run should not have a timeout — let Claude run forever."""
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
-        config = ClaudeConfig()
+        config = AgentConfig()
         invoke_claude_code("/tmp/wt", "prompt", config)
         assert "timeout" not in mock_run.call_args[1]
+
+    def test_codex_cli_args_include_required_flags(self, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"thread.started","thread_id":"thr_123"}\n',
+            stderr="",
+            returncode=0,
+        )
+        config = AgentConfig(backend="codex", model="gpt-5")
+
+        result = invoke_claude_code("/tmp/wt", "the prompt", config)
+
+        args_list = mock_run.call_args[0][0]
+        assert args_list[:2] == ["codex", "exec"]
+        assert "--json" in args_list
+        assert "--dangerously-bypass-approvals-and-sandbox" in args_list
+        assert "--model" in args_list
+        assert "gpt-5" in args_list
+        assert args_list[-1] == "the prompt"
+        assert result["events"][0]["thread_id"] == "thr_123"
+
+    def test_cursor_cli_args_use_stream_json(self, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"system","subtype":"init","session_id":"sess_123"}\n',
+            stderr="",
+            returncode=0,
+        )
+        config = AgentConfig(backend="cursor", model="gpt-5")
+
+        result = invoke_claude_code("/tmp/wt", "the prompt", config)
+
+        args_list = mock_run.call_args[0][0]
+        assert args_list[:2] == ["cursor", "agent"]
+        assert "--print" in args_list
+        assert "--output-format" in args_list
+        assert "stream-json" in args_list
+        assert "--yolo" in args_list
+        assert "--workspace" in args_list
+        assert "/tmp/wt" in args_list
+        assert args_list[-1] == "the prompt"
+        assert result["events"][0]["session_id"] == "sess_123"
+
+    def test_backend_artifacts_written_for_structured_backends(self, tmp_path: Path, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout=(
+                '{"type":"system","subtype":"init","session_id":"sess_123"}\n'
+                '{"type":"tool.call","name":"read_file"}\n'
+            ),
+            stderr="warning text",
+            returncode=0,
+        )
+        config = AgentConfig(backend="cursor")
+
+        invoke_claude_code(str(tmp_path), "prompt", config)
+
+        assert (tmp_path / BACKEND_STDOUT_ARTIFACT_NAME).read_text().startswith('{"type":"system"')
+        assert (tmp_path / BACKEND_STDERR_ARTIFACT_NAME).read_text() == "warning text"
+        payload = json.loads((tmp_path / BACKEND_RESULT_ARTIFACT_NAME).read_text())
+        assert payload["backend"] == "cursor"
+        assert payload["usage"]["session_id"] == "sess_123"
+        assert payload["usage"]["tool_event_count"] == 1
+
+    def test_gemini_tolerates_text_preamble_before_json_stream(self, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout=(
+                "MCP issues detected. Run /mcp list for status.\n"
+                '{"type":"init","session_id":"sess_123"}\n'
+                '{"type":"result","status":"success","stats":{"input_tokens":10,"output_tokens":2}}\n'
+            ),
+            stderr="",
+            returncode=0,
+        )
+        config = AgentConfig(backend="gemini")
+
+        result = invoke_claude_code("/tmp/wt", "prompt", config)
+
+        assert result["events"][0]["type"] == "init"
+        assert result["unparsable_lines"] == ["MCP issues detected. Run /mcp list for status."]
+
+    @pytest.mark.parametrize(
+        ("backend", "expected_prefix", "expected_flags"),
+        [
+            ("gemini", ["gemini"], ["--yolo", "--prompt", "--output-format", "stream-json"]),
+            (
+                "opencode",
+                ["opencode", "run"],
+                ["--format", "json", "--dangerously-skip-permissions", "--dir", "/tmp/wt"],
+            ),
+        ],
+    )
+    def test_gemini_and_opencode_cli_args(self, mocker, backend, expected_prefix, expected_flags):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"system","session_id":"sess_123"}\n',
+            stderr="",
+            returncode=0,
+        )
+        config = AgentConfig(backend=backend, model="test-model")
+
+        result = invoke_claude_code("/tmp/wt", "the prompt", config)
+
+        args_list = mock_run.call_args[0][0]
+        assert args_list[: len(expected_prefix)] == expected_prefix
+        for flag in expected_flags:
+            assert flag in args_list
+        assert "test-model" in args_list
+        assert result["events"][0]["session_id"] == "sess_123"
+
+    def test_opencode_usage_normalization_captures_session_id_and_cost(self, tmp_path: Path, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout=(
+                '{"type":"step_start","sessionID":"ses_123"}\n'
+                '{"type":"step_finish","part":{"tokens":{"input":10,"output":2},"cost":0.25}}\n'
+            ),
+            stderr="",
+            returncode=0,
+        )
+        config = AgentConfig(backend="opencode")
+
+        invoke_claude_code(str(tmp_path), "prompt", config)
+
+        payload = json.loads((tmp_path / BACKEND_RESULT_ARTIFACT_NAME).read_text())
+        assert payload["usage"]["session_id"] == "ses_123"
+        assert payload["usage"]["cost_usd"] == 0.25
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -564,6 +564,7 @@ class TestInvokeClaudeCode:
         assert "json" in args_list
         assert "--allowedTools" in args_list
         assert "Read,Edit" in args_list
+        assert "--model" not in args_list
         assert "--max-turns" not in args_list
         assert "-p" in args_list
         assert "the prompt" in args_list
@@ -671,7 +672,7 @@ class TestInvokeClaudeCode:
             (
                 "opencode",
                 ["opencode", "run"],
-                ["--format", "json", "--dangerously-skip-permissions", "--dir", "/tmp/wt"],
+                ["--format", "json", "--dangerously-skip-permissions"],
             ),
         ],
     )

--- a/tests/unit/test_mutator_seedless.py
+++ b/tests/unit/test_mutator_seedless.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import patch
 
 import pytest
 
-from helix.config import ClaudeConfig, EvaluatorConfig, HelixConfig, SeedlessConfig
+from helix.config import EvaluatorConfig, HelixConfig, SeedlessConfig
 from helix.exceptions import MutationError
-from helix.mutator import (
-    SEEDLESS_INIT_PROMPT_TEMPLATE,
-    build_seed_generation_prompt,
-    generate_seed,
-)
+from helix.mutator import build_seed_generation_prompt, generate_seed
 
 
 # ---------------------------------------------------------------------------
@@ -123,15 +119,15 @@ class TestGenerateSeed:
         args, kwargs = mock_invoke.call_args
         assert args[1] == prompt
 
-    def test_passes_claude_config_to_invoke(self):
-        """generate_seed must pass config.claude as third arg to invoke_claude_code."""
+    def test_passes_agent_config_to_invoke(self):
+        """generate_seed must pass config.agent as third arg to invoke_claude_code."""
         config = make_config()
 
         with patch("helix.mutator.invoke_claude_code", return_value={}) as mock_invoke:
             generate_seed("/tmp/wt", "prompt", config)
 
         args, kwargs = mock_invoke.call_args
-        assert args[2] is config.claude
+        assert args[2] is config.agent
 
     def test_raises_on_failure_immediately(self):
         """If invoke_claude_code raises MutationError, generate_seed propagates it immediately."""

--- a/tests/unit/test_rate_limit_fixes.py
+++ b/tests/unit/test_rate_limit_fixes.py
@@ -17,7 +17,7 @@ import pytest
 from click.testing import CliRunner
 
 from helix.cli import cli
-from helix.config import ClaudeConfig
+from helix.config import AgentConfig
 from helix.exceptions import HelixError, MutationError, RateLimitError, print_helix_error
 from helix.logging_config import setup_file_logging
 from helix.mutator import invoke_claude_code
@@ -117,7 +117,7 @@ class TestFix2RateLimitDiagnostics:
         mock_result.stderr = "Error: 529 overloaded please retry"
         mocker.patch("helix.mutator.subprocess.run", return_value=mock_result)
 
-        config = ClaudeConfig()
+        config = AgentConfig()
         with pytest.raises(RateLimitError) as exc_info:
             invoke_claude_code("/tmp/wt", "test prompt", config)
 
@@ -142,7 +142,7 @@ class TestFix2RateLimitDiagnostics:
         mock_result.stderr = ""
         mocker.patch("helix.mutator.subprocess.run", return_value=mock_result)
 
-        config = ClaudeConfig()
+        config = AgentConfig()
         with pytest.raises(RateLimitError) as exc_info:
             invoke_claude_code("/tmp/wt", "test prompt", config)
 

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -45,7 +45,7 @@ def make_state(
 def test_state_saved_before_crash(tmp_path: Path) -> None:
     """State.json must be written before an exception propagates out of run_evolution."""
     from helix.config import (
-        ClaudeConfig,
+        AgentConfig,
         DatasetConfig,
         EvolutionConfig,
         EvaluatorConfig,
@@ -64,7 +64,7 @@ def test_state_saved_before_crash(tmp_path: Path) -> None:
         objective="test",
         evaluator=EvaluatorConfig(command="echo 1"),
         evolution=EvolutionConfig(max_generations=3),
-        claude=ClaudeConfig(),
+        agent=AgentConfig(),
         dataset=DatasetConfig(),
         worktree=WorktreeConfig(),
     )
@@ -138,9 +138,9 @@ def test_looks_like_rate_limit_keywords() -> None:
 
 def test_rate_limit_raises_rate_limit_error(tmp_path: Path) -> None:
     """invoke_claude_code raises RateLimitError when subprocess returns rate-limit stderr."""
-    from helix.config import ClaudeConfig
+    from helix.config import AgentConfig
 
-    config = ClaudeConfig()
+    config = AgentConfig()
 
     fake_result = MagicMock()
     fake_result.returncode = 1
@@ -154,9 +154,9 @@ def test_rate_limit_raises_rate_limit_error(tmp_path: Path) -> None:
 
 def test_rate_limit_not_raised_for_normal_errors(tmp_path: Path) -> None:
     """invoke_claude_code raises MutationError (not RateLimitError) for ordinary failures."""
-    from helix.config import ClaudeConfig
+    from helix.config import AgentConfig
 
-    config = ClaudeConfig()
+    config = AgentConfig()
 
     fake_result = MagicMock()
     fake_result.returncode = 1
@@ -170,9 +170,9 @@ def test_rate_limit_not_raised_for_normal_errors(tmp_path: Path) -> None:
 
 def test_rate_limit_in_json_result(tmp_path: Path) -> None:
     """invoke_claude_code raises RateLimitError when JSON result contains overload error."""
-    from helix.config import ClaudeConfig
+    from helix.config import AgentConfig
 
-    config = ClaudeConfig()
+    config = AgentConfig()
 
     json_payload = json.dumps({
         "is_error": True,
@@ -221,7 +221,7 @@ def test_resume_skips_missing_worktrees(tmp_path: Path, capsys) -> None:
 
     # Patch run_evolution so we don't actually try to evolve
     # (imported locally in the resume() function, so patch it at the source module)
-    with patch("helix.evolution.run_evolution") as mock_evolve:
+    with patch("helix.evolution.run_evolution"):
         runner = CliRunner()
         result = runner.invoke(cli, ["resume", "--dir", str(project_root)])
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -162,7 +162,7 @@ wheels = [
 
 [[package]]
 name = "helix-evo"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What changed
- replace the backend-specific mutation config with an `agent` config section and remove the backward-compat `claude` alias
- add backend support for Claude Code, Codex CLI, Cursor Agent, Gemini CLI, and OpenCode in the HELIX mutator/merge flow
- persist normalized backend artifacts so HELIX keeps session, tool-usage, token, and cost data across supported backends
- update docs/tests and bump the package version from `0.1.3` to `0.2.0`

## Why
HELIX previously only supported Claude Code. The goal of this change is to let HELIX launch the other installed backends in yolo/headless mode while preserving the output files needed for usage accounting.

## Impact
Users can now select `agent.backend` in `helix.toml` or pass `--backend` on the CLI. This is a breaking config change because the supported config section is now `[agent]` rather than `[claude]`.

## Validation
- `uv sync --all-extras`
- `uv run pytest tests/unit/ -q`
- `uv run mypy --strict src/helix/`
- manual smoke tests of the installed headless backend commands for codex, cursor, gemini, and opencode; claude command shape verified but the local account was rate-limited during execution