### PR TITLE
Fix upstream reference cache conformance divergences 29-34

### DIFF
--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -343,10 +343,10 @@ class EvolutionConfig(BaseModel):
         ),
     )
     cache_evaluation: bool = Field(
-        default=True,
+        default=False,
         description=(
-            "Enable (candidate_hash, example_id) evaluation cache. "
-            "GEPA parity: EngineConfig.cache_evaluation."
+            "Enable content-addressed evaluation caches. Defaults off, matching "
+            "GEPA Optimize Anything's conservative cache_evaluation behavior."
         ),
     )
     acceptance_criterion: Literal["strict_improvement", "improvement_or_equal"] = Field(

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -625,22 +625,58 @@ def _worktree_lock(worktree_path: str | Path) -> threading.Lock:
 
 
 def _candidate_content_key(candidate: Candidate) -> str:
-    """Return a stable content key for cache reuse across equivalent candidates."""
+    """Return a stable content key for cache reuse across equivalent candidates.
+
+    Contract: the caller is responsible for ensuring the candidate's worktree
+    has its evaluation-relevant content committed (clean working tree, no
+    untracked files). The key is derived from ``HEAD^{tree}``, which is
+    content-addressable over the *committed* tracked tree only — it does not
+    reflect uncommitted modifications, the staged index, or untracked files.
+
+    Defensive behavior: if the worktree is detected to be dirty (modified
+    tracked files or untracked, non-ignored files present), we fall back to
+    ``candidate.id`` so that two candidates with identical HEAD trees but
+    differing dirty state cannot collide on the same cache key. Submodule
+    contents are summarized as gitlinks inside the parent tree, so changing
+    the submodule pointer changes the key but in-place edits inside an
+    uncommitted submodule do not — keep submodule state committed for
+    reliable reuse.
+    """
     try:
-        result = subprocess.run(
+        tree_proc = subprocess.run(
             ["git", "rev-parse", "HEAD^{tree}"],
             cwd=candidate.worktree_path,
             check=True,
             capture_output=True,
             text=True,
         )
-        sha = result.stdout.strip()
-        if sha:
-            return sha
-    except Exception:
+        sha = tree_proc.stdout.strip()
+        if not sha:
+            return candidate.id
+
+        # Reject the tree SHA if the worktree is dirty or has untracked
+        # (non-ignored) files; otherwise we'd risk a false cache hit.
+        status_proc = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=normal"],
+            cwd=candidate.worktree_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        if status_proc.stdout.strip():
+            logger.warning(
+                "Candidate %s worktree is not clean; falling back to id cache "
+                "key to avoid stale-content cache hits.",
+                candidate.id,
+            )
+            return candidate.id
+        return sha
+    except Exception as exc:
         logger.warning(
-            "Could not resolve git tree for candidate %s; falling back to id cache key.",
+            "Could not resolve git tree for candidate %s (%s); falling back "
+            "to id cache key.",
             candidate.id,
+            exc,
         )
     return candidate.id
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -628,7 +628,7 @@ def _candidate_content_key(candidate: Candidate) -> str:
     """Return a stable content key for cache reuse across equivalent candidates."""
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
+            ["git", "rev-parse", "HEAD^{tree}"],
             cwd=candidate.worktree_path,
             check=True,
             capture_output=True,
@@ -639,7 +639,7 @@ def _candidate_content_key(candidate: Candidate) -> str:
             return sha
     except Exception:
         logger.warning(
-            "Could not resolve git HEAD for candidate %s; falling back to id cache key.",
+            "Could not resolve git tree for candidate %s; falling back to id cache key.",
             candidate.id,
         )
     return candidate.id

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -9,6 +9,7 @@ import os
 import random as _random
 import shutil
 import shlex
+import subprocess
 import threading
 import traceback
 from pathlib import Path
@@ -623,22 +624,46 @@ def _worktree_lock(worktree_path: str | Path) -> threading.Lock:
         return lock
 
 
+def _candidate_content_key(candidate: Candidate) -> str:
+    """Return a stable content key for cache reuse across equivalent candidates."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=candidate.worktree_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        sha = result.stdout.strip()
+        if sha:
+            return sha
+    except Exception:
+        logger.warning(
+            "Could not resolve git HEAD for candidate %s; falling back to id cache key.",
+            candidate.id,
+        )
+    return candidate.id
+
+
 def _cached_eval(
     candidate: Candidate,
     config: HelixConfig,
     split: str,
-    cache: EvaluationCache,
+    cache: EvaluationCache | None,
 ) -> tuple[EvalResult, bool]:
     """Run evaluator with cache.  Returns (result, was_cached).
 
-    GEPA parity (Fix 11): avoid re-evaluating identical (candidate_id, split)
-    pairs.  Only genuinely new evaluations should consume budget.
+    GEPA parity: cache only when enabled, and key by candidate content rather
+    than HELIX's lineage id so equivalent candidates can reuse results.
     """
-    cached = cache.get(candidate.id, split)
+    if cache is None:
+        return run_evaluator(candidate, config, split=split), False
+    candidate_key = _candidate_content_key(candidate)
+    cached = cache.get(candidate_key, split)
     if cached is not None:
         return EvalResult.from_dict(cached), True
     result = run_evaluator(candidate, config, split=split)
-    cache.put(candidate.id, split, result.to_dict())
+    cache.put(candidate_key, split, result.to_dict())
     return result, False
 
 
@@ -669,11 +694,6 @@ def _cached_evaluate_batch(
     subprocess (0 if all were cached) — mirrors GEPA's
     ``len(uncached_ids)`` return value.
     """
-    # Cache keys must remain stable across re-evals of the same candidate
-    # identity, but train/val batches must not alias when they share
-    # positional ids like "0", "1", ... .
-    cand_dict: dict[str, str] = {"id": candidate.id, "split": split}
-
     # Non-cached branch — mirrors GEPA state.py:628-633 verbatim.
     if cache is None:
         # Per-worktree lock (see ``_worktree_lock`` docstring): serializes
@@ -693,6 +713,13 @@ def _cached_evaluate_batch(
     # Cached branch — delegate to the GEPA-parity helper on the cache
     # itself (helix.eval_cache.EvaluationCache.evaluate_with_cache_full,
     # which is a line-for-line port of GEPA state.py:94-130).
+    # Cache keys must remain stable across equivalent candidate content, but
+    # train/val batches must not alias when they share positional ids like
+    # "0", "1", ... .
+    cand_dict: dict[str, str] = {
+        "content_key": _candidate_content_key(candidate),
+        "split": split,
+    }
 
     # Closure side-channel: the cache stores ``(output, score, objective_scores)``
     # per id but has no slot for freeform ``side_info``.  Collect fresh
@@ -804,6 +831,57 @@ def _cached_evaluate_batch(
         objective_scores=objective_scores_list,
     )
     return merged, num_actual_evals
+
+
+def _inject_top_k_best_example_history(
+    eval_result: EvalResult,
+    frontier: ParetoFrontier,
+    *,
+    k: int = 3,
+) -> EvalResult:
+    """Attach per-example best-history context for reflection prompts.
+
+    Optimize Anything exposes top-performing example histories to reflection.
+    HELIX's compatible surface is a per-example ``side_info`` field named
+    ``top_k_best_example_history``; it is rendered by the existing diagnostics
+    prompt path without changing candidate/worktree semantics.
+    """
+    if k <= 0 or not eval_result.instance_scores or not frontier._results:
+        return eval_result
+
+    example_ids = list(eval_result.instance_scores.keys())
+    history_by_id: dict[str, list[dict[str, Any]]] = {}
+    for eid in example_ids:
+        rows: list[dict[str, Any]] = []
+        for cid, result in frontier._results.items():
+            if eid in result.instance_scores:
+                rows.append(
+                    {
+                        "candidate_id": cid,
+                        "score": float(result.instance_scores[eid]),
+                    }
+                )
+        rows.sort(key=lambda row: row["score"], reverse=True)
+        if rows:
+            history_by_id[eid] = rows[:k]
+
+    if not history_by_id:
+        return eval_result
+
+    per_example = (
+        [dict(item) for item in eval_result.per_example_side_info]
+        if eval_result.per_example_side_info is not None
+        else [{} for _ in example_ids]
+    )
+    if len(per_example) != len(example_ids):
+        per_example = [{} for _ in example_ids]
+
+    for idx, eid in enumerate(example_ids):
+        history_rows = history_by_id.get(eid)
+        if history_rows:
+            per_example[idx]["top_k_best_example_history"] = history_rows
+    eval_result.per_example_side_info = per_example
+    return eval_result
 
 
 def _full_val_example_ids(
@@ -921,9 +999,11 @@ def _run_evolution_impl(
     rng = _random.Random(config.rng_seed)
     frontier = ParetoFrontier(rng=rng, frontier_type=config.evolution.frontier_type)
 
-    # GEPA parity (Fix 11): evaluation cache — skip re-evaluation of
-    # identical (candidate_id, split) pairs.
-    eval_cache = EvaluationCache()
+    # No-example/single-task cache.  This is deliberately gated by
+    # cache_evaluation, the same flag as the per-example cache below.
+    eval_cache: EvaluationCache | None = (
+        EvaluationCache() if config.evolution.cache_evaluation else None
+    )
 
     # -- Phase 3 integration: minibatch sampling + GEPA-style acceptance.
     # Construct train/val loaders.  Missing train_path → single-task
@@ -1190,9 +1270,11 @@ def _run_evolution_impl(
             )
         else:
             _refresh_protected_evaluator_files(seed, config, project_root)
-            seed_result = run_evaluator(seed, config)
+            seed_result, _seed_cached = _cached_eval(seed, config, "val", eval_cache)
             seed_result.candidate_id = seed.id
-            state.budget.evaluations += _evaluation_budget_units()
+            state.budget.evaluations += _evaluation_budget_units(
+                was_cached=_seed_cached
+            )
 
         _save_evaluation(base_dir, seed_result)
         frontier.add(seed, seed_result)
@@ -1893,10 +1975,17 @@ def _run_evolution_impl(
                     eval_for_mutate = parent_mb_result
                 else:
                     set_phase(HelixPhase.TRAIN_EVALUATION)
-                    eval_for_mutate, _ = _cached_eval(
+                    eval_for_mutate, _train_cached = _cached_eval(
                         parent, config, "train", eval_cache
                     )
                     eval_for_mutate.candidate_id = parent.id
+                    state.budget.evaluations += _evaluation_budget_units(
+                        was_cached=_train_cached
+                    )
+
+                eval_for_mutate = _inject_top_k_best_example_history(
+                    eval_for_mutate, frontier
+                )
 
                 # Skip-if-perfect (GEPA reflective_mutation.py:308-327, audit
                 # finding M1 in audit-init-engine.md B1/B2):

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -6,6 +6,7 @@ import json
 import os
 import pickle
 import tempfile
+import warnings
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -36,23 +37,23 @@ class BudgetState:
 
 
 class EvaluationCache:
-    """Simple evaluation cache keyed by (candidate_id, split).
+    """Simple evaluation cache keyed by (candidate_content_key, split).
 
-    GEPA parity: avoids re-evaluating identical candidates.
-    GEPA uses (candidate_hash, example_id); HELIX uses (candidate_id, split)
-    since HELIX evaluates whole candidates via shell commands.
+    GEPA parity: avoids re-evaluating identical candidate content.  GEPA uses
+    ``(candidate_hash, example_id)``; HELIX's no-example/single-task path has
+    no example ids, so it uses the content key plus split.
     """
 
     def __init__(self) -> None:
         self._cache: dict[tuple[str, str], dict[str, Any]] = {}
 
-    def get(self, candidate_id: str, split: str) -> dict[str, Any] | None:
+    def get(self, candidate_key: str, split: str) -> dict[str, Any] | None:
         """Return cached result dict or None."""
-        return self._cache.get((candidate_id, split))
+        return self._cache.get((candidate_key, split))
 
-    def put(self, candidate_id: str, split: str, result_dict: dict[str, Any]) -> None:
+    def put(self, candidate_key: str, split: str, result_dict: dict[str, Any]) -> None:
         """Store a result in the cache."""
-        self._cache[(candidate_id, split)] = result_dict
+        self._cache[(candidate_key, split)] = result_dict
 
     def __len__(self) -> int:
         return len(self._cache)
@@ -270,11 +271,22 @@ def load_eval_cache(base_dir: Path) -> dict[Any, Any] | None:
     target = _eval_cache_path(base_dir)
     if not target.exists():
         return None
-    with open(target, "rb") as f:
-        loaded = pickle.load(f)
-    if not isinstance(loaded, dict):
-        raise ValueError(
-            f"eval_cache.pkl at {target} did not contain a dict "
-            f"(got {type(loaded).__name__})."
+    try:
+        with open(target, "rb") as f:
+            loaded = pickle.load(f)
+    except Exception as exc:
+        warnings.warn(
+            f"Ignoring unreadable eval cache at {target}: {type(exc).__name__}: {exc}",
+            RuntimeWarning,
+            stacklevel=2,
         )
+        return None
+    if not isinstance(loaded, dict):
+        warnings.warn(
+            f"Ignoring eval cache at {target}: expected dict, got "
+            f"{type(loaded).__name__}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
     return loaded

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -111,7 +111,7 @@ class TestEvolutionConfigNewFields:
 
         assert cfg.max_workers == (os.cpu_count() or 32)
         assert cfg.num_parallel_proposals == 1
-        assert cfg.cache_evaluation is True
+        assert cfg.cache_evaluation is False
         assert cfg.acceptance_criterion == "strict_improvement"
         assert cfg.val_stage_size is None
 

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -79,7 +79,7 @@ def _git(args: list[str], cwd: Path) -> str:
 
 
 def _init_repo(path: Path) -> None:
-    path.mkdir()
+    path.mkdir(exist_ok=True)
     _git(["init"], path)
     _git(["config", "user.name", "HELIX Test"], path)
     _git(["config", "user.email", "helix-test@noreply"], path)
@@ -774,6 +774,9 @@ class TestCachedEvaluateBatch:
         assert commit_a != commit_b
         assert tree_a == tree_b
 
+        # Pin the contract directly: equivalent trees ⇒ equal content keys.
+        assert _candidate_content_key(cand_a) == _candidate_content_key(cand_b)
+
         run_eval_mock = mocker.patch("helix.evolution.run_evaluator")
         mocker.patch("helix.evolution._write_helix_batch")
 
@@ -844,6 +847,34 @@ class TestCachedEvaluateBatch:
         assert num_actual == 2
         assert result.candidate_id == cand_b.id
         assert result.instance_scores == {"0": 0.5, "1": 0.5}
+
+    def test_content_key_falls_back_when_worktree_is_dirty(
+        self, tmp_path: Path
+    ) -> None:
+        """Dirty / untracked worktree must NOT key by tree SHA (avoid stale hits)."""
+        from helix.evolution import _candidate_content_key
+
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        (repo / "prompt.md").write_text("v1\n")
+        _git(["add", "prompt.md"], repo)
+        _git(["commit", "-m", "initial content"], repo)
+
+        cand = self._make_cand("cand-dirty")
+        cand.worktree_path = str(repo)
+        clean_key = _candidate_content_key(cand)
+        tree_sha = _git(["rev-parse", "HEAD^{tree}"], repo)
+        assert clean_key == tree_sha  # sanity: clean repo keys by tree SHA
+
+        # Modify a tracked file without committing → key must fall back to id.
+        (repo / "prompt.md").write_text("v1-uncommitted\n")
+        assert _candidate_content_key(cand) == cand.id
+
+        # Reset and try untracked file → still falls back to id.
+        _git(["checkout", "--", "prompt.md"], repo)
+        assert _candidate_content_key(cand) == tree_sha
+        (repo / "scratch.txt").write_text("untracked\n")
+        assert _candidate_content_key(cand) == cand.id
 
     def test_cache_miss_invokes_full_evaluator(self, mocker: Any) -> None:
         """Empty cache → evaluator is invoked with ALL requested ids."""

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -9,6 +9,7 @@ mock all I/O and mock ``run_evaluator`` with controlled score sequences.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -64,6 +65,24 @@ def _write_train_jsonl(path: Path, n: int = 6) -> Path:
         for i in range(n):
             f.write(json.dumps({"idx": i, "x": i}) + "\n")
     return p
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir()
+    _git(["init"], path)
+    _git(["config", "user.name", "HELIX Test"], path)
+    _git(["config", "user.email", "helix-test@noreply"], path)
 
 
 def test_top_k_best_example_history_injection_preserves_side_info() -> None:
@@ -720,6 +739,111 @@ class TestCachedEvaluateBatch:
         assert run_eval_mock.call_count == 0
         assert result.candidate_id == cand_b.id
         assert result.instance_scores == {"0": 0.7, "1": 0.8}
+
+    def test_tree_key_reuses_cache_across_different_commits_with_same_tree(
+        self, mocker: Any, tmp_path: Path
+    ) -> None:
+        """Commit metadata/history changes must not invalidate content cache."""
+        from helix.eval_cache import EvaluationCache as MBCache
+        from helix.evolution import _cached_evaluate_batch, _candidate_content_key
+
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        (repo / "prompt.md").write_text("same tracked content\n")
+        _git(["add", "prompt.md"], repo)
+        _git(["commit", "-m", "initial content"], repo)
+
+        cand_a = self._make_cand("cand-A")
+        cand_a.worktree_path = str(repo)
+        commit_a = _git(["rev-parse", "HEAD"], repo)
+        tree_a = _git(["rev-parse", "HEAD^{tree}"], repo)
+
+        cache: MBCache[object, str] = MBCache[object, str]()
+        cache.put_batch(
+            {"content_key": _candidate_content_key(cand_a), "split": "train"},
+            ["0", "1"],
+            [None, None],
+            [0.7, 0.8],
+        )
+
+        _git(["commit", "--allow-empty", "-m", "metadata only"], repo)
+        cand_b = self._make_cand("cand-B")
+        cand_b.worktree_path = str(repo)
+        commit_b = _git(["rev-parse", "HEAD"], repo)
+        tree_b = _git(["rev-parse", "HEAD^{tree}"], repo)
+        assert commit_a != commit_b
+        assert tree_a == tree_b
+
+        run_eval_mock = mocker.patch("helix.evolution.run_evaluator")
+        mocker.patch("helix.evolution._write_helix_batch")
+
+        result, num_actual = _cached_evaluate_batch(
+            cand_b, ["0", "1"], cache, self._trivial_config(), "train", tmp_path,
+        )
+
+        assert num_actual == 0
+        assert run_eval_mock.call_count == 0
+        assert result.candidate_id == cand_b.id
+        assert result.instance_scores == {"0": 0.7, "1": 0.8}
+
+    def test_tree_key_misses_cache_when_tracked_content_changes(
+        self, mocker: Any, tmp_path: Path
+    ) -> None:
+        """Tracked file changes must produce a different cache identity."""
+        from helix.eval_cache import EvaluationCache as MBCache
+        from helix.evolution import _cached_evaluate_batch, _candidate_content_key
+
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        (repo / "prompt.md").write_text("v1\n")
+        _git(["add", "prompt.md"], repo)
+        _git(["commit", "-m", "initial content"], repo)
+
+        cand_a = self._make_cand("cand-A")
+        cand_a.worktree_path = str(repo)
+        tree_a = _git(["rev-parse", "HEAD^{tree}"], repo)
+
+        cache: MBCache[object, str] = MBCache[object, str]()
+        cache.put_batch(
+            {"content_key": _candidate_content_key(cand_a), "split": "train"},
+            ["0", "1"],
+            [None, None],
+            [0.7, 0.8],
+        )
+
+        (repo / "prompt.md").write_text("v2\n")
+        _git(["add", "prompt.md"], repo)
+        _git(["commit", "-m", "changed tracked content"], repo)
+        cand_b = self._make_cand("cand-B")
+        cand_b.worktree_path = str(repo)
+        tree_b = _git(["rev-parse", "HEAD^{tree}"], repo)
+        assert tree_a != tree_b
+
+        seen_instance_ids: list[list[str] | None] = []
+
+        def fake_run(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            seen_instance_ids.append(instance_ids)
+            return _make_result(
+                candidate.id, {eid: 0.5 for eid in (instance_ids or [])}
+            )
+
+        mocker.patch("helix.evolution.run_evaluator", side_effect=fake_run)
+        mocker.patch("helix.evolution._write_helix_batch")
+
+        result, num_actual = _cached_evaluate_batch(
+            cand_b, ["0", "1"], cache, self._trivial_config(), "train", tmp_path,
+        )
+
+        assert seen_instance_ids == [["0", "1"]]
+        assert num_actual == 2
+        assert result.candidate_id == cand_b.id
+        assert result.instance_scores == {"0": 0.5, "1": 0.5}
 
     def test_cache_miss_invokes_full_evaluator(self, mocker: Any) -> None:
         """Empty cache → evaluator is invoked with ALL requested ids."""

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -22,8 +22,13 @@ from helix.config import (
     SeedlessConfig,
     WorktreeConfig,
 )
-from helix.evolution import HelixDataLoader, _make_data_loader, run_evolution
-from helix.population import Candidate, EvalResult
+from helix.evolution import (
+    HelixDataLoader,
+    _inject_top_k_best_example_history,
+    _make_data_loader,
+    run_evolution,
+)
+from helix.population import Candidate, EvalResult, ParetoFrontier
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +64,40 @@ def _write_train_jsonl(path: Path, n: int = 6) -> Path:
         for i in range(n):
             f.write(json.dumps({"idx": i, "x": i}) + "\n")
     return p
+
+
+def test_top_k_best_example_history_injection_preserves_side_info() -> None:
+    """Reflection evals expose top-K per-example frontier history."""
+    frontier = ParetoFrontier()
+    cand_a = _make_candidate("cand-a")
+    cand_b = _make_candidate("cand-b")
+    frontier.add(cand_a, _make_result("cand-a", {"0": 0.2, "1": 0.9}))
+    frontier.add(cand_b, _make_result("cand-b", {"0": 0.8, "1": 0.4}))
+
+    current = EvalResult(
+        candidate_id="cand-current",
+        scores={},
+        asi={},
+        instance_scores={"0": 0.1, "1": 0.1},
+        per_example_side_info=[{"trace": "keep-0"}, {"trace": "keep-1"}],
+    )
+
+    updated = _inject_top_k_best_example_history(current, frontier, k=1)
+
+    assert updated.per_example_side_info == [
+        {
+            "trace": "keep-0",
+            "top_k_best_example_history": [
+                {"candidate_id": "cand-b", "score": 0.8}
+            ],
+        },
+        {
+            "trace": "keep-1",
+            "top_k_best_example_history": [
+                {"candidate_id": "cand-a", "score": 0.9}
+            ],
+        },
+    ]
 
 
 def _make_minibatch_config(
@@ -627,7 +666,7 @@ class TestCachedEvaluateBatch:
 
         cache: MBCache[object, str] = MBCache[object, str]()
         cand = self._make_cand("cand-A")
-        cand_dict = {"id": cand.id, "split": "train"}
+        cand_dict = {"content_key": cand.id, "split": "train"}
         cache.put_batch(
             cand_dict,
             ["0", "1", "2"],
@@ -650,6 +689,37 @@ class TestCachedEvaluateBatch:
         )
         assert num_actual == 0
         assert result.instance_scores == {"0": 0.1, "1": 0.2, "2": 0.3}
+
+    def test_content_key_reuses_cache_across_candidate_ids(self, mocker: Any) -> None:
+        """Equivalent candidate content should reuse per-example cache entries."""
+        from helix.eval_cache import EvaluationCache as MBCache
+        from helix.evolution import _cached_evaluate_batch
+
+        cache: MBCache[object, str] = MBCache[object, str]()
+        cand_b = self._make_cand("cand-B")
+        mocker.patch(
+            "helix.evolution._candidate_content_key",
+            side_effect=lambda candidate: "same-content",
+        )
+
+        cache.put_batch(
+            {"content_key": "same-content", "split": "train"},
+            ["0", "1"],
+            [None, None],
+            [0.7, 0.8],
+        )
+
+        run_eval_mock = mocker.patch("helix.evolution.run_evaluator")
+        mocker.patch("helix.evolution._write_helix_batch")
+
+        result, num_actual = _cached_evaluate_batch(
+            cand_b, ["0", "1"], cache, self._trivial_config(), "train", Path("/tmp"),
+        )
+
+        assert num_actual == 0
+        assert run_eval_mock.call_count == 0
+        assert result.candidate_id == cand_b.id
+        assert result.instance_scores == {"0": 0.7, "1": 0.8}
 
     def test_cache_miss_invokes_full_evaluator(self, mocker: Any) -> None:
         """Empty cache → evaluator is invoked with ALL requested ids."""
@@ -686,6 +756,40 @@ class TestCachedEvaluateBatch:
         assert num_actual == 3
         assert result.instance_scores == {"0": 0.5, "1": 0.5, "2": 0.5}
 
+    def test_cache_disabled_invokes_evaluator_every_time(self, mocker: Any) -> None:
+        """cache=None is the strict off mode behind cache_evaluation=False."""
+        from helix.evolution import _cached_evaluate_batch
+
+        cand = self._make_cand("cand-no-cache")
+        seen_instance_ids: list[list[str] | None] = []
+
+        def fake_run(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            seen_instance_ids.append(instance_ids)
+            return _make_result(
+                candidate.id, {eid: 0.4 for eid in (instance_ids or [])}
+            )
+
+        mocker.patch("helix.evolution.run_evaluator", side_effect=fake_run)
+        mocker.patch("helix.evolution._write_helix_batch")
+
+        first, first_actual = _cached_evaluate_batch(
+            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/tmp"),
+        )
+        second, second_actual = _cached_evaluate_batch(
+            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/tmp"),
+        )
+
+        assert seen_instance_ids == [["0", "1"], ["0", "1"]]
+        assert first_actual == 2
+        assert second_actual == 2
+        assert first.instance_scores == second.instance_scores == {"0": 0.4, "1": 0.4}
+
     def test_partial_cache_hit(self, mocker: Any) -> None:
         """2-of-3 cached → evaluator runs with ONLY the 1 uncached id."""
         from helix.eval_cache import EvaluationCache as MBCache
@@ -693,7 +797,7 @@ class TestCachedEvaluateBatch:
 
         cache: MBCache[object, str] = MBCache[object, str]()
         cand = self._make_cand("cand-C")
-        cand_dict = {"id": cand.id, "split": "train"}
+        cand_dict = {"content_key": cand.id, "split": "train"}
         # Pre-populate 0 and 2; leave 1 uncached.
         cache.put_batch(
             cand_dict,
@@ -765,7 +869,7 @@ class TestCachedEvaluateBatch:
 
         cache: MBCache[object, str] = MBCache[object, str]()
         cand = self._make_cand("cand-pcfm")
-        cand_dict = {"id": cand.id, "split": "train"}
+        cand_dict = {"content_key": cand.id, "split": "train"}
         # Pre-populate ids "0" and "2" with both score AND
         # objective_scores (the cache stores these natively).
         cache.put_batch(

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -200,16 +200,26 @@ def test_eval_cache_load_returns_none_when_missing(tmp_path: Path) -> None:
     assert load_eval_cache(tmp_path) is None
 
 
-def test_eval_cache_load_rejects_non_dict(tmp_path: Path) -> None:
-    """A corrupt eval_cache.pkl must raise rather than silently succeed."""
+def test_eval_cache_load_tolerates_non_dict(tmp_path: Path) -> None:
+    """A corrupt eval_cache.pkl warns and resumes with an empty cache."""
     import pickle as _pickle
 
     helix_dir = tmp_path / ".helix"
     helix_dir.mkdir(parents=True)
     (helix_dir / "eval_cache.pkl").write_bytes(_pickle.dumps(["not", "a", "dict"]))
 
-    with pytest.raises(ValueError, match="did not contain a dict"):
-        load_eval_cache(tmp_path)
+    with pytest.warns(RuntimeWarning, match="Ignoring eval cache"):
+        assert load_eval_cache(tmp_path) is None
+
+
+def test_eval_cache_load_tolerates_unreadable_pickle(tmp_path: Path) -> None:
+    """Unreadable pickle bytes should not abort resume."""
+    helix_dir = tmp_path / ".helix"
+    helix_dir.mkdir(parents=True)
+    (helix_dir / "eval_cache.pkl").write_bytes(b"not a pickle")
+
+    with pytest.warns(RuntimeWarning, match="Ignoring unreadable eval cache"):
+        assert load_eval_cache(tmp_path) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Default evaluation caching to off to match upstream reference Optimize Anything behavior.
- Key evaluation cache by candidate content rather than candidate id.
- Includes the tree-key refinement from former stacked PR #15: cache identity now uses `git rev-parse HEAD^{tree}` so reuse depends on tracked file content, not commit metadata/history.
- Make cache loading tolerant of corrupt/unexpected persisted cache data.
- Preserve actual uncached evaluation accounting and expose top-k best-example history for reflection diagnostics.

## Validation
- Focused cache/default/persistence/minibatch tests passed in branch audit.
- Budget tests passed in branch audit.
- Tree-key tests passed after including #15 changes.
- Full repo ruff remains blocked by pre-existing examples/web_researcher/evaluate.py F841 outside this branch.
