### PR TITLE
Key upstream reference evaluation cache by git tree

### DIFF
--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -625,22 +625,58 @@ def _worktree_lock(worktree_path: str | Path) -> threading.Lock:
 
 
 def _candidate_content_key(candidate: Candidate) -> str:
-    """Return a stable content key for cache reuse across equivalent candidates."""
+    """Return a stable content key for cache reuse across equivalent candidates.
+
+    Contract: the caller is responsible for ensuring the candidate's worktree
+    has its evaluation-relevant content committed (clean working tree, no
+    untracked files). The key is derived from ``HEAD^{tree}``, which is
+    content-addressable over the *committed* tracked tree only — it does not
+    reflect uncommitted modifications, the staged index, or untracked files.
+
+    Defensive behavior: if the worktree is detected to be dirty (modified
+    tracked files or untracked, non-ignored files present), we fall back to
+    ``candidate.id`` so that two candidates with identical HEAD trees but
+    differing dirty state cannot collide on the same cache key. Submodule
+    contents are summarized as gitlinks inside the parent tree, so changing
+    the submodule pointer changes the key but in-place edits inside an
+    uncommitted submodule do not — keep submodule state committed for
+    reliable reuse.
+    """
     try:
-        result = subprocess.run(
+        tree_proc = subprocess.run(
             ["git", "rev-parse", "HEAD^{tree}"],
             cwd=candidate.worktree_path,
             check=True,
             capture_output=True,
             text=True,
         )
-        sha = result.stdout.strip()
-        if sha:
-            return sha
-    except Exception:
+        sha = tree_proc.stdout.strip()
+        if not sha:
+            return candidate.id
+
+        # Reject the tree SHA if the worktree is dirty or has untracked
+        # (non-ignored) files; otherwise we'd risk a false cache hit.
+        status_proc = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=normal"],
+            cwd=candidate.worktree_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        if status_proc.stdout.strip():
+            logger.warning(
+                "Candidate %s worktree is not clean; falling back to id cache "
+                "key to avoid stale-content cache hits.",
+                candidate.id,
+            )
+            return candidate.id
+        return sha
+    except Exception as exc:
         logger.warning(
-            "Could not resolve git tree for candidate %s; falling back to id cache key.",
+            "Could not resolve git tree for candidate %s (%s); falling back "
+            "to id cache key.",
             candidate.id,
+            exc,
         )
     return candidate.id
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -628,7 +628,7 @@ def _candidate_content_key(candidate: Candidate) -> str:
     """Return a stable content key for cache reuse across equivalent candidates."""
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
+            ["git", "rev-parse", "HEAD^{tree}"],
             cwd=candidate.worktree_path,
             check=True,
             capture_output=True,
@@ -639,7 +639,7 @@ def _candidate_content_key(candidate: Candidate) -> str:
             return sha
     except Exception:
         logger.warning(
-            "Could not resolve git HEAD for candidate %s; falling back to id cache key.",
+            "Could not resolve git tree for candidate %s; falling back to id cache key.",
             candidate.id,
         )
     return candidate.id

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -79,7 +79,7 @@ def _git(args: list[str], cwd: Path) -> str:
 
 
 def _init_repo(path: Path) -> None:
-    path.mkdir()
+    path.mkdir(exist_ok=True)
     _git(["init"], path)
     _git(["config", "user.name", "HELIX Test"], path)
     _git(["config", "user.email", "helix-test@noreply"], path)
@@ -774,6 +774,9 @@ class TestCachedEvaluateBatch:
         assert commit_a != commit_b
         assert tree_a == tree_b
 
+        # Pin the contract directly: equivalent trees ⇒ equal content keys.
+        assert _candidate_content_key(cand_a) == _candidate_content_key(cand_b)
+
         run_eval_mock = mocker.patch("helix.evolution.run_evaluator")
         mocker.patch("helix.evolution._write_helix_batch")
 
@@ -844,6 +847,34 @@ class TestCachedEvaluateBatch:
         assert num_actual == 2
         assert result.candidate_id == cand_b.id
         assert result.instance_scores == {"0": 0.5, "1": 0.5}
+
+    def test_content_key_falls_back_when_worktree_is_dirty(
+        self, tmp_path: Path
+    ) -> None:
+        """Dirty / untracked worktree must NOT key by tree SHA (avoid stale hits)."""
+        from helix.evolution import _candidate_content_key
+
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        (repo / "prompt.md").write_text("v1\n")
+        _git(["add", "prompt.md"], repo)
+        _git(["commit", "-m", "initial content"], repo)
+
+        cand = self._make_cand("cand-dirty")
+        cand.worktree_path = str(repo)
+        clean_key = _candidate_content_key(cand)
+        tree_sha = _git(["rev-parse", "HEAD^{tree}"], repo)
+        assert clean_key == tree_sha  # sanity: clean repo keys by tree SHA
+
+        # Modify a tracked file without committing → key must fall back to id.
+        (repo / "prompt.md").write_text("v1-uncommitted\n")
+        assert _candidate_content_key(cand) == cand.id
+
+        # Reset and try untracked file → still falls back to id.
+        _git(["checkout", "--", "prompt.md"], repo)
+        assert _candidate_content_key(cand) == tree_sha
+        (repo / "scratch.txt").write_text("untracked\n")
+        assert _candidate_content_key(cand) == cand.id
 
     def test_cache_miss_invokes_full_evaluator(self, mocker: Any) -> None:
         """Empty cache → evaluator is invoked with ALL requested ids."""

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -9,6 +9,7 @@ mock all I/O and mock ``run_evaluator`` with controlled score sequences.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -64,6 +65,24 @@ def _write_train_jsonl(path: Path, n: int = 6) -> Path:
         for i in range(n):
             f.write(json.dumps({"idx": i, "x": i}) + "\n")
     return p
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir()
+    _git(["init"], path)
+    _git(["config", "user.name", "HELIX Test"], path)
+    _git(["config", "user.email", "helix-test@noreply"], path)
 
 
 def test_top_k_best_example_history_injection_preserves_side_info() -> None:
@@ -720,6 +739,111 @@ class TestCachedEvaluateBatch:
         assert run_eval_mock.call_count == 0
         assert result.candidate_id == cand_b.id
         assert result.instance_scores == {"0": 0.7, "1": 0.8}
+
+    def test_tree_key_reuses_cache_across_different_commits_with_same_tree(
+        self, mocker: Any, tmp_path: Path
+    ) -> None:
+        """Commit metadata/history changes must not invalidate content cache."""
+        from helix.eval_cache import EvaluationCache as MBCache
+        from helix.evolution import _cached_evaluate_batch, _candidate_content_key
+
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        (repo / "prompt.md").write_text("same tracked content\n")
+        _git(["add", "prompt.md"], repo)
+        _git(["commit", "-m", "initial content"], repo)
+
+        cand_a = self._make_cand("cand-A")
+        cand_a.worktree_path = str(repo)
+        commit_a = _git(["rev-parse", "HEAD"], repo)
+        tree_a = _git(["rev-parse", "HEAD^{tree}"], repo)
+
+        cache: MBCache[object, str] = MBCache[object, str]()
+        cache.put_batch(
+            {"content_key": _candidate_content_key(cand_a), "split": "train"},
+            ["0", "1"],
+            [None, None],
+            [0.7, 0.8],
+        )
+
+        _git(["commit", "--allow-empty", "-m", "metadata only"], repo)
+        cand_b = self._make_cand("cand-B")
+        cand_b.worktree_path = str(repo)
+        commit_b = _git(["rev-parse", "HEAD"], repo)
+        tree_b = _git(["rev-parse", "HEAD^{tree}"], repo)
+        assert commit_a != commit_b
+        assert tree_a == tree_b
+
+        run_eval_mock = mocker.patch("helix.evolution.run_evaluator")
+        mocker.patch("helix.evolution._write_helix_batch")
+
+        result, num_actual = _cached_evaluate_batch(
+            cand_b, ["0", "1"], cache, self._trivial_config(), "train", tmp_path,
+        )
+
+        assert num_actual == 0
+        assert run_eval_mock.call_count == 0
+        assert result.candidate_id == cand_b.id
+        assert result.instance_scores == {"0": 0.7, "1": 0.8}
+
+    def test_tree_key_misses_cache_when_tracked_content_changes(
+        self, mocker: Any, tmp_path: Path
+    ) -> None:
+        """Tracked file changes must produce a different cache identity."""
+        from helix.eval_cache import EvaluationCache as MBCache
+        from helix.evolution import _cached_evaluate_batch, _candidate_content_key
+
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        (repo / "prompt.md").write_text("v1\n")
+        _git(["add", "prompt.md"], repo)
+        _git(["commit", "-m", "initial content"], repo)
+
+        cand_a = self._make_cand("cand-A")
+        cand_a.worktree_path = str(repo)
+        tree_a = _git(["rev-parse", "HEAD^{tree}"], repo)
+
+        cache: MBCache[object, str] = MBCache[object, str]()
+        cache.put_batch(
+            {"content_key": _candidate_content_key(cand_a), "split": "train"},
+            ["0", "1"],
+            [None, None],
+            [0.7, 0.8],
+        )
+
+        (repo / "prompt.md").write_text("v2\n")
+        _git(["add", "prompt.md"], repo)
+        _git(["commit", "-m", "changed tracked content"], repo)
+        cand_b = self._make_cand("cand-B")
+        cand_b.worktree_path = str(repo)
+        tree_b = _git(["rev-parse", "HEAD^{tree}"], repo)
+        assert tree_a != tree_b
+
+        seen_instance_ids: list[list[str] | None] = []
+
+        def fake_run(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            seen_instance_ids.append(instance_ids)
+            return _make_result(
+                candidate.id, {eid: 0.5 for eid in (instance_ids or [])}
+            )
+
+        mocker.patch("helix.evolution.run_evaluator", side_effect=fake_run)
+        mocker.patch("helix.evolution._write_helix_batch")
+
+        result, num_actual = _cached_evaluate_batch(
+            cand_b, ["0", "1"], cache, self._trivial_config(), "train", tmp_path,
+        )
+
+        assert seen_instance_ids == [["0", "1"]]
+        assert num_actual == 2
+        assert result.candidate_id == cand_b.id
+        assert result.instance_scores == {"0": 0.5, "1": 0.5}
 
     def test_cache_miss_invokes_full_evaluator(self, mocker: Any) -> None:
         """Empty cache → evaluator is invoked with ALL requested ids."""


### PR DESCRIPTION
## Summary
- Refines the upstream reference cache conformance branch by using git tree identity rather than commit HEAD identity for candidate content cache keys.
- Uses the tracked file tree hash so cache reuse ignores commit metadata/history but changes when tracked content changes.
- Keeps fallback behavior when git tree resolution is unavailable.

## Validation
- Focused TestCachedEvaluateBatch.
- Full tests/unit.
- ruff check src tests.
- git diff --check.