### PR TITLE
Centralize Helix budget accounting

### DIFF
--- a/src/helix/budget.py
+++ b/src/helix/budget.py
@@ -1,16 +1,55 @@
-"""Central budget and progress accounting helpers for HELIX evolution."""
+"""Central budget and progress accounting helpers for HELIX evolution.
+
+Threading model
+---------------
+None of these helpers lock ``state``; callers serialize access by calling
+them only from the main evolution thread.  Today this invariant is
+maintained by ``evolution.py``: every ``budget.*`` call site is in the
+main loop, the presample/iteration loop, or a ``concurrent.futures.
+as_completed`` consumer (which runs serially on the submitting thread).
+The functions submitted to the parallel ``ThreadPoolExecutor``s
+(``_eval_parent``, ``_do_mutate``) are state-free — they neither read
+nor mutate ``EvolutionState``.
+
+If you ever move a ``budget.*`` call into a worker function body,
+introduce a ``threading.Lock`` here first; otherwise concurrent
+``next_mutation_id`` / ``next_merge_id`` calls can produce duplicate
+``g{gen}-s{n}`` ids and concurrent ``+=`` updates can drop charges.
+"""
 
 from __future__ import annotations
 
-from typing import Any
+import warnings
+from collections.abc import Mapping
+from typing import Any, TypedDict
 
 from helix.config import HelixConfig
 from helix.state import EvolutionState
 from helix.trace import TRACE, EventType
 
 
+class UsageDict(TypedDict, total=False):
+    """Subset of backend usage-payload fields read by ``charge_llm_usage``.
+
+    Pinning the keys makes the contract explicit at type-check time
+    without requiring callers to convert their existing
+    ``Candidate.usage: dict[str, Any]`` payloads.  ``charge_llm_usage``
+    accepts any read-only mapping so this remains backward-compatible.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+
+
 def budget_exhausted(state: EvolutionState, config: HelixConfig) -> bool:
-    """Return True if the configured evaluation budget is exhausted."""
+    """Return True iff the configured evaluation budget cap is set and reached.
+
+    A non-positive ``config.evolution.max_evaluations`` (``<= 0``)
+    disables the cap entirely; HELIX then runs until ``max_generations``
+    alone and this predicate always returns ``False``.  Mirrors GEPA's
+    metric-call cap (``optimize_anything.py`` ``max_metric_calls``).
+    """
     cap = config.evolution.max_evaluations
     return cap > 0 and state.budget.evaluations >= cap
 
@@ -18,7 +57,12 @@ def budget_exhausted(state: EvolutionState, config: HelixConfig) -> bool:
 def evaluation_budget_units(
     *, num_actual_examples: int | None = None, was_cached: bool = False
 ) -> int:
-    """Return evaluation budget units for an evaluation attempt."""
+    """Return evaluation budget units for an evaluation attempt.
+
+    Cached results charge 0 units; minibatch evals with N uncached
+    examples charge N (clamped at 0); single-task / no-example paths
+    charge 1 (one evaluator invocation).
+    """
     if was_cached:
         return 0
     if num_actual_examples is not None:
@@ -35,17 +79,28 @@ def charge_evaluation(
     split: str | None = None,
     source: str | None = None,
 ) -> int:
-    """Charge metric-call/evaluation budget using HELIX's existing semantics."""
+    """Charge metric-call/evaluation budget using HELIX's existing semantics.
+
+    No-op charges (``units == 0`` from a cache hit or a 0-example
+    minibatch) update neither the counter nor the trace stream — this
+    keeps ``BUDGET_UPDATE`` events focused on actual budget consumption
+    and avoids inflating long-run trace files.  Use the ``source``
+    argument to label the call site (e.g., ``"seed_val"``,
+    ``"merge_subsample"``, ``"mutation_minibatch_gate"``); it is
+    forwarded to ``Event.reason``.
+    """
     units = evaluation_budget_units(
         num_actual_examples=num_actual_examples,
         was_cached=was_cached,
     )
+    if units == 0:
+        return 0
     state.budget.evaluations += units
     TRACE.emit(
         EventType.BUDGET_UPDATE,
         candidate_id=candidate_id,
         split=split,
-        decision=source,
+        reason=source,
         budget_delta=units,
         budget_evaluations=state.budget.evaluations,
     )
@@ -54,12 +109,18 @@ def charge_evaluation(
 
 def charge_llm_usage(
     state: EvolutionState,
-    usage: dict[str, Any] | None,
+    usage: UsageDict | Mapping[str, Any] | None,
     *,
     candidate_id: str | None = None,
     source: str | None = None,
 ) -> None:
-    """Charge token and cost counters from a backend usage payload."""
+    """Charge token and cost counters from a backend usage payload.
+
+    Safe to call with ``None`` or an empty mapping; both short-circuit
+    without touching counters or emitting a trace event.  A non-empty
+    mapping with all-zero deltas still emits one ``BUDGET_UPDATE`` event
+    (the call indicates a real backend response was processed).
+    """
     if not usage:
         return
     input_delta = int(usage.get("input_tokens", 0))
@@ -71,7 +132,7 @@ def charge_llm_usage(
     TRACE.emit(
         EventType.BUDGET_UPDATE,
         candidate_id=candidate_id,
-        decision=source,
+        reason=source,
         input_tokens_delta=input_delta,
         output_tokens_delta=output_delta,
         cost_usd_delta=cost_delta,
@@ -81,22 +142,26 @@ def charge_llm_usage(
     )
 
 
-def start_generation(state: EvolutionState, generation: int) -> None:
+def set_generation(state: EvolutionState, generation: int) -> None:
     """Record the active generation."""
     state.generation = generation
     TRACE.emit(
         EventType.BUDGET_UPDATE,
-        decision="generation",
+        reason="generation",
         generation=state.generation,
     )
 
 
 def advance_proposal_counter(state: EvolutionState, *, source: str) -> int:
-    """Advance HELIX/GEPA's monotonic proposal counter."""
+    """Advance HELIX/GEPA's monotonic proposal counter.
+
+    ``EvolutionState.i`` defaults to ``-1`` (GEPA ``core/state.py``
+    parity); the first call therefore yields ``0``.
+    """
     state.i += 1
     TRACE.emit(
         EventType.BUDGET_UPDATE,
-        decision=source,
+        reason=source,
         proposal_index=state.i,
     )
     return state.i
@@ -109,7 +174,7 @@ def next_mutation_id(state: EvolutionState, generation: int) -> str:
     TRACE.emit(
         EventType.BUDGET_UPDATE,
         candidate_id=mutation_id,
-        decision="mutation_id",
+        reason="mutation_id",
         mutation_counter=state.mutation_counter,
     )
     return mutation_id
@@ -122,7 +187,7 @@ def next_merge_id(state: EvolutionState, generation: int) -> str:
     TRACE.emit(
         EventType.BUDGET_UPDATE,
         candidate_id=merge_id,
-        decision="merge_id",
+        reason="merge_id",
         merge_counter=state.merge_counter,
     )
     return merge_id
@@ -133,17 +198,33 @@ def record_merge_invocation(state: EvolutionState) -> None:
     state.total_merge_invocations += 1
     TRACE.emit(
         EventType.BUDGET_UPDATE,
-        decision="merge_invocation",
+        reason="merge_invocation",
         merge_invocations=state.total_merge_invocations,
     )
 
 
 def record_discovery_budget(state: EvolutionState, candidate_id: str) -> None:
-    """Stamp the evaluation budget at which a candidate entered the frontier."""
+    """Stamp the evaluation budget at which a candidate entered the frontier.
+
+    Warns (without raising) when ``candidate_id`` has already been
+    recorded.  A duplicate stamp overwrites the original discovery
+    budget and almost always indicates a real bug in the accept path —
+    each accepted candidate should hit this exactly once.  Resume
+    paths that legitimately re-process a candidate should skip this
+    call rather than rely on overwrite semantics.
+    """
+    if candidate_id in state.num_metric_calls_by_discovery:
+        warnings.warn(
+            f"discovery budget already recorded for {candidate_id!r}: "
+            f"overwriting "
+            f"{state.num_metric_calls_by_discovery[candidate_id]} "
+            f"-> {state.budget.evaluations}",
+            stacklevel=2,
+        )
     state.num_metric_calls_by_discovery[candidate_id] = state.budget.evaluations
     TRACE.emit(
         EventType.BUDGET_UPDATE,
         candidate_id=candidate_id,
-        decision="discovery_budget",
+        reason="discovery_budget",
         budget_evaluations=state.budget.evaluations,
     )

--- a/src/helix/budget.py
+++ b/src/helix/budget.py
@@ -1,0 +1,149 @@
+"""Central budget and progress accounting helpers for HELIX evolution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from helix.config import HelixConfig
+from helix.state import EvolutionState
+from helix.trace import TRACE, EventType
+
+
+def budget_exhausted(state: EvolutionState, config: HelixConfig) -> bool:
+    """Return True if the configured evaluation budget is exhausted."""
+    cap = config.evolution.max_evaluations
+    return cap > 0 and state.budget.evaluations >= cap
+
+
+def evaluation_budget_units(
+    *, num_actual_examples: int | None = None, was_cached: bool = False
+) -> int:
+    """Return evaluation budget units for an evaluation attempt."""
+    if was_cached:
+        return 0
+    if num_actual_examples is not None:
+        return max(0, int(num_actual_examples))
+    return 1
+
+
+def charge_evaluation(
+    state: EvolutionState,
+    *,
+    num_actual_examples: int | None = None,
+    was_cached: bool = False,
+    candidate_id: str | None = None,
+    split: str | None = None,
+    source: str | None = None,
+) -> int:
+    """Charge metric-call/evaluation budget using HELIX's existing semantics."""
+    units = evaluation_budget_units(
+        num_actual_examples=num_actual_examples,
+        was_cached=was_cached,
+    )
+    state.budget.evaluations += units
+    TRACE.emit(
+        EventType.BUDGET_UPDATE,
+        candidate_id=candidate_id,
+        split=split,
+        decision=source,
+        budget_delta=units,
+        budget_evaluations=state.budget.evaluations,
+    )
+    return units
+
+
+def charge_llm_usage(
+    state: EvolutionState,
+    usage: dict[str, Any] | None,
+    *,
+    candidate_id: str | None = None,
+    source: str | None = None,
+) -> None:
+    """Charge token and cost counters from a backend usage payload."""
+    if not usage:
+        return
+    input_delta = int(usage.get("input_tokens", 0))
+    output_delta = int(usage.get("output_tokens", 0))
+    cost_delta = float(usage.get("cost_usd", 0.0))
+    state.budget.input_tokens += input_delta
+    state.budget.output_tokens += output_delta
+    state.budget.cost_usd += cost_delta
+    TRACE.emit(
+        EventType.BUDGET_UPDATE,
+        candidate_id=candidate_id,
+        decision=source,
+        input_tokens_delta=input_delta,
+        output_tokens_delta=output_delta,
+        cost_usd_delta=cost_delta,
+        input_tokens=state.budget.input_tokens,
+        output_tokens=state.budget.output_tokens,
+        cost_usd=state.budget.cost_usd,
+    )
+
+
+def start_generation(state: EvolutionState, generation: int) -> None:
+    """Record the active generation."""
+    state.generation = generation
+    TRACE.emit(
+        EventType.BUDGET_UPDATE,
+        decision="generation",
+        generation=state.generation,
+    )
+
+
+def advance_proposal_counter(state: EvolutionState, *, source: str) -> int:
+    """Advance HELIX/GEPA's monotonic proposal counter."""
+    state.i += 1
+    TRACE.emit(
+        EventType.BUDGET_UPDATE,
+        decision=source,
+        proposal_index=state.i,
+    )
+    return state.i
+
+
+def next_mutation_id(state: EvolutionState, generation: int) -> str:
+    """Allocate the next mutation candidate id."""
+    state.mutation_counter += 1
+    mutation_id = f"g{generation}-s{state.mutation_counter}"
+    TRACE.emit(
+        EventType.BUDGET_UPDATE,
+        candidate_id=mutation_id,
+        decision="mutation_id",
+        mutation_counter=state.mutation_counter,
+    )
+    return mutation_id
+
+
+def next_merge_id(state: EvolutionState, generation: int) -> str:
+    """Allocate the next merge candidate id."""
+    state.merge_counter += 1
+    merge_id = f"g{generation}-m{state.merge_counter}"
+    TRACE.emit(
+        EventType.BUDGET_UPDATE,
+        candidate_id=merge_id,
+        decision="merge_id",
+        merge_counter=state.merge_counter,
+    )
+    return merge_id
+
+
+def record_merge_invocation(state: EvolutionState) -> None:
+    """Record one accepted merge invocation."""
+    state.total_merge_invocations += 1
+    TRACE.emit(
+        EventType.BUDGET_UPDATE,
+        decision="merge_invocation",
+        merge_invocations=state.total_merge_invocations,
+    )
+
+
+def record_discovery_budget(state: EvolutionState, candidate_id: str) -> None:
+    """Stamp the evaluation budget at which a candidate entered the frontier."""
+    state.num_metric_calls_by_discovery[candidate_id] = state.budget.evaluations
+    TRACE.emit(
+        EventType.BUDGET_UPDATE,
+        candidate_id=candidate_id,
+        decision="discovery_budget",
+        budget_evaluations=state.budget.evaluations,
+    )

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -80,31 +80,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def budget_exhausted(state: EvolutionState, config: HelixConfig) -> bool:
-    """Return True if evaluation budget is exhausted.
-
-    Uses only the ``evaluations`` counter.  In dataset/minibatch mode HELIX
-    counts per-example evaluations, i.e. the number of examples actually sent
-    to the evaluator after per-example cache hits are removed.  Legacy
-    single-task/no-example evaluator calls still count as one metric call
-    unless served from cache (no per-example ids exist in this path).
-    When ``max_evaluations`` is the sentinel ``-1`` (the default), the cap is
-    disabled and this always returns False; HELIX then runs until
-    ``max_generations`` alone.
-    """
-    return budget_api.budget_exhausted(state, config)
-
-
-def _evaluation_budget_units(
-    *, num_actual_examples: int | None = None, was_cached: bool = False
-) -> int:
-    """Return evaluation budget units for an evaluation attempt."""
-    return budget_api.evaluation_budget_units(
-        num_actual_examples=num_actual_examples,
-        was_cached=was_cached,
-    )
-
-
 def degrades(new_result: EvalResult, baseline: EvalResult, threshold: float) -> bool:
     """Return True if the new result regresses below baseline by more than threshold."""
     return new_result.sum_score() < baseline.sum_score() - threshold
@@ -1399,7 +1374,7 @@ def _run_evolution_impl(
             live.current_usage = UsageStats()
             live.update(phase=f"Starting Generation {gen}")
 
-            budget_api.start_generation(state, gen)
+            budget_api.set_generation(state, gen)
             # GEPA parity (engine.py:649): bump ``state.i`` unconditionally at
             # the top of every iteration so the proposal counter — used by the
             # batch sampler and as a tiebreaker elsewhere — advances regardless
@@ -1407,7 +1382,7 @@ def _run_evolution_impl(
             budget_api.advance_proposal_counter(state, source="iteration")
             TRACE.emit(EventType.ITER_START, decision=str(gen))
 
-            if budget_exhausted(state, config):
+            if budget_api.budget_exhausted(state, config):
                 print_warning("Budget exhausted -- stopping early.")
                 break
 
@@ -1675,7 +1650,7 @@ def _run_evolution_impl(
                             _save_evaluation(base_dir, merge_result)
 
                             # GEPA parity (Fix 13): mid-generation budget check.
-                            if budget_exhausted(state, config):
+                            if budget_api.budget_exhausted(state, config):
                                 print_warning(
                                     "Budget exhausted mid-generation -- stopping."
                                 )
@@ -1778,7 +1753,7 @@ def _run_evolution_impl(
                                     )
                                 _save_evaluation(base_dir, full_val_result)
 
-                                if budget_exhausted(state, config):
+                                if budget_api.budget_exhausted(state, config):
                                     print_warning(
                                         "Budget exhausted during merge full-val eval -- stopping."
                                     )
@@ -1862,7 +1837,7 @@ def _run_evolution_impl(
             _budget_break = False
 
             for _p_idx in range(n_proposals):
-                if budget_exhausted(state, config):
+                if budget_api.budget_exhausted(state, config):
                     _budget_break = True
                     break
 
@@ -2024,7 +1999,7 @@ def _run_evolution_impl(
                         source="parent_minibatch",
                     )
 
-                if budget_exhausted(state, config):
+                if budget_api.budget_exhausted(state, config):
                     _budget_break = True
                     break
 
@@ -2280,7 +2255,7 @@ def _run_evolution_impl(
                         source="mutation_minibatch_gate",
                     )
 
-                    if budget_exhausted(state, config):
+                    if budget_api.budget_exhausted(state, config):
                         print_warning("Budget exhausted mid-generation -- stopping.")
                         _save_state(state)
                         _budget_break = True
@@ -2367,7 +2342,7 @@ def _run_evolution_impl(
                         source="mutation_train_gate",
                     )
 
-                    if budget_exhausted(state, config):
+                    if budget_api.budget_exhausted(state, config):
                         print_warning("Budget exhausted mid-generation -- stopping.")
                         _save_state(state)
                         _budget_break = True
@@ -2436,7 +2411,7 @@ def _run_evolution_impl(
                         source="mutation_val_stage",
                     )
 
-                    if budget_exhausted(state, config):
+                    if budget_api.budget_exhausted(state, config):
                         print_warning("Budget exhausted mid-generation -- stopping.")
                         _save_state(state)
                         _budget_break = True
@@ -2537,7 +2512,7 @@ def _run_evolution_impl(
                         source="mutation_full_val",
                     )
 
-                if budget_exhausted(state, config):
+                if budget_api.budget_exhausted(state, config):
                     print_warning("Budget exhausted mid-generation -- stopping.")
                     _save_state(state)
                     _budget_break = True

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -2019,8 +2019,12 @@ def _run_evolution_impl(
                         parent, config, "train", eval_cache
                     )
                     eval_for_mutate.candidate_id = parent.id
-                    state.budget.evaluations += _evaluation_budget_units(
-                        was_cached=_train_cached
+                    budget_api.charge_evaluation(
+                        state,
+                        was_cached=_train_cached,
+                        candidate_id=parent.id,
+                        split="train",
+                        source="parent_train_no_minibatch",
                     )
 
                 eval_for_mutate = _inject_top_k_best_example_history(

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -21,6 +21,7 @@ from helix.batch_sampler import (
     EpochShuffledBatchSampler,
     StratifiedBatchSampler,
 )
+from helix import budget as budget_api
 from helix.config import HelixConfig, load_dataset_examples
 from helix.eval_cache import EvaluationCache as MinibatchEvalCache
 from helix.eval_policy import (
@@ -91,19 +92,17 @@ def budget_exhausted(state: EvolutionState, config: HelixConfig) -> bool:
     disabled and this always returns False; HELIX then runs until
     ``max_generations`` alone.
     """
-    cap = config.evolution.max_evaluations
-    return cap > 0 and state.budget.evaluations >= cap
+    return budget_api.budget_exhausted(state, config)
 
 
 def _evaluation_budget_units(
     *, num_actual_examples: int | None = None, was_cached: bool = False
 ) -> int:
     """Return evaluation budget units for an evaluation attempt."""
-    if was_cached:
-        return 0
-    if num_actual_examples is not None:
-        return max(0, int(num_actual_examples))
-    return 1
+    return budget_api.evaluation_budget_units(
+        num_actual_examples=num_actual_examples,
+        was_cached=was_cached,
+    )
 
 
 def degrades(new_result: EvalResult, baseline: EvalResult, threshold: float) -> bool:
@@ -1270,9 +1269,12 @@ def _run_evolution_impl(
             try:
                 usage = generate_seed(seed.worktree_path, seed_prompt, config)
                 seed.usage = usage
-                state.budget.input_tokens += int(usage.get("input_tokens", 0))
-                state.budget.output_tokens += int(usage.get("output_tokens", 0))
-                state.budget.cost_usd += float(usage.get("cost_usd", 0.0))
+                budget_api.charge_llm_usage(
+                    state,
+                    usage,
+                    candidate_id=seed.id,
+                    source="seed_generation",
+                )
             except Exception:
                 remove_worktree(seed)
                 raise
@@ -1313,15 +1315,23 @@ def _run_evolution_impl(
                 project_root,
             )
             seed_result.candidate_id = seed.id
-            state.budget.evaluations += _evaluation_budget_units(
-                num_actual_examples=_seed_num_actual
+            budget_api.charge_evaluation(
+                state,
+                num_actual_examples=_seed_num_actual,
+                candidate_id=seed.id,
+                split="val",
+                source="seed_val_batch",
             )
         else:
             _refresh_protected_evaluator_files(seed, config, project_root)
             seed_result, _seed_cached = _cached_eval(seed, config, "val", eval_cache)
             seed_result.candidate_id = seed.id
-            state.budget.evaluations += _evaluation_budget_units(
-                was_cached=_seed_cached
+            budget_api.charge_evaluation(
+                state,
+                was_cached=_seed_cached,
+                candidate_id=seed.id,
+                split="val",
+                source="seed_val",
             )
 
         _save_evaluation(base_dir, seed_result)
@@ -1333,7 +1343,7 @@ def _run_evolution_impl(
         # Mirrors GEPA core/state.py:537 (``num_metric_calls_by_discovery
         # .append(num_metric_calls_by_discovery_of_new_program)`` inside
         # ``update_state_with_new_program``).
-        state.num_metric_calls_by_discovery[seed.id] = state.budget.evaluations
+        budget_api.record_discovery_budget(state, seed.id)
         _save_state(state)
 
         record_entry(
@@ -1389,12 +1399,12 @@ def _run_evolution_impl(
             live.current_usage = UsageStats()
             live.update(phase=f"Starting Generation {gen}")
 
-            state.generation = gen
+            budget_api.start_generation(state, gen)
             # GEPA parity (engine.py:649): bump ``state.i`` unconditionally at
             # the top of every iteration so the proposal counter — used by the
             # batch sampler and as a tiebreaker elsewhere — advances regardless
             # of whether we sampled from the frontier or skipped.
-            state.i += 1
+            budget_api.advance_proposal_counter(state, source="iteration")
             TRACE.emit(EventType.ITER_START, decision=str(gen))
 
             if budget_exhausted(state, config):
@@ -1523,8 +1533,7 @@ def _run_evolution_impl(
                     a = frontier._candidates[cid_i]
                     b = frontier._candidates[cid_j]
 
-                    state.merge_counter += 1
-                    merge_id = f"g{gen}-m{state.merge_counter}"
+                    merge_id = budget_api.next_merge_id(state, gen)
 
                     merged = merge(
                         candidate_a=a,
@@ -1554,14 +1563,11 @@ def _run_evolution_impl(
                     else:
                         if merged.usage:
                             live.update(usage=merged.usage)
-                            state.budget.input_tokens += int(
-                                merged.usage.get("input_tokens", 0)
-                            )
-                            state.budget.output_tokens += int(
-                                merged.usage.get("output_tokens", 0)
-                            )
-                            state.budget.cost_usd += float(
-                                merged.usage.get("cost_usd", 0.0)
+                            budget_api.charge_llm_usage(
+                                state,
+                                merged.usage,
+                                candidate_id=merged.id,
+                                source="merge",
                             )
 
                         merge_tamper = _detect_evaluator_tamper(
@@ -1659,8 +1665,12 @@ def _run_evolution_impl(
                                 project_root,
                             )
                             merge_result.candidate_id = merged.id
-                            state.budget.evaluations += _evaluation_budget_units(
-                                num_actual_examples=_merge_evals
+                            budget_api.charge_evaluation(
+                                state,
+                                num_actual_examples=_merge_evals,
+                                candidate_id=merged.id,
+                                split="val",
+                                source="merge_subsample",
                             )
                             _save_evaluation(base_dir, merge_result)
 
@@ -1744,10 +1754,12 @@ def _run_evolution_impl(
                                         project_root,
                                     )
                                     full_val_result.candidate_id = merged.id
-                                    state.budget.evaluations += (
-                                        _evaluation_budget_units(
-                                            num_actual_examples=_full_n
-                                        )
+                                    budget_api.charge_evaluation(
+                                        state,
+                                        num_actual_examples=_full_n,
+                                        candidate_id=merged.id,
+                                        split="val",
+                                        source="merge_full_val_batch",
                                     )
                                 else:
                                     full_val_result, _full_val_cached = _cached_eval(
@@ -1757,10 +1769,12 @@ def _run_evolution_impl(
                                         eval_cache,
                                     )
                                     full_val_result.candidate_id = merged.id
-                                    state.budget.evaluations += (
-                                        _evaluation_budget_units(
-                                            was_cached=_full_val_cached
-                                        )
+                                    budget_api.charge_evaluation(
+                                        state,
+                                        was_cached=_full_val_cached,
+                                        candidate_id=merged.id,
+                                        split="val",
+                                        source="merge_full_val",
                                     )
                                 _save_evaluation(base_dir, full_val_result)
 
@@ -1772,7 +1786,7 @@ def _run_evolution_impl(
                                     break
 
                                 merges_due -= 1
-                                state.total_merge_invocations += 1
+                                budget_api.record_merge_invocation(state)
                                 frontier.add(merged, full_val_result)
                                 state.frontier = list(frontier._candidates.keys())
                                 state.instance_scores[merged.id] = (
@@ -1782,9 +1796,7 @@ def _run_evolution_impl(
                                 # record per-program discovery budget at the
                                 # moment the merged program enters the
                                 # frontier.  GEPA core/state.py:537.
-                                state.num_metric_calls_by_discovery[merged.id] = (
-                                    state.budget.evaluations
-                                )
+                                budget_api.record_discovery_budget(state, merged.id)
                             else:
                                 print_warning(
                                     f"Merge {merge_id} score {merge_score:.4f} < "
@@ -1861,7 +1873,9 @@ def _run_evolution_impl(
                 # the per-proposal counter advances independently of the
                 # outer loop.  The bump is unconditional (no minibatch gate).
                 if _p_idx > 0:
-                    state.i += 1
+                    budget_api.advance_proposal_counter(
+                        state, source="parallel_proposal"
+                    )
 
                 parent = frontier.select_parent()
                 parent_frontier_result = frontier._results.get(parent.id)
@@ -1890,8 +1904,7 @@ def _run_evolution_impl(
                         split="train",
                     )
 
-                state.mutation_counter += 1
-                new_id = f"g{gen}-s{state.mutation_counter}"
+                new_id = budget_api.next_mutation_id(state, gen)
                 presample_contexts.append(
                     (parent, parent_frontier_result, subsample_ids, new_id)
                 )
@@ -2003,8 +2016,12 @@ def _run_evolution_impl(
                     continue
 
                 if subsample_ids is not None:
-                    state.budget.evaluations += _evaluation_budget_units(
-                        num_actual_examples=_n_uncached
+                    budget_api.charge_evaluation(
+                        state,
+                        num_actual_examples=_n_uncached,
+                        candidate_id=parent.id,
+                        split="train",
+                        source="parent_minibatch",
                     )
 
                 if budget_exhausted(state, config):
@@ -2118,14 +2135,11 @@ def _run_evolution_impl(
                             mutation_results[idx] = child
                             if child and child.usage:
                                 live.update(usage=child.usage)
-                                state.budget.input_tokens += int(
-                                    child.usage.get("input_tokens", 0)
-                                )
-                                state.budget.output_tokens += int(
-                                    child.usage.get("output_tokens", 0)
-                                )
-                                state.budget.cost_usd += float(
-                                    child.usage.get("cost_usd", 0.0)
+                                budget_api.charge_llm_usage(
+                                    state,
+                                    child.usage,
+                                    candidate_id=child.id,
+                                    source="mutation",
                                 )
                         except Exception as exc:
                             _ctx = proposal_contexts[idx]
@@ -2169,13 +2183,12 @@ def _run_evolution_impl(
                     mutation_results.append(child)
                     if child and child.usage:
                         live.update(usage=child.usage)
-                        state.budget.input_tokens += int(
-                            child.usage.get("input_tokens", 0)
+                        budget_api.charge_llm_usage(
+                            state,
+                            child.usage,
+                            candidate_id=child.id,
+                            source="mutation",
                         )
-                        state.budget.output_tokens += int(
-                            child.usage.get("output_tokens", 0)
-                        )
-                        state.budget.cost_usd += float(child.usage.get("cost_usd", 0.0))
 
             # ---- Step 3: Process acceptances SEQUENTIALLY ----
             # Each accepted mutation's full val eval updates state before
@@ -2259,8 +2272,12 @@ def _run_evolution_impl(
                     )
                     gating_result.candidate_id = child.id
                     _last_eval_result = gating_result
-                    state.budget.evaluations += _evaluation_budget_units(
-                        num_actual_examples=_n
+                    budget_api.charge_evaluation(
+                        state,
+                        num_actual_examples=_n,
+                        candidate_id=child.id,
+                        split="train",
+                        source="mutation_minibatch_gate",
                     )
 
                     if budget_exhausted(state, config):
@@ -2342,8 +2359,12 @@ def _run_evolution_impl(
                     # must come from the same train eval that was passed into the mutator,
                     # not the parent's stored val frontier result.
                     parent_acceptance_result = _eval_for_mutate
-                    state.budget.evaluations += _evaluation_budget_units(
-                        was_cached=_gating_cached
+                    budget_api.charge_evaluation(
+                        state,
+                        was_cached=_gating_cached,
+                        candidate_id=child.id,
+                        split="train",
+                        source="mutation_train_gate",
                     )
 
                     if budget_exhausted(state, config):
@@ -2407,8 +2428,12 @@ def _run_evolution_impl(
                     )
                     stage_result.candidate_id = child.id
                     _last_eval_result = stage_result
-                    state.budget.evaluations += _evaluation_budget_units(
-                        num_actual_examples=_n
+                    budget_api.charge_evaluation(
+                        state,
+                        num_actual_examples=_n,
+                        candidate_id=child.id,
+                        split="val",
+                        source="mutation_val_stage",
                     )
 
                     if budget_exhausted(state, config):
@@ -2491,8 +2516,12 @@ def _run_evolution_impl(
                     )
                     val_result.candidate_id = child.id
                     _last_eval_result = val_result
-                    state.budget.evaluations += _evaluation_budget_units(
-                        num_actual_examples=_n
+                    budget_api.charge_evaluation(
+                        state,
+                        num_actual_examples=_n,
+                        candidate_id=child.id,
+                        split="val",
+                        source="mutation_full_val_batch",
                     )
                 else:
                     val_result, _val_cached = _cached_eval(
@@ -2500,8 +2529,12 @@ def _run_evolution_impl(
                     )
                     val_result.candidate_id = child.id
                     _last_eval_result = val_result
-                    state.budget.evaluations += _evaluation_budget_units(
-                        was_cached=_val_cached
+                    budget_api.charge_evaluation(
+                        state,
+                        was_cached=_val_cached,
+                        candidate_id=child.id,
+                        split="val",
+                        source="mutation_full_val",
                     )
 
                 if budget_exhausted(state, config):
@@ -2519,7 +2552,7 @@ def _run_evolution_impl(
                 # GEPA parity (audit-rng-state-persist C/§3): record per-program
                 # discovery budget at the moment the child enters the frontier.
                 # GEPA core/state.py:537.
-                state.num_metric_calls_by_discovery[child.id] = state.budget.evaluations
+                budget_api.record_discovery_budget(state, child.id)
                 TRACE.emit(
                     EventType.FRONTIER_UPDATE,
                     candidate_id=child.id,

--- a/src/helix/trace.py
+++ b/src/helix/trace.py
@@ -32,6 +32,7 @@ class EventType(str, Enum):
     FRONTIER_UPDATE = "FRONTIER_UPDATE"
     ITER_END = "ITER_END"
     OPT_END = "OPT_END"
+    BUDGET_UPDATE = "BUDGET_UPDATE"
 
 
 @dataclass
@@ -44,6 +45,19 @@ class Event:
     miss_ids: list[Any] | None = None
     decision: str | None = None
     score: float | None = None
+    budget_delta: int | None = None
+    budget_evaluations: int | None = None
+    input_tokens_delta: int | None = None
+    output_tokens_delta: int | None = None
+    cost_usd_delta: float | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cost_usd: float | None = None
+    generation: int | None = None
+    proposal_index: int | None = None
+    mutation_counter: int | None = None
+    merge_counter: int | None = None
+    merge_invocations: int | None = None
     source: str | None = None  # "file:line" — captured via inspect when enabled
 
 

--- a/src/helix/trace.py
+++ b/src/helix/trace.py
@@ -44,6 +44,13 @@ class Event:
     hit_ids: list[Any] | None = None
     miss_ids: list[Any] | None = None
     decision: str | None = None
+    # Human-readable label for *why* an event was emitted (e.g., the
+    # ``charge_evaluation`` source: "seed_val", "merge_subsample",
+    # "mutation_minibatch_gate", ...).  Distinct from ``decision``,
+    # which carries iteration-level accept/reject text, and from
+    # ``source`` below, which is reserved for the ``"file:line"`` stack
+    # frame captured by ``inspect`` when enabled.
+    reason: str | None = None
     score: float | None = None
     budget_delta: int | None = None
     budget_evaluations: int | None = None

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -2,19 +2,38 @@
 
 from __future__ import annotations
 
-import re
 import json
+import re
+import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
-from helix.backends import BACKENDS
 from helix import budget
-from helix.config import AgentConfig, EvolutionConfig, EvaluatorConfig, HelixConfig
+from helix.backends import BACKENDS
+from helix.config import (
+    AgentConfig,
+    EvaluatorConfig,
+    EvolutionConfig,
+    HelixConfig,
+    SandboxConfig,
+)
 from helix.mutator import invoke_claude_code
 from helix.state import BudgetState, EvolutionState
 from helix.trace import TRACE, EventType
+
+
+# Mapping from backend name to the executable that ``_build_backend_args``
+# emits as args[0].  Used by parser-coverage tests to assert that
+# ``invoke_claude_code`` actually dispatched to the requested backend CLI
+# (rather than short-circuiting via the differential-testing override).
+_BACKEND_EXECUTABLE = {
+    "claude": "claude",
+    "codex": "codex",
+    "cursor": "cursor",
+    "gemini": "gemini",
+    "opencode": "opencode",
+}
 
 
 def make_state(evaluations: int = 0) -> EvolutionState:
@@ -76,7 +95,7 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
 @pytest.mark.parametrize(
     ("backend", "stdout", "expected"),
     [
-        (
+        pytest.param(
             "claude",
             json.dumps(
                 {
@@ -87,8 +106,9 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 }
             ),
             (11, 7, 0.31),
+            id="claude",
         ),
-        (
+        pytest.param(
             "codex",
             "\n".join(
                 [
@@ -100,8 +120,9 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 ]
             ),
             (12, 8, 0.32),
+            id="codex",
         ),
-        (
+        pytest.param(
             "cursor",
             "\n".join(
                 [
@@ -113,8 +134,9 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 ]
             ),
             (13, 9, 0.33),
+            id="cursor",
         ),
-        (
+        pytest.param(
             "gemini",
             "\n".join(
                 [
@@ -127,8 +149,9 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 ]
             ),
             (14, 10, 0.34),
+            id="gemini",
         ),
-        (
+        pytest.param(
             "opencode",
             "\n".join(
                 [
@@ -140,6 +163,7 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 ]
             ),
             (15, 11, 0.35),
+            id="opencode",
         ),
     ],
 )
@@ -154,7 +178,15 @@ def test_backend_usage_parsing_charges_llm_budget(
     worktree = tmp_path / backend
     worktree.mkdir()
     mock_run = mocker.patch("helix.mutator.subprocess.run")
-    mock_run.return_value = MagicMock(stdout=stdout, stderr="", returncode=0)
+    # Use the real CompletedProcess type so attribute typos in the production
+    # path (e.g. ``result.exit_code`` vs ``returncode``) surface as test
+    # failures rather than being silently absorbed by ``MagicMock``.
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[_BACKEND_EXECUTABLE[backend]],
+        returncode=0,
+        stdout=stdout,
+        stderr="",
+    )
     state = make_state()
 
     _parsed, usage = invoke_claude_code(
@@ -162,6 +194,14 @@ def test_backend_usage_parsing_charges_llm_budget(
         "read the prompt artifact",
         AgentConfig(backend=backend),
     )
+
+    # Guard against future refactors that bypass ``_build_backend_args`` or
+    # leave ``_MUTATOR_OVERRIDE`` set globally — the test must observe the
+    # real backend dispatch, not a short-circuited override.
+    assert mock_run.call_count == 1
+    invoked_args = mock_run.call_args.args[0]
+    assert invoked_args[0] == _BACKEND_EXECUTABLE[backend]
+
     budget.charge_llm_usage(
         state,
         usage,
@@ -173,6 +213,160 @@ def test_backend_usage_parsing_charges_llm_budget(
     assert state.budget.input_tokens == expected_input
     assert state.budget.output_tokens == expected_output
     assert state.budget.cost_usd == pytest.approx(expected_cost)
+
+
+def test_backend_usage_parsing_under_sandbox_charges_llm_budget(
+    tmp_path: Path, mocker
+) -> None:
+    """Cover the ``run_sandboxed_command`` branch of ``invoke_claude_code``.
+
+    The parametrized test above exercises the direct ``subprocess.run`` path.
+    This variant flips ``SandboxConfig.enabled=True`` so the dispatch goes
+    through ``run_sandboxed_command`` instead, ensuring sandboxed invocations
+    still produce a usage payload that flows into ``charge_llm_usage``.
+    """
+    worktree = tmp_path / "claude"
+    worktree.mkdir()
+    stdout = json.dumps(
+        {
+            "type": "result",
+            "session_id": "sandbox-session",
+            "usage": {"input_tokens": 17, "output_tokens": 9},
+            "total_cost_usd": 0.45,
+        }
+    )
+    mock_sandboxed = mocker.patch("helix.mutator.run_sandboxed_command")
+    mock_sandboxed.return_value = subprocess.CompletedProcess(
+        args=["claude"], returncode=0, stdout=stdout, stderr=""
+    )
+    mocker.patch(
+        "helix.mutator.resolve_sandbox_image",
+        return_value="ghcr.io/example/image:latest",
+    )
+    # Belt-and-suspenders: the direct path must NOT be exercised when sandbox
+    # is enabled, so leave ``subprocess.run`` patched to fail loudly.
+    mock_run = mocker.patch(
+        "helix.mutator.subprocess.run",
+        side_effect=AssertionError(
+            "subprocess.run must not be called when sandbox is enabled"
+        ),
+    )
+    state = make_state()
+
+    _parsed, usage = invoke_claude_code(
+        str(worktree),
+        "read the prompt artifact",
+        AgentConfig(backend="claude"),
+        sandbox=SandboxConfig(enabled=True),
+    )
+
+    assert mock_sandboxed.call_count == 1
+    assert mock_run.call_count == 0
+
+    budget.charge_llm_usage(
+        state, usage, candidate_id="claude-candidate", source="claude"
+    )
+
+    assert state.budget.input_tokens == 17
+    assert state.budget.output_tokens == 9
+    assert state.budget.cost_usd == pytest.approx(0.45)
+
+
+def test_backend_usage_parsing_extracts_cached_and_reasoning_tokens(
+    tmp_path: Path, mocker
+) -> None:
+    """Lock in parser support for cached_input_tokens and reasoning_tokens.
+
+    ``charge_llm_usage`` does not yet sum these into ``BudgetState``, but the
+    backend output parser exposes them via ``_normalise_usage_stats`` so a
+    future budget-API extension can rely on the alias map remaining intact.
+    """
+    worktree = tmp_path / "claude"
+    worktree.mkdir()
+    stdout = json.dumps(
+        {
+            "type": "result",
+            "session_id": "claude-session",
+            "usage": {
+                "input_tokens": 11,
+                "output_tokens": 7,
+                # ``cacheReadInputTokens`` is the alias the parser actually
+                # recognises (see ``_normalise_usage_stats`` aliases).
+                "cacheReadInputTokens": 3,
+            },
+            "reasoning_tokens": 5,
+            "total_cost_usd": 0.31,
+        }
+    )
+    mock_run = mocker.patch("helix.mutator.subprocess.run")
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["claude"], returncode=0, stdout=stdout, stderr=""
+    )
+
+    _parsed, usage = invoke_claude_code(
+        str(worktree),
+        "read the prompt artifact",
+        AgentConfig(backend="claude"),
+    )
+
+    assert usage["input_tokens"] == 11
+    assert usage["output_tokens"] == 7
+    assert usage["cached_input_tokens"] == 3
+    assert usage["reasoning_tokens"] == 5
+    assert usage["cost_usd"] == pytest.approx(0.31)
+
+
+def test_charge_llm_usage_handles_empty_and_partial_payloads() -> None:
+    """Regression guard for the early-return / default-zero paths."""
+    state = make_state()
+
+    # ``None`` usage: short-circuit, no mutation.
+    budget.charge_llm_usage(state, None, candidate_id="c", source="x")
+    assert state.budget.input_tokens == 0
+    assert state.budget.output_tokens == 0
+    assert state.budget.cost_usd == 0.0
+
+    # Empty dict: short-circuit (falsy), no mutation.
+    budget.charge_llm_usage(state, {}, candidate_id="c", source="x")
+    assert state.budget.input_tokens == 0
+    assert state.budget.output_tokens == 0
+    assert state.budget.cost_usd == 0.0
+
+    # Partial payload: only present keys are summed; absent keys default to 0.
+    budget.charge_llm_usage(
+        state,
+        {"input_tokens": 7},
+        candidate_id="c",
+        source="x",
+    )
+    assert state.budget.input_tokens == 7
+    assert state.budget.output_tokens == 0
+    assert state.budget.cost_usd == 0.0
+
+
+def test_charge_llm_usage_emits_budget_update_event() -> None:
+    """Lock in the BUDGET_UPDATE trace contract for charge_llm_usage."""
+    state = make_state()
+
+    with TRACE.record() as events:
+        budget.charge_llm_usage(
+            state,
+            {"input_tokens": 11, "output_tokens": 7, "cost_usd": 0.31},
+            candidate_id="g1-s1",
+            source="mutation",
+        )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.type is EventType.BUDGET_UPDATE
+    assert event.candidate_id == "g1-s1"
+    assert event.decision == "mutation"
+    assert event.input_tokens_delta == 11
+    assert event.output_tokens_delta == 7
+    assert event.cost_usd_delta == pytest.approx(0.31)
+    assert event.input_tokens == 11
+    assert event.output_tokens == 7
+    assert event.cost_usd == pytest.approx(0.31)
 
 
 def test_progress_counters_update_through_budget_api() -> None:

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -1,0 +1,104 @@
+"""Tests for centralized HELIX budget/progress accounting."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from helix import budget
+from helix.config import EvolutionConfig, EvaluatorConfig, HelixConfig
+from helix.state import BudgetState, EvolutionState
+from helix.trace import TRACE, EventType
+
+
+def make_state(evaluations: int = 0) -> EvolutionState:
+    return EvolutionState(
+        generation=0,
+        frontier=[],
+        instance_scores={},
+        budget=BudgetState(evaluations=evaluations),
+        config_hash="test",
+    )
+
+
+def make_config(max_evaluations: int) -> HelixConfig:
+    return HelixConfig(
+        objective="Improve the code",
+        evaluator=EvaluatorConfig(command="pytest -q"),
+        evolution=EvolutionConfig(max_evaluations=max_evaluations),
+    )
+
+
+def test_evaluation_units_preserve_existing_semantics() -> None:
+    assert budget.evaluation_budget_units(num_actual_examples=5) == 5
+    assert budget.evaluation_budget_units(num_actual_examples=0) == 0
+    assert budget.evaluation_budget_units(was_cached=True) == 0
+    assert budget.evaluation_budget_units() == 1
+
+
+def test_budget_exhausted_preserves_evaluation_cap_semantics() -> None:
+    assert budget.budget_exhausted(make_state(10), make_config(100)) is False
+    assert budget.budget_exhausted(make_state(200), make_config(200)) is True
+    assert budget.budget_exhausted(make_state(250), make_config(200)) is True
+    assert budget.budget_exhausted(make_state(250), make_config(-1)) is False
+
+
+def test_charge_evaluation_updates_counter_and_emits_event() -> None:
+    state = make_state(3)
+
+    with TRACE.record() as events:
+        charged = budget.charge_evaluation(
+            state,
+            num_actual_examples=2,
+            candidate_id="g1-s1",
+            split="train",
+            source="mutation_minibatch_gate",
+        )
+
+    assert charged == 2
+    assert state.budget.evaluations == 5
+    assert len(events) == 1
+    event = events[0]
+    assert event.type is EventType.BUDGET_UPDATE
+    assert event.candidate_id == "g1-s1"
+    assert event.split == "train"
+    assert event.decision == "mutation_minibatch_gate"
+    assert event.budget_delta == 2
+    assert event.budget_evaluations == 5
+
+
+def test_progress_counters_update_through_budget_api() -> None:
+    state = make_state()
+
+    budget.start_generation(state, 4)
+    first_i = budget.advance_proposal_counter(state, source="iteration")
+    mutation_id = budget.next_mutation_id(state, 4)
+    merge_id = budget.next_merge_id(state, 4)
+    budget.record_merge_invocation(state)
+    state.budget.evaluations = 9
+    budget.record_discovery_budget(state, mutation_id)
+
+    assert state.generation == 4
+    assert first_i == 0
+    assert state.i == 0
+    assert mutation_id == "g4-s1"
+    assert state.mutation_counter == 1
+    assert merge_id == "g4-m1"
+    assert state.merge_counter == 1
+    assert state.total_merge_invocations == 1
+    assert state.num_metric_calls_by_discovery == {"g4-s1": 9}
+
+
+def test_evolution_counter_mutations_route_through_budget_api() -> None:
+    evolution_py = Path(__file__).parents[2] / "src" / "helix" / "evolution.py"
+    source = evolution_py.read_text()
+
+    forbidden_patterns = [
+        r"state\.budget\.(evaluations|input_tokens|output_tokens|cost_usd)\s*\+=",
+        r"state\.generation\s*=",
+        r"state\.i\s*\+=",
+        r"state\.(mutation_counter|merge_counter|total_merge_invocations)\s*\+=",
+        r"state\.num_metric_calls_by_discovery\[[^\]]+\]\s*=",
+    ]
+    for pattern in forbidden_patterns:
+        assert re.search(pattern, source) is None

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import re
+import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
+import pytest
+
+from helix.backends import BACKENDS
 from helix import budget
-from helix.config import EvolutionConfig, EvaluatorConfig, HelixConfig
+from helix.config import AgentConfig, EvolutionConfig, EvaluatorConfig, HelixConfig
+from helix.mutator import invoke_claude_code
 from helix.state import BudgetState, EvolutionState
 from helix.trace import TRACE, EventType
 
@@ -65,6 +71,108 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
     assert event.decision == "mutation_minibatch_gate"
     assert event.budget_delta == 2
     assert event.budget_evaluations == 5
+
+
+@pytest.mark.parametrize(
+    ("backend", "stdout", "expected"),
+    [
+        (
+            "claude",
+            json.dumps(
+                {
+                    "type": "result",
+                    "session_id": "claude-session",
+                    "usage": {"input_tokens": 11, "output_tokens": 7},
+                    "total_cost_usd": 0.31,
+                }
+            ),
+            (11, 7, 0.31),
+        ),
+        (
+            "codex",
+            "\n".join(
+                [
+                    '{"type":"session.started","session_id":"codex-session"}',
+                    (
+                        '{"type":"turn","usage":{"prompt_tokens":12,'
+                        '"completion_tokens":8,"total_cost_usd":0.32}}'
+                    ),
+                ]
+            ),
+            (12, 8, 0.32),
+        ),
+        (
+            "cursor",
+            "\n".join(
+                [
+                    '{"type":"system","sessionId":"cursor-session"}',
+                    (
+                        '{"type":"assistant","usage":{"inputTokens":13,'
+                        '"outputTokens":9,"costUsd":0.33}}'
+                    ),
+                ]
+            ),
+            (13, 9, 0.33),
+        ),
+        (
+            "gemini",
+            "\n".join(
+                [
+                    "MCP advisory preamble tolerated by the Gemini parser.",
+                    '{"type":"init","session_id":"gemini-session"}',
+                    (
+                        '{"type":"result","usageMetadata":{"prompt_tokens":14,'
+                        '"completion_tokens":10},"cost":0.34}'
+                    ),
+                ]
+            ),
+            (14, 10, 0.34),
+        ),
+        (
+            "opencode",
+            "\n".join(
+                [
+                    '{"type":"step_start","sessionID":"opencode-session"}',
+                    (
+                        '{"type":"step_finish","part":{"tokens":{"input":15,'
+                        '"output":11},"cost":0.35}}'
+                    ),
+                ]
+            ),
+            (15, 11, 0.35),
+        ),
+    ],
+)
+def test_backend_usage_parsing_charges_llm_budget(
+    backend: str,
+    stdout: str,
+    expected: tuple[int, int, float],
+    tmp_path: Path,
+    mocker,
+) -> None:
+    assert backend in BACKENDS
+    worktree = tmp_path / backend
+    worktree.mkdir()
+    mock_run = mocker.patch("helix.mutator.subprocess.run")
+    mock_run.return_value = MagicMock(stdout=stdout, stderr="", returncode=0)
+    state = make_state()
+
+    _parsed, usage = invoke_claude_code(
+        str(worktree),
+        "read the prompt artifact",
+        AgentConfig(backend=backend),
+    )
+    budget.charge_llm_usage(
+        state,
+        usage,
+        candidate_id=f"{backend}-candidate",
+        source=backend,
+    )
+
+    expected_input, expected_output, expected_cost = expected
+    assert state.budget.input_tokens == expected_input
+    assert state.budget.output_tokens == expected_output
+    assert state.budget.cost_usd == pytest.approx(expected_cost)
 
 
 def test_progress_counters_update_through_budget_api() -> None:

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -89,6 +89,81 @@ def test_progress_counters_update_through_budget_api() -> None:
     assert state.num_metric_calls_by_discovery == {"g4-s1": 9}
 
 
+def test_charge_llm_usage_none_is_silent_noop() -> None:
+    """Passing ``usage=None`` must not touch counters or emit a trace event."""
+    state = make_state()
+    state.budget.input_tokens = 7
+    state.budget.output_tokens = 11
+    state.budget.cost_usd = 1.25
+
+    with TRACE.record() as events:
+        budget.charge_llm_usage(state, None, candidate_id="c", source="s")
+        # The empty-dict case is the same falsy short-circuit; pin it too.
+        budget.charge_llm_usage(state, {}, candidate_id="c", source="s")
+
+    assert state.budget.input_tokens == 7
+    assert state.budget.output_tokens == 11
+    assert state.budget.cost_usd == 1.25
+    assert events == []
+
+
+def test_charge_llm_usage_zero_delta_still_emits_event() -> None:
+    """A non-empty usage dict with all-zero deltas should still emit one event.
+
+    Pins current behavior so a future "skip on zero" optimization is a
+    deliberate, test-visible decision rather than an accidental change.
+    """
+    state = make_state()
+    usage = {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}
+
+    with TRACE.record() as events:
+        budget.charge_llm_usage(state, usage, candidate_id="c", source="mutation")
+
+    assert state.budget.input_tokens == 0
+    assert state.budget.output_tokens == 0
+    assert state.budget.cost_usd == 0.0
+    assert len(events) == 1
+    event = events[0]
+    assert event.type is EventType.BUDGET_UPDATE
+    assert event.decision == "mutation"
+    assert event.input_tokens_delta == 0
+    assert event.output_tokens_delta == 0
+    assert event.cost_usd_delta == 0.0
+
+
+def test_cached_charge_at_cap_does_not_overshoot_budget_exhausted() -> None:
+    """A ``was_cached=True`` charge adds 0 units; the cap predicate must agree."""
+    config = make_config(max_evaluations=100)
+
+    # One unit shy of the cap: cached charge keeps us shy, not exhausted.
+    state = make_state(99)
+    charged = budget.charge_evaluation(state, was_cached=True, source="test")
+    assert charged == 0
+    assert state.budget.evaluations == 99
+    assert budget.budget_exhausted(state, config) is False
+
+    # Exactly at the cap: cached charge keeps us at the cap, exhausted.
+    state = make_state(100)
+    charged = budget.charge_evaluation(state, was_cached=True, source="test")
+    assert charged == 0
+    assert state.budget.evaluations == 100
+    assert budget.budget_exhausted(state, config) is True
+
+
+def test_advance_proposal_counter_increments_monotonically() -> None:
+    """Pin GEPA-parity initial value (-1) and per-call increment semantics."""
+    state = make_state()
+    # ``EvolutionState.i`` defaults to -1 (GEPA core/state.py parity); the
+    # first ``advance`` should yield 0, the second 1, and so on.
+    assert state.i == -1
+    assert budget.advance_proposal_counter(state, source="iteration") == 0
+    assert state.i == 0
+    assert budget.advance_proposal_counter(state, source="iteration") == 1
+    assert state.i == 1
+    assert budget.advance_proposal_counter(state, source="parallel_proposal") == 2
+    assert state.i == 2
+
+
 def test_evolution_counter_mutations_route_through_budget_api() -> None:
     evolution_py = Path(__file__).parents[2] / "src" / "helix" / "evolution.py"
     source = evolution_py.read_text()

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -87,7 +87,7 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
     assert event.type is EventType.BUDGET_UPDATE
     assert event.candidate_id == "g1-s1"
     assert event.split == "train"
-    assert event.decision == "mutation_minibatch_gate"
+    assert event.reason == "mutation_minibatch_gate"
     assert event.budget_delta == 2
     assert event.budget_evaluations == 5
 
@@ -360,7 +360,7 @@ def test_charge_llm_usage_emits_budget_update_event() -> None:
     event = events[0]
     assert event.type is EventType.BUDGET_UPDATE
     assert event.candidate_id == "g1-s1"
-    assert event.decision == "mutation"
+    assert event.reason == "mutation"
     assert event.input_tokens_delta == 11
     assert event.output_tokens_delta == 7
     assert event.cost_usd_delta == pytest.approx(0.31)
@@ -372,7 +372,7 @@ def test_charge_llm_usage_emits_budget_update_event() -> None:
 def test_progress_counters_update_through_budget_api() -> None:
     state = make_state()
 
-    budget.start_generation(state, 4)
+    budget.set_generation(state, 4)
     first_i = budget.advance_proposal_counter(state, source="iteration")
     mutation_id = budget.next_mutation_id(state, 4)
     merge_id = budget.next_merge_id(state, 4)
@@ -427,29 +427,67 @@ def test_charge_llm_usage_zero_delta_still_emits_event() -> None:
     assert len(events) == 1
     event = events[0]
     assert event.type is EventType.BUDGET_UPDATE
-    assert event.decision == "mutation"
+    assert event.reason == "mutation"
     assert event.input_tokens_delta == 0
     assert event.output_tokens_delta == 0
     assert event.cost_usd_delta == 0.0
 
 
 def test_cached_charge_at_cap_does_not_overshoot_budget_exhausted() -> None:
-    """A ``was_cached=True`` charge adds 0 units; the cap predicate must agree."""
+    """A ``was_cached=True`` charge adds 0 units; the cap predicate must agree.
+
+    Also pins the new "skip emit on units==0" behavior: a cached charge
+    must not produce a ``BUDGET_UPDATE`` event, since no budget was
+    actually consumed.
+    """
     config = make_config(max_evaluations=100)
 
-    # One unit shy of the cap: cached charge keeps us shy, not exhausted.
+    # One unit shy of the cap: cached charge keeps us shy, not exhausted,
+    # and emits no trace event.
     state = make_state(99)
-    charged = budget.charge_evaluation(state, was_cached=True, source="test")
+    with TRACE.record() as events:
+        charged = budget.charge_evaluation(state, was_cached=True, source="test")
     assert charged == 0
     assert state.budget.evaluations == 99
+    assert events == []
     assert budget.budget_exhausted(state, config) is False
 
     # Exactly at the cap: cached charge keeps us at the cap, exhausted.
     state = make_state(100)
-    charged = budget.charge_evaluation(state, was_cached=True, source="test")
+    with TRACE.record() as events:
+        charged = budget.charge_evaluation(state, was_cached=True, source="test")
     assert charged == 0
     assert state.budget.evaluations == 100
+    assert events == []
     assert budget.budget_exhausted(state, config) is True
+
+    # Zero-example minibatch is the same units==0 short-circuit.
+    state = make_state(50)
+    with TRACE.record() as events:
+        charged = budget.charge_evaluation(
+            state, num_actual_examples=0, source="empty_minibatch"
+        )
+    assert charged == 0
+    assert state.budget.evaluations == 50
+    assert events == []
+
+
+def test_record_discovery_budget_warns_on_duplicate_id() -> None:
+    """Duplicate stamps overwrite but emit a warning so bugs are visible."""
+    import warnings as _warnings
+
+    state = make_state(5)
+    budget.record_discovery_budget(state, "g1-s1")
+    assert state.num_metric_calls_by_discovery == {"g1-s1": 5}
+
+    state.budget.evaluations = 9
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        budget.record_discovery_budget(state, "g1-s1")
+
+    assert len(caught) == 1
+    assert "g1-s1" in str(caught[0].message)
+    assert state.num_metric_calls_by_discovery == {"g1-s1": 9}
 
 
 def test_advance_proposal_counter_increments_monotonically() -> None:

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -14,6 +14,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -38,6 +39,7 @@ from helix.evolution import (
     run_evolution,
 )
 from helix.lineage import LineageEntry
+from helix.mutator import generate_seed as _real_generate_seed
 from helix.population import Candidate, EvalResult
 from helix.state import BudgetState, EvolutionState
 
@@ -515,7 +517,28 @@ class TestGatingInEvolutionLoop:
         assert best.id == "g1-s1"
 
 
+def _filter_charge_calls(spy, *, source: str, candidate_id: str) -> list:
+    """Return the spy invocations whose kwargs match (source, candidate_id)."""
+    return [
+        call
+        for call in spy.call_args_list
+        if call.kwargs.get("source") == source
+        and call.kwargs.get("candidate_id") == candidate_id
+    ]
+
+
 class TestLlmUsageBudgetIntegration:
+    """Verify ``run_evolution`` charges LLM usage through the central budget API.
+
+    Each test mocks the LLM-producing step (``generate_seed``, ``mutate``,
+    ``merge``) to return a synthetic usage payload, spies on
+    ``budget_api.charge_llm_usage`` (preserving its real side effects), and
+    asserts that the spy was invoked exactly once for the candidate of
+    interest with the expected ``source`` tag and resulting BudgetState
+    delta.  Exactly-once is important because a future double-charge bug
+    would otherwise inflate the budget silently.
+    """
+
     def test_seedless_generation_usage_charged_through_budget_api(
         self, mocker, tmp_path, all_mocks
     ):
@@ -548,16 +571,85 @@ class TestLlmUsageBudgetIntegration:
             tmp_path / ".helix",
         )
 
-        seed_call = next(
-            call
-            for call in spy.call_args_list
-            if call.kwargs.get("source") == "seed_generation"
+        seed_calls = _filter_charge_calls(
+            spy, source="seed_generation", candidate_id="g0-s0"
         )
-        state = seed_call.args[0]
-        assert seed_call.kwargs["candidate_id"] == "g0-s0"
+        assert len(seed_calls) == 1, (
+            "expected exactly one seed_generation charge for g0-s0, "
+            f"got {len(seed_calls)}: {seed_calls!r}"
+        )
+        state = seed_calls[0].args[0]
         assert state.budget.input_tokens == 21
         assert state.budget.output_tokens == 12
         assert state.budget.cost_usd == pytest.approx(0.41)
+
+    def test_seedless_generation_usage_flows_through_real_parser(
+        self, mocker, tmp_path, all_mocks
+    ):
+        """End-to-end seedless coverage that exercises ``_normalise_usage_stats``.
+
+        The sibling test stubs out ``generate_seed`` entirely, so a regression
+        in the backend output parser would not surface there.  This variant
+        keeps the real ``generate_seed`` → ``invoke_claude_code`` → parser
+        chain intact (only ``subprocess.run`` is mocked), then asserts the
+        parsed usage dict is what reaches ``charge_llm_usage``.
+        """
+        seed = make_candidate("g0-s0")
+        seed.worktree_path = str(tmp_path / "seed-worktree")
+        Path(seed.worktree_path).mkdir(parents=True, exist_ok=True)
+        mocker.patch("helix.evolution.create_empty_seed_worktree", return_value=seed)
+        mocker.patch(
+            "helix.evolution.build_seed_generation_prompt", return_value="<seed prompt>"
+        )
+        # Restore the real ``generate_seed`` so it dispatches through
+        # ``invoke_claude_code`` and hits the production parser pipeline.
+        all_mocks["generate_seed"].side_effect = _real_generate_seed
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "session_id": "seedless-session",
+                "usage": {"input_tokens": 31, "output_tokens": 19},
+                "total_cost_usd": 0.51,
+            }
+        )
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["claude"], returncode=0, stdout=stdout, stderr=""
+        )
+        all_mocks["run_evaluator"].return_value = make_eval_result("g0-s0", {"i1": 0.5})
+        all_mocks["mutate"].return_value = None
+        spy = mocker.patch(
+            "helix.evolution.budget_api.charge_llm_usage",
+            wraps=budget_api.charge_llm_usage,
+        )
+
+        run_evolution(
+            HelixConfig(
+                objective="Optimise the solver",
+                seedless=SeedlessConfig(enabled=True),
+                evaluator=EvaluatorConfig(command="pytest -q"),
+                evolution=EvolutionConfig(
+                    max_generations=1,
+                    max_evaluations=1000,
+                    perfect_score_threshold=None,
+                ),
+            ),
+            tmp_path,
+            tmp_path / ".helix",
+        )
+
+        # The real backend dispatch must have been hit exactly once.
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.args[0][0] == "claude"
+
+        seed_calls = _filter_charge_calls(
+            spy, source="seed_generation", candidate_id="g0-s0"
+        )
+        assert len(seed_calls) == 1
+        state = seed_calls[0].args[0]
+        assert state.budget.input_tokens == 31
+        assert state.budget.output_tokens == 19
+        assert state.budget.cost_usd == pytest.approx(0.51)
 
     def test_mutation_usage_charged_through_budget_api(
         self, mocker, tmp_path, all_mocks
@@ -585,11 +677,14 @@ class TestLlmUsageBudgetIntegration:
             tmp_path / ".helix",
         )
 
-        mutation_call = next(
-            call for call in spy.call_args_list if call.kwargs.get("source") == "mutation"
+        mutation_calls = _filter_charge_calls(
+            spy, source="mutation", candidate_id="g1-s1"
         )
-        state = mutation_call.args[0]
-        assert mutation_call.kwargs["candidate_id"] == "g1-s1"
+        assert len(mutation_calls) == 1, (
+            "expected exactly one mutation charge for g1-s1, "
+            f"got {len(mutation_calls)}: {mutation_calls!r}"
+        )
+        state = mutation_calls[0].args[0]
         assert state.budget.input_tokens == 22
         assert state.budget.output_tokens == 13
         assert state.budget.cost_usd == pytest.approx(0.42)
@@ -632,11 +727,12 @@ class TestLlmUsageBudgetIntegration:
             tmp_path / ".helix",
         )
 
-        merge_call = next(
-            call for call in spy.call_args_list if call.kwargs.get("source") == "merge"
+        merge_calls = _filter_charge_calls(spy, source="merge", candidate_id="g2-m1")
+        assert len(merge_calls) == 1, (
+            "expected exactly one merge charge for g2-m1, "
+            f"got {len(merge_calls)}: {merge_calls!r}"
         )
-        state = merge_call.args[0]
-        assert merge_call.kwargs["candidate_id"] == "g2-m1"
+        state = merge_calls[0].args[0]
         assert state.budget.input_tokens == 23
         assert state.budget.output_tokens == 14
         assert state.budget.cost_usd == pytest.approx(0.43)

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from helix import budget as budget_api
 from helix.config import (
     DatasetConfig,
     EvolutionConfig,
@@ -26,6 +27,7 @@ from helix.config import (
     EvaluatorSidecarConfig,
     HelixConfig,
     SandboxConfig,
+    SeedlessConfig,
     WorktreeConfig,
 )
 from helix.evolution import (
@@ -511,6 +513,133 @@ class TestGatingInEvolutionLoop:
         )
         best = run_evolution(config, tmp_path, tmp_path / ".helix")
         assert best.id == "g1-s1"
+
+
+class TestLlmUsageBudgetIntegration:
+    def test_seedless_generation_usage_charged_through_budget_api(
+        self, mocker, tmp_path, all_mocks
+    ):
+        seed = make_candidate("g0-s0")
+        usage = {"input_tokens": 21, "output_tokens": 12, "cost_usd": 0.41}
+        mocker.patch("helix.evolution.create_empty_seed_worktree", return_value=seed)
+        mocker.patch(
+            "helix.evolution.build_seed_generation_prompt", return_value="<seed prompt>"
+        )
+        all_mocks["generate_seed"].return_value = usage
+        all_mocks["run_evaluator"].return_value = make_eval_result("g0-s0", {"i1": 0.5})
+        all_mocks["mutate"].return_value = None
+        spy = mocker.patch(
+            "helix.evolution.budget_api.charge_llm_usage",
+            wraps=budget_api.charge_llm_usage,
+        )
+
+        run_evolution(
+            HelixConfig(
+                objective="Optimise the solver",
+                seedless=SeedlessConfig(enabled=True),
+                evaluator=EvaluatorConfig(command="pytest -q"),
+                evolution=EvolutionConfig(
+                    max_generations=1,
+                    max_evaluations=1000,
+                    perfect_score_threshold=None,
+                ),
+            ),
+            tmp_path,
+            tmp_path / ".helix",
+        )
+
+        seed_call = next(
+            call
+            for call in spy.call_args_list
+            if call.kwargs.get("source") == "seed_generation"
+        )
+        state = seed_call.args[0]
+        assert seed_call.kwargs["candidate_id"] == "g0-s0"
+        assert state.budget.input_tokens == 21
+        assert state.budget.output_tokens == 12
+        assert state.budget.cost_usd == pytest.approx(0.41)
+
+    def test_mutation_usage_charged_through_budget_api(
+        self, mocker, tmp_path, all_mocks
+    ):
+        seed = make_candidate("g0-s0")
+        child = make_candidate("g1-s1", generation=1)
+        child.usage = {"input_tokens": 22, "output_tokens": 13, "cost_usd": 0.42}
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            if candidate.id == "g1-s1":
+                return make_eval_result("g1-s1", {"i1": 0.9})
+            return make_eval_result(candidate.id, {"i1": 0.3})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        spy = mocker.patch(
+            "helix.evolution.budget_api.charge_llm_usage",
+            wraps=budget_api.charge_llm_usage,
+        )
+
+        run_evolution(
+            make_config(max_generations=1, perfect_score_threshold=None),
+            tmp_path,
+            tmp_path / ".helix",
+        )
+
+        mutation_call = next(
+            call for call in spy.call_args_list if call.kwargs.get("source") == "mutation"
+        )
+        state = mutation_call.args[0]
+        assert mutation_call.kwargs["candidate_id"] == "g1-s1"
+        assert state.budget.input_tokens == 22
+        assert state.budget.output_tokens == 13
+        assert state.budget.cost_usd == pytest.approx(0.42)
+
+    def test_merge_usage_charged_through_budget_api(self, mocker, tmp_path, all_mocks):
+        seed = make_candidate("g0-s0")
+        child = make_candidate("g1-s1", generation=1)
+        merged = make_candidate("g2-m1", generation=2)
+        merged.operation = "merge"
+        merged.parent_ids = ["g0-s0", "g1-s1"]
+        merged.usage = {"input_tokens": 23, "output_tokens": 14, "cost_usd": 0.43}
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+        all_mocks["merge"].return_value = merged
+        all_mocks["find_merge_triplet"].return_value = ("g0-s0", "g1-s1", "g0-s0")
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            if candidate.id == "g1-s1":
+                return make_eval_result("g1-s1", {"1": 0.9, "2": 0.9})
+            if candidate.id == "g2-m1":
+                return make_eval_result("g2-m1", {"1": 1.0, "2": 1.0})
+            return make_eval_result(candidate.id, {"1": 0.3, "2": 0.3})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        spy = mocker.patch(
+            "helix.evolution.budget_api.charge_llm_usage",
+            wraps=budget_api.charge_llm_usage,
+        )
+
+        run_evolution(
+            make_config(
+                max_generations=2,
+                perfect_score_threshold=None,
+                merge_enabled=True,
+                max_merge_invocations=5,
+                merge_val_overlap_floor=1,
+                merge_subsample_size=2,
+            ),
+            tmp_path,
+            tmp_path / ".helix",
+        )
+
+        merge_call = next(
+            call for call in spy.call_args_list if call.kwargs.get("source") == "merge"
+        )
+        state = merge_call.args[0]
+        assert merge_call.kwargs["candidate_id"] == "g2-m1"
+        assert state.budget.input_tokens == 23
+        assert state.budget.output_tokens == 14
+        assert state.budget.cost_usd == pytest.approx(0.43)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -31,10 +31,12 @@ from helix.config import (
     SeedlessConfig,
     WorktreeConfig,
 )
-from helix.evolution import (
-    _evaluation_budget_units,
-    _load_evaluation,
+from helix.budget import (
     budget_exhausted,
+    evaluation_budget_units as _evaluation_budget_units,
+)
+from helix.evolution import (
+    _load_evaluation,
     degrades,
     run_evolution,
 )
@@ -744,6 +746,14 @@ class TestLlmUsageBudgetIntegration:
 
 
 class TestMergeBehavior:
+    # ``mutate`` is mocked to return the same ``child`` candidate on every
+    # call, so its id (``g1-s1``) gets re-recorded across generations.  In
+    # production ``next_mutation_id`` allocates a fresh id per gen, so the
+    # duplicate-discovery warning would never fire there.  Filter it here
+    # to keep the suite quiet without weakening the production guard.
+    @pytest.mark.filterwarnings(
+        "ignore:discovery budget already recorded:UserWarning"
+    )
     def test_merge_fires_when_new_program_accepted(self, mocker, tmp_path, all_mocks):
         """Merge is triggered in the NEXT generation after acceptance (GEPA parity).
 


### PR DESCRIPTION
## Summary
- Adds a centralized budget/progress accounting API in src/helix/budget.py.
- Routes evaluation, token/cost, generation, proposal, mutation, merge, and discovery counters through the shared API.
- Extends trace events with BUDGET_UPDATE metadata.
- Preserves current max-generation/evaluation behavior while making upstream reference-style budget hooks testable.

## Validation
- Full pytest passed in worker verification: 688 passed.
- mypy passed.
- changed-file ruff passed.
- Full repo ruff remains blocked by pre-existing examples/web_researcher/evaluate.py F841 outside this branch.