### PR TITLE
Test backend LLM budget usage accounting

### DIFF
--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -2,19 +2,38 @@
 
 from __future__ import annotations
 
-import re
 import json
+import re
+import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
-from helix.backends import BACKENDS
 from helix import budget
-from helix.config import AgentConfig, EvolutionConfig, EvaluatorConfig, HelixConfig
+from helix.backends import BACKENDS
+from helix.config import (
+    AgentConfig,
+    EvaluatorConfig,
+    EvolutionConfig,
+    HelixConfig,
+    SandboxConfig,
+)
 from helix.mutator import invoke_claude_code
 from helix.state import BudgetState, EvolutionState
 from helix.trace import TRACE, EventType
+
+
+# Mapping from backend name to the executable that ``_build_backend_args``
+# emits as args[0].  Used by parser-coverage tests to assert that
+# ``invoke_claude_code`` actually dispatched to the requested backend CLI
+# (rather than short-circuiting via the differential-testing override).
+_BACKEND_EXECUTABLE = {
+    "claude": "claude",
+    "codex": "codex",
+    "cursor": "cursor",
+    "gemini": "gemini",
+    "opencode": "opencode",
+}
 
 
 def make_state(evaluations: int = 0) -> EvolutionState:
@@ -76,7 +95,7 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
 @pytest.mark.parametrize(
     ("backend", "stdout", "expected"),
     [
-        (
+        pytest.param(
             "claude",
             json.dumps(
                 {
@@ -87,8 +106,9 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 }
             ),
             (11, 7, 0.31),
+            id="claude",
         ),
-        (
+        pytest.param(
             "codex",
             "\n".join(
                 [
@@ -100,8 +120,9 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 ]
             ),
             (12, 8, 0.32),
+            id="codex",
         ),
-        (
+        pytest.param(
             "cursor",
             "\n".join(
                 [
@@ -113,8 +134,9 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 ]
             ),
             (13, 9, 0.33),
+            id="cursor",
         ),
-        (
+        pytest.param(
             "gemini",
             "\n".join(
                 [
@@ -127,8 +149,9 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 ]
             ),
             (14, 10, 0.34),
+            id="gemini",
         ),
-        (
+        pytest.param(
             "opencode",
             "\n".join(
                 [
@@ -140,6 +163,7 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
                 ]
             ),
             (15, 11, 0.35),
+            id="opencode",
         ),
     ],
 )
@@ -154,7 +178,15 @@ def test_backend_usage_parsing_charges_llm_budget(
     worktree = tmp_path / backend
     worktree.mkdir()
     mock_run = mocker.patch("helix.mutator.subprocess.run")
-    mock_run.return_value = MagicMock(stdout=stdout, stderr="", returncode=0)
+    # Use the real CompletedProcess type so attribute typos in the production
+    # path (e.g. ``result.exit_code`` vs ``returncode``) surface as test
+    # failures rather than being silently absorbed by ``MagicMock``.
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[_BACKEND_EXECUTABLE[backend]],
+        returncode=0,
+        stdout=stdout,
+        stderr="",
+    )
     state = make_state()
 
     _parsed, usage = invoke_claude_code(
@@ -162,6 +194,14 @@ def test_backend_usage_parsing_charges_llm_budget(
         "read the prompt artifact",
         AgentConfig(backend=backend),
     )
+
+    # Guard against future refactors that bypass ``_build_backend_args`` or
+    # leave ``_MUTATOR_OVERRIDE`` set globally — the test must observe the
+    # real backend dispatch, not a short-circuited override.
+    assert mock_run.call_count == 1
+    invoked_args = mock_run.call_args.args[0]
+    assert invoked_args[0] == _BACKEND_EXECUTABLE[backend]
+
     budget.charge_llm_usage(
         state,
         usage,
@@ -173,6 +213,160 @@ def test_backend_usage_parsing_charges_llm_budget(
     assert state.budget.input_tokens == expected_input
     assert state.budget.output_tokens == expected_output
     assert state.budget.cost_usd == pytest.approx(expected_cost)
+
+
+def test_backend_usage_parsing_under_sandbox_charges_llm_budget(
+    tmp_path: Path, mocker
+) -> None:
+    """Cover the ``run_sandboxed_command`` branch of ``invoke_claude_code``.
+
+    The parametrized test above exercises the direct ``subprocess.run`` path.
+    This variant flips ``SandboxConfig.enabled=True`` so the dispatch goes
+    through ``run_sandboxed_command`` instead, ensuring sandboxed invocations
+    still produce a usage payload that flows into ``charge_llm_usage``.
+    """
+    worktree = tmp_path / "claude"
+    worktree.mkdir()
+    stdout = json.dumps(
+        {
+            "type": "result",
+            "session_id": "sandbox-session",
+            "usage": {"input_tokens": 17, "output_tokens": 9},
+            "total_cost_usd": 0.45,
+        }
+    )
+    mock_sandboxed = mocker.patch("helix.mutator.run_sandboxed_command")
+    mock_sandboxed.return_value = subprocess.CompletedProcess(
+        args=["claude"], returncode=0, stdout=stdout, stderr=""
+    )
+    mocker.patch(
+        "helix.mutator.resolve_sandbox_image",
+        return_value="ghcr.io/example/image:latest",
+    )
+    # Belt-and-suspenders: the direct path must NOT be exercised when sandbox
+    # is enabled, so leave ``subprocess.run`` patched to fail loudly.
+    mock_run = mocker.patch(
+        "helix.mutator.subprocess.run",
+        side_effect=AssertionError(
+            "subprocess.run must not be called when sandbox is enabled"
+        ),
+    )
+    state = make_state()
+
+    _parsed, usage = invoke_claude_code(
+        str(worktree),
+        "read the prompt artifact",
+        AgentConfig(backend="claude"),
+        sandbox=SandboxConfig(enabled=True),
+    )
+
+    assert mock_sandboxed.call_count == 1
+    assert mock_run.call_count == 0
+
+    budget.charge_llm_usage(
+        state, usage, candidate_id="claude-candidate", source="claude"
+    )
+
+    assert state.budget.input_tokens == 17
+    assert state.budget.output_tokens == 9
+    assert state.budget.cost_usd == pytest.approx(0.45)
+
+
+def test_backend_usage_parsing_extracts_cached_and_reasoning_tokens(
+    tmp_path: Path, mocker
+) -> None:
+    """Lock in parser support for cached_input_tokens and reasoning_tokens.
+
+    ``charge_llm_usage`` does not yet sum these into ``BudgetState``, but the
+    backend output parser exposes them via ``_normalise_usage_stats`` so a
+    future budget-API extension can rely on the alias map remaining intact.
+    """
+    worktree = tmp_path / "claude"
+    worktree.mkdir()
+    stdout = json.dumps(
+        {
+            "type": "result",
+            "session_id": "claude-session",
+            "usage": {
+                "input_tokens": 11,
+                "output_tokens": 7,
+                # ``cacheReadInputTokens`` is the alias the parser actually
+                # recognises (see ``_normalise_usage_stats`` aliases).
+                "cacheReadInputTokens": 3,
+            },
+            "reasoning_tokens": 5,
+            "total_cost_usd": 0.31,
+        }
+    )
+    mock_run = mocker.patch("helix.mutator.subprocess.run")
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["claude"], returncode=0, stdout=stdout, stderr=""
+    )
+
+    _parsed, usage = invoke_claude_code(
+        str(worktree),
+        "read the prompt artifact",
+        AgentConfig(backend="claude"),
+    )
+
+    assert usage["input_tokens"] == 11
+    assert usage["output_tokens"] == 7
+    assert usage["cached_input_tokens"] == 3
+    assert usage["reasoning_tokens"] == 5
+    assert usage["cost_usd"] == pytest.approx(0.31)
+
+
+def test_charge_llm_usage_handles_empty_and_partial_payloads() -> None:
+    """Regression guard for the early-return / default-zero paths."""
+    state = make_state()
+
+    # ``None`` usage: short-circuit, no mutation.
+    budget.charge_llm_usage(state, None, candidate_id="c", source="x")
+    assert state.budget.input_tokens == 0
+    assert state.budget.output_tokens == 0
+    assert state.budget.cost_usd == 0.0
+
+    # Empty dict: short-circuit (falsy), no mutation.
+    budget.charge_llm_usage(state, {}, candidate_id="c", source="x")
+    assert state.budget.input_tokens == 0
+    assert state.budget.output_tokens == 0
+    assert state.budget.cost_usd == 0.0
+
+    # Partial payload: only present keys are summed; absent keys default to 0.
+    budget.charge_llm_usage(
+        state,
+        {"input_tokens": 7},
+        candidate_id="c",
+        source="x",
+    )
+    assert state.budget.input_tokens == 7
+    assert state.budget.output_tokens == 0
+    assert state.budget.cost_usd == 0.0
+
+
+def test_charge_llm_usage_emits_budget_update_event() -> None:
+    """Lock in the BUDGET_UPDATE trace contract for charge_llm_usage."""
+    state = make_state()
+
+    with TRACE.record() as events:
+        budget.charge_llm_usage(
+            state,
+            {"input_tokens": 11, "output_tokens": 7, "cost_usd": 0.31},
+            candidate_id="g1-s1",
+            source="mutation",
+        )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.type is EventType.BUDGET_UPDATE
+    assert event.candidate_id == "g1-s1"
+    assert event.decision == "mutation"
+    assert event.input_tokens_delta == 11
+    assert event.output_tokens_delta == 7
+    assert event.cost_usd_delta == pytest.approx(0.31)
+    assert event.input_tokens == 11
+    assert event.output_tokens == 7
+    assert event.cost_usd == pytest.approx(0.31)
 
 
 def test_progress_counters_update_through_budget_api() -> None:

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import re
+import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
+import pytest
+
+from helix.backends import BACKENDS
 from helix import budget
-from helix.config import EvolutionConfig, EvaluatorConfig, HelixConfig
+from helix.config import AgentConfig, EvolutionConfig, EvaluatorConfig, HelixConfig
+from helix.mutator import invoke_claude_code
 from helix.state import BudgetState, EvolutionState
 from helix.trace import TRACE, EventType
 
@@ -65,6 +71,108 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
     assert event.decision == "mutation_minibatch_gate"
     assert event.budget_delta == 2
     assert event.budget_evaluations == 5
+
+
+@pytest.mark.parametrize(
+    ("backend", "stdout", "expected"),
+    [
+        (
+            "claude",
+            json.dumps(
+                {
+                    "type": "result",
+                    "session_id": "claude-session",
+                    "usage": {"input_tokens": 11, "output_tokens": 7},
+                    "total_cost_usd": 0.31,
+                }
+            ),
+            (11, 7, 0.31),
+        ),
+        (
+            "codex",
+            "\n".join(
+                [
+                    '{"type":"session.started","session_id":"codex-session"}',
+                    (
+                        '{"type":"turn","usage":{"prompt_tokens":12,'
+                        '"completion_tokens":8,"total_cost_usd":0.32}}'
+                    ),
+                ]
+            ),
+            (12, 8, 0.32),
+        ),
+        (
+            "cursor",
+            "\n".join(
+                [
+                    '{"type":"system","sessionId":"cursor-session"}',
+                    (
+                        '{"type":"assistant","usage":{"inputTokens":13,'
+                        '"outputTokens":9,"costUsd":0.33}}'
+                    ),
+                ]
+            ),
+            (13, 9, 0.33),
+        ),
+        (
+            "gemini",
+            "\n".join(
+                [
+                    "MCP advisory preamble tolerated by the Gemini parser.",
+                    '{"type":"init","session_id":"gemini-session"}',
+                    (
+                        '{"type":"result","usageMetadata":{"prompt_tokens":14,'
+                        '"completion_tokens":10},"cost":0.34}'
+                    ),
+                ]
+            ),
+            (14, 10, 0.34),
+        ),
+        (
+            "opencode",
+            "\n".join(
+                [
+                    '{"type":"step_start","sessionID":"opencode-session"}',
+                    (
+                        '{"type":"step_finish","part":{"tokens":{"input":15,'
+                        '"output":11},"cost":0.35}}'
+                    ),
+                ]
+            ),
+            (15, 11, 0.35),
+        ),
+    ],
+)
+def test_backend_usage_parsing_charges_llm_budget(
+    backend: str,
+    stdout: str,
+    expected: tuple[int, int, float],
+    tmp_path: Path,
+    mocker,
+) -> None:
+    assert backend in BACKENDS
+    worktree = tmp_path / backend
+    worktree.mkdir()
+    mock_run = mocker.patch("helix.mutator.subprocess.run")
+    mock_run.return_value = MagicMock(stdout=stdout, stderr="", returncode=0)
+    state = make_state()
+
+    _parsed, usage = invoke_claude_code(
+        str(worktree),
+        "read the prompt artifact",
+        AgentConfig(backend=backend),
+    )
+    budget.charge_llm_usage(
+        state,
+        usage,
+        candidate_id=f"{backend}-candidate",
+        source=backend,
+    )
+
+    expected_input, expected_output, expected_cost = expected
+    assert state.budget.input_tokens == expected_input
+    assert state.budget.output_tokens == expected_output
+    assert state.budget.cost_usd == pytest.approx(expected_cost)
 
 
 def test_progress_counters_update_through_budget_api() -> None:

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -14,6 +14,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -38,6 +39,7 @@ from helix.evolution import (
     run_evolution,
 )
 from helix.lineage import LineageEntry
+from helix.mutator import generate_seed as _real_generate_seed
 from helix.population import Candidate, EvalResult
 from helix.state import BudgetState, EvolutionState
 
@@ -515,7 +517,28 @@ class TestGatingInEvolutionLoop:
         assert best.id == "g1-s1"
 
 
+def _filter_charge_calls(spy, *, source: str, candidate_id: str) -> list:
+    """Return the spy invocations whose kwargs match (source, candidate_id)."""
+    return [
+        call
+        for call in spy.call_args_list
+        if call.kwargs.get("source") == source
+        and call.kwargs.get("candidate_id") == candidate_id
+    ]
+
+
 class TestLlmUsageBudgetIntegration:
+    """Verify ``run_evolution`` charges LLM usage through the central budget API.
+
+    Each test mocks the LLM-producing step (``generate_seed``, ``mutate``,
+    ``merge``) to return a synthetic usage payload, spies on
+    ``budget_api.charge_llm_usage`` (preserving its real side effects), and
+    asserts that the spy was invoked exactly once for the candidate of
+    interest with the expected ``source`` tag and resulting BudgetState
+    delta.  Exactly-once is important because a future double-charge bug
+    would otherwise inflate the budget silently.
+    """
+
     def test_seedless_generation_usage_charged_through_budget_api(
         self, mocker, tmp_path, all_mocks
     ):
@@ -548,16 +571,85 @@ class TestLlmUsageBudgetIntegration:
             tmp_path / ".helix",
         )
 
-        seed_call = next(
-            call
-            for call in spy.call_args_list
-            if call.kwargs.get("source") == "seed_generation"
+        seed_calls = _filter_charge_calls(
+            spy, source="seed_generation", candidate_id="g0-s0"
         )
-        state = seed_call.args[0]
-        assert seed_call.kwargs["candidate_id"] == "g0-s0"
+        assert len(seed_calls) == 1, (
+            "expected exactly one seed_generation charge for g0-s0, "
+            f"got {len(seed_calls)}: {seed_calls!r}"
+        )
+        state = seed_calls[0].args[0]
         assert state.budget.input_tokens == 21
         assert state.budget.output_tokens == 12
         assert state.budget.cost_usd == pytest.approx(0.41)
+
+    def test_seedless_generation_usage_flows_through_real_parser(
+        self, mocker, tmp_path, all_mocks
+    ):
+        """End-to-end seedless coverage that exercises ``_normalise_usage_stats``.
+
+        The sibling test stubs out ``generate_seed`` entirely, so a regression
+        in the backend output parser would not surface there.  This variant
+        keeps the real ``generate_seed`` → ``invoke_claude_code`` → parser
+        chain intact (only ``subprocess.run`` is mocked), then asserts the
+        parsed usage dict is what reaches ``charge_llm_usage``.
+        """
+        seed = make_candidate("g0-s0")
+        seed.worktree_path = str(tmp_path / "seed-worktree")
+        Path(seed.worktree_path).mkdir(parents=True, exist_ok=True)
+        mocker.patch("helix.evolution.create_empty_seed_worktree", return_value=seed)
+        mocker.patch(
+            "helix.evolution.build_seed_generation_prompt", return_value="<seed prompt>"
+        )
+        # Restore the real ``generate_seed`` so it dispatches through
+        # ``invoke_claude_code`` and hits the production parser pipeline.
+        all_mocks["generate_seed"].side_effect = _real_generate_seed
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "session_id": "seedless-session",
+                "usage": {"input_tokens": 31, "output_tokens": 19},
+                "total_cost_usd": 0.51,
+            }
+        )
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["claude"], returncode=0, stdout=stdout, stderr=""
+        )
+        all_mocks["run_evaluator"].return_value = make_eval_result("g0-s0", {"i1": 0.5})
+        all_mocks["mutate"].return_value = None
+        spy = mocker.patch(
+            "helix.evolution.budget_api.charge_llm_usage",
+            wraps=budget_api.charge_llm_usage,
+        )
+
+        run_evolution(
+            HelixConfig(
+                objective="Optimise the solver",
+                seedless=SeedlessConfig(enabled=True),
+                evaluator=EvaluatorConfig(command="pytest -q"),
+                evolution=EvolutionConfig(
+                    max_generations=1,
+                    max_evaluations=1000,
+                    perfect_score_threshold=None,
+                ),
+            ),
+            tmp_path,
+            tmp_path / ".helix",
+        )
+
+        # The real backend dispatch must have been hit exactly once.
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.args[0][0] == "claude"
+
+        seed_calls = _filter_charge_calls(
+            spy, source="seed_generation", candidate_id="g0-s0"
+        )
+        assert len(seed_calls) == 1
+        state = seed_calls[0].args[0]
+        assert state.budget.input_tokens == 31
+        assert state.budget.output_tokens == 19
+        assert state.budget.cost_usd == pytest.approx(0.51)
 
     def test_mutation_usage_charged_through_budget_api(
         self, mocker, tmp_path, all_mocks
@@ -585,11 +677,14 @@ class TestLlmUsageBudgetIntegration:
             tmp_path / ".helix",
         )
 
-        mutation_call = next(
-            call for call in spy.call_args_list if call.kwargs.get("source") == "mutation"
+        mutation_calls = _filter_charge_calls(
+            spy, source="mutation", candidate_id="g1-s1"
         )
-        state = mutation_call.args[0]
-        assert mutation_call.kwargs["candidate_id"] == "g1-s1"
+        assert len(mutation_calls) == 1, (
+            "expected exactly one mutation charge for g1-s1, "
+            f"got {len(mutation_calls)}: {mutation_calls!r}"
+        )
+        state = mutation_calls[0].args[0]
         assert state.budget.input_tokens == 22
         assert state.budget.output_tokens == 13
         assert state.budget.cost_usd == pytest.approx(0.42)
@@ -632,11 +727,12 @@ class TestLlmUsageBudgetIntegration:
             tmp_path / ".helix",
         )
 
-        merge_call = next(
-            call for call in spy.call_args_list if call.kwargs.get("source") == "merge"
+        merge_calls = _filter_charge_calls(spy, source="merge", candidate_id="g2-m1")
+        assert len(merge_calls) == 1, (
+            "expected exactly one merge charge for g2-m1, "
+            f"got {len(merge_calls)}: {merge_calls!r}"
         )
-        state = merge_call.args[0]
-        assert merge_call.kwargs["candidate_id"] == "g2-m1"
+        state = merge_calls[0].args[0]
         assert state.budget.input_tokens == 23
         assert state.budget.output_tokens == 14
         assert state.budget.cost_usd == pytest.approx(0.43)

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from helix import budget as budget_api
 from helix.config import (
     DatasetConfig,
     EvolutionConfig,
@@ -26,6 +27,7 @@ from helix.config import (
     EvaluatorSidecarConfig,
     HelixConfig,
     SandboxConfig,
+    SeedlessConfig,
     WorktreeConfig,
 )
 from helix.evolution import (
@@ -511,6 +513,133 @@ class TestGatingInEvolutionLoop:
         )
         best = run_evolution(config, tmp_path, tmp_path / ".helix")
         assert best.id == "g1-s1"
+
+
+class TestLlmUsageBudgetIntegration:
+    def test_seedless_generation_usage_charged_through_budget_api(
+        self, mocker, tmp_path, all_mocks
+    ):
+        seed = make_candidate("g0-s0")
+        usage = {"input_tokens": 21, "output_tokens": 12, "cost_usd": 0.41}
+        mocker.patch("helix.evolution.create_empty_seed_worktree", return_value=seed)
+        mocker.patch(
+            "helix.evolution.build_seed_generation_prompt", return_value="<seed prompt>"
+        )
+        all_mocks["generate_seed"].return_value = usage
+        all_mocks["run_evaluator"].return_value = make_eval_result("g0-s0", {"i1": 0.5})
+        all_mocks["mutate"].return_value = None
+        spy = mocker.patch(
+            "helix.evolution.budget_api.charge_llm_usage",
+            wraps=budget_api.charge_llm_usage,
+        )
+
+        run_evolution(
+            HelixConfig(
+                objective="Optimise the solver",
+                seedless=SeedlessConfig(enabled=True),
+                evaluator=EvaluatorConfig(command="pytest -q"),
+                evolution=EvolutionConfig(
+                    max_generations=1,
+                    max_evaluations=1000,
+                    perfect_score_threshold=None,
+                ),
+            ),
+            tmp_path,
+            tmp_path / ".helix",
+        )
+
+        seed_call = next(
+            call
+            for call in spy.call_args_list
+            if call.kwargs.get("source") == "seed_generation"
+        )
+        state = seed_call.args[0]
+        assert seed_call.kwargs["candidate_id"] == "g0-s0"
+        assert state.budget.input_tokens == 21
+        assert state.budget.output_tokens == 12
+        assert state.budget.cost_usd == pytest.approx(0.41)
+
+    def test_mutation_usage_charged_through_budget_api(
+        self, mocker, tmp_path, all_mocks
+    ):
+        seed = make_candidate("g0-s0")
+        child = make_candidate("g1-s1", generation=1)
+        child.usage = {"input_tokens": 22, "output_tokens": 13, "cost_usd": 0.42}
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            if candidate.id == "g1-s1":
+                return make_eval_result("g1-s1", {"i1": 0.9})
+            return make_eval_result(candidate.id, {"i1": 0.3})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        spy = mocker.patch(
+            "helix.evolution.budget_api.charge_llm_usage",
+            wraps=budget_api.charge_llm_usage,
+        )
+
+        run_evolution(
+            make_config(max_generations=1, perfect_score_threshold=None),
+            tmp_path,
+            tmp_path / ".helix",
+        )
+
+        mutation_call = next(
+            call for call in spy.call_args_list if call.kwargs.get("source") == "mutation"
+        )
+        state = mutation_call.args[0]
+        assert mutation_call.kwargs["candidate_id"] == "g1-s1"
+        assert state.budget.input_tokens == 22
+        assert state.budget.output_tokens == 13
+        assert state.budget.cost_usd == pytest.approx(0.42)
+
+    def test_merge_usage_charged_through_budget_api(self, mocker, tmp_path, all_mocks):
+        seed = make_candidate("g0-s0")
+        child = make_candidate("g1-s1", generation=1)
+        merged = make_candidate("g2-m1", generation=2)
+        merged.operation = "merge"
+        merged.parent_ids = ["g0-s0", "g1-s1"]
+        merged.usage = {"input_tokens": 23, "output_tokens": 14, "cost_usd": 0.43}
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+        all_mocks["merge"].return_value = merged
+        all_mocks["find_merge_triplet"].return_value = ("g0-s0", "g1-s1", "g0-s0")
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            if candidate.id == "g1-s1":
+                return make_eval_result("g1-s1", {"1": 0.9, "2": 0.9})
+            if candidate.id == "g2-m1":
+                return make_eval_result("g2-m1", {"1": 1.0, "2": 1.0})
+            return make_eval_result(candidate.id, {"1": 0.3, "2": 0.3})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        spy = mocker.patch(
+            "helix.evolution.budget_api.charge_llm_usage",
+            wraps=budget_api.charge_llm_usage,
+        )
+
+        run_evolution(
+            make_config(
+                max_generations=2,
+                perfect_score_threshold=None,
+                merge_enabled=True,
+                max_merge_invocations=5,
+                merge_val_overlap_floor=1,
+                merge_subsample_size=2,
+            ),
+            tmp_path,
+            tmp_path / ".helix",
+        )
+
+        merge_call = next(
+            call for call in spy.call_args_list if call.kwargs.get("source") == "merge"
+        )
+        state = merge_call.args[0]
+        assert merge_call.kwargs["candidate_id"] == "g2-m1"
+        assert state.budget.input_tokens == 23
+        assert state.budget.output_tokens == 14
+        assert state.budget.cost_usd == pytest.approx(0.43)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds test-only coverage proving backend usage payloads flow into EvolutionState.budget through charge_llm_usage.
- Covers claude, codex, cursor, gemini, and opencode parsing paths through mocked real backend outputs.
- Verifies seedless generation, mutation, and merge call sites charge centralized budget accounting.

## Validation
- Focused backend/budget tests: 17 passed.
- Affected suite: 154 passed.
- Full suite: uv run pytest -q => 696 passed.
- Separate installed-command smoke check confirmed all five backend CLIs are installed; true no-network live usage-output E2E is unavailable because live mutation paths invoke models.