### PR TITLE
Guard incompatible upstream reference resume semantics

### DIFF
--- a/examples/web_researcher/evaluate.py
+++ b/examples/web_researcher/evaluate.py
@@ -245,7 +245,7 @@ def evaluate():
             got = agent.solve(question_text)
             if not isinstance(got, str):
                 got = str(got) if got is not None else ""
-        except Exception as ex:
+        except Exception:
             got = ""
 
         # Score

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -26,7 +26,7 @@ from helix.display import (
     print_warning,
     render_frontier_table,
 )
-from helix.exceptions import RateLimitError
+from helix.exceptions import RateLimitError, ResumeIncompatibleError, print_helix_error
 from helix.lineage import load_lineage
 from helix.population import EvalResult, FrontierType, ParetoFrontier, Candidate
 from helix.state import load_state, save_state
@@ -673,6 +673,13 @@ def evolve(
     setup_file_logging(base_dir)
     try:
         run_evolution(config, project_root, base_dir)
+    except ResumeIncompatibleError as exc:
+        # The current config would reinterpret persisted state.  Show the
+        # full Rich panel (with operation/phase/suggestion) instead of
+        # letting a raw traceback escape from the CLI.
+        logger.error("Resume rejected: %s", exc)
+        print_helix_error(exc)
+        raise SystemExit(2)
     except RateLimitError as exc:
         # Rate limits exhausted retries and bubbled all the way to the CLI.
         # State has been saved during the run; tell the user how to resume.
@@ -952,6 +959,18 @@ def resume(config_path: str, project_dir: Path | None) -> None:
     print_info(f"Resuming from generation {state.generation if state else 0}…")
     try:
         run_evolution(config, project_root, base_dir)
+    except ResumeIncompatibleError as exc:
+        logger.error("Resume rejected: %s", exc)
+        print_helix_error(exc)
+        raise SystemExit(2)
+    except RateLimitError as exc:
+        logger.error("Rate limit reached during resume: %s", exc)
+        print_error(
+            f"Rate limit reached: {exc}\n"
+            "Evolution state has been saved. "
+            "Run [cyan]helix resume[/cyan] again when rate limits clear."
+        )
+        raise SystemExit(2)
     except KeyboardInterrupt:
         _handle_keyboard_interrupt(project_root)
     else:

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -64,6 +64,7 @@ from helix.population import (
 from helix.sandbox import start_evaluator_sidecar
 from helix.state import (
     BudgetState,
+    clear_eval_cache,
     EvaluationCache,
     EvolutionState,
     load_eval_cache,
@@ -95,6 +96,93 @@ def degrades(new_result: EvalResult, baseline: EvalResult, threshold: float) -> 
 def _config_hash(config: HelixConfig) -> str:
     data = config.model_dump_json()
     return hashlib.sha256(data.encode()).hexdigest()[:16]
+
+
+def _resume_semantics(config: HelixConfig) -> dict[str, Any]:
+    """Return config fields that define resume-compatible optimization semantics."""
+    return {
+        "objective": config.objective,
+        "rng_seed": config.rng_seed,
+        "evaluator": {
+            "command": config.evaluator.command,
+            "score_parser": config.evaluator.score_parser,
+            "extra_commands": list(config.evaluator.extra_commands),
+            "protected_files": list(config.evaluator.protected_files),
+        },
+        "dataset": config.dataset.model_dump(mode="json"),
+        "seedless": {
+            "enabled": config.seedless.enabled,
+            "train_path": (
+                str(config.seedless.train_path)
+                if config.seedless.train_path is not None
+                else None
+            ),
+            "val_path": (
+                str(config.seedless.val_path)
+                if config.seedless.val_path is not None
+                else None
+            ),
+        },
+        "evolution": {
+            "frontier_type": config.evolution.frontier_type,
+            "acceptance_criterion": config.evolution.acceptance_criterion,
+            "minibatch_size": config.evolution.minibatch_size,
+            "batch_sampler": config.evolution.batch_sampler,
+            "group_key_separator": config.evolution.group_key_separator,
+            "val_stage_size": config.evolution.val_stage_size,
+            "merge_enabled": config.evolution.merge_enabled,
+            "max_merge_invocations": config.evolution.max_merge_invocations,
+            "merge_val_overlap_floor": config.evolution.merge_val_overlap_floor,
+            "merge_subsample_size": config.evolution.merge_subsample_size,
+        },
+    }
+
+
+def _semantic_diffs(
+    saved: dict[str, Any],
+    current: dict[str, Any],
+    prefix: str = "",
+) -> list[str]:
+    diffs: list[str] = []
+    for key in sorted(set(saved) | set(current)):
+        path = f"{prefix}.{key}" if prefix else key
+        if key not in saved:
+            diffs.append(f"{path}: missing in saved state, current={current[key]!r}")
+            continue
+        if key not in current:
+            diffs.append(f"{path}: saved={saved[key]!r}, missing in current config")
+            continue
+        saved_value = saved[key]
+        current_value = current[key]
+        if isinstance(saved_value, dict) and isinstance(current_value, dict):
+            diffs.extend(_semantic_diffs(saved_value, current_value, path))
+        elif saved_value != current_value:
+            diffs.append(f"{path}: saved={saved_value!r}, current={current_value!r}")
+    return diffs
+
+
+def _validate_resume_semantics(state: EvolutionState, config: HelixConfig) -> None:
+    """Reject resume when current config would reinterpret persisted state."""
+    current = _resume_semantics(config)
+    if state.frontier_type != config.evolution.frontier_type:
+        raise ValueError(
+            "Cannot resume with a different evolution.frontier_type: "
+            f"saved={state.frontier_type!r}, current={config.evolution.frontier_type!r}. "
+            "Start a fresh run or restore the original config."
+        )
+
+    if not state.resume_semantics:
+        return
+
+    diffs = _semantic_diffs(state.resume_semantics, current)
+    if diffs:
+        preview = "; ".join(diffs[:5])
+        if len(diffs) > 5:
+            preview += f"; ... {len(diffs) - 5} more"
+        raise ValueError(
+            "Cannot resume because the current config changes optimization "
+            f"semantics: {preview}. Start a fresh run or restore the original config."
+        )
 
 
 def init_base_dir(base_dir: Path, config: HelixConfig) -> None:
@@ -1215,6 +1303,8 @@ def _run_evolution_impl(
         _persisted_cache = load_eval_cache(project_root)
         if _persisted_cache is not None:
             minibatch_cache._cache.update(_persisted_cache)
+    else:
+        clear_eval_cache(project_root)
 
     # Acceptance criterion (GEPA §5.1).
     acceptance = (
@@ -1259,6 +1349,8 @@ def _run_evolution_impl(
         save_state(s, project_root)
         if minibatch_cache is not None:
             save_eval_cache(minibatch_cache._cache, project_root)
+        else:
+            clear_eval_cache(project_root)
 
     def _sync_frontier_state() -> None:
         assert state is not None
@@ -1277,10 +1369,14 @@ def _run_evolution_impl(
             # with the SAME axis later — even if ``helix.toml``'s
             # ``evolution.frontier_type`` is edited between runs.
             frontier_type=config.evolution.frontier_type,
+            resume_semantics=_resume_semantics(config),
         )
         needs_seed = True
     else:
         needs_seed = False
+        _validate_resume_semantics(state, config)
+        if not state.resume_semantics:
+            state.resume_semantics = _resume_semantics(config)
         # Keep ``state.frontier_type`` pinned to whatever was stored;
         # it already matches the frontier that was built.  On a legacy
         # state with no persisted field (defaulted to "instance" by

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -110,22 +110,52 @@ def _resume_semantics(config: HelixConfig) -> dict[str, Any]:
     Top-level keys:
       * ``objective``: changes the optimization target outright.
       * ``rng_seed``: pinned for full determinism parity with the prior run.
-      * ``evaluator``: command, parser, extra commands, protected files —
-        all influence what saved scores actually mean.
+      * ``evaluator``: command, parser, stdout/stderr capture flags, extra
+        commands, protected files, sidecar configuration — all influence
+        what saved scores actually mean (GEPA Optimize Anything parity).
       * ``dataset``: full pydantic dump; train/val splits and grouping
         affect which examples saved scores were computed against.
       * ``seedless``: enabled flag and external train/val paths.
       * ``evolution``: frontier dimensionality, acceptance, minibatch /
         sampler shape, val-stage size, and merge policy.
+
+    Deliberately omitted (safe to toggle between runs):
+      * ``evolution.cache_evaluation``: cache state is handled
+        separately via ``eval_cache.pkl`` persistence.
+      * ``evolution.max_generations`` / ``max_evaluations`` / parallelism:
+        budgets and concurrency, not score interpretation.
+      * ``agent.*``: changing the mutation backend / model / effort
+        affects only future proposals, not the meaning of saved scores.
+        (GEPA likewise treats the LM client as out-of-band of the
+        persisted state.)
+      * ``sandbox`` / ``worktree`` / top-level ``seed`` / ``passthrough_env``
+        / ``env``: runtime / filesystem layout.  The separate
+        ``evaluator_integrity_manifest`` covers evaluator-environment
+        drift.
     """
+    # GEPA Optimize Anything parity: ``EvaluatorConfig.include_stdout`` /
+    # ``include_stderr`` directly change which bytes the score parser sees,
+    # so toggling them mid-run can silently reinterpret saved scores.
+    # ``sidecar`` describes a completely different evaluator runtime
+    # (image, runner image, endpoint); resuming under a different sidecar
+    # would compare scores produced by different binaries.  Both are
+    # hard-rejected on resume to match the strict-equality stance GEPA
+    # gets implicitly by pickling its full config alongside state.
     return {
         "objective": config.objective,
         "rng_seed": config.rng_seed,
         "evaluator": {
             "command": config.evaluator.command,
             "score_parser": config.evaluator.score_parser,
+            "include_stdout": config.evaluator.include_stdout,
+            "include_stderr": config.evaluator.include_stderr,
             "extra_commands": list(config.evaluator.extra_commands),
             "protected_files": list(config.evaluator.protected_files),
+            "sidecar": (
+                config.evaluator.sidecar.model_dump(mode="json")
+                if config.evaluator.sidecar is not None
+                else None
+            ),
         },
         "dataset": config.dataset.model_dump(mode="json"),
         "seedless": {

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -48,6 +48,7 @@ from helix.exceptions import (
     HelixError,
     PromptArtifactCollisionError,
     RateLimitError,
+    ResumeIncompatibleError,
     print_helix_error,
 )
 from helix.executor import run_evaluator
@@ -99,7 +100,24 @@ def _config_hash(config: HelixConfig) -> str:
 
 
 def _resume_semantics(config: HelixConfig) -> dict[str, Any]:
-    """Return config fields that define resume-compatible optimization semantics."""
+    """Return config fields that define resume-compatible optimization semantics.
+
+    The returned shape is the authoritative resume-compatibility contract.
+    Any field present here is hard-rejected on resume if it changes; fields
+    deliberately omitted (notably ``evolution.cache_evaluation``) may be
+    toggled freely between runs.
+
+    Top-level keys:
+      * ``objective``: changes the optimization target outright.
+      * ``rng_seed``: pinned for full determinism parity with the prior run.
+      * ``evaluator``: command, parser, extra commands, protected files —
+        all influence what saved scores actually mean.
+      * ``dataset``: full pydantic dump; train/val splits and grouping
+        affect which examples saved scores were computed against.
+      * ``seedless``: enabled flag and external train/val paths.
+      * ``evolution``: frontier dimensionality, acceptance, minibatch /
+        sampler shape, val-stage size, and merge policy.
+    """
     return {
         "objective": config.objective,
         "rng_seed": config.rng_seed,
@@ -138,6 +156,24 @@ def _resume_semantics(config: HelixConfig) -> dict[str, Any]:
     }
 
 
+_DIFF_VALUE_PREVIEW_CHARS = 80
+
+
+def _format_diff_value(value: Any) -> str:
+    """Render a single value in a diff message, truncating long reprs.
+
+    List-shaped fields (e.g. ``evaluator.extra_commands``,
+    ``evaluator.protected_files``) can otherwise overwhelm the rejection
+    message with full file/path dumps; clamp to a fixed character budget
+    with an explicit ellipsis so the structural shape stays visible but
+    long bodies don't drown the user.
+    """
+    rendered = repr(value)
+    if len(rendered) > _DIFF_VALUE_PREVIEW_CHARS:
+        return rendered[: _DIFF_VALUE_PREVIEW_CHARS - 3] + "..."
+    return rendered
+
+
 def _semantic_diffs(
     saved: dict[str, Any],
     current: dict[str, Any],
@@ -147,28 +183,48 @@ def _semantic_diffs(
     for key in sorted(set(saved) | set(current)):
         path = f"{prefix}.{key}" if prefix else key
         if key not in saved:
-            diffs.append(f"{path}: missing in saved state, current={current[key]!r}")
+            diffs.append(
+                f"{path}: missing in saved state, current={_format_diff_value(current[key])}"
+            )
             continue
         if key not in current:
-            diffs.append(f"{path}: saved={saved[key]!r}, missing in current config")
+            diffs.append(
+                f"{path}: saved={_format_diff_value(saved[key])}, missing in current config"
+            )
             continue
         saved_value = saved[key]
         current_value = current[key]
         if isinstance(saved_value, dict) and isinstance(current_value, dict):
             diffs.extend(_semantic_diffs(saved_value, current_value, path))
         elif saved_value != current_value:
-            diffs.append(f"{path}: saved={saved_value!r}, current={current_value!r}")
+            diffs.append(
+                f"{path}: saved={_format_diff_value(saved_value)}, "
+                f"current={_format_diff_value(current_value)}"
+            )
     return diffs
 
 
+_RESUME_REMEDIATION_SUGGESTION = (
+    "Restore the original config to keep resuming, or run `helix clean` and "
+    "start a fresh run to use the new config."
+)
+
+
 def _validate_resume_semantics(state: EvolutionState, config: HelixConfig) -> None:
-    """Reject resume when current config would reinterpret persisted state."""
+    """Reject resume when current config would reinterpret persisted state.
+
+    Raises :class:`ResumeIncompatibleError` (a :class:`HelixError`) so the
+    CLI can route through ``print_helix_error`` instead of letting the
+    user see a raw Python traceback.
+    """
     current = _resume_semantics(config)
     if state.frontier_type != config.evolution.frontier_type:
-        raise ValueError(
+        raise ResumeIncompatibleError(
             "Cannot resume with a different evolution.frontier_type: "
-            f"saved={state.frontier_type!r}, current={config.evolution.frontier_type!r}. "
-            "Start a fresh run or restore the original config."
+            f"saved={state.frontier_type!r}, current={config.evolution.frontier_type!r}.",
+            operation="resume",
+            phase="validate_resume_semantics",
+            suggestion=_RESUME_REMEDIATION_SUGGESTION,
         )
 
     if not state.resume_semantics:
@@ -179,9 +235,12 @@ def _validate_resume_semantics(state: EvolutionState, config: HelixConfig) -> No
         preview = "; ".join(diffs[:5])
         if len(diffs) > 5:
             preview += f"; ... {len(diffs) - 5} more"
-        raise ValueError(
+        raise ResumeIncompatibleError(
             "Cannot resume because the current config changes optimization "
-            f"semantics: {preview}. Start a fresh run or restore the original config."
+            f"semantics: {preview}.",
+            operation="resume",
+            phase="validate_resume_semantics",
+            suggestion=_RESUME_REMEDIATION_SUGGESTION,
         )
 
 
@@ -1303,8 +1362,13 @@ def _run_evolution_impl(
         _persisted_cache = load_eval_cache(project_root)
         if _persisted_cache is not None:
             minibatch_cache._cache.update(_persisted_cache)
-    else:
-        clear_eval_cache(project_root)
+    # NOTE: when cache_evaluation is disabled we DO NOT eagerly delete the
+    # persisted ``eval_cache.pkl`` here.  Doing so before ``load_state`` +
+    # ``_validate_resume_semantics`` could destroy the cache on a resume
+    # that we are about to reject (e.g. wrong frontier_type), leaving the
+    # user with no way to fall back to the original config.  The first
+    # ``_save_state`` call below performs the delete once we have decided
+    # the run is actually proceeding under this config.
 
     # Acceptance criterion (GEPA §5.1).
     acceptance = (
@@ -1345,12 +1409,21 @@ def _run_evolution_impl(
     # the cache atomically alongside everything else (state.py:306-340); HELIX
     # routes the (candidate_id, example_id)-keyed companion pickle through
     # this helper so every save site stays consistent without rewriting them.
+    # One-shot guard for the disabled-cache cleanup: ``clear_eval_cache``
+    # is idempotent but on every save invocation we'd otherwise issue a
+    # fresh ``unlink()`` that always raises FileNotFoundError after the
+    # first successful delete.  A flag avoids that noise while still
+    # guaranteeing the stale on-disk pickle is cleared at least once per
+    # run.
+    _eval_cache_cleared = [False]
+
     def _save_state(s: EvolutionState) -> None:
         save_state(s, project_root)
         if minibatch_cache is not None:
             save_eval_cache(minibatch_cache._cache, project_root)
-        else:
+        elif not _eval_cache_cleared[0]:
             clear_eval_cache(project_root)
+            _eval_cache_cleared[0] = True
 
     def _sync_frontier_state() -> None:
         assert state is not None
@@ -1376,6 +1449,13 @@ def _run_evolution_impl(
         needs_seed = False
         _validate_resume_semantics(state, config)
         if not state.resume_semantics:
+            # Legacy state predating the resume_semantics guard: validation
+            # short-circuits, so surface that the guard is dormant for THIS
+            # resume but will be active on the next save and onward.
+            print_info(
+                "No persisted resume_semantics found on this state (legacy run); "
+                "the current config will be pinned for future resumes."
+            )
             state.resume_semantics = _resume_semantics(config)
         # Keep ``state.frontier_type`` pinned to whatever was stored;
         # it already matches the frontier that was built.  On a legacy

--- a/src/helix/exceptions.py
+++ b/src/helix/exceptions.py
@@ -93,6 +93,19 @@ class EvaluatorError(HelixError):
     """Raised when an evaluator subprocess fails."""
 
 
+class ResumeIncompatibleError(HelixError):
+    """Raised when resuming would reinterpret persisted evolution state.
+
+    Triggered by ``helix.evolution._validate_resume_semantics`` when the
+    current ``HelixConfig`` differs from the snapshot recorded in
+    ``EvolutionState.resume_semantics`` for a field that changes the
+    meaning of saved scores / frontier (e.g. ``frontier_type``,
+    ``minibatch_size``, ``acceptance_criterion``).  Caught by the
+    ``helix evolve`` and ``helix resume`` CLI handlers so the user sees a
+    friendly error instead of a Python traceback.
+    """
+
+
 class RateLimitError(HelixError):
     """Raised when Claude Code hits a rate / usage limit.
 

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -18,8 +18,9 @@ from helix.population import FrontierType
 # GEPA parity (audit-rng-state-persist D1):
 # GEPA core/state.py:153 declares ``_VALIDATION_SCHEMA_VERSION: ClassVar[int] = 5``
 # and migrates older state dicts on load (state.py:355-376).  HELIX previously
-# had no schema version on ``state.json``; newer bumps mark explicit
-# JSON-native schema additions.
+# had no schema version on ``state.json``; subsequent bumps mark explicit
+# JSON-native schema additions (the unversioned predecessor is treated as
+# v0; ``load_state`` migrates by default-filling missing fields).
 SCHEMA_VERSION: int = 2
 
 
@@ -116,6 +117,11 @@ class EvolutionState:
     # fall back to ``"instance"`` (HELIX's historical single-axis
     # default) in ``load_state``.
     frontier_type: FrontierType = "instance"
+    # Resume compatibility metadata for settings that affect optimization
+    # semantics.  This is intentionally a small JSON-native dict rather than
+    # a GEPA-style single pickled artifact: HELIX still persists worktrees,
+    # evaluations, lineage, and state as separate artifacts.
+    resume_semantics: dict[str, Any] = field(default_factory=dict)
     # GEPA parity (audit-rng-state-persist D1): persisted schema version.
     # Mirrors GEPA core/state.py:182 / class-var :153.  Bumped when the
     # serialized schema changes; ``load_state`` migrates older payloads by
@@ -166,6 +172,7 @@ def save_state(state: EvolutionState, base_dir: Path) -> None:
         "num_metric_calls_by_discovery": state.num_metric_calls_by_discovery,
         "active_frontier": state.active_frontier,
         "frontier_type": state.frontier_type,
+        "resume_semantics": state.resume_semantics,
     }
 
     # Atomic write: write to tmp file in same directory, then rename
@@ -237,6 +244,7 @@ def load_state(base_dir: Path) -> EvolutionState | None:
         num_metric_calls_by_discovery=data.get("num_metric_calls_by_discovery", {}),
         active_frontier=data.get("active_frontier", {}),
         frontier_type=frontier_type,
+        resume_semantics=data.get("resume_semantics", {}),
         schema_version=SCHEMA_VERSION,
     )
 
@@ -321,3 +329,17 @@ def _quarantine_corrupt_cache(target: Path, *, reason: str) -> Path:
         # the file in place.  The save path uses ``os.replace`` to overwrite
         # atomically, so a future successful save still wins.
         return target
+
+
+def clear_eval_cache(base_dir: Path) -> None:
+    """Remove the persisted per-example eval cache if present.
+
+    Used by ``run_evolution`` when ``cache_evaluation`` is disabled to make
+    sure a stale pickle from a prior cache-enabled run does not get
+    revived later.  Idempotent: a missing target is a no-op.
+    """
+    target = _eval_cache_path(base_dir)
+    try:
+        target.unlink()
+    except FileNotFoundError:
+        return

--- a/tests/unit/test_evolution_seedless.py
+++ b/tests/unit/test_evolution_seedless.py
@@ -278,6 +278,7 @@ class TestRunEvolutionResume:
             instance_scores={"g0-s0": {"i1": 0.5}},
             budget=BudgetState(evaluations=1),
             config_hash="abc123",
+            frontier_type=config.evolution.frontier_type,
         )
         seedless_mocks["load_state"].return_value = existing_state
         # _load_evaluation must return a result for frontier reconstruction
@@ -305,6 +306,7 @@ class TestRunEvolutionResume:
             instance_scores={"g0-s0": {"i1": 0.5}},
             budget=BudgetState(evaluations=1),
             config_hash="abc123",
+            frontier_type=config.evolution.frontier_type,
         )
         seedless_mocks["load_state"].return_value = existing_state
         seed_result = make_eval_result("g0-s0")

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from helix.exceptions import RateLimitError
+from helix.exceptions import RateLimitError, ResumeIncompatibleError
 from helix.mutator import MutationError, invoke_claude_code, _looks_like_rate_limit
 from helix.state import BudgetState, EvolutionState, load_state, save_state
 
@@ -281,7 +281,7 @@ def test_resume_rejects_frontier_type_change() -> None:
     state.resume_semantics = _resume_semantics(config)
     state.resume_semantics["evolution"]["frontier_type"] = "instance"
 
-    with pytest.raises(ValueError, match="frontier_type"):
+    with pytest.raises(ResumeIncompatibleError, match="frontier_type"):
         _validate_resume_semantics(state, config)
 
 
@@ -304,7 +304,7 @@ def test_resume_rejects_semantic_config_change() -> None:
     state.frontier_type = "hybrid"
     state.resume_semantics = _resume_semantics(saved_config)
 
-    with pytest.raises(ValueError, match="minibatch_size"):
+    with pytest.raises(ResumeIncompatibleError, match="minibatch_size"):
         _validate_resume_semantics(state, current_config)
 
 
@@ -328,6 +328,150 @@ def test_resume_allows_cache_toggle_without_semantic_rejection() -> None:
     state.resume_semantics = _resume_semantics(saved_config)
 
     _validate_resume_semantics(state, current_config)
+
+
+def test_resume_legacy_state_with_empty_resume_semantics_does_not_raise() -> None:
+    """Legacy states predating the resume_semantics guard short-circuit cleanly.
+
+    The frontier_type attribute IS still checked (it has been persisted
+    since v1) — only the broader semantic comparison short-circuits when
+    ``resume_semantics`` is empty.
+    """
+    from helix.config import EvolutionConfig, EvaluatorConfig, HelixConfig
+    from helix.evolution import _validate_resume_semantics
+
+    config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1"),
+        evolution=EvolutionConfig(frontier_type="instance", minibatch_size=11),
+    )
+    state = make_state(frontier=[])
+    state.frontier_type = "instance"
+    state.resume_semantics = {}  # legacy: no semantics persisted yet
+
+    # Should not raise — the early-return path is the documented migration
+    # behaviour for v0/v1 state.json payloads.
+    _validate_resume_semantics(state, config)
+
+
+def test_resume_rejection_preserves_persisted_eval_cache(tmp_path: Path) -> None:
+    """A rejected resume must NOT delete the on-disk eval cache pickle.
+
+    Regression guard: the ordering bug previously cleared
+    ``.helix/eval_cache.pkl`` at startup whenever ``cache_evaluation`` was
+    disabled, even if the run was about to be rejected by
+    ``_validate_resume_semantics``.  After the fix, the pickle survives a
+    rejected resume so the user can correct the config and resume with
+    cache state intact.
+    """
+    from helix.config import (
+        AgentConfig,
+        DatasetConfig,
+        EvolutionConfig,
+        EvaluatorConfig,
+        HelixConfig,
+        WorktreeConfig,
+    )
+    from helix.eval_cache import EvaluationCache as MinibatchEvalCache
+    from helix.evolution import _resume_semantics, run_evolution
+    from helix.state import (
+        BudgetState,
+        EvolutionState,
+        load_eval_cache,
+        save_eval_cache,
+        save_state,
+    )
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    base_dir = project_root / ".helix"
+    base_dir.mkdir()
+
+    # Saved run: cache_evaluation was True, frontier_type=instance.
+    saved_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1"),
+        evolution=EvolutionConfig(
+            frontier_type="instance",
+            cache_evaluation=True,
+            max_generations=1,
+        ),
+        agent=AgentConfig(),
+        dataset=DatasetConfig(),
+        worktree=WorktreeConfig(),
+    )
+    state = EvolutionState(
+        generation=0,
+        frontier=[],
+        instance_scores={},
+        budget=BudgetState(),
+        config_hash="cafef00d",
+        frontier_type="instance",
+        resume_semantics=_resume_semantics(saved_config),
+    )
+    save_state(state, project_root)
+
+    # Persist a non-trivial eval cache.
+    cache: MinibatchEvalCache[object, str] = MinibatchEvalCache[object, str]()
+    cache.put({"prompt.md": "v1"}, "task_a", output="out-a", score=0.7)
+    save_eval_cache(cache._cache, project_root)
+    assert load_eval_cache(project_root) is not None
+
+    # Resume with frontier_type=hybrid AND cache_evaluation=False — under the
+    # old code the cache would be wiped at startup before the rejection.
+    current_config = saved_config.model_copy(
+        update={
+            "evolution": saved_config.evolution.model_copy(
+                update={"frontier_type": "hybrid", "cache_evaluation": False}
+            )
+        }
+    )
+
+    with pytest.raises(ResumeIncompatibleError, match="frontier_type"):
+        run_evolution(current_config, project_root, base_dir)
+
+    # The persisted cache MUST still be on disk so the user can correct
+    # the config and resume without losing cache state.
+    assert load_eval_cache(project_root) is not None, (
+        "eval_cache.pkl must survive a rejected resume; the destructive "
+        "clear_eval_cache() call should not run before validation."
+    )
+
+
+def test_resume_cli_emits_friendly_error_on_incompatible_config(tmp_path: Path) -> None:
+    """`helix resume` should never surface a raw Python traceback.
+
+    When ``_validate_resume_semantics`` raises ``ResumeIncompatibleError``
+    the CLI catches it and routes through ``print_helix_error`` for a
+    Rich-formatted panel + ``SystemExit(2)``.
+    """
+    from click.testing import CliRunner
+    from helix.cli import cli
+    from helix.exceptions import ResumeIncompatibleError
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / "helix.toml").write_text(
+        'objective = "test"\n\n[evaluator]\ncommand = "echo 1"\n'
+    )
+
+    incompat = ResumeIncompatibleError(
+        "Cannot resume with a different evolution.frontier_type: "
+        "saved='instance', current='hybrid'.",
+        operation="resume",
+        phase="validate_resume_semantics",
+        suggestion="Restore the original config or run `helix clean`.",
+    )
+
+    with patch("helix.evolution.run_evolution", side_effect=incompat):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["resume", "--dir", str(project_root)])
+
+    assert result.exit_code == 2, (result.exit_code, result.output)
+    # No traceback from a bare ValueError; the friendly panel is rendered
+    # via ``print_helix_error``.
+    assert "Traceback" not in result.output, result.output
+    assert "frontier_type" in result.output, result.output
 
 
 def test_evolve_success_prints_clean_hint(tmp_path: Path) -> None:

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -266,6 +266,70 @@ def test_resume_keyboard_interrupt_preserves_state_and_prints_clean_hint(tmp_pat
     assert "helix clean" in result.output.lower(), result.output
 
 
+def test_resume_rejects_frontier_type_change() -> None:
+    """A persisted frontier cannot be resumed under a different dimensionality."""
+    from helix.config import EvolutionConfig, EvaluatorConfig, HelixConfig
+    from helix.evolution import _resume_semantics, _validate_resume_semantics
+
+    config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1"),
+        evolution=EvolutionConfig(frontier_type="hybrid"),
+    )
+    state = make_state(frontier=[])
+    state.frontier_type = "instance"
+    state.resume_semantics = _resume_semantics(config)
+    state.resume_semantics["evolution"]["frontier_type"] = "instance"
+
+    with pytest.raises(ValueError, match="frontier_type"):
+        _validate_resume_semantics(state, config)
+
+
+def test_resume_rejects_semantic_config_change() -> None:
+    """Config edits that change optimization semantics must hard-fail resume."""
+    from helix.config import EvolutionConfig, EvaluatorConfig, HelixConfig
+    from helix.evolution import _resume_semantics, _validate_resume_semantics
+
+    saved_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1"),
+        evolution=EvolutionConfig(frontier_type="hybrid", minibatch_size=3),
+    )
+    current_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1"),
+        evolution=EvolutionConfig(frontier_type="hybrid", minibatch_size=7),
+    )
+    state = make_state(frontier=[])
+    state.frontier_type = "hybrid"
+    state.resume_semantics = _resume_semantics(saved_config)
+
+    with pytest.raises(ValueError, match="minibatch_size"):
+        _validate_resume_semantics(state, current_config)
+
+
+def test_resume_allows_cache_toggle_without_semantic_rejection() -> None:
+    """Cache toggles are handled by cache persistence, not semantic rejection."""
+    from helix.config import EvolutionConfig, EvaluatorConfig, HelixConfig
+    from helix.evolution import _resume_semantics, _validate_resume_semantics
+
+    saved_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1"),
+        evolution=EvolutionConfig(frontier_type="hybrid", cache_evaluation=True),
+    )
+    current_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1"),
+        evolution=EvolutionConfig(frontier_type="hybrid", cache_evaluation=False),
+    )
+    state = make_state(frontier=[])
+    state.frontier_type = "hybrid"
+    state.resume_semantics = _resume_semantics(saved_config)
+
+    _validate_resume_semantics(state, current_config)
+
+
 def test_evolve_success_prints_clean_hint(tmp_path: Path) -> None:
     """CLI evolve should remind the user that HELIX state/worktrees remain on disk."""
     from click.testing import CliRunner

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -330,6 +330,117 @@ def test_resume_allows_cache_toggle_without_semantic_rejection() -> None:
     _validate_resume_semantics(state, current_config)
 
 
+def test_resume_rejects_evaluator_stdout_capture_change() -> None:
+    """Toggling ``evaluator.include_stdout`` reinterprets parser input.
+
+    GEPA Optimize Anything parity: any field that changes which bytes
+    the score parser sees is hard-rejected on resume.  Saved scores
+    were computed against one capture policy; a different policy can
+    silently flip results without the user knowing.
+    """
+    from helix.config import EvaluatorConfig, EvolutionConfig, HelixConfig
+    from helix.evolution import _resume_semantics, _validate_resume_semantics
+
+    saved_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1", include_stdout=True),
+        evolution=EvolutionConfig(frontier_type="instance"),
+    )
+    current_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1", include_stdout=False),
+        evolution=EvolutionConfig(frontier_type="instance"),
+    )
+    state = make_state(frontier=[])
+    state.frontier_type = "instance"
+    state.resume_semantics = _resume_semantics(saved_config)
+
+    with pytest.raises(ResumeIncompatibleError, match="include_stdout"):
+        _validate_resume_semantics(state, current_config)
+
+
+def test_resume_rejects_evaluator_sidecar_change() -> None:
+    """Sidecar swap implies a different evaluator runtime entirely.
+
+    Resuming under a different sidecar would compare scores produced
+    by different evaluator binaries — the strict-equality stance GEPA
+    gets implicitly by pickling its full config alongside state.
+    """
+    from helix.config import (
+        EvaluatorConfig,
+        EvaluatorSidecarConfig,
+        EvolutionConfig,
+        HelixConfig,
+    )
+    from helix.evolution import _resume_semantics, _validate_resume_semantics
+
+    saved_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(
+            command="python /runner/eval.py",
+            sidecar=EvaluatorSidecarConfig(
+                image="my-eval:v1",
+                command="python -m bench",
+                endpoint="http://eval:8080/run",
+            ),
+        ),
+        evolution=EvolutionConfig(frontier_type="instance"),
+    )
+    current_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(
+            command="python /runner/eval.py",
+            sidecar=EvaluatorSidecarConfig(
+                image="my-eval:v2",  # bumped image version
+                command="python -m bench",
+                endpoint="http://eval:8080/run",
+            ),
+        ),
+        evolution=EvolutionConfig(frontier_type="instance"),
+    )
+    state = make_state(frontier=[])
+    state.frontier_type = "instance"
+    state.resume_semantics = _resume_semantics(saved_config)
+
+    with pytest.raises(ResumeIncompatibleError, match="sidecar"):
+        _validate_resume_semantics(state, current_config)
+
+
+def test_resume_allows_agent_backend_change() -> None:
+    """Mutation-backend swaps are intentionally NOT in resume_semantics.
+
+    Changing ``agent.backend`` / ``model`` / ``effort`` affects only
+    future proposals — saved frontier scores stay valid.  GEPA likewise
+    treats the LM client as out-of-band of the persisted state.
+    """
+    from helix.config import (
+        AgentConfig,
+        EvaluatorConfig,
+        EvolutionConfig,
+        HelixConfig,
+    )
+    from helix.evolution import _resume_semantics, _validate_resume_semantics
+
+    saved_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1"),
+        evolution=EvolutionConfig(frontier_type="instance"),
+        agent=AgentConfig(backend="claude", model="sonnet"),
+    )
+    current_config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(command="echo 1"),
+        evolution=EvolutionConfig(frontier_type="instance"),
+        agent=AgentConfig(backend="codex", model="gpt-5"),
+    )
+    state = make_state(frontier=[])
+    state.frontier_type = "instance"
+    state.resume_semantics = _resume_semantics(saved_config)
+
+    # Should not raise — agent.* lives outside the resume contract.
+    _validate_resume_semantics(state, current_config)
+
+
 def test_resume_legacy_state_with_empty_resume_semantics_does_not_raise() -> None:
     """Legacy states predating the resume_semantics guard short-circuit cleanly.
 

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -29,6 +29,7 @@ from helix.state import (
     SCHEMA_VERSION,
     BudgetState,
     EvolutionState,
+    clear_eval_cache,
     load_eval_cache,
     load_state,
     save_eval_cache,
@@ -352,6 +353,7 @@ def test_state_json_keys_when_val_stage_disabled(tmp_path: Path) -> None:
         "num_metric_calls_by_discovery",
         "active_frontier",
         "frontier_type",
+        "resume_semantics",
     }
     assert set(raw.keys()) == expected_keys, (
         f"state.json keys diverged from schema_version={SCHEMA_VERSION} "
@@ -375,3 +377,14 @@ def test_legacy_state_load_followed_by_save_writes_versioned_payload(tmp_path: P
     raw = json.loads((tmp_path / ".helix" / "state.json").read_text())
     assert raw["schema_version"] == SCHEMA_VERSION
     assert raw["num_metric_calls_by_discovery"] == {}
+
+
+def test_clear_eval_cache_removes_stale_pickle(tmp_path: Path) -> None:
+    """Disabling cache must not leave a stale pickle for later resumes."""
+    cache: MinibatchEvalCache[object, str] = MinibatchEvalCache[object, str]()
+    cache.put({"prompt.md": "v1"}, "task_a", output="out-a", score=0.4)
+    save_eval_cache(cache._cache, tmp_path)
+
+    clear_eval_cache(tmp_path)
+
+    assert load_eval_cache(tmp_path) is None


### PR DESCRIPTION
## Summary
- Adds persisted resume_semantics metadata for optimization-meaningful config fields.
- Rejects resume when frontier type or other semantic settings would reinterpret saved state.
- Clears persisted eval cache when cache_evaluation is disabled so stale cache state is not revived later.
- Preserves Helix worktrees/directories as the artifact model.

## Validation
- Full pytest passed in worker verification: 687 passed.
- Focused resume/state/seedless tests: 34 passed.
- ruff check src tests passed.
- Full repo ruff remains blocked by pre-existing examples/web_researcher/evaluate.py F841 outside this branch.