### PR TITLE
Return structured HelixResult from evolution

### DIFF
--- a/src/helix/__init__.py
+++ b/src/helix/__init__.py
@@ -2,7 +2,22 @@
 
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
+from helix.population import (
+    Candidate,
+    CandidateSummary,
+    EvalResult,
+    HelixResult,
+)
+
 try:
     __version__ = _pkg_version("helix-evo")
 except PackageNotFoundError:  # not installed (e.g. source checkout without pip install -e .)
     __version__ = "0.0.0+unknown"
+
+__all__ = [
+    "Candidate",
+    "CandidateSummary",
+    "EvalResult",
+    "HelixResult",
+    "__version__",
+]

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -872,15 +872,33 @@ def _build_helix_result(
     config: HelixConfig,
     lineage_path: Path,
 ) -> HelixResult:
-    """Build the structured programmatic result for a completed run."""
+    """Build the structured programmatic result for a completed run.
+
+    Reads the lineage JSON once at end-of-run.  ``record_entry`` flushes
+    every accept-time mutation/merge to disk synchronously, so the file
+    is the authoritative source by the time we get here.  Falls back to
+    each candidate's in-memory ``parent_ids`` / ``operation`` /
+    ``generation`` when no lineage entry is present (defensive — every
+    real accept site writes one).
+
+    Per-candidate data is materialized once on each
+    :class:`CandidateSummary`; :class:`HelixResult` exposes
+    ``aggregate_scores`` / ``sum_scores`` / ``instance_scores`` /
+    ``objective_scores`` / ``parents`` as cached views over that list,
+    so there is a single source of truth.
+    """
     lineage = load_lineage(lineage_path)
     non_dominated_ids = sorted(frontier.get_non_dominated())
     non_dominated = set(non_dominated_ids)
-    parents: dict[str, list[str]] = {}
     summaries: list[CandidateSummary] = []
 
-    for cid, candidate in frontier._candidates.items():
+    for cid, candidate in frontier.candidates.items():
         entry = lineage.get(cid)
+        # Parent resolution priority:
+        #   1. ``LineageEntry.parents`` — multi-parent (merge) source of truth.
+        #   2. ``Candidate.parent_ids`` — populated at construction for both
+        #      mutations and merges, used when lineage has nothing.
+        #   3. ``LineageEntry.parent`` — legacy single-parent fallback.
         candidate_parents = (
             list(entry.parents)
             if entry is not None and entry.parents
@@ -888,9 +906,8 @@ def _build_helix_result(
         )
         if not candidate_parents and entry is not None and entry.parent is not None:
             candidate_parents = [entry.parent]
-        parents[cid] = candidate_parents
 
-        result = frontier._results.get(cid)
+        result = frontier.get_result(cid)
         aggregate_score = result.aggregate_score() if result is not None else 0.0
         sum_score = result.sum_score() if result is not None else 0.0
         summaries.append(
@@ -918,25 +935,12 @@ def _build_helix_result(
     summaries.sort(key=lambda s: (s.generation, s.id))
     return HelixResult(
         best_candidate=best,
-        best_result=frontier._results.get(best.id),
-        candidates=list(frontier._candidates.values()),
+        best_result=frontier.get_result(best.id),
+        candidates=list(frontier.candidates.values()),
         candidate_summaries=summaries,
-        parents=parents,
-        aggregate_scores={
-            cid: result.aggregate_score() for cid, result in frontier._results.items()
-        },
-        sum_scores={cid: result.sum_score() for cid, result in frontier._results.items()},
-        instance_scores={
-            cid: dict(result.instance_scores) for cid, result in frontier._results.items()
-        },
-        objective_scores={
-            cid: (
-                list(result.objective_scores)
-                if result.objective_scores is not None
-                else None
-            )
-            for cid, result in frontier._results.items()
-        },
+        # Insertion-order copy of state.frontier — preserves accept order
+        # so callers can replay ``frontier_ids`` in chronological order.
+        # ``non_dominated_ids`` is sorted (above) for stable diffing.
         frontier_ids=list(state.frontier),
         non_dominated_ids=non_dominated_ids,
         frontier_type=state.frontier_type,

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -51,7 +51,13 @@ from helix.executor import run_evaluator
 from helix.lineage import LineageEntry, find_merge_triplet, load_lineage, record_entry
 from helix.merger import merge, select_eval_subsample_for_merged_program
 from helix.mutator import mutate, build_seed_generation_prompt, generate_seed
-from helix.population import Candidate, EvalResult, ParetoFrontier
+from helix.population import (
+    Candidate,
+    CandidateSummary,
+    EvalResult,
+    HelixResult,
+    ParetoFrontier,
+)
 from helix.sandbox import start_evaluator_sidecar
 from helix.state import (
     BudgetState,
@@ -857,6 +863,91 @@ def _has_example_scores(result: EvalResult | None, example_ids: list[str]) -> bo
     return all(eid in result.instance_scores for eid in example_ids)
 
 
+def _build_helix_result(
+    *,
+    best: Candidate,
+    frontier: ParetoFrontier,
+    state: EvolutionState,
+    base_dir: Path,
+    config: HelixConfig,
+    lineage_path: Path,
+) -> HelixResult:
+    """Build the structured programmatic result for a completed run."""
+    lineage = load_lineage(lineage_path)
+    non_dominated_ids = sorted(frontier.get_non_dominated())
+    non_dominated = set(non_dominated_ids)
+    parents: dict[str, list[str]] = {}
+    summaries: list[CandidateSummary] = []
+
+    for cid, candidate in frontier._candidates.items():
+        entry = lineage.get(cid)
+        candidate_parents = (
+            list(entry.parents)
+            if entry is not None and entry.parents
+            else list(candidate.parent_ids)
+        )
+        if not candidate_parents and entry is not None and entry.parent is not None:
+            candidate_parents = [entry.parent]
+        parents[cid] = candidate_parents
+
+        result = frontier._results.get(cid)
+        aggregate_score = result.aggregate_score() if result is not None else 0.0
+        sum_score = result.sum_score() if result is not None else 0.0
+        summaries.append(
+            CandidateSummary(
+                candidate=candidate,
+                aggregate_score=aggregate_score,
+                sum_score=sum_score,
+                scores=dict(result.scores) if result is not None else {},
+                instance_scores=(
+                    dict(result.instance_scores) if result is not None else {}
+                ),
+                objective_scores=(
+                    list(result.objective_scores)
+                    if result is not None and result.objective_scores is not None
+                    else None
+                ),
+                parents=candidate_parents,
+                operation=entry.operation if entry is not None else candidate.operation,
+                generation=entry.generation if entry is not None else candidate.generation,
+                discovered_at_evaluation=state.num_metric_calls_by_discovery.get(cid),
+                is_non_dominated=cid in non_dominated,
+            )
+        )
+
+    summaries.sort(key=lambda s: (s.generation, s.id))
+    return HelixResult(
+        best_candidate=best,
+        best_result=frontier._results.get(best.id),
+        candidates=list(frontier._candidates.values()),
+        candidate_summaries=summaries,
+        parents=parents,
+        aggregate_scores={
+            cid: result.aggregate_score() for cid, result in frontier._results.items()
+        },
+        sum_scores={cid: result.sum_score() for cid, result in frontier._results.items()},
+        instance_scores={
+            cid: dict(result.instance_scores) for cid, result in frontier._results.items()
+        },
+        objective_scores={
+            cid: (
+                list(result.objective_scores)
+                if result.objective_scores is not None
+                else None
+            )
+            for cid, result in frontier._results.items()
+        },
+        frontier_ids=list(state.frontier),
+        non_dominated_ids=non_dominated_ids,
+        frontier_type=state.frontier_type,
+        budget=state.budget,
+        discovery_counts=dict(state.num_metric_calls_by_discovery),
+        run_dir=str(base_dir),
+        seed=config.rng_seed,
+        config_hash=state.config_hash,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
@@ -866,7 +957,7 @@ def run_evolution(
     config: HelixConfig,
     project_root: Path,
     base_dir: Path,
-) -> Candidate:
+) -> HelixResult:
     """Run the HELIX evolutionary loop."""
     if config.sandbox.enabled and config.sandbox.evaluator:
         if config.evaluator.sidecar is None:
@@ -889,7 +980,7 @@ def _run_evolution_impl(
     config: HelixConfig,
     project_root: Path,
     base_dir: Path,
-) -> Candidate:
+) -> HelixResult:
     """Run the HELIX evolutionary loop.
 
     Parameters
@@ -904,8 +995,8 @@ def _run_evolution_impl(
 
     Returns
     -------
-    Candidate
-        The best candidate from the final frontier.
+    HelixResult
+        Structured result for the completed run, including the best candidate.
     """
     TRACE.emit(EventType.OPT_START)
     init_base_dir(base_dir, config)
@@ -2424,4 +2515,11 @@ def _run_evolution_impl(
 
     print_success(f"Evolution complete.  Best candidate: {best.id}")
     TRACE.emit(EventType.OPT_END, candidate_id=best.id)
-    return best
+    return _build_helix_result(
+        best=best,
+        frontier=frontier,
+        state=state,
+        base_dir=base_dir,
+        config=config,
+        lineage_path=lineage_path,
+    )

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -12,6 +12,7 @@ import shlex
 import subprocess
 import threading
 import traceback
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -1044,7 +1045,11 @@ def _build_helix_result(
         frontier_ids=list(state.frontier),
         non_dominated_ids=non_dominated_ids,
         frontier_type=state.frontier_type,
-        budget=state.budget,
+        # Defensive shallow copy — ``state.budget`` is mutated by the
+        # budget-accounting code throughout the run; the snapshot must
+        # not alias it (GEPA parity: ``GEPAResult.from_state`` shallow-
+        # copies every collection coming off the live state).
+        budget=replace(state.budget),
         discovery_counts=dict(state.num_metric_calls_by_discovery),
         run_dir=str(base_dir),
         seed=config.rng_seed,

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -208,6 +208,11 @@ class HelixResult:
     seed: int | None
     config_hash: str
 
+    @property
+    def id(self) -> str:
+        """Compatibility alias for callers that previously received Candidate."""
+        return self.best_candidate.id
+
     @cached_property
     def parents(self) -> dict[str, list[str]]:
         """Lineage parent ids per candidate, derived from ``candidate_summaries``."""

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -10,9 +10,14 @@ import hashlib
 import json
 import logging
 import random
-from dataclasses import dataclass, field
-from typing import Any, Literal
+from dataclasses import asdict, dataclass, field
+from functools import cached_property
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Literal, Mapping
 
+
+if TYPE_CHECKING:
+    from helix.state import BudgetState
 
 logger = logging.getLogger(__name__)
 
@@ -176,44 +181,67 @@ class HelixResult:
 
     Mirrors GEPA-style programmatic access without changing the on-disk
     worktree/state model: callers can inspect the best candidate, every
-    accepted candidate summary, lineage, scores, budgets, frontier axes, and
+    accepted candidate, lineage, scores, budgets, frontier axes, and
     run identity without scraping CLI output or JSON files.
+
+    Canonical per-candidate data lives on :attr:`candidate_summaries`
+    (sorted by ``(generation, id)``).  The ``parents``,
+    ``aggregate_scores``, ``sum_scores``, ``instance_scores``, and
+    ``objective_scores`` cached properties are convenience views derived
+    from that list — they share no storage and stay consistent by
+    construction.
     """
 
     best_candidate: Candidate
     best_result: EvalResult | None
     candidates: list[Candidate]
     candidate_summaries: list[CandidateSummary]
-    parents: dict[str, list[str]]
-    aggregate_scores: dict[str, float]
-    sum_scores: dict[str, float]
-    instance_scores: dict[str, dict[str, float]]
-    objective_scores: dict[str, list[dict[str, float]] | None]
+    # ``frontier_ids`` preserves insertion order from
+    # ``EvolutionState.frontier``; ``non_dominated_ids`` is sorted for
+    # stable diffing across runs.  Both intentional.
     frontier_ids: list[str]
     non_dominated_ids: list[str]
     frontier_type: FrontierType
-    budget: Any
+    budget: "BudgetState"
     discovery_counts: dict[str, int]
     run_dir: str
     seed: int | None
     config_hash: str
 
-    @property
-    def id(self) -> str:
-        """Compatibility alias for callers that previously used best.id."""
-        return self.best_candidate.id
+    @cached_property
+    def parents(self) -> dict[str, list[str]]:
+        """Lineage parent ids per candidate, derived from ``candidate_summaries``."""
+        return {s.id: list(s.parents) for s in self.candidate_summaries}
+
+    @cached_property
+    def aggregate_scores(self) -> dict[str, float]:
+        """Per-candidate mean instance score (GEPA aggregate semantics)."""
+        return {s.id: s.aggregate_score for s in self.candidate_summaries}
+
+    @cached_property
+    def sum_scores(self) -> dict[str, float]:
+        """Per-candidate sum of instance scores (GEPA acceptance semantics)."""
+        return {s.id: s.sum_score for s in self.candidate_summaries}
+
+    @cached_property
+    def instance_scores(self) -> dict[str, dict[str, float]]:
+        """Per-candidate per-instance score map."""
+        return {s.id: dict(s.instance_scores) for s in self.candidate_summaries}
+
+    @cached_property
+    def objective_scores(self) -> dict[str, list[dict[str, float]] | None]:
+        """Per-candidate per-example objective slots (None when not harvested)."""
+        return {
+            s.id: (list(s.objective_scores) if s.objective_scores is not None else None)
+            for s in self.candidate_summaries
+        }
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to a JSON-compatible dict."""
-        budget_dict = (
-            self.budget
-            if isinstance(self.budget, dict)
-            else {
-                key: getattr(self.budget, key)
-                for key in ("evaluations", "input_tokens", "output_tokens", "cost_usd")
-                if hasattr(self.budget, key)
-            }
-        )
+        """Serialize to a JSON-compatible dict.
+
+        ``budget`` is rendered via :func:`dataclasses.asdict` so any new
+        :class:`helix.state.BudgetState` field shows up automatically.
+        """
         return {
             "best_candidate_id": self.best_candidate.id,
             "best_result": self.best_result.to_dict() if self.best_result else None,
@@ -223,11 +251,11 @@ class HelixResult:
             "sum_scores": self.sum_scores,
             "instance_scores": self.instance_scores,
             "objective_scores": self.objective_scores,
-            "frontier_ids": self.frontier_ids,
-            "non_dominated_ids": self.non_dominated_ids,
+            "frontier_ids": list(self.frontier_ids),
+            "non_dominated_ids": list(self.non_dominated_ids),
             "frontier_type": self.frontier_type,
-            "budget": budget_dict,
-            "discovery_counts": self.discovery_counts,
+            "budget": asdict(self.budget),
+            "discovery_counts": dict(self.discovery_counts),
             "run_dir": self.run_dir,
             "seed": self.seed,
             "config_hash": self.config_hash,
@@ -320,6 +348,28 @@ class ParetoFrontier:
     def frontier_type(self) -> FrontierType:
         """Selected Pareto dimensionality (GEPA parity)."""
         return self._frontier_type
+
+    # ------------------------------------------------------------------
+    # Public read-only accessors
+    # ------------------------------------------------------------------
+    # ``_candidates`` and ``_results`` are append-only internal storage;
+    # external callers (e.g. ``_build_helix_result``, ``render_frontier_table``)
+    # use these read-only views so the storage layout can change without
+    # breaking them.
+
+    @property
+    def candidates(self) -> Mapping[str, Candidate]:
+        """Read-only view of all stored candidates keyed by id."""
+        return MappingProxyType(self._candidates)
+
+    @property
+    def results(self) -> Mapping[str, EvalResult]:
+        """Read-only view of stored evaluation results keyed by candidate id."""
+        return MappingProxyType(self._results)
+
+    def get_result(self, candidate_id: str) -> EvalResult | None:
+        """Return the stored ``EvalResult`` for *candidate_id* or ``None``."""
+        return self._results.get(candidate_id)
 
     # ------------------------------------------------------------------
     # Mutation helpers — mirrors GEPAState._update_pareto_front_for_val_id

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -129,6 +129,111 @@ class EvalResult:
         )
 
 
+@dataclass
+class CandidateSummary:
+    """Programmatic summary of one evolved candidate in a HELIX result."""
+
+    candidate: Candidate
+    aggregate_score: float
+    sum_score: float
+    scores: dict[str, float]
+    instance_scores: dict[str, float]
+    objective_scores: list[dict[str, float]] | None
+    parents: list[str]
+    operation: str
+    generation: int
+    discovered_at_evaluation: int | None = None
+    is_non_dominated: bool = False
+
+    @property
+    def id(self) -> str:
+        """Candidate id convenience alias."""
+        return self.candidate.id
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "id": self.candidate.id,
+            "worktree_path": self.candidate.worktree_path,
+            "branch_name": self.candidate.branch_name,
+            "generation": self.generation,
+            "parents": self.parents,
+            "operation": self.operation,
+            "usage": self.candidate.usage,
+            "aggregate_score": self.aggregate_score,
+            "sum_score": self.sum_score,
+            "scores": self.scores,
+            "instance_scores": self.instance_scores,
+            "objective_scores": self.objective_scores,
+            "discovered_at_evaluation": self.discovered_at_evaluation,
+            "is_non_dominated": self.is_non_dominated,
+        }
+
+
+@dataclass
+class HelixResult:
+    """Structured result object returned by a HELIX evolution run.
+
+    Mirrors GEPA-style programmatic access without changing the on-disk
+    worktree/state model: callers can inspect the best candidate, every
+    accepted candidate summary, lineage, scores, budgets, frontier axes, and
+    run identity without scraping CLI output or JSON files.
+    """
+
+    best_candidate: Candidate
+    best_result: EvalResult | None
+    candidates: list[Candidate]
+    candidate_summaries: list[CandidateSummary]
+    parents: dict[str, list[str]]
+    aggregate_scores: dict[str, float]
+    sum_scores: dict[str, float]
+    instance_scores: dict[str, dict[str, float]]
+    objective_scores: dict[str, list[dict[str, float]] | None]
+    frontier_ids: list[str]
+    non_dominated_ids: list[str]
+    frontier_type: FrontierType
+    budget: Any
+    discovery_counts: dict[str, int]
+    run_dir: str
+    seed: int | None
+    config_hash: str
+
+    @property
+    def id(self) -> str:
+        """Compatibility alias for callers that previously used best.id."""
+        return self.best_candidate.id
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        budget_dict = (
+            self.budget
+            if isinstance(self.budget, dict)
+            else {
+                key: getattr(self.budget, key)
+                for key in ("evaluations", "input_tokens", "output_tokens", "cost_usd")
+                if hasattr(self.budget, key)
+            }
+        )
+        return {
+            "best_candidate_id": self.best_candidate.id,
+            "best_result": self.best_result.to_dict() if self.best_result else None,
+            "candidates": [summary.to_dict() for summary in self.candidate_summaries],
+            "parents": self.parents,
+            "aggregate_scores": self.aggregate_scores,
+            "sum_scores": self.sum_scores,
+            "instance_scores": self.instance_scores,
+            "objective_scores": self.objective_scores,
+            "frontier_ids": self.frontier_ids,
+            "non_dominated_ids": self.non_dominated_ids,
+            "frontier_type": self.frontier_type,
+            "budget": budget_dict,
+            "discovery_counts": self.discovery_counts,
+            "run_dir": self.run_dir,
+            "seed": self.seed,
+            "config_hash": self.config_hash,
+        }
+
+
 class ParetoFrontier:
     """GEPA-style unbounded frontier with coverage-based dominance.
 

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -12,7 +12,6 @@ import logging
 import random
 from collections.abc import Iterator, Mapping
 from dataclasses import asdict, dataclass, field
-from functools import cached_property
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -213,21 +212,29 @@ class CandidateSummary:
         }
 
 
-@dataclass
+@dataclass(frozen=True)
 class HelixResult:
-    """Structured result object returned by a HELIX evolution run.
+    """Immutable snapshot returned by a HELIX evolution run.
 
     Mirrors GEPA-style programmatic access without changing the on-disk
     worktree/state model: callers can inspect the best candidate, every
     accepted candidate, lineage, scores, budgets, frontier axes, and
     run identity without scraping CLI output or JSON files.
 
+    GEPA parity: matches the immutability shape of ``GEPAResult``
+    (``src/gepa/core/result.py``) — top-level ``frozen=True`` with plain
+    list/dict fields and ``@property`` views recomputed on each access.
+    The ``frozen=True`` dataclass blocks attribute reassignment; the
+    construction site (``_build_helix_result``) takes shallow defensive
+    copies of every collection so no field aliases the live
+    :class:`EvolutionState`.
+
     Canonical per-candidate data lives on :attr:`candidate_summaries`
-    (sorted by ``(generation, id)``).  The ``parents``,
-    ``aggregate_scores``, ``sum_scores``, ``instance_scores``, and
-    ``objective_scores`` cached properties are convenience views derived
-    from that list — they share no storage and stay consistent by
-    construction.
+    (sorted by ``(generation, id)``).  ``parents``, ``aggregate_scores``,
+    ``sum_scores``, ``instance_scores``, and ``objective_scores`` are
+    plain ``@property`` views (not cached) — they recompute from
+    ``candidate_summaries`` on every access, so they cannot drift out of
+    sync with the canonical list.
     """
 
     best_candidate: Candidate
@@ -251,27 +258,27 @@ class HelixResult:
         """Compatibility alias for callers that previously received Candidate."""
         return self.best_candidate.id
 
-    @cached_property
+    @property
     def parents(self) -> dict[str, list[str]]:
         """Lineage parent ids per candidate, derived from ``candidate_summaries``."""
         return {s.id: list(s.parents) for s in self.candidate_summaries}
 
-    @cached_property
+    @property
     def aggregate_scores(self) -> dict[str, float]:
         """Per-candidate mean instance score (GEPA aggregate semantics)."""
         return {s.id: s.aggregate_score for s in self.candidate_summaries}
 
-    @cached_property
+    @property
     def sum_scores(self) -> dict[str, float]:
         """Per-candidate sum of instance scores (GEPA acceptance semantics)."""
         return {s.id: s.sum_score for s in self.candidate_summaries}
 
-    @cached_property
+    @property
     def instance_scores(self) -> dict[str, dict[str, float]]:
         """Per-candidate per-instance score map."""
         return {s.id: dict(s.instance_scores) for s in self.candidate_summaries}
 
-    @cached_property
+    @property
     def objective_scores(self) -> dict[str, list[dict[str, float]] | None]:
         """Per-candidate per-example objective slots (None when not harvested)."""
         return {

--- a/tests/unit/test_align_iteration.py
+++ b/tests/unit/test_align_iteration.py
@@ -343,10 +343,10 @@ class TestLegacyGatingUsesSumOnly:
             max_generations=1,
             max_evaluations=100_000,
         )
-        best = run_evolution(config, tmp_path, tmp_path / ".helix")
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
         # Strict sum-score acceptance: 0.55 > 0.5 → child becomes best.
-        assert best.id == "g1-s1", (
+        assert result.best_candidate.id == "g1-s1", (
             f"Expected child to be accepted under GEPA strict-sum "
-            f"acceptance; got best={best.id}."
+            f"acceptance; got best={result.best_candidate.id}."
         )

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -80,21 +80,30 @@ def make_config(
     max_merge_invocations: int = 5,
     merge_val_overlap_floor: int = 5,
     merge_subsample_size: int = 5,
+    frontier_type: str | None = None,
 ) -> HelixConfig:
+    """Build a HelixConfig for evolution unit tests.
+
+    ``frontier_type`` defaults to ``None`` so :class:`EvolutionConfig`'s
+    own default (``"hybrid"``) is preserved for the bulk of the suite —
+    only tests that assert on it pass an explicit value.
+    """
+    evolution_kwargs: dict[str, object] = dict(
+        max_generations=max_generations,
+        max_evaluations=max_evaluations,
+        perfect_score_threshold=perfect_score_threshold,
+        merge_enabled=merge_enabled,
+        max_merge_invocations=max_merge_invocations,
+        merge_val_overlap_floor=merge_val_overlap_floor,
+        merge_subsample_size=merge_subsample_size,
+    )
+    if frontier_type is not None:
+        evolution_kwargs["frontier_type"] = frontier_type
     return HelixConfig(
         objective="Improve the code",
         evaluator=EvaluatorConfig(command="pytest -q"),
         dataset=DatasetConfig(),
-        evolution=EvolutionConfig(
-            max_generations=max_generations,
-            max_evaluations=max_evaluations,
-            perfect_score_threshold=perfect_score_threshold,
-            merge_enabled=merge_enabled,
-            max_merge_invocations=max_merge_invocations,
-            merge_val_overlap_floor=merge_val_overlap_floor,
-            merge_subsample_size=merge_subsample_size,
-            frontier_type="instance",
-        ),
+        evolution=EvolutionConfig(**evolution_kwargs),
         worktree=WorktreeConfig(cleanup_dominated=cleanup_dominated),
     )
 
@@ -510,8 +519,8 @@ class TestGatingInEvolutionLoop:
             max_generations=1,
             max_evaluations=10000,
         )
-        best = run_evolution(config, tmp_path, tmp_path / ".helix")
-        assert best.id == "g1-s1"
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+        assert result.best_candidate.id == "g1-s1"
 
     def test_returns_structured_helix_result(self, mocker, tmp_path, all_mocks):
         """run_evolution exposes GEPA-style structured result metadata."""
@@ -560,11 +569,13 @@ class TestGatingInEvolutionLoop:
 
         all_mocks["run_evaluator"].side_effect = run_eval
 
-        config = make_config(max_generations=1, max_evaluations=10000)
+        config = make_config(
+            max_generations=1, max_evaluations=10000, frontier_type="instance",
+        )
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
         assert isinstance(result, HelixResult)
-        assert result.id == "g1-s1"
+        assert result.best_candidate.id == "g1-s1"
         assert result.best_candidate is child
         assert result.best_result is not None
         assert result.best_result.scores == {"accuracy": 0.9}
@@ -585,6 +596,163 @@ class TestGatingInEvolutionLoop:
         assert result.seed == config.rng_seed
         assert result.config_hash
         assert result.candidate_summaries[-1].to_dict()["parents"] == ["g0-s0"]
+
+    def test_helix_result_keeps_multiple_non_dominated_candidates(
+        self, mocker, tmp_path, all_mocks,
+    ):
+        """Two complementary children should both be flagged non-dominated.
+
+        Each child wins on a disjoint per-instance axis, so neither
+        dominates the other under the ``"instance"`` frontier and the
+        seed (which loses on every axis) is dominated.
+        """
+        seed = make_candidate("g0-s0")
+        child_a = make_candidate("g1-s1", generation=1)
+        child_b = make_candidate("g2-s1", generation=2)
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].side_effect = [child_a, child_b]
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            # Each child wins on a different instance key; child_b's sum
+            # strictly exceeds child_a's so the strict acceptance gate
+            # passes in gen 2 regardless of which parent is selected.
+            scores = {
+                "g0-s0": {"i1": 0.1, "i2": 0.1},
+                "g1-s1": {"i1": 0.9, "i2": 0.1},
+                "g2-s1": {"i1": 0.2, "i2": 0.95},
+            }[candidate.id]
+            return make_eval_result(candidate.id, scores)
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = make_config(
+            max_generations=2, max_evaluations=10000, frontier_type="instance",
+        )
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert set(result.non_dominated_ids) == {"g1-s1", "g2-s1"}
+        # ``non_dominated_ids`` is sorted for stability.
+        assert result.non_dominated_ids == sorted(result.non_dominated_ids)
+        flagged = {s.id for s in result.candidate_summaries if s.is_non_dominated}
+        assert flagged == {"g1-s1", "g2-s1"}
+
+    def test_helix_result_to_dict_round_trips_through_json(
+        self, mocker, tmp_path, all_mocks,
+    ):
+        """``HelixResult.to_dict()`` must be JSON-serialisable end to end.
+
+        Catches any field that sneaks in a non-JSON-native type (enums,
+        Path, BudgetState dataclass, etc.) — the asdict() call on
+        ``budget`` is the specific failure mode we want to lock in.
+        """
+        seed = make_candidate("g0-s0")
+        child = make_candidate("g1-s1", generation=1)
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            if candidate.id == "g1-s1":
+                return make_eval_result("g1-s1", {"i1": 0.9, "i2": 0.9})
+            return make_eval_result(candidate.id, {"i1": 0.3, "i2": 0.3})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = make_config(
+            max_generations=1, max_evaluations=10000, frontier_type="instance",
+        )
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        payload = result.to_dict()
+        # Must round-trip cleanly — asdict(budget) is the load-bearing piece.
+        rendered = json.loads(json.dumps(payload))
+        assert rendered["best_candidate_id"] == "g1-s1"
+        assert rendered["frontier_type"] == "instance"
+        assert rendered["budget"]["evaluations"] == result.budget.evaluations
+        assert rendered["budget"]["input_tokens"] == result.budget.input_tokens
+        assert rendered["budget"]["output_tokens"] == result.budget.output_tokens
+        assert rendered["budget"]["cost_usd"] == result.budget.cost_usd
+
+    def test_helix_result_records_merge_parents(self, mocker, tmp_path, all_mocks):
+        """A merged candidate's summary surfaces both parents in lineage order.
+
+        Mirrors :class:`TestMergeBehavior` setup so a merge actually
+        fires, then asserts the resulting :class:`HelixResult` exposes
+        ``parents`` of length 2 for the merged candidate — exercising
+        the multi-parent branch of ``_build_helix_result`` that single-
+        parent mutations cannot reach.
+        """
+        seed = make_candidate("g0-s0")
+        child = Candidate(
+            id="g1-s1",
+            worktree_path="/tmp/helix/g1-s1",
+            branch_name="helix/g1-s1",
+            generation=1,
+            parent_id=seed.id,
+            parent_ids=[seed.id],
+            operation="mutate",
+        )
+        merged = Candidate(
+            id="g2-m1",
+            worktree_path="/tmp/helix/g2-m1",
+            branch_name="helix/g2-m1",
+            generation=2,
+            parent_id=seed.id,
+            parent_ids=[seed.id, child.id],
+            operation="merge",
+        )
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+        all_mocks["merge"].return_value = merged
+        all_mocks["find_merge_triplet"].return_value = ("g0-s0", "g1-s1", "g0-s0")
+        # Static lineage seen by ``_build_helix_result`` at end-of-run.
+        all_mocks["load_lineage"].return_value = {
+            "g0-s0": LineageEntry(
+                id="g0-s0", parent=None, parents=[], operation="seed",
+                generation=0, files_changed=[],
+            ),
+            "g1-s1": LineageEntry(
+                id="g1-s1", parent="g0-s0", parents=["g0-s0"],
+                operation="mutate", generation=1, files_changed=["solve.py"],
+            ),
+            "g2-m1": LineageEntry(
+                id="g2-m1", parent="g0-s0", parents=["g0-s0", "g1-s1"],
+                operation="merge", generation=2, files_changed=["solve.py"],
+            ),
+        }
+
+        def run_eval(candidate, config, split=None, instance_ids=None, **kwargs):
+            # Complementary parent scores so both are non-dominated and
+            # eligible for merge.  Merged subsample sum (1.5) >= max
+            # parent subsample sum (1.4), so the merge is accepted.
+            scores_by_id = {
+                "g0-s0": {"1": 0.5, "2": 0.8},
+                "g1-s1": {"1": 0.9, "2": 0.5},
+                "g2-m1": {"1": 0.9, "2": 0.6},
+            }
+            scores = scores_by_id[candidate.id]
+            if instance_ids is not None:
+                scores = {k: scores.get(k, 0.0) for k in instance_ids}
+            return make_eval_result(candidate.id, scores)
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = make_config(
+            max_generations=2,
+            merge_enabled=True,
+            max_merge_invocations=5,
+            merge_val_overlap_floor=1,
+            max_evaluations=10000,
+            frontier_type="instance",
+        )
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert "g2-m1" in result.parents, "merged candidate missing from result"
+        assert result.parents["g2-m1"] == ["g0-s0", "g1-s1"]
+        merged_summary = next(
+            s for s in result.candidate_summaries if s.id == "g2-m1"
+        )
+        assert merged_summary.operation == "merge"
+        assert merged_summary.parents == ["g0-s0", "g1-s1"]
 
 
 # ---------------------------------------------------------------------------
@@ -1804,7 +1972,7 @@ def test_sandboxed_run_starts_evaluator_sidecar(tmp_path: Path, all_mocks):
             evaluator=True,
             extra_hosts={"evaluator-endpoint": "10.0.0.1"},
         ),
-        evolution=EvolutionConfig(max_generations=0, frontier_type="instance"),
+        evolution=EvolutionConfig(max_generations=0),
     )
 
     run_evolution(config, tmp_path, tmp_path / ".helix")

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -768,6 +768,128 @@ class TestGatingInEvolutionLoop:
         assert merged_summary.operation == "merge"
         assert merged_summary.parents == ["g0-s0", "g1-s1"]
 
+    def test_helix_result_is_frozen(self, mocker, tmp_path, all_mocks):
+        """``HelixResult`` blocks attribute reassignment (GEPA parity).
+
+        :class:`gepa.core.result.GEPAResult` uses
+        ``@dataclass(frozen=True)`` to make the snapshot immutable at
+        the top level.  Confirm HELIX matches: reassigning any field
+        raises :class:`dataclasses.FrozenInstanceError`.
+        """
+        from dataclasses import FrozenInstanceError
+
+        seed = make_candidate("g0-s0")
+        child = make_candidate("g1-s1", generation=1)
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            return make_eval_result(
+                candidate.id,
+                {"i1": 0.9, "i2": 0.9} if candidate.id == "g1-s1" else {"i1": 0.3, "i2": 0.3},
+            )
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        config = make_config(
+            max_generations=1, max_evaluations=10000, frontier_type="instance",
+        )
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        with pytest.raises(FrozenInstanceError):
+            result.seed = 99
+        with pytest.raises(FrozenInstanceError):
+            result.run_dir = "/elsewhere"
+
+    def test_helix_result_budget_does_not_alias_state(
+        self, mocker, tmp_path, all_mocks,
+    ):
+        """``_build_helix_result`` must shallow-copy ``state.budget``.
+
+        Regression for the construction-site aliasing bug: previously
+        ``budget=state.budget`` shared the same ``BudgetState`` instance
+        with the live :class:`EvolutionState`.  Mutating the live state
+        after the run returned would silently update the snapshot.
+        Now ``budget=replace(state.budget)`` decouples them — same
+        discipline as
+        :meth:`gepa.core.result.GEPAResult.from_state`.
+
+        We can't easily reach the live state object after
+        ``run_evolution`` returns (it's local to the impl), so instead
+        verify the structural property: ``result.budget`` is a
+        :class:`BudgetState` and mutating an arbitrary
+        :class:`BudgetState` cannot affect the snapshot.
+        """
+        seed = make_candidate("g0-s0")
+        child = make_candidate("g1-s1", generation=1)
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+        all_mocks["run_evaluator"].side_effect = lambda candidate, *a, **kw: (
+            make_eval_result(candidate.id, {"i1": 0.9, "i2": 0.9})
+            if candidate.id == "g1-s1"
+            else make_eval_result(candidate.id, {"i1": 0.3, "i2": 0.3})
+        )
+
+        config = make_config(
+            max_generations=1, max_evaluations=10000, frontier_type="instance",
+        )
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        snapshot_evals = result.budget.evaluations
+        # Construct a fresh ``BudgetState`` with a sentinel value and
+        # confirm the snapshot doesn't share storage with anything.
+        scratch = BudgetState(evaluations=10**9)
+        assert result.budget is not scratch
+        assert result.budget.evaluations == snapshot_evals
+        # The snapshot is itself frozen-by-convention via the ``HelixResult``
+        # ``frozen=True`` wrapper — reassigning ``result.budget`` raises.
+        from dataclasses import FrozenInstanceError
+        with pytest.raises(FrozenInstanceError):
+            result.budget = scratch
+
+    def test_helix_result_score_views_recompute_from_summaries(
+        self, mocker, tmp_path, all_mocks,
+    ):
+        """Score-view properties must recompute from ``candidate_summaries``.
+
+        Previously these were ``@cached_property`` and could go stale
+        if anyone mutated ``candidate_summaries`` after first access.
+        With plain ``@property`` (GEPA parity — every ``GEPAResult``
+        property recomputes), there is no cache and the views always
+        reflect the canonical list.
+        """
+        seed = make_candidate("g0-s0")
+        child = make_candidate("g1-s1", generation=1)
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+        all_mocks["run_evaluator"].side_effect = lambda candidate, *a, **kw: (
+            make_eval_result(candidate.id, {"i1": 0.9, "i2": 0.9})
+            if candidate.id == "g1-s1"
+            else make_eval_result(candidate.id, {"i1": 0.3, "i2": 0.3})
+        )
+
+        config = make_config(
+            max_generations=1, max_evaluations=10000, frontier_type="instance",
+        )
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        # First access materializes the view.
+        first = result.aggregate_scores
+        assert "g1-s1" in first
+        # Mutate ``candidate_summaries`` in place — the dataclass is
+        # frozen at the top level but list contents are not.  A fresh
+        # property read MUST reflect the change (no stale cache).
+        original_summaries = list(result.candidate_summaries)
+        result.candidate_summaries.clear()
+        try:
+            assert result.aggregate_scores == {}
+            assert result.sum_scores == {}
+            assert result.parents == {}
+        finally:
+            # Restore for any later assertions / cleanup.
+            result.candidate_summaries.extend(original_summaries)
+        # After restore the view recomputes back to the original.
+        assert result.aggregate_scores == first
+
 
 def _filter_charge_calls(spy, *, source: str, candidate_id: str) -> list:
     """Return the spy invocations whose kwargs match (source, candidate_id)."""

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -575,6 +575,7 @@ class TestGatingInEvolutionLoop:
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
         assert isinstance(result, HelixResult)
+        assert result.id == "g1-s1"
         assert result.best_candidate.id == "g1-s1"
         assert result.best_candidate is child
         assert result.best_result is not None
@@ -665,6 +666,7 @@ class TestGatingInEvolutionLoop:
         payload = result.to_dict()
         # Must round-trip cleanly — asdict(budget) is the load-bearing piece.
         rendered = json.loads(json.dumps(payload))
+        assert result.id == rendered["best_candidate_id"]
         assert rendered["best_candidate_id"] == "g1-s1"
         assert rendered["frontier_type"] == "instance"
         assert rendered["budget"]["evaluations"] == result.budget.evaluations

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -36,7 +36,7 @@ from helix.evolution import (
     run_evolution,
 )
 from helix.lineage import LineageEntry
-from helix.population import Candidate, EvalResult
+from helix.population import Candidate, EvalResult, HelixResult
 from helix.state import BudgetState, EvolutionState
 
 
@@ -93,6 +93,7 @@ def make_config(
             max_merge_invocations=max_merge_invocations,
             merge_val_overlap_floor=merge_val_overlap_floor,
             merge_subsample_size=merge_subsample_size,
+            frontier_type="instance",
         ),
         worktree=WorktreeConfig(cleanup_dominated=cleanup_dominated),
     )
@@ -511,6 +512,79 @@ class TestGatingInEvolutionLoop:
         )
         best = run_evolution(config, tmp_path, tmp_path / ".helix")
         assert best.id == "g1-s1"
+
+    def test_returns_structured_helix_result(self, mocker, tmp_path, all_mocks):
+        """run_evolution exposes GEPA-style structured result metadata."""
+        seed = make_candidate("g0-s0")
+        child = Candidate(
+            id="g1-s1",
+            worktree_path="/tmp/helix/g1-s1",
+            branch_name="helix/g1-s1",
+            generation=1,
+            parent_id=seed.id,
+            parent_ids=[seed.id],
+            operation="mutate",
+            usage={"input_tokens": 7, "output_tokens": 3, "cost_usd": 0.01},
+        )
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+        all_mocks["load_lineage"].return_value = {
+            "g0-s0": LineageEntry(
+                id="g0-s0",
+                parent=None,
+                parents=[],
+                operation="seed",
+                generation=0,
+                files_changed=[],
+            ),
+            "g1-s1": LineageEntry(
+                id="g1-s1",
+                parent="g0-s0",
+                parents=["g0-s0"],
+                operation="mutate",
+                generation=1,
+                files_changed=["solve.py"],
+            ),
+        }
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            if candidate.id == "g1-s1":
+                return EvalResult(
+                    candidate_id="g1-s1",
+                    scores={"accuracy": 0.9},
+                    asi={},
+                    instance_scores={"i1": 0.8, "i2": 1.0},
+                    objective_scores=[{"quality": 0.7}, {"quality": 0.9}],
+                )
+            return make_eval_result(candidate.id, {"i1": 0.2, "i2": 0.4})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = make_config(max_generations=1, max_evaluations=10000)
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert isinstance(result, HelixResult)
+        assert result.id == "g1-s1"
+        assert result.best_candidate is child
+        assert result.best_result is not None
+        assert result.best_result.scores == {"accuracy": 0.9}
+        assert result.parents["g1-s1"] == ["g0-s0"]
+        assert result.aggregate_scores["g1-s1"] == pytest.approx(0.9)
+        assert result.sum_scores["g1-s1"] == pytest.approx(1.8)
+        assert result.instance_scores["g1-s1"] == {"i1": 0.8, "i2": 1.0}
+        assert result.objective_scores["g1-s1"] == [
+            {"quality": 0.7},
+            {"quality": 0.9},
+        ]
+        assert result.frontier_ids == ["g0-s0", "g1-s1"]
+        assert set(result.non_dominated_ids) == {"g1-s1"}
+        assert result.frontier_type == "instance"
+        assert result.discovery_counts == {"g0-s0": 1, "g1-s1": 3}
+        assert result.budget.evaluations == 3
+        assert result.run_dir == str(tmp_path / ".helix")
+        assert result.seed == config.rng_seed
+        assert result.config_hash
+        assert result.candidate_summaries[-1].to_dict()["parents"] == ["g0-s0"]
 
 
 # ---------------------------------------------------------------------------
@@ -1730,7 +1804,7 @@ def test_sandboxed_run_starts_evaluator_sidecar(tmp_path: Path, all_mocks):
             evaluator=True,
             extra_hosts={"evaluator-endpoint": "10.0.0.1"},
         ),
-        evolution=EvolutionConfig(max_generations=0),
+        evolution=EvolutionConfig(max_generations=0, frontier_type="instance"),
     )
 
     run_evolution(config, tmp_path, tmp_path / ".helix")


### PR DESCRIPTION
## Summary
- Adds CandidateSummary and HelixResult programmatic result types.
- Changes run_evolution to return structured metadata instead of only the best Candidate.
- Exposes best candidate/result, candidate summaries, parents, scores, fronts, budgets, discovery counts, run dir, seed, and config hash.
- Keeps a compatibility id alias for callers that previously used best.id.

## Validation
- ruff, mypy, targeted evolution pytest, and full pytest passed in worker verification.
- Full pytest result reported by worker: 684 passed.
- Unrelated local worktree edits were preserved unstaged.