### PR TITLE
Enforce upstream reference frontier and acceptance semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validation errors, pointing users at likely typos or misplaced keys.
 
 ### Changed
+- **BREAKING**: `score_parser = "helix_result"` now rejects malformed
+  `side_info["scores"]` payloads instead of silently dropping fields.
+  Non-dict `"scores"` values, non-string objective names, and non-finite
+  / non-numeric objective values now raise `EvaluatorError` at parse
+  time.  Previously these were dropped (with a logged warning at most),
+  which let evaluators stuff arbitrary diagnostics under `"scores"` —
+  including pairwise / Bradley-Terry payloads — and then misread the
+  result as scalar objective semantics.  Pairwise / BT payloads are
+  not implemented in HELIX yet; emit them under a different
+  `side_info` key.  Migration: ensure `side_info["scores"]` is a
+  `dict[str, float|int|bool]` with finite numeric values, or omit the
+  key entirely.
+- **BREAKING**: Non-`"instance"` `evolution.frontier_type` values now
+  fail loudly when an `EvalResult` lacks per-example `objective_scores`,
+  has length-mismatched `objective_scores`, or has all-empty objective
+  slots.  `ParetoFrontier.add()` raises the new
+  `MissingObjectiveScoresError` instead of silently degenerating to
+  scalar / instance-axis behaviour.  `select_parent()` likewise raises
+  rather than falling back to all-candidate sampling on objective-bearing
+  modes.  The `"instance"` path keeps its existing fallback semantics.
 - **BREAKING**: `score_parser = "helix_result"` now takes a **per-example**
   `HELIX_RESULT=[[score_0, side_info_0], [score_1, side_info_1], ...]`
   payload — one `[score, side_info]` pair per id in `helix_batch.json`.

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -95,8 +95,8 @@ class EvaluatorConfig(BaseModel):
     ``"json_score"``) aggregate to a single score and do NOT produce
     id-keyed per-instance scores; combining them with ``instance_ids``
     triggers the zero-fill warning in :mod:`helix.executor`.  They also
-    leave ``objective_scores`` empty, so the multi-axis frontier
-    degenerates to the instance path when they're selected.
+    leave ``objective_scores`` empty, so ``frontier_type`` values other
+    than ``"instance"`` fail loudly when selected with these parsers.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -410,8 +410,8 @@ class EvolutionConfig(BaseModel):
             "only the Pareto retention / parent-selection decision is "
             "multi-axis.  Non-``instance`` paths require ``helix_result`` "
             'to emit per-example ``side_info["scores"]`` dicts — without '
-            "them the objective / cartesian frontiers stay empty and "
-            "behaviour degenerates to the instance path."
+            "them the objective / cartesian frontiers raise instead of "
+            "falling back to scalar semantics."
         ),
     )
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1058,6 +1058,11 @@ def _run_evolution_impl(
         if minibatch_cache is not None:
             save_eval_cache(minibatch_cache._cache, project_root)
 
+    def _sync_frontier_state() -> None:
+        assert state is not None
+        state.frontier = list(frontier._candidates.keys())
+        state.active_frontier = frontier.active_frontier_snapshot()
+
     if state is None:
         state = EvolutionState(
             generation=0,
@@ -1102,6 +1107,7 @@ def _run_evolution_impl(
                 )
                 candidates[cid] = cand
                 frontier.add(cand, result)
+        _sync_frontier_state()
 
     # ------------------------------------------------------------------
     # Seed evaluation
@@ -1196,7 +1202,7 @@ def _run_evolution_impl(
 
         _save_evaluation(base_dir, seed_result)
         frontier.add(seed, seed_result)
-        state.frontier = list(frontier._candidates.keys())
+        _sync_frontier_state()
         state.instance_scores[seed.id] = seed_result.instance_scores
         # GEPA parity (audit-rng-state-persist C/§3): record per-program
         # discovery budget at the moment the program enters the frontier.
@@ -1644,7 +1650,7 @@ def _run_evolution_impl(
                                 merges_due -= 1
                                 state.total_merge_invocations += 1
                                 frontier.add(merged, full_val_result)
-                                state.frontier = list(frontier._candidates.keys())
+                                _sync_frontier_state()
                                 state.instance_scores[merged.id] = (
                                     full_val_result.instance_scores
                                 )
@@ -2377,7 +2383,7 @@ def _run_evolution_impl(
                 set_phase(HelixPhase.PARETO_UPDATE)
                 _save_evaluation(base_dir, val_result)
                 frontier.add(child, val_result)
-                state.frontier = list(frontier._candidates.keys())
+                _sync_frontier_state()
                 state.instance_scores[child.id] = val_result.instance_scores
                 # GEPA parity (audit-rng-state-persist C/§3): record per-program
                 # discovery budget at the moment the child enters the frontier.

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1060,7 +1060,7 @@ def _run_evolution_impl(
 
     def _sync_frontier_state() -> None:
         assert state is not None
-        state.frontier = list(frontier._candidates.keys())
+        state.frontier = frontier.candidate_ids()
         state.active_frontier = frontier.active_frontier_snapshot()
 
     if state is None:

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -147,6 +147,25 @@ def _harvest_objective_scores(side_info: dict[str, Any]) -> dict[str, float]:
     not implemented in HELIX yet, so non-scalar objective values fail
     loudly instead of being dropped and misread as scalar objective
     semantics.
+
+    Stricter than upstream GEPA (a very minor improvement)
+    ------------------------------------------------------
+    GEPA's adapter does ``objective_score.update(side_info["scores"])``
+    blindly, so non-finite / non-numeric / non-string-keyed entries
+    sail through the parser and only blow up later inside
+    ``_aggregate_objective_scores`` (``state.py:432``) where the error
+    message is far less actionable.  HELIX validates at parse time and
+    raises :class:`EvaluatorError` with the offending key/value type.
+    Practical consequence: an evaluator built against upstream GEPA
+    that legitimately emits finite numeric scalars under ``"scores"``
+    is unaffected; only payloads that would break GEPA later are
+    rejected here earlier.
+
+    Per-predictor namespacing (``param_name + "_specific_info"``,
+    ``optimize_anything_adapter.py:266-270``) is intentionally not
+    replicated: HELIX evolves whole git worktrees rather than
+    multi-component named-predictor programs.  See the tracking issue
+    on ``KE7/helix`` for the architectural gap.
     """
     raw = side_info.get("scores")
     if raw is None:

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -143,24 +143,40 @@ def _harvest_objective_scores(side_info: dict[str, Any]) -> dict[str, float]:
     (``optimize_anything_adapter.py:260-272``): the reserved
     ``"scores"`` key carries a dict of ``{objective_name: float}`` that
     becomes the per-example ``objective_scores`` slot feeding the
-    multi-axis Pareto frontier.  Non-dict values and non-numeric /
-    non-finite entries are silently dropped so evaluators can stuff
-    arbitrary diagnostics under ``"scores"`` without the parser
-    rejecting well-formed payloads elsewhere (the primary per-example
-    score is what the minibatch gate depends on; the objective axis
-    is best-effort).
+    multi-axis Pareto frontier.  Pairwise / Bradley-Terry payloads are
+    not implemented in HELIX yet, so non-scalar objective values fail
+    loudly instead of being dropped and misread as scalar objective
+    semantics.
     """
     raw = side_info.get("scores")
-    if not isinstance(raw, dict):
+    if raw is None:
         return {}
+    if not isinstance(raw, dict):
+        raise EvaluatorError(
+            'helix_result side_info["scores"] must be a dict of '
+            "{objective_name: numeric_score}; pairwise/Bradley-Terry "
+            "objective payloads are not supported.",
+            operation="parse_helix_result",
+        )
     out: dict[str, float] = {}
     for k, v in raw.items():
         if not isinstance(k, str):
-            continue
+            raise EvaluatorError(
+                'helix_result side_info["scores"] objective names must be strings; '
+                f"got {type(k).__name__}.",
+                operation="parse_helix_result",
+            )
         if isinstance(v, bool):
             out[k] = 1.0 if v else 0.0
         elif isinstance(v, (int, float)) and math.isfinite(float(v)):
             out[k] = float(v)
+        else:
+            raise EvaluatorError(
+                'helix_result side_info["scores"] values must be finite numeric '
+                f"scalars; objective {k!r} had {type(v).__name__}. "
+                "Pairwise/Bradley-Terry objective payloads are not supported.",
+                operation="parse_helix_result",
+            )
     return out
 
 

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -460,7 +460,35 @@ class ParetoFrontier:
         self._update_cartesian(candidate.id, result)
 
     def _validate_objective_scores(self, cid: str, result: EvalResult) -> None:
-        """Reject non-instance frontier modes with no usable objective axes."""
+        """Reject non-instance frontier modes with no usable objective axes.
+
+        Mirrors GEPA's seed-time check at ``state.py:213-219`` and the
+        per-update check at ``state.py:564-569`` (both raise plain
+        ``ValueError`` when ``valset_evaluation.objective_scores_by_val_id``
+        is missing/empty).  HELIX raises a typed
+        :class:`MissingObjectiveScoresError(ValueError)` for catchability
+        and, in two narrow places, is *very slightly* stricter than
+        upstream GEPA (both are minor improvements that should never
+        trigger for a well-formed evaluator):
+
+        * **Length parity with ``instance_scores``.** GEPA stores
+          objective scores as ``dict[val_id, ObjectiveScores]`` keyed
+          parallel to ``scores_by_val_id``, so the cardinality match is
+          a structural impossibility.  HELIX uses a *positional* list
+          against ``instance_scores.keys()`` order, so the length check
+          here is the necessary structural guard — not a real
+          divergence, just the correct invariant for a list-shaped
+          field.
+        * **All-empty inner slots.**  GEPA tolerates the case where
+          every per-val_id objective dict is ``{}`` (its
+          ``_update_objective_pareto_front`` has ``if not
+          objective_scores: return``).  HELIX rejects it: a candidate
+          with literally zero objective signal cannot contribute to any
+          objective frontier, and failing here surfaces the empty-axis
+          condition with a per-candidate error message rather than as a
+          downstream "empty active frontier" raise three call sites
+          later.
+        """
         if self._frontier_type == "instance":
             return
         if result.objective_scores is None:

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -17,7 +17,15 @@ FrontierType = Literal["instance", "objective", "hybrid", "cartesian"]
 
 
 class MissingObjectiveScoresError(ValueError):
-    """Raised when an objective-bearing frontier mode lacks objective scores."""
+    """Raised by ``ParetoFrontier`` when an objective-bearing frontier mode
+    cannot consume the supplied ``EvalResult.objective_scores``.
+
+    Covers all "the objective axis is unusable" shapes — absent
+    (``None``), length-mismatched against ``instance_scores``, all-empty
+    slots, or no active per-key entries left at parent-selection time.
+    Subclassing :class:`ValueError` keeps callers that catch ``ValueError``
+    working unchanged.
+    """
 
 
 @dataclass
@@ -278,6 +286,10 @@ class ParetoFrontier:
         in any per-example slot, take the mean of that objective's
         scores across the entire ``objective_scores`` list.
         """
+        # Early-return covers the ``frontier_type == "instance"`` path,
+        # where objective_scores is intentionally optional.  Objective-
+        # bearing modes never reach here with a missing/empty list
+        # because ``_validate_objective_scores`` rejects them first.
         if result.objective_scores is None or not result.objective_scores:
             return
         aggregated: dict[str, list[float]] = {}
@@ -312,6 +324,13 @@ class ParetoFrontier:
         # is positional to the same id list.  Zip together.
         val_ids = list(result.instance_scores.keys())
         if len(val_ids) != len(result.objective_scores):
+            # Defense-in-depth: ``add()`` already calls
+            # ``_validate_objective_scores`` which rejects this same
+            # mismatch up front, so on the normal path this branch is
+            # unreachable.  It still fires from ``_rebuild_axes`` after
+            # ``update_scores`` if a caller swapped in a malformed
+            # ``EvalResult`` — keep the raise so the invariant survives
+            # both entry points.
             raise MissingObjectiveScoresError(
                 f"cartesian frontier requires objective_scores length to match "
                 f"instance_scores for candidate {cid!r} "
@@ -329,8 +348,18 @@ class ParetoFrontier:
 
     def update_scores(self, result: EvalResult) -> None:
         """Update the evaluation result for an existing candidate and rebuild tracking."""
+        self._validate_objective_scores(result.candidate_id, result)
         self._results[result.candidate_id] = result
         self._rebuild_axes()
+
+    def candidate_ids(self) -> list[str]:
+        """Return all evaluated candidate ids in insertion order.
+
+        Stable, JSON-serializable view used by callers (e.g.
+        ``evolution._sync_frontier_state``) that need to mirror the
+        append-only candidate set without reaching into ``_candidates``.
+        """
+        return list(self._candidates.keys())
 
     def _rebuild_axes(self) -> None:
         """Rebuild all per-axis best tracking from scratch.

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -8,16 +8,16 @@ from __future__ import annotations
 
 import hashlib
 import json
-import logging
 import random
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 
-logger = logging.getLogger(__name__)
-
-
 FrontierType = Literal["instance", "objective", "hybrid", "cartesian"]
+
+
+class MissingObjectiveScoresError(ValueError):
+    """Raised when an objective-bearing frontier mode lacks objective scores."""
 
 
 @dataclass
@@ -222,6 +222,7 @@ class ParetoFrontier:
 
     def add(self, candidate: Candidate, result: EvalResult) -> None:
         """Add a candidate and its evaluation result.  Population is append-only."""
+        self._validate_objective_scores(candidate.id, result)
         self._candidates[candidate.id] = candidate
         self._results[candidate.id] = result
         self._update_per_key(candidate.id, result)
@@ -230,6 +231,29 @@ class ParetoFrontier:
         # lets a caller inspect any axis post-hoc.
         self._update_objective(candidate.id, result)
         self._update_cartesian(candidate.id, result)
+
+    def _validate_objective_scores(self, cid: str, result: EvalResult) -> None:
+        """Reject non-instance frontier modes with no usable objective axes."""
+        if self._frontier_type == "instance":
+            return
+        if result.objective_scores is None:
+            raise MissingObjectiveScoresError(
+                f"frontier_type={self._frontier_type!r} requires per-example "
+                f"objective_scores for candidate {cid!r}; use the helix_result "
+                'parser and emit side_info["scores"] for each example.'
+            )
+        if len(result.objective_scores) != len(result.instance_scores):
+            raise MissingObjectiveScoresError(
+                f"frontier_type={self._frontier_type!r} requires objective_scores "
+                f"length to match instance_scores for candidate {cid!r} "
+                f"({len(result.objective_scores)} != {len(result.instance_scores)})."
+            )
+        if not any(slot for slot in result.objective_scores):
+            raise MissingObjectiveScoresError(
+                f"frontier_type={self._frontier_type!r} requires at least one "
+                f"objective score for candidate {cid!r}; all objective_scores "
+                "slots were empty."
+            )
 
     def _update_per_key(self, cid: str, result: EvalResult) -> None:
         """Incrementally update per-key best tracking for a single candidate.
@@ -288,17 +312,11 @@ class ParetoFrontier:
         # is positional to the same id list.  Zip together.
         val_ids = list(result.instance_scores.keys())
         if len(val_ids) != len(result.objective_scores):
-            # Defensive: skip cartesian updates when lengths disagree
-            # (should not happen on the helix_result path but could on
-            # hand-constructed EvalResults in tests).  Log at DEBUG so
-            # the skip is traceable without polluting the default log.
-            logger.debug(
-                "ParetoFrontier._update_cartesian: skipping cid=%r — "
-                "objective_scores length %d does not match "
-                "instance_scores length %d",
-                cid, len(result.objective_scores), len(val_ids),
+            raise MissingObjectiveScoresError(
+                f"cartesian frontier requires objective_scores length to match "
+                f"instance_scores for candidate {cid!r} "
+                f"({len(result.objective_scores)} != {len(val_ids)})."
             )
-            return
         for val_id, slot in zip(val_ids, result.objective_scores):
             for obj_name, score in slot.items():
                 key = f"{val_id}::{obj_name}"
@@ -363,6 +381,13 @@ class ParetoFrontier:
         for k, v in self._objective_best.items():
             merged[f"obj::{k}"] = v
         return merged
+
+    def active_frontier_snapshot(self) -> dict[str, list[str]]:
+        """Return a JSON-ready copy of the active fronts by frontier key."""
+        return {
+            key: sorted(front)
+            for key, front in sorted(self._active_frontier().items())
+        }
 
     # ------------------------------------------------------------------
     # GEPA coverage-based dominance
@@ -528,11 +553,16 @@ class ParetoFrontier:
             cid for cid, freq in program_frequency.items() for _ in range(freq)
         ]
 
-        # GEPA-parity fix for score-only evaluators: if no instance scores
-        # were recorded (e.g. evaluator uses aggregate scores only), the cleaned
-        # per-key frontier is empty and sampling_list would be empty.  Fall back
-        # to selecting uniformly from all candidates so evolution can continue.
+        # Instance mode keeps HELIX's score-only fallback.  Objective-bearing
+        # modes validate objective_scores at add/update time, so an empty
+        # active frontier there is a state invariant failure rather than a
+        # reason to silently use scalar/all-candidate semantics.
         if not sampling_list:
+            if self._frontier_type != "instance":
+                raise MissingObjectiveScoresError(
+                    f"frontier_type={self._frontier_type!r} has no active "
+                    "objective frontier entries; cannot select a parent."
+                )
             sampling_list = list(self._candidates.keys())
         return self._candidates[self._rng.choice(sampling_list)]
 

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -16,9 +16,9 @@ from helix.population import FrontierType
 # GEPA parity (audit-rng-state-persist D1):
 # GEPA core/state.py:153 declares ``_VALIDATION_SCHEMA_VERSION: ClassVar[int] = 5``
 # and migrates older state dicts on load (state.py:355-376).  HELIX previously
-# had no schema version on ``state.json``; bumping to 1 marks the first
-# versioned schema (the unversioned predecessor is treated as v0 on load).
-SCHEMA_VERSION: int = 1
+# had no schema version on ``state.json``; newer bumps mark explicit
+# JSON-native schema additions.
+SCHEMA_VERSION: int = 2
 
 
 @dataclass
@@ -100,6 +100,11 @@ class EvolutionState:
     # the frontier.  Empty by default; populated at every accept site (seed,
     # mutation, merge) in evolution.py.
     num_metric_calls_by_discovery: dict[str, int] = field(default_factory=dict)
+    # Active Pareto-front snapshot for the selected ``frontier_type``.
+    # ``frontier`` remains HELIX's append-only candidate id list; this
+    # separate JSON-native field makes the retained fronts visible without
+    # conflating them with all evaluated candidates.
+    active_frontier: dict[str, list[str]] = field(default_factory=dict)
     # Persisted ``evolution.frontier_type`` (GEPA ``FrontierType`` parity
     # — ``src/gepa/core/state.py:22-23``).  Captured at evolve-time so
     # read-only CLI commands (``helix frontier``, ``helix best``,
@@ -157,6 +162,7 @@ def save_state(state: EvolutionState, base_dir: Path) -> None:
         "merge_description_triplets": state.merge_description_triplets,
         "i": state.i,
         "num_metric_calls_by_discovery": state.num_metric_calls_by_discovery,
+        "active_frontier": state.active_frontier,
         "frontier_type": state.frontier_type,
     }
 
@@ -227,6 +233,7 @@ def load_state(base_dir: Path) -> EvolutionState | None:
         merge_description_triplets=data.get("merge_description_triplets", []),
         i=data.get("i", -1),
         num_metric_calls_by_discovery=data.get("num_metric_calls_by_discovery", {}),
+        active_frontier=data.get("active_frontier", {}),
         frontier_type=frontier_type,
         schema_version=SCHEMA_VERSION,
     )

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -1731,8 +1731,8 @@ def test_sandboxed_run_starts_evaluator_sidecar(tmp_path: Path, all_mocks):
             evaluator=True,
             extra_hosts={"evaluator-endpoint": "10.0.0.1"},
         ),
-            evolution=EvolutionConfig(max_generations=0, frontier_type="instance"),
-        )
+        evolution=EvolutionConfig(max_generations=0, frontier_type="instance"),
+    )
 
     run_evolution(config, tmp_path, tmp_path / ".helix")
 
@@ -1742,3 +1742,67 @@ def test_sandboxed_run_starts_evaluator_sidecar(tmp_path: Path, all_mocks):
         fixed_env=config.env,
         extra_hosts=config.sandbox.extra_hosts,
     )
+
+
+# ---------------------------------------------------------------------------
+# run_evolution — active_frontier sync on multi-axis frontier_type
+# ---------------------------------------------------------------------------
+
+
+class TestActiveFrontierSyncOnObjectiveMode:
+    """Regression: ``state.active_frontier`` must be kept in lock-step with
+    ``ParetoFrontier.active_frontier_snapshot()`` at every accept site
+    (init, seed, mutation, merge) when ``frontier_type != "instance"``.
+
+    Without this sync, resume on a multi-axis run would lose the
+    retained Pareto front.  The four touch points
+    (``_sync_frontier_state`` calls) are inspected indirectly by
+    asserting on the ``EvolutionState`` passed into ``save_state`` after
+    a minimal seed-only run.
+    """
+
+    def test_seed_acceptance_populates_active_frontier_for_objective_mode(
+        self, mocker, tmp_path, all_mocks
+    ):
+        seed = make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            # Per-example objective_scores positional to instance_scores order.
+            return EvalResult(
+                candidate_id=candidate.id,
+                scores={},
+                asi={},
+                instance_scores={"i1": 0.5, "i2": 0.6},
+                objective_scores=[{"quality": 0.7}, {"quality": 0.9}],
+            )
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = HelixConfig(
+            objective="Improve the code",
+            evaluator=EvaluatorConfig(command="pytest -q"),
+            dataset=DatasetConfig(),
+            evolution=EvolutionConfig(
+                max_generations=0,
+                max_evaluations=10,
+                perfect_score_threshold=None,
+                frontier_type="objective",
+            ),
+            worktree=WorktreeConfig(),
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        save_calls = all_mocks["save_state"].call_args_list
+        assert save_calls, "save_state should have been invoked at least once"
+        last_state = save_calls[-1].args[0]
+
+        # Objective-mode active_frontier keys are bare objective names
+        # (no inst:: / obj:: prefix — that prefixing only happens on the
+        # hybrid path).  Mean across the two example slots is 0.8.
+        assert last_state.active_frontier == {"quality": ["g0-s0"]}, (
+            "active_frontier must be populated after seed acceptance "
+            "in objective frontier mode"
+        )
+        # And the append-only candidate list is in lock-step.
+        assert last_state.frontier == ["g0-s0"]

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -93,6 +93,7 @@ def make_config(
             max_merge_invocations=max_merge_invocations,
             merge_val_overlap_floor=merge_val_overlap_floor,
             merge_subsample_size=merge_subsample_size,
+            frontier_type="instance",
         ),
         worktree=WorktreeConfig(cleanup_dominated=cleanup_dominated),
     )
@@ -1730,8 +1731,8 @@ def test_sandboxed_run_starts_evaluator_sidecar(tmp_path: Path, all_mocks):
             evaluator=True,
             extra_hosts={"evaluator-endpoint": "10.0.0.1"},
         ),
-        evolution=EvolutionConfig(max_generations=0),
-    )
+            evolution=EvolutionConfig(max_generations=0, frontier_type="instance"),
+        )
 
     run_evolution(config, tmp_path, tmp_path / ".helix")
 

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -42,7 +43,7 @@ from helix.evolution import (
 )
 from helix.lineage import LineageEntry
 from helix.mutator import generate_seed as _real_generate_seed
-from helix.population import Candidate, EvalResult, HelixResult
+from helix.population import Candidate, EvalResult, HelixResult, ParetoFrontier
 from helix.state import BudgetState, EvolutionState
 
 
@@ -63,17 +64,39 @@ def make_candidate(cid: str = "g0-s0", generation: int = 0) -> Candidate:
     )
 
 
+# Sentinel for ``make_eval_result(objective_scores=...)`` so callers can
+# explicitly pass ``None`` to construct an objectiveless EvalResult (used
+# only by tests that exercise the missing-objectives validation path).
+_DEFAULT_OBJECTIVES: Any = object()
+
+
 def make_eval_result(
     candidate_id: str = "g0-s0",
     instance_scores: dict[str, float] | None = None,
+    objective_scores: list[dict[str, float]] | None = _DEFAULT_OBJECTIVES,
 ) -> EvalResult:
+    """Build an :class:`EvalResult` for evolution unit tests.
+
+    Defaults to a per-example ``objective_scores`` slot list (one
+    ``{"quality": <instance_score>}`` per id) so the result satisfies
+    :meth:`ParetoFrontier._validate_objective_scores` under the
+    GEPA-O.A. default ``frontier_type = "hybrid"``.  Tests that
+    intentionally exercise the missing-objectives path pass
+    ``objective_scores=None`` explicitly.
+    """
     if instance_scores is None:
         instance_scores = {"i1": 0.5, "i2": 0.5}
+    if objective_scores is _DEFAULT_OBJECTIVES:
+        # Caller did not specify — synthesise valid slots.
+        objective_scores = [
+            {"quality": float(score)} for score in instance_scores.values()
+        ]
     return EvalResult(
         candidate_id=candidate_id,
         scores={},
         asi={},
         instance_scores=instance_scores,
+        objective_scores=objective_scores,
     )
 
 
@@ -86,21 +109,18 @@ def make_config(
     max_merge_invocations: int = 5,
     merge_val_overlap_floor: int = 5,
     merge_subsample_size: int = 5,
-    frontier_type: str = "instance",
+    frontier_type: str = "hybrid",
 ) -> HelixConfig:
     """Build a HelixConfig for evolution unit tests.
 
-    ``frontier_type`` defaults to ``"instance"`` (NOT
-    :class:`EvolutionConfig`'s GEPA-O.A. ``"hybrid"`` default).  The
-    bulk of this suite drives ``run_evolution`` against
-    ``make_eval_result`` outputs that carry no per-example
-    ``objective_scores``; under HELIX's stricter
-    ``ParetoFrontier._validate_objective_scores`` such results would
-    correctly raise ``MissingObjectiveScoresError`` on any
-    objective-bearing frontier mode.  Pinning ``"instance"`` here keeps
-    those tests focused on whatever they're actually exercising; tests
-    that want to assert on multi-axis frontier behaviour pass a
-    different value explicitly.
+    ``frontier_type`` defaults to ``"hybrid"`` to match
+    :class:`EvolutionConfig`'s GEPA-O.A. default
+    (``src/gepa/optimize_anything.py:476``).  The companion
+    :func:`make_eval_result` synthesises per-example
+    ``objective_scores`` slots so results pass
+    :meth:`ParetoFrontier._validate_objective_scores` under the default;
+    tests that need a specific frontier dimensionality pass an
+    explicit value.
     """
     evolution_kwargs: dict[str, object] = dict(
         max_generations=max_generations,
@@ -582,9 +602,7 @@ class TestGatingInEvolutionLoop:
 
         all_mocks["run_evaluator"].side_effect = run_eval
 
-        config = make_config(
-            max_generations=1, max_evaluations=10000, frontier_type="instance",
-        )
+        config = make_config(max_generations=1, max_evaluations=10000)
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
         assert isinstance(result, HelixResult)
@@ -603,7 +621,8 @@ class TestGatingInEvolutionLoop:
         ]
         assert result.frontier_ids == ["g0-s0", "g1-s1"]
         assert set(result.non_dominated_ids) == {"g1-s1"}
-        assert result.frontier_type == "instance"
+        # ``make_config`` defaults to GEPA-O.A. ``"hybrid"``.
+        assert result.frontier_type == "hybrid"
         # Counts reflect ``state.budget.evaluations`` at accept time.  The
         # absolute numbers depend on the budget-accounting policy in
         # ``helix.budget`` (see PR #16 / centralized accounting); we lock
@@ -645,9 +664,7 @@ class TestGatingInEvolutionLoop:
 
         all_mocks["run_evaluator"].side_effect = run_eval
 
-        config = make_config(
-            max_generations=2, max_evaluations=10000, frontier_type="instance",
-        )
+        config = make_config(max_generations=2, max_evaluations=10000)
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
         assert set(result.non_dominated_ids) == {"g1-s1", "g2-s1"}
@@ -677,9 +694,7 @@ class TestGatingInEvolutionLoop:
 
         all_mocks["run_evaluator"].side_effect = run_eval
 
-        config = make_config(
-            max_generations=1, max_evaluations=10000, frontier_type="instance",
-        )
+        config = make_config(max_generations=1, max_evaluations=10000)
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
         payload = result.to_dict()
@@ -687,7 +702,8 @@ class TestGatingInEvolutionLoop:
         rendered = json.loads(json.dumps(payload))
         assert result.id == rendered["best_candidate_id"]
         assert rendered["best_candidate_id"] == "g1-s1"
-        assert rendered["frontier_type"] == "instance"
+        # ``make_config`` defaults to GEPA-O.A. ``"hybrid"``.
+        assert rendered["frontier_type"] == "hybrid"
         assert rendered["budget"]["evaluations"] == result.budget.evaluations
         assert rendered["budget"]["input_tokens"] == result.budget.input_tokens
         assert rendered["budget"]["output_tokens"] == result.budget.output_tokens
@@ -763,7 +779,6 @@ class TestGatingInEvolutionLoop:
             max_merge_invocations=5,
             merge_val_overlap_floor=1,
             max_evaluations=10000,
-            frontier_type="instance",
         )
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
@@ -797,9 +812,7 @@ class TestGatingInEvolutionLoop:
             )
 
         all_mocks["run_evaluator"].side_effect = run_eval
-        config = make_config(
-            max_generations=1, max_evaluations=10000, frontier_type="instance",
-        )
+        config = make_config(max_generations=1, max_evaluations=10000)
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
         with pytest.raises(FrozenInstanceError):
@@ -836,9 +849,7 @@ class TestGatingInEvolutionLoop:
             else make_eval_result(candidate.id, {"i1": 0.3, "i2": 0.3})
         )
 
-        config = make_config(
-            max_generations=1, max_evaluations=10000, frontier_type="instance",
-        )
+        config = make_config(max_generations=1, max_evaluations=10000)
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
         snapshot_evals = result.budget.evaluations
@@ -874,9 +885,7 @@ class TestGatingInEvolutionLoop:
             else make_eval_result(candidate.id, {"i1": 0.3, "i2": 0.3})
         )
 
-        config = make_config(
-            max_generations=1, max_evaluations=10000, frontier_type="instance",
-        )
+        config = make_config(max_generations=1, max_evaluations=10000)
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
         # First access materializes the view.
@@ -946,11 +955,6 @@ class TestLlmUsageBudgetIntegration:
                     max_generations=1,
                     max_evaluations=1000,
                     perfect_score_threshold=None,
-                    # Pin instance frontier: this test's EvalResult has
-                    # no per-example objective_scores, so the default
-                    # GEPA-O.A. ``"hybrid"`` frontier would (correctly)
-                    # raise ``MissingObjectiveScoresError``.
-                    frontier_type="instance",
                 ),
             ),
             tmp_path,
@@ -1018,10 +1022,6 @@ class TestLlmUsageBudgetIntegration:
                     max_generations=1,
                     max_evaluations=1000,
                     perfect_score_threshold=None,
-                    # See sibling test: pin instance frontier so the
-                    # objectiveless EvalResult doesn't trip the default
-                    # GEPA-O.A. ``"hybrid"`` validator.
-                    frontier_type="instance",
                 ),
             ),
             tmp_path,
@@ -2353,7 +2353,7 @@ def test_sandboxed_run_starts_evaluator_sidecar(tmp_path: Path, all_mocks):
             evaluator=True,
             extra_hosts={"evaluator-endpoint": "10.0.0.1"},
         ),
-        evolution=EvolutionConfig(max_generations=0, frontier_type="instance"),
+        evolution=EvolutionConfig(max_generations=0),
     )
 
     run_evolution(config, tmp_path, tmp_path / ".helix")
@@ -2374,14 +2374,28 @@ def test_sandboxed_run_starts_evaluator_sidecar(tmp_path: Path, all_mocks):
 class TestActiveFrontierSyncOnObjectiveMode:
     """Regression: ``state.active_frontier`` must be kept in lock-step with
     ``ParetoFrontier.active_frontier_snapshot()`` at every accept site
-    (init, seed, mutation, merge) when ``frontier_type != "instance"``.
+    (init/load, seed, mutation, merge) when
+    ``frontier_type != "instance"``.
 
     Without this sync, resume on a multi-axis run would lose the
-    retained Pareto front.  The four touch points
-    (``_sync_frontier_state`` calls) are inspected indirectly by
-    asserting on the ``EvolutionState`` passed into ``save_state`` after
-    a minimal seed-only run.
+    retained Pareto front.  Each ``_sync_frontier_state`` call site
+    in :mod:`helix.evolution` is exercised by inspecting the
+    ``EvolutionState`` passed into ``save_state``.
     """
+
+    @staticmethod
+    def _objective_eval(
+        cid: str,
+        instance_scores: dict[str, float],
+        quality: list[float],
+    ) -> EvalResult:
+        return EvalResult(
+            candidate_id=cid,
+            scores={},
+            asi={},
+            instance_scores=instance_scores,
+            objective_scores=[{"quality": q} for q in quality],
+        )
 
     def test_seed_acceptance_populates_active_frontier_for_objective_mode(
         self, mocker, tmp_path, all_mocks
@@ -2390,13 +2404,10 @@ class TestActiveFrontierSyncOnObjectiveMode:
         all_mocks["create_seed_worktree"].return_value = seed
 
         def run_eval(candidate, config, split=None, instances=None, **kwargs):
-            # Per-example objective_scores positional to instance_scores order.
-            return EvalResult(
-                candidate_id=candidate.id,
-                scores={},
-                asi={},
-                instance_scores={"i1": 0.5, "i2": 0.6},
-                objective_scores=[{"quality": 0.7}, {"quality": 0.9}],
+            return self._objective_eval(
+                candidate.id,
+                {"i1": 0.5, "i2": 0.6},
+                [0.7, 0.9],
             )
 
         all_mocks["run_evaluator"].side_effect = run_eval
@@ -2428,3 +2439,149 @@ class TestActiveFrontierSyncOnObjectiveMode:
         )
         # And the append-only candidate list is in lock-step.
         assert last_state.frontier == ["g0-s0"]
+
+    def test_mutation_acceptance_updates_active_frontier_for_objective_mode(
+        self, mocker, tmp_path, all_mocks
+    ):
+        """The mutation accept site (``evolution.py`` line ~2383) must
+        also re-snapshot the active frontier."""
+        seed = make_candidate("g0-s0")
+        child = make_candidate("g1-s1", generation=1)
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+
+        def run_eval(candidate, config, split=None, instances=None, **kwargs):
+            if candidate.id == "g1-s1":
+                # Child wins on the objective axis — should displace seed.
+                return self._objective_eval(
+                    "g1-s1",
+                    {"i1": 0.9, "i2": 0.95},
+                    [0.92, 0.95],
+                )
+            return self._objective_eval(
+                candidate.id,
+                {"i1": 0.5, "i2": 0.6},
+                [0.5, 0.6],
+            )
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = HelixConfig(
+            objective="Improve the code",
+            evaluator=EvaluatorConfig(command="pytest -q"),
+            dataset=DatasetConfig(),
+            evolution=EvolutionConfig(
+                max_generations=1,
+                max_evaluations=100,
+                perfect_score_threshold=None,
+                frontier_type="objective",
+            ),
+            worktree=WorktreeConfig(),
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        save_calls = all_mocks["save_state"].call_args_list
+        assert save_calls, "save_state should have been invoked at least once"
+        last_state = save_calls[-1].args[0]
+
+        # Child's mean quality (0.935) strictly exceeds seed's (0.55), so
+        # it is the sole objective-axis winner after the mutation
+        # acceptance sync runs.
+        assert last_state.active_frontier == {"quality": ["g1-s1"]}, (
+            "active_frontier must reflect the mutation-acceptance sync, "
+            f"got {last_state.active_frontier!r}"
+        )
+        assert set(last_state.frontier) == {"g0-s0", "g1-s1"}
+
+    def test_init_sync_rebuilds_active_frontier_on_resume(
+        self, mocker, tmp_path, all_mocks
+    ):
+        """On resume (``load_state`` returns non-None), evolution rebuilds
+        the in-memory frontier and must call
+        ``ParetoFrontier.active_frontier_snapshot()`` via the init
+        sync site (``evolution.py`` post-load branch).
+
+        Spying on ``active_frontier_snapshot`` is the most direct
+        observation: it isolates the init touch point from save-state
+        plumbing (``save_state`` only fires later in the loop, which
+        does not run when ``max_generations=0``).
+        """
+        seed = make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = None  # No mutation this run.
+
+        # The resume path skips ``frontier.add`` for any id whose
+        # worktree dir is missing on disk — create the placeholder so
+        # the frontier rebuild actually runs.
+        base_dir = tmp_path / ".helix"
+        worktree_dir = base_dir / "worktrees" / "g0-s0"
+        worktree_dir.mkdir(parents=True, exist_ok=True)
+
+        # Simulate a prior run's persisted state and re-load it.
+        prior_state = EvolutionState(
+            generation=0,
+            frontier=["g0-s0"],
+            instance_scores={"g0-s0": {"i1": 0.5, "i2": 0.6}},
+            budget=BudgetState(evaluations=1),
+            config_hash="cfg-prior",
+            i=0,
+            num_metric_calls_by_discovery={"g0-s0": 0},
+            active_frontier={"stale": ["should-be-rebuilt"]},
+            frontier_type="objective",
+        )
+        all_mocks["load_state"].return_value = prior_state
+
+        # Resume rebuilds the frontier from on-disk evaluations; provide
+        # the per-example objective_scores so the validator is satisfied.
+        prior_eval = self._objective_eval(
+            "g0-s0",
+            {"i1": 0.5, "i2": 0.6},
+            [0.7, 0.9],
+        )
+        all_mocks["_load_evaluation"].return_value = prior_eval
+        all_mocks["load_lineage"].return_value = {
+            "g0-s0": LineageEntry(
+                id="g0-s0",
+                parent=None,
+                parents=[],
+                operation="seed",
+                generation=0,
+                files_changed=[],
+            ),
+        }
+
+        snapshot_spy = mocker.spy(
+            ParetoFrontier, "active_frontier_snapshot"
+        )
+
+        config = HelixConfig(
+            objective="Improve the code",
+            evaluator=EvaluatorConfig(command="pytest -q"),
+            dataset=DatasetConfig(),
+            evolution=EvolutionConfig(
+                max_generations=0,
+                max_evaluations=10,
+                perfect_score_threshold=None,
+                frontier_type="objective",
+            ),
+            worktree=WorktreeConfig(),
+        )
+        run_evolution(config, tmp_path, base_dir)
+
+        # The init sync site must have invoked the snapshot helper, and
+        # the first call's return value must reflect the rebuilt
+        # frontier (stale placeholder gone, replaced by the loaded
+        # candidate's objective-axis snapshot).
+        assert snapshot_spy.call_count >= 1, (
+            "init sync site did not call active_frontier_snapshot; "
+            "the rebuild path is broken"
+        )
+        first_snapshot = snapshot_spy.spy_return_list[0]
+        assert "stale" not in first_snapshot, (
+            "init sync must overwrite the stale snapshot from the "
+            f"prior state.json; got {first_snapshot!r}"
+        )
+        assert first_snapshot == {"quality": ["g0-s0"]}, (
+            "init sync must rebuild active_frontier from the loaded "
+            f"EvalResult; got {first_snapshot!r}"
+        )

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -83,6 +83,7 @@ def _make_minibatch_config(
         cache_evaluation=cache_evaluation,
         acceptance_criterion=acceptance_criterion,
         val_stage_size=val_stage_size,
+        frontier_type="instance",
     )
     if max_workers is not None:
         evo_kwargs["max_workers"] = max_workers
@@ -539,6 +540,7 @@ class TestMinibatchGateIntegration:
                 max_generations=1,
                 max_evaluations=100,
                 perfect_score_threshold=None,
+                frontier_type="instance",
             ),
             worktree=WorktreeConfig(),
         )
@@ -616,6 +618,7 @@ class TestCachedEvaluateBatch:
                 perfect_score_threshold=None,
                 minibatch_size=3,
                 cache_evaluation=True,
+                frontier_type="instance",
             ),
             worktree=WorktreeConfig(),
         )
@@ -1620,6 +1623,7 @@ class TestWholeCandidateBudget:
                 max_generations=1,
                 max_evaluations=100,
                 perfect_score_threshold=None,
+                frontier_type="instance",
             ),
             worktree=WorktreeConfig(),
         )

--- a/tests/unit/test_evolution_seedless.py
+++ b/tests/unit/test_evolution_seedless.py
@@ -39,6 +39,12 @@ def make_eval_result(
     candidate_id: str = "g0-s0",
     instance_scores: dict[str, float] | None = None,
 ) -> EvalResult:
+    """Build an EvalResult with default per-example ``objective_scores``.
+
+    The synthesised objective slots let the result satisfy
+    :meth:`ParetoFrontier._validate_objective_scores` under the
+    GEPA-O.A. default ``frontier_type = "hybrid"``.
+    """
     if instance_scores is None:
         instance_scores = {"i1": 0.5}
     return EvalResult(
@@ -46,6 +52,9 @@ def make_eval_result(
         scores={"score": 0.5},
         asi={},
         instance_scores=instance_scores,
+        objective_scores=[
+            {"quality": float(score)} for score in instance_scores.values()
+        ],
     )
 
 
@@ -55,6 +64,13 @@ def make_config(
     max_generations: int = 1,
     max_evaluations: int = 1000,
 ) -> HelixConfig:
+    """Build a HelixConfig for the seedless test suite.
+
+    Leaves ``frontier_type`` at :class:`EvolutionConfig`'s
+    GEPA-O.A. default (``"hybrid"``).  Eval results from
+    :func:`make_eval_result` carry per-example ``objective_scores``
+    so the validator is satisfied.
+    """
     from helix.config import SeedlessConfig
 
     return HelixConfig(
@@ -66,7 +82,6 @@ def make_config(
             max_generations=max_generations,
             max_evaluations=max_evaluations,
             perfect_score_threshold=None,
-            frontier_type="instance",
         ),
         worktree=WorktreeConfig(),
     )

--- a/tests/unit/test_evolution_seedless.py
+++ b/tests/unit/test_evolution_seedless.py
@@ -66,6 +66,7 @@ def make_config(
             max_generations=max_generations,
             max_evaluations=max_evaluations,
             perfect_score_threshold=None,
+            frontier_type="instance",
         ),
         worktree=WorktreeConfig(),
     )

--- a/tests/unit/test_parser_helix_result.py
+++ b/tests/unit/test_parser_helix_result.py
@@ -198,16 +198,15 @@ class TestObjectiveScoresHarvest:
             {},
         ]
 
-    def test_scores_key_non_dict_ignored(self, tmp_path: Path) -> None:
+    def test_scores_key_non_dict_rejected(self, tmp_path: Path) -> None:
         _write_batch(tmp_path, ["a"])
         payload = [[1.0, {"scores": "not-a-dict"}]]
         line = f"HELIX_RESULT={json.dumps(payload)}"
 
-        _s, _is, _pesi, obj = helix_result_parse(0, line + "\n", "", tmp_path)
+        with pytest.raises(EvaluatorError, match="scores.*dict"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
 
-        assert obj == [{}]
-
-    def test_scores_drops_non_numeric_and_non_finite(self, tmp_path: Path) -> None:
+    def test_scores_rejects_non_numeric_and_non_finite(self, tmp_path: Path) -> None:
         _write_batch(tmp_path, ["a"])
         # Hand-rolled JSON to smuggle NaN / Infinity past json.dumps.
         stdout = (
@@ -215,9 +214,16 @@ class TestObjectiveScoresHarvest:
             '{"good": 0.5, "bad_str": "nope", "nan": NaN, "inf": Infinity}}]]\n'
         )
 
-        _s, _is, _pesi, obj = helix_result_parse(0, stdout, "", tmp_path)
+        with pytest.raises(EvaluatorError, match="finite numeric scalars"):
+            helix_result_parse(0, stdout, "", tmp_path)
 
-        assert obj == [{"good": 0.5}]
+    def test_pairwise_objective_payload_rejected(self, tmp_path: Path) -> None:
+        _write_batch(tmp_path, ["a"])
+        payload = [[1.0, {"scores": {"bt": {"wins": [["a", "b"]]}}}]]
+        line = f"HELIX_RESULT={json.dumps(payload)}"
+
+        with pytest.raises(EvaluatorError, match="Bradley-Terry.*not supported"):
+            helix_result_parse(0, line + "\n", "", tmp_path)
 
     def test_scores_harvest_coerces_bool_and_int(self, tmp_path: Path) -> None:
         _write_batch(tmp_path, ["a"])

--- a/tests/unit/test_population_multi_axis_frontier.py
+++ b/tests/unit/test_population_multi_axis_frontier.py
@@ -24,7 +24,12 @@ import random
 
 import pytest
 
-from helix.population import Candidate, EvalResult, ParetoFrontier
+from helix.population import (
+    Candidate,
+    EvalResult,
+    MissingObjectiveScoresError,
+    ParetoFrontier,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -156,13 +161,14 @@ class TestObjectiveFrontier:
         assert frontier._objective_best["latency"] == {"a"}
         assert frontier._objective_best["accuracy"] == {"a", "b"}
 
-    def test_empty_objective_scores_is_noop(self):
-        frontier = ParetoFrontier(frontier_type="objective")
-        frontier.add(
-            _make_candidate("a"),
-            _make_result("a", {"i0": 1.0}, objective_scores=None),
-        )
-        assert frontier._objective_best == {}
+    @pytest.mark.parametrize("frontier_type", ["objective", "hybrid", "cartesian"])
+    def test_missing_objective_scores_fails_loudly(self, frontier_type):
+        frontier = ParetoFrontier(frontier_type=frontier_type)
+        with pytest.raises(MissingObjectiveScoresError, match="requires"):
+            frontier.add(
+                _make_candidate("a"),
+                _make_result("a", {"i0": 1.0}, objective_scores=None),
+            )
 
     def test_active_frontier_is_objective_dict(self):
         frontier = ParetoFrontier(frontier_type="objective")
@@ -239,18 +245,26 @@ class TestCartesianFrontier:
         assert frontier._cartesian_best["i0::obj"] == {"a"}
         assert frontier._cartesian_best["i1::obj"] == {"b"}
 
-    def test_length_mismatch_skips_cartesian_update(self):
+    def test_length_mismatch_fails_loudly(self):
         """Defensive: if ``objective_scores`` length ≠ ``instance_scores``
-        length (should not happen on the helix_result path), skip."""
+        length (should not happen on the helix_result path), raise."""
         frontier = ParetoFrontier(frontier_type="cartesian")
-        frontier.add(
-            _make_candidate("a"),
-            _make_result(
-                "a", {"i0": 1.0, "i1": 0.0},
-                objective_scores=[{"obj": 0.5}],  # len 1 vs ids len 2
-            ),
-        )
-        assert frontier._cartesian_best == {}
+        with pytest.raises(MissingObjectiveScoresError, match="length"):
+            frontier.add(
+                _make_candidate("a"),
+                _make_result(
+                    "a", {"i0": 1.0, "i1": 0.0},
+                    objective_scores=[{"obj": 0.5}],  # len 1 vs ids len 2
+                ),
+            )
+
+    def test_empty_objective_slots_fail_loudly(self):
+        frontier = ParetoFrontier(frontier_type="hybrid")
+        with pytest.raises(MissingObjectiveScoresError, match="all objective_scores"):
+            frontier.add(
+                _make_candidate("a"),
+                _make_result("a", {"i0": 1.0}, objective_scores=[{}]),
+            )
 
     def test_active_frontier_is_cartesian_dict(self):
         frontier = ParetoFrontier(frontier_type="cartesian")
@@ -284,6 +298,23 @@ class TestHybridFrontier:
         assert "inst::i0" in merged
         assert "inst::i1" in merged
         assert "obj::obj" in merged
+
+    def test_active_frontier_snapshot_is_distinct_from_candidates(self):
+        frontier = ParetoFrontier(frontier_type="hybrid")
+        frontier.add(
+            _make_candidate("a"),
+            _make_result("a", {"i0": 1.0}, objective_scores=[{"obj": 0.1}]),
+        )
+        frontier.add(
+            _make_candidate("b"),
+            _make_result("b", {"i0": 0.0}, objective_scores=[{"obj": 0.9}]),
+        )
+
+        assert list(frontier._candidates) == ["a", "b"]
+        assert frontier.active_frontier_snapshot() == {
+            "inst::i0": ["a"],
+            "obj::obj": ["b"],
+        }
 
     def test_hybrid_survives_on_either_axis(self):
         """Candidate a wins an instance key but is dominated on objective;
@@ -343,10 +374,10 @@ class TestSelectParentRespectsFrontierType:
         objective-axis winners rather than falling back to
         instance-axis."""
         frontier = ParetoFrontier(frontier_type="objective", rng=random.Random(0))
-        # Candidate a wins on instance but has no objective_scores.
+        # Candidate a wins on instance but loses objective.
         frontier.add(
             _make_candidate("a"),
-            _make_result("a", {"i0": 1.0}, objective_scores=None),
+            _make_result("a", {"i0": 1.0}, objective_scores=[{"obj": 0.1}]),
         )
         # Candidate b is the sole objective-axis winner.
         frontier.add(

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -63,7 +63,7 @@ def test_state_saved_before_crash(tmp_path: Path) -> None:
     config = HelixConfig(
         objective="test",
         evaluator=EvaluatorConfig(command="echo 1"),
-        evolution=EvolutionConfig(max_generations=3),
+        evolution=EvolutionConfig(max_generations=3, frontier_type="instance"),
         agent=AgentConfig(),
         dataset=DatasetConfig(),
         worktree=WorktreeConfig(),

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -63,6 +63,7 @@ def _make_full_state() -> EvolutionState:
             "g1-s1": 14,
             "g2-m1": 28,
         },
+        active_frontier={"task_a": ["g2-m1"], "task_b": ["g2-m1"]},
     )
 
 
@@ -80,6 +81,7 @@ def test_state_roundtrip_preserves_all_fields(tmp_path: Path) -> None:
     assert loaded == state
     # Sanity-check that the new fields specifically survived.
     assert loaded.num_metric_calls_by_discovery == state.num_metric_calls_by_discovery
+    assert loaded.active_frontier == state.active_frontier
     assert loaded.schema_version == SCHEMA_VERSION
 
 
@@ -323,6 +325,7 @@ def test_state_json_keys_when_val_stage_disabled(tmp_path: Path) -> None:
         "merge_description_triplets",
         "i",
         "num_metric_calls_by_discovery",
+        "active_frontier",
         "frontier_type",
     }
     assert set(raw.keys()) == expected_keys, (


### PR DESCRIPTION
## Summary
- Makes non-instance frontier modes fail loudly when objective scores are missing or malformed.
- Adds MissingObjectiveScoresError and stricter helix_result objective-score validation.
- Keeps all candidates distinct from the active frontier snapshot.
- Preserves strict upstream reference multi-axis behavior for objective, hybrid, and cartesian frontiers.

## Validation
- Clean branch E2E/parser/frontier suite: 75 passed.
- Clean branch full unit suite: 688 passed.
- Worker verification also reported tests pass except full repo ruff blocked by pre-existing examples/web_researcher/evaluate.py F841.