### PR TITLE
Add evaluator reserved metadata log channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,8 @@ command = "uv run python evaluate.py"
 #   HELIX_RESULT=[s_0, [s_1, si_1], s_2, ...]           # mixed
 # Positional to `helix_batch.json`. HELIX zips it into id-keyed
 # `instance_scores` and stores the side_info list for the reflection
-# prompt. Use for minibatch runs (`dataset.train_size` set).
+# prompt. `HELIX_RESULT` is a machine protocol; use `from helix import log`
+# for human-readable evaluator notes.
 score_parser = "json_score"
 include_stdout = true
 include_stderr = true
@@ -564,6 +565,19 @@ print(json.dumps({
     "instance_scores": {"puzzle_001": 1.0, "puzzle_002": 0.0}
 }))
 ```
+
+For GEPA-style reflective feedback, prefer structured per-example
+`side_info` when using `score_parser = "helix_result"`. For additional
+human-readable notes that are not tied to one example, evaluators may call
+`from helix import log` and then `log("what happened", key=value)`. HELIX
+captures these notes through `HELIX_ASI_LOG`, not stdout, and renders them as
+Evaluator Notes in mutation prompts.
+
+Raw `HELIX_RESULT=...` JSON is only consumed by HELIX as a machine protocol and
+is not shown to mutators. Evaluator stdout/stderr remain stored for debugging,
+but successful mutation prompts omit them when structured diagnostics or
+`helix.log()` notes are available; failed evaluations still include stdout and
+stderr as fallback debug context.
 
 ---
 

--- a/src/helix/__init__.py
+++ b/src/helix/__init__.py
@@ -2,7 +2,11 @@
 
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
+from helix.asi import log
+
 try:
     __version__ = _pkg_version("helix-evo")
 except PackageNotFoundError:  # not installed (e.g. source checkout without pip install -e .)
     __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__", "log"]

--- a/src/helix/asi.py
+++ b/src/helix/asi.py
@@ -1,0 +1,82 @@
+"""Evaluator-facing arbitrary side information channel."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+HELIX_ASI_LOG_ENV = "HELIX_ASI_LOG"
+
+
+def log(*values: object, sep: str = " ", **fields: Any) -> None:
+    """Record evaluator notes for HELIX mutation prompts.
+
+    Evaluators can call ``from helix import log`` and then ``log(...)`` during
+    a HELIX-managed evaluation.  HELIX captures the notes through a per-
+    invocation file path in ``HELIX_ASI_LOG`` rather than through ordinary
+    stdout, keeping stdout free for machine protocols such as ``HELIX_RESULT``.
+
+    Outside a HELIX evaluator invocation this is a no-op, which lets evaluator
+    code keep the same imports in local debug runs.
+    """
+    path = os.environ.get(HELIX_ASI_LOG_ENV)
+    if not path:
+        return
+
+    record: dict[str, Any] = {}
+    if values:
+        record["message"] = sep.join(str(value) for value in values)
+    record.update(fields)
+    if not record:
+        return
+
+    try:
+        with Path(path).open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True, default=str))
+            fh.write("\n")
+    except OSError:
+        return
+
+
+def read_text(raw: str) -> str:
+    """Render raw HELIX ASI log text."""
+    lines: list[str] = []
+    for raw_line in raw.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            lines.append(line)
+            continue
+        if not isinstance(payload, dict):
+            lines.append(str(payload))
+            continue
+        message = payload.pop("message", None)
+        if message is not None:
+            lines.append(str(message))
+        for key, value in sorted(payload.items()):
+            lines.append(f"{key}: {value}")
+    return "\n".join(lines)
+
+
+def read(path: str | Path) -> str:
+    """Read and render a HELIX ASI log file."""
+    log_path = Path(path)
+    try:
+        raw = log_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+    return read_text(raw)
+
+
+def clear(path: str | Path) -> None:
+    """Remove a HELIX ASI log file if it exists."""
+    try:
+        Path(path).unlink()
+    except FileNotFoundError:
+        pass

--- a/src/helix/asi.py
+++ b/src/helix/asi.py
@@ -33,12 +33,39 @@ def log(*values: object, sep: str = " ", **fields: Any) -> None:
     if not record:
         return
 
+    # Single ``write`` call so the JSON record + trailing newline land
+    # together: POSIX guarantees ``write(2)`` of <= ``PIPE_BUF`` bytes
+    # to a file opened ``O_APPEND`` is atomic across processes /
+    # threads, so concurrent ``helix.log()`` calls from a multi-worker
+    # evaluator can interleave whole records but never split a single
+    # record across two appends.
+    line = json.dumps(record, sort_keys=True, default=str) + "\n"
     try:
         with Path(path).open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(record, sort_keys=True, default=str))
-            fh.write("\n")
+            fh.write(line)
     except OSError:
+        # Logging is best-effort: if the worktree filesystem is
+        # read-only or full we silently drop the note rather than
+        # turning an evaluator-side observability call into a hard
+        # crash.  Tested in ``test_asi.py``.
         return
+
+
+def _render_field_value(value: Any) -> str:
+    """Render a single ``helix.log(**fields)`` value for prompt context.
+
+    Scalars round-trip via ``str(...)`` so a logged ``score=0.7`` shows
+    up as ``0.7`` (not ``"0.7"``).  Nested dicts / lists / tuples
+    serialize via ``json.dumps`` with ``default=str`` so an evaluator
+    that logs structured data sees a readable JSON literal in the
+    mutation prompt instead of Python's repr-style ``{'k': 'v'}``.
+    """
+    if isinstance(value, (dict, list, tuple)):
+        try:
+            return json.dumps(value, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            return str(value)
+    return str(value)
 
 
 def read_text(raw: str) -> str:
@@ -60,7 +87,7 @@ def read_text(raw: str) -> str:
         if message is not None:
             lines.append(str(message))
         for key, value in sorted(payload.items()):
-            lines.append(f"{key}: {value}")
+            lines.append(f"{key}: {_render_field_value(value)}")
     return "\n".join(lines)
 
 

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -147,10 +147,24 @@ def _collect_asi(
         stderr: Main command stderr.
         extra_outputs: List of (stdout, stderr) tuples from extra_commands.
         config: HelixConfig controlling what to include.
+        log: Rendered ``helix.log()`` notes captured from the evaluator's
+            ``HELIX_ASI_LOG`` file.  Stored under the ``"log"`` key when
+            non-empty so the mutation prompt can render it as
+            ``## Evaluator Notes``.
+        returncode: Evaluator subprocess exit code.  Stored as a
+            stringified ``"_returncode"`` key so downstream consumers
+            (notably the mutation prompt builder) can distinguish
+            success from failure when deciding whether stdout/stderr
+            should be surfaced as fallback debug context.  Kept inside
+            ``asi`` rather than promoted to a typed field to preserve
+            the GEPA O.A. EvaluationBatch interface.
 
     Returns:
-        Dict with keys "stdout", "stderr", "log", "extra_0", etc.
-        All values are the FULL output — never truncated.
+        Dict with keys "stdout", "stderr", "log", "_returncode",
+        "extra_0", "extra_1", etc.  All values are the FULL output —
+        never truncated.  Reserved keys consumed by HELIX itself
+        (``log``, ``_returncode``) are filtered out before the catch-all
+        "extra" rendering in the mutation prompt.
     """
     asi: dict[str, str] = {}
 
@@ -234,19 +248,37 @@ def run_evaluator(
     )
     helix_log_name = f".helix_asi_log_{uuid.uuid4().hex}.jsonl"
     helix_log_path = Path(candidate.worktree_path) / helix_log_name
+    # Absolute path inside the sidecar — the evaluator command may run
+    # with a different cwd than the one we mount the worktree at, so the
+    # ``HELIX_ASI_LOG`` env var and the trailing capture command both
+    # use the absolute ``/workspace/...`` form to remove that
+    # assumption.
+    helix_log_sandbox_path = f"/workspace/{helix_log_name}"
     cmd_tokens = _validate_and_split_command(evaluator.command)
     if config.sandbox.enabled and config.sandbox.evaluator:
-        env[HELIX_ASI_LOG_ENV] = f"/workspace/{helix_log_name}"
+        env[HELIX_ASI_LOG_ENV] = helix_log_sandbox_path
         if current_evaluator_sidecar_runtime() is None:
             raise ValueError(
                 "Sandboxed sidecar evaluation requires an active evaluator sidecar. "
                 "Run evaluations through helix.evolution.run_evolution."
             )
+        # The trailing ``cat`` command captures the JSONL log file from
+        # inside the sidecar.  ``2>/dev/null || true`` keeps a missing
+        # file (no ``helix.log()`` calls) from looking like a sandbox
+        # error.  Cleanup is deliberately asymmetric vs. the host path
+        # below: the worktree is disposed by the caller after
+        # evaluation, so we do not need to ``rm`` the log inside the
+        # sandbox.  If worktrees become reusable, reintroduce an
+        # explicit ``rm`` step here to mirror the host ``finally``.
         command_results = run_sandboxed_commands(
             [
                 cmd_tokens,
                 *[_validate_and_split_command(cmd) for cmd in evaluator.extra_commands],
-                ["sh", "-c", f"cat {shlex.quote(helix_log_name)} 2>/dev/null || true"],
+                [
+                    "sh",
+                    "-c",
+                    f"cat {shlex.quote(helix_log_sandbox_path)} 2>/dev/null || true",
+                ],
             ],
             cwd=candidate.worktree_path,
             env=env,
@@ -260,6 +292,10 @@ def run_evaluator(
         helix_log_text = read_asi_log_text(command_results[-1].stdout)
         extra_outputs = [(item.stdout, item.stderr) for item in command_results[1:-1]]
     else:
+        # Host path: the same env var also propagates to ``extra_commands``
+        # below — those subprocesses will append to the same JSONL file
+        # if they call ``helix.log()``.  Notes from extras are merged in
+        # invocation order with the main command's notes.
         env[HELIX_ASI_LOG_ENV] = str(helix_log_path)
         try:
             result = subprocess.run(

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -6,8 +6,16 @@ import logging
 import os
 import shlex
 import subprocess
+import uuid
+from pathlib import Path
 from typing import Any
 
+from helix.asi import (
+    HELIX_ASI_LOG_ENV,
+    clear as clear_asi_log,
+    read as read_asi_log,
+    read_text as read_asi_log_text,
+)
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig
 from helix.exceptions import EvaluatorError, format_error_context
@@ -128,8 +136,11 @@ def _collect_asi(
     stderr: str,
     extra_outputs: list[tuple[str, str]],
     config: HelixConfig,
+    *,
+    log: str = "",
+    returncode: int | None = None,
 ) -> dict[str, str]:
-    """Collect arbitrary string info from stdout, stderr, and extra command outputs.
+    """Collect arbitrary string info from evaluator outputs and helix.log notes.
 
     Args:
         stdout: Main command stdout.
@@ -138,11 +149,15 @@ def _collect_asi(
         config: HelixConfig controlling what to include.
 
     Returns:
-        Dict with keys "stdout", "stderr", "extra_0", "extra_1", etc.
+        Dict with keys "stdout", "stderr", "log", "extra_0", etc.
         All values are the FULL output — never truncated.
     """
     asi: dict[str, str] = {}
 
+    if returncode is not None:
+        asi["_returncode"] = str(returncode)
+    if log:
+        asi["log"] = log
     if config.evaluator.include_stdout:
         asi["stdout"] = stdout
     if config.evaluator.include_stderr:
@@ -217,8 +232,11 @@ def run_evaluator(
         passthrough_env=config.passthrough_env,
         fixed_env=config.env,
     )
+    helix_log_name = f".helix_asi_log_{uuid.uuid4().hex}.jsonl"
+    helix_log_path = Path(candidate.worktree_path) / helix_log_name
     cmd_tokens = _validate_and_split_command(evaluator.command)
     if config.sandbox.enabled and config.sandbox.evaluator:
+        env[HELIX_ASI_LOG_ENV] = f"/workspace/{helix_log_name}"
         if current_evaluator_sidecar_runtime() is None:
             raise ValueError(
                 "Sandboxed sidecar evaluation requires an active evaluator sidecar. "
@@ -228,6 +246,7 @@ def run_evaluator(
             [
                 cmd_tokens,
                 *[_validate_and_split_command(cmd) for cmd in evaluator.extra_commands],
+                ["sh", "-c", f"cat {shlex.quote(helix_log_name)} 2>/dev/null || true"],
             ],
             cwd=candidate.worktree_path,
             env=env,
@@ -238,28 +257,34 @@ def run_evaluator(
             agent_backend=config.agent.backend,
         )
         result = command_results[0]
-        extra_outputs = [(item.stdout, item.stderr) for item in command_results[1:]]
+        helix_log_text = read_asi_log_text(command_results[-1].stdout)
+        extra_outputs = [(item.stdout, item.stderr) for item in command_results[1:-1]]
     else:
-        result = subprocess.run(
-            cmd_tokens,
-            shell=False,
-            cwd=candidate.worktree_path,
-            capture_output=True,
-            text=True,
-            env=env,
-        )
-        extra_outputs = []
-        for extra_cmd in evaluator.extra_commands:
-            extra_cmd_tokens = _validate_and_split_command(extra_cmd)
-            extra_result = subprocess.run(
-                extra_cmd_tokens,
+        env[HELIX_ASI_LOG_ENV] = str(helix_log_path)
+        try:
+            result = subprocess.run(
+                cmd_tokens,
                 shell=False,
                 cwd=candidate.worktree_path,
                 capture_output=True,
                 text=True,
                 env=env,
             )
-            extra_outputs.append((extra_result.stdout, extra_result.stderr))
+            extra_outputs = []
+            for extra_cmd in evaluator.extra_commands:
+                extra_cmd_tokens = _validate_and_split_command(extra_cmd)
+                extra_result = subprocess.run(
+                    extra_cmd_tokens,
+                    shell=False,
+                    cwd=candidate.worktree_path,
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                )
+                extra_outputs.append((extra_result.stdout, extra_result.stderr))
+            helix_log_text = read_asi_log(helix_log_path)
+        finally:
+            clear_asi_log(helix_log_path)
 
     stdout = result.stdout
     stderr = result.stderr
@@ -285,7 +310,14 @@ def run_evaluator(
         )
 
     # Collect ASI
-    asi = _collect_asi(stdout, stderr, extra_outputs, config)
+    asi = _collect_asi(
+        stdout,
+        stderr,
+        extra_outputs,
+        config,
+        log=helix_log_text,
+        returncode=returncode,
+    )
 
     # Guard: at most one HELIX_RESULT= line is expected.  Multiple is an
     # evaluator-contract violation (race or accidental double-emit).

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -128,7 +128,25 @@ def _has_structured_diagnostics(eval_result: EvalResult) -> bool:
 
 
 def _evaluator_failed(eval_result: EvalResult) -> bool:
+    """Return True iff the evaluator subprocess exited non-zero.
+
+    ``_returncode`` rides inside ``asi`` (rather than as a typed field
+    on :class:`EvalResult`) to preserve the GEPA O.A. EvaluationBatch
+    interface — every HELIX-specific signal that downstream tooling
+    might want to inspect lives in the same string-keyed bag.
+    ``executor._collect_asi`` writes ``str(returncode)``; absent or
+    unparseable values are treated as success so we never spuriously
+    promote stdout/stderr into the prompt for archived records.
+    """
     return eval_result.asi.get("_returncode") not in (None, "0", 0)
+
+
+# All ``_render_*`` helpers below share a strict invariant: they return
+# either the empty string (the section is suppressed) or a block of
+# text that ends with a single trailing blank line (``"\n\n"``).  The
+# ``MUTATION_PROMPT_TEMPLATE`` chains them together verbatim and relies
+# on this convention to keep section spacing consistent.  Update both
+# the helper and the template if you change it.
 
 
 def _render_evaluator_notes(eval_result: EvalResult) -> str:
@@ -395,7 +413,11 @@ def build_mutation_prompt(
     if not scores_text:
         scores_text = "  (no scores recorded)"
 
-    # Collect any extra_N entries from ASI
+    # Collect any extra_N entries from ASI.  The reserved keys here
+    # are surfaced through dedicated prompt sections (or the
+    # ``EvalResult.evaluator_returncode`` typed field, in the case of
+    # the historical ``_returncode`` legacy key) and must never leak
+    # into the catch-all "extra" rendering.
     extra_entries = {
         k: v
         for k, v in sorted(eval_result.asi.items())

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -72,15 +72,7 @@ MUTATION_PROMPT_TEMPLATE = """\
 ## Current Evaluation Scores
 {scores}
 
-## Evaluator Output
-
-### stdout
-{asi_stdout}
-
-### stderr
-{asi_stderr}
-
-{extra_asi_section}{diagnostics_section}## Background / Context
+{diagnostics_section}{evaluator_notes_section}{evaluator_output_section}{extra_asi_section}## Background / Context
 {background}
 
 ## Your Task
@@ -107,6 +99,65 @@ def _turn_budget_section(max_turns: int | None) -> str:
         f"accordingly — prioritize the highest-impact changes first and be "
         f"efficient with your tool usage.\n"
     )
+
+
+def _strip_machine_protocol_from_evaluator_stream(text: str) -> str:
+    """Remove evaluator machine-contract lines before showing stdout/stderr.
+
+    The raw evaluator stdout/stderr remains stored in ASI artifacts for
+    debugging and parsing.  This helper only affects mutation prompts.
+    ``HELIX_RESULT=`` is a machine protocol consumed by HELIX, never human
+    reflection context for the mutator.
+    """
+    if not text:
+        return ""
+
+    kept: list[str] = []
+    for line in text.splitlines():
+        if line.strip().startswith("HELIX_RESULT="):
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
+
+
+def _has_structured_diagnostics(eval_result: EvalResult) -> bool:
+    return (
+        eval_result.per_example_side_info is not None
+        or eval_result.side_info is not None
+    )
+
+
+def _evaluator_failed(eval_result: EvalResult) -> bool:
+    return eval_result.asi.get("_returncode") not in (None, "0", 0)
+
+
+def _render_evaluator_notes(eval_result: EvalResult) -> str:
+    notes = eval_result.asi.get("log", "").strip()
+    if not notes:
+        return ""
+    return f"## Evaluator Notes\n{notes}\n\n"
+
+
+def _render_evaluator_output_fallback(eval_result: EvalResult) -> str:
+    """Render stdout/stderr only when they are useful fallback diagnostics."""
+    has_notes = bool(eval_result.asi.get("log", "").strip())
+    include_streams = _evaluator_failed(eval_result) or (
+        not _has_structured_diagnostics(eval_result) and not has_notes
+    )
+    if not include_streams:
+        return ""
+
+    stdout = _strip_machine_protocol_from_evaluator_stream(
+        eval_result.asi.get("stdout", "")
+    )
+    stderr = _strip_machine_protocol_from_evaluator_stream(
+        eval_result.asi.get("stderr", "")
+    )
+    if not stdout:
+        stdout = "(no stdout)"
+    if not stderr:
+        stderr = "(no stderr)"
+    return f"## Evaluator Output\n\n### stdout\n{stdout}\n\n### stderr\n{stderr}\n\n"
 
 
 def build_seed_generation_prompt(
@@ -344,14 +395,11 @@ def build_mutation_prompt(
     if not scores_text:
         scores_text = "  (no scores recorded)"
 
-    asi_stdout = eval_result.asi.get("stdout", "(no stdout)")
-    asi_stderr = eval_result.asi.get("stderr", "(no stderr)")
-
     # Collect any extra_N entries from ASI
     extra_entries = {
         k: v
         for k, v in sorted(eval_result.asi.items())
-        if k not in ("stdout", "stderr", "error")
+        if k not in ("stdout", "stderr", "error", "log", "_returncode")
     }
     if extra_entries:
         extra_lines = "\n".join(f"### {k}\n{v}" for k, v in extra_entries.items())
@@ -398,8 +446,8 @@ def build_mutation_prompt(
         system_prompt=AUTONOMOUS_SYSTEM_PROMPT,
         objective=objective,
         scores=scores_text,
-        asi_stdout=asi_stdout,
-        asi_stderr=asi_stderr,
+        evaluator_notes_section=_render_evaluator_notes(eval_result),
+        evaluator_output_section=_render_evaluator_output_fallback(eval_result),
         extra_asi_section=extra_asi_section,
         diagnostics_section=diagnostics_section,
         background=bg,

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -63,7 +63,38 @@ class EvalResult:
     """
     candidate_id: str
     scores: dict[str, float]          # aggregate/summary scores
-    asi: dict[str, str]               # arbitrary string info (metadata)
+    # Arbitrary string info (metadata) collected from the evaluator.
+    # Mirrors GEPA O.A. ``EvaluationBatch``'s side-info bag — every
+    # HELIX-specific signal that downstream tooling might want to
+    # inspect lives here in the same string-keyed dict rather than as
+    # a typed field on this dataclass.  That keeps the cross-language
+    # GEPA contract intact.
+    #
+    # Reserved-key convention
+    # -----------------------
+    # Keys starting with an underscore (``_<name>``) are HELIX-internal
+    # sentinels written by ``executor._collect_asi`` and consumed
+    # elsewhere in HELIX (e.g. the mutation prompt builder).  They are:
+    #
+    # * stringified (``asi[k]`` is always ``str`` — callers must parse);
+    # * filtered out of any catch-all rendering surface (the mutation
+    #   prompt's "Extra Evaluator Info" section in
+    #   :func:`helix.mutator.build_mutation_prompt` is the canonical
+    #   example);
+    # * not part of the GEPA O.A. contract — third-party evaluators
+    #   must never set or read them.
+    #
+    # Currently reserved:
+    #
+    # * ``_returncode`` — evaluator subprocess exit code (str), used by
+    #   the mutator to gate stdout/stderr fallback rendering.
+    #
+    # Add new sentinels here (and to the mutator's filter list at
+    # ``mutator.build_mutation_prompt``) when introducing more.
+    # Non-underscore keys (``stdout``, ``stderr``, ``log``, ``extra_N``,
+    # arbitrary evaluator-emitted notes) are NOT reserved and round-trip
+    # to the GEPA O.A. consumer unchanged.
+    asi: dict[str, str]
     instance_scores: dict[str, float] # per-instance scores, keyed by HELIX example-id
     # Legacy batch-level diagnostics dict.  No longer populated by the
     # ``helix_result`` parser (which uses ``per_example_side_info``);

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -72,17 +72,21 @@ class EvalResult:
     #
     # Reserved-key convention
     # -----------------------
-    # Keys starting with an underscore (``_<name>``) are HELIX-internal
-    # sentinels written by ``executor._collect_asi`` and consumed
-    # elsewhere in HELIX (e.g. the mutation prompt builder).  They are:
+    # Inside this otherwise GEPA-shaped result, keys starting with an
+    # underscore (``_<name>``) are HELIX-internal sentinels: written by
+    # ``executor._collect_asi``, consumed elsewhere in HELIX (e.g. the
+    # mutation prompt builder), and *not* part of the evaluator-facing
+    # surface.  They are:
     #
     # * stringified (``asi[k]`` is always ``str`` — callers must parse);
     # * filtered out of any catch-all rendering surface (the mutation
     #   prompt's "Extra Evaluator Info" section in
     #   :func:`helix.mutator.build_mutation_prompt` is the canonical
     #   example);
-    # * not part of the GEPA O.A. contract — third-party evaluators
-    #   must never set or read them.
+    # * HELIX-internal, not evaluator-facing — evaluator code (the
+    #   user's ``evaluate.py`` or any GEPA-style downstream consumer)
+    #   must never set or read these keys.  HELIX owns them and may
+    #   rename them or change their string format without notice.
     #
     # Currently reserved:
     #
@@ -91,9 +95,11 @@ class EvalResult:
     #
     # Add new sentinels here (and to the mutator's filter list at
     # ``mutator.build_mutation_prompt``) when introducing more.
+    #
     # Non-underscore keys (``stdout``, ``stderr``, ``log``, ``extra_N``,
-    # arbitrary evaluator-emitted notes) are NOT reserved and round-trip
-    # to the GEPA O.A. consumer unchanged.
+    # arbitrary evaluator-emitted notes) ARE the evaluator-facing
+    # surface — they round-trip unchanged to GEPA-style consumers and
+    # are stable for evaluator authors to depend on.
     asi: dict[str, str]
     instance_scores: dict[str, float] # per-instance scores, keyed by HELIX example-id
     # Legacy batch-level diagnostics dict.  No longer populated by the

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -402,11 +402,18 @@ def _sync_back_workspace(
 def _sync_back_backend_transcripts(src: Path, dst: Path) -> None:
     """Preserve HELIX-owned transcript artifacts while hiding .helix* from agents."""
     source = src / ".helix_artifacts" / "backend_transcripts"
-    if not source.exists():
+    try:
+        if not source.exists():
+            return
+    except OSError as exc:
+        logger.warning("skipping inaccessible backend transcript artifacts %s: %s", source, exc)
         return
     target = dst / ".helix_artifacts" / "backend_transcripts"
     target.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source, target, dirs_exist_ok=True)
+    try:
+        shutil.copytree(source, target, dirs_exist_ok=True)
+    except OSError as exc:
+        logger.warning("skipping backend transcript artifact copy from %s: %s", source, exc)
 
 
 def _init_synthetic_git_repo(workspace: Path) -> None:

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 import json
+import logging
 import os
 import shlex
 import shutil
@@ -20,6 +21,9 @@ from typing import Literal
 
 from helix.backends import BACKEND_AUTH_COMMANDS, DEFAULT_BACKEND_IMAGES
 from helix.config import EvaluatorSidecarConfig, SandboxConfig
+
+
+logger = logging.getLogger(__name__)
 
 
 HELIX_ARTIFACT_NAMES = {
@@ -250,21 +254,32 @@ def _copy_tree_contents(
     dst.mkdir(parents=True, exist_ok=True)
     ignore = _ignore_for_sync if for_sync else _ignore_for_copy
     omitted = omit_paths or set()
-    for child in src.iterdir():
+    try:
+        children = list(src.iterdir())
+    except OSError as exc:
+        logger.warning("skipping inaccessible sandbox directory %s: %s", src, exc)
+        return
+    for child in children:
         rel = child.relative_to(src)
         if ignore(rel) or _matches_omitted_path(rel, omitted):
             continue
         if skip_special_files and not _is_supported_workspace_file(child):
             continue
         target = dst / child.name
-        if child.is_symlink():
+        try:
+            child_is_symlink = child.is_symlink()
+            child_is_dir = child.is_dir()
+        except OSError as exc:
+            logger.warning("skipping inaccessible sandbox path %s: %s", child, exc)
+            continue
+        if child_is_symlink:
             if target.exists() or target.is_symlink():
                 if target.is_dir() and not target.is_symlink():
                     shutil.rmtree(target)
                 else:
                     target.unlink()
             os.symlink(os.readlink(child), target)
-        elif child.is_dir():
+        elif child_is_dir:
             if target.exists() or target.is_symlink():
                 if not target.is_dir() or target.is_symlink():
                     target.unlink()
@@ -285,7 +300,10 @@ def _copy_tree_contents(
                     shutil.rmtree(target)
                 else:
                     target.unlink()
-            shutil.copy2(child, target)
+            try:
+                shutil.copy2(child, target)
+            except PermissionError as exc:
+                logger.warning("skipping inaccessible sandbox file %s: %s", child, exc)
 
 
 def _remove_extraneous_files(
@@ -296,13 +314,29 @@ def _remove_extraneous_files(
     omit_paths: set[Path] | None = None,
 ) -> None:
     omitted = omit_paths or set()
-    for child in list(dst.iterdir()):
+    try:
+        children = list(dst.iterdir())
+    except OSError as exc:
+        logger.warning("skipping inaccessible destination directory %s: %s", dst, exc)
+        return
+    for child in children:
         rel = child.relative_to(dst)
         if _ignore_for_sync(rel) or _matches_omitted_path(rel, omitted):
             continue
         if skip_special_files and not _is_supported_workspace_file(child):
             continue
-        if not (src / rel).exists() and not (src / rel).is_symlink():
+        source_child = src / rel
+        try:
+            source_exists = source_child.exists() or source_child.is_symlink()
+        except OSError as exc:
+            logger.warning(
+                "keeping %s because sandbox source %s is inaccessible: %s",
+                child,
+                source_child,
+                exc,
+            )
+            continue
+        if not source_exists:
             if child.is_dir() and not child.is_symlink():
                 shutil.rmtree(child)
             else:
@@ -319,6 +353,28 @@ def _remove_extraneous_files(
                     if path != rel and rel in path.parents
                 },
             )
+
+
+def _safe_rmtree(path: Path, *, docker_image: str | None = None) -> None:
+    try:
+        shutil.rmtree(path)
+        return
+    except FileNotFoundError:
+        return
+    except OSError as first_exc:
+        if docker_image and (host_owner := _host_owner()):
+            _docker_chown_workspace(path, docker_image, host_owner)
+            try:
+                shutil.rmtree(path)
+                return
+            except OSError as second_exc:
+                logger.warning(
+                    "failed to clean sandbox temp dir %s after chown: %s",
+                    path,
+                    second_exc,
+                )
+                return
+        logger.warning("failed to clean sandbox temp dir %s: %s", path, first_exc)
 
 
 def _sync_back_workspace(
@@ -802,8 +858,9 @@ def run_sandboxed_commands(
     docker_image = image or sandbox.image
     if docker_image is None:
         raise ValueError("sandbox image must be provided")
-    with tempfile.TemporaryDirectory(prefix="helix-sandbox-") as tmp:
-        workspace = Path(tmp) / "workspace"
+    tmp_path = Path(tempfile.mkdtemp(prefix="helix-sandbox-"))
+    try:
+        workspace = tmp_path / "workspace"
         omit_paths = (
             {Path(item) for item in sandbox.omit_from_agent}
             if scope == "agent"
@@ -872,7 +929,9 @@ def run_sandboxed_commands(
             )
             if scope == "agent":
                 _sync_back_backend_transcripts(workspace, source)
-    return results
+        return results
+    finally:
+        _safe_rmtree(tmp_path, docker_image=docker_image)
 
 
 def run_sandboxed_command(

--- a/tests/unit/test_asi.py
+++ b/tests/unit/test_asi.py
@@ -1,0 +1,234 @@
+"""Unit tests for :mod:`helix.asi` — the evaluator-facing log channel.
+
+The contract under test:
+
+* ``helix.log(...)`` is a no-op when ``HELIX_ASI_LOG`` is unset
+  (evaluator code can keep the same imports in local debug runs).
+* When the env var points at a writable path, calls append one
+  JSONL record per call.  The record + trailing newline land in a
+  single ``write(2)`` so concurrent appends from a multi-worker
+  evaluator cannot interleave a single record across two writes.
+* Filesystem failures are swallowed: logging is best-effort and
+  must never turn an evaluator observability call into a hard
+  crash.
+* :func:`helix.asi.read_text` renders the captured records with
+  scalars formatted bare and nested values formatted as JSON
+  literals (so the mutation prompt shows readable structured data
+  instead of Python repr).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from helix import asi
+
+
+# ---------------------------------------------------------------------------
+# log(): no-op outside HELIX
+# ---------------------------------------------------------------------------
+
+
+class TestLogNoOpOutsideHelix:
+    def test_no_env_var_no_raise(self, monkeypatch):
+        """Without ``HELIX_ASI_LOG`` set, ``helix.log`` must silently
+        succeed — evaluator scripts often run locally for debug and the
+        same imports must keep working."""
+        monkeypatch.delenv(asi.HELIX_ASI_LOG_ENV, raising=False)
+        # No assertion — just must not raise.
+        asi.log("hello", score=1.0)
+
+    def test_empty_env_var_no_raise(self, monkeypatch):
+        """An empty-string env var is treated identically to unset."""
+        monkeypatch.setenv(asi.HELIX_ASI_LOG_ENV, "")
+        asi.log("hello", score=1.0)
+
+    def test_no_file_created_when_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(asi.HELIX_ASI_LOG_ENV, raising=False)
+        asi.log("hello")
+        # Nothing should have been written anywhere — including the
+        # default tmp_path location.
+        assert not any(tmp_path.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# log(): happy path + atomicity
+# ---------------------------------------------------------------------------
+
+
+class TestLogWritesRecord:
+    def test_writes_jsonl_record_with_message(self, tmp_path, monkeypatch):
+        target = tmp_path / "asi.jsonl"
+        monkeypatch.setenv(asi.HELIX_ASI_LOG_ENV, str(target))
+        asi.log("hello world", score=0.5)
+        lines = target.read_text().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["message"] == "hello world"
+        assert record["score"] == 0.5
+
+    def test_appends_one_line_per_call(self, tmp_path, monkeypatch):
+        target = tmp_path / "asi.jsonl"
+        monkeypatch.setenv(asi.HELIX_ASI_LOG_ENV, str(target))
+        asi.log("first")
+        asi.log("second")
+        asi.log("third")
+        assert target.read_text().splitlines() == [
+            json.dumps({"message": "first"}, sort_keys=True),
+            json.dumps({"message": "second"}, sort_keys=True),
+            json.dumps({"message": "third"}, sort_keys=True),
+        ]
+
+    def test_record_emits_in_single_write(self, tmp_path, monkeypatch):
+        """Atomicity invariant: the record + ``"\\n"`` go out in a
+        single ``write`` call so POSIX ``O_APPEND`` semantics keep a
+        single record from being split by an interleaved append.
+
+        We patch the file handle's ``write`` method and assert it was
+        called exactly once for the body (the trailing newline must
+        ride along, not be a second write).
+        """
+        target = tmp_path / "asi.jsonl"
+        monkeypatch.setenv(asi.HELIX_ASI_LOG_ENV, str(target))
+
+        original_open = Path.open
+        write_calls: list[str] = []
+
+        class _SpyHandle:
+            def __init__(self, real_handle):
+                self._real = real_handle
+
+            def __enter__(self):
+                self._real.__enter__()
+                return self
+
+            def __exit__(self, *exc):
+                return self._real.__exit__(*exc)
+
+            def write(self, data):
+                write_calls.append(data)
+                return self._real.write(data)
+
+        def _spy_open(self, *args, **kwargs):
+            return _SpyHandle(original_open(self, *args, **kwargs))
+
+        with patch.object(Path, "open", _spy_open):
+            asi.log("atomic", marker=1)
+
+        assert len(write_calls) == 1, f"expected one write call, got {write_calls!r}"
+        assert write_calls[0].endswith("\n")
+        assert json.loads(write_calls[0])["message"] == "atomic"
+
+    def test_empty_call_skips_write(self, tmp_path, monkeypatch):
+        """``log()`` with neither values nor fields is a no-op even
+        when the env var is set — there's nothing to record."""
+        target = tmp_path / "asi.jsonl"
+        monkeypatch.setenv(asi.HELIX_ASI_LOG_ENV, str(target))
+        asi.log()
+        assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# log(): OSError / unwritable path is best-effort
+# ---------------------------------------------------------------------------
+
+
+class TestLogOSErrorSwallowed:
+    def test_unwritable_directory_does_not_raise(self, tmp_path, monkeypatch):
+        """Pointing the env var at a non-existent directory makes the
+        ``open("a")`` call fail with ``OSError``.  ``helix.log`` must
+        swallow it: observability is best-effort and an evaluator
+        should never crash because its log file disappeared."""
+        bad_path = tmp_path / "does" / "not" / "exist" / "asi.jsonl"
+        monkeypatch.setenv(asi.HELIX_ASI_LOG_ENV, str(bad_path))
+        # Must not raise.
+        asi.log("hello")
+        assert not bad_path.exists()
+
+    def test_open_oserror_is_swallowed(self, tmp_path, monkeypatch):
+        """Belt-and-suspenders: explicitly inject an ``OSError`` from
+        the ``open`` call (e.g. read-only filesystem)."""
+        target = tmp_path / "asi.jsonl"
+        monkeypatch.setenv(asi.HELIX_ASI_LOG_ENV, str(target))
+
+        def _boom(self, *_args, **_kwargs):
+            raise OSError("read-only filesystem")
+
+        with patch.object(Path, "open", _boom):
+            asi.log("should not crash")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# read_text(): rendering
+# ---------------------------------------------------------------------------
+
+
+class TestReadTextRendering:
+    def test_message_renders_as_bare_line(self):
+        raw = json.dumps({"message": "the note"}) + "\n"
+        assert asi.read_text(raw) == "the note"
+
+    def test_scalar_field_renders_unquoted(self):
+        raw = json.dumps({"score": 0.42}) + "\n"
+        assert "score: 0.42" in asi.read_text(raw)
+
+    def test_nested_dict_renders_as_json_literal(self):
+        """Nested values must render via ``json.dumps`` so the mutation
+        prompt sees a readable JSON literal (e.g.
+        ``trajectory: {"step": 1}``) instead of Python's repr-style
+        single-quoted ``{'step': 1}``."""
+        raw = json.dumps({"trajectory": {"step": 1, "ok": True}}) + "\n"
+        rendered = asi.read_text(raw)
+        # JSON serialisation: double-quoted keys + ``true`` (not Python ``True``).
+        assert "trajectory: " in rendered
+        assert '"step": 1' in rendered
+        assert '"ok": true' in rendered
+        # Must NOT be Python repr.
+        assert "'step': 1" not in rendered
+
+    def test_list_field_renders_as_json_literal(self):
+        raw = json.dumps({"attempts": ["fail", "ok"]}) + "\n"
+        rendered = asi.read_text(raw)
+        assert 'attempts: ["fail", "ok"]' in rendered
+
+    def test_non_json_line_passes_through(self):
+        """A garbage line (e.g. evaluator wrote freeform text into the
+        same file) must not crash the renderer; pass it through
+        verbatim."""
+        rendered = asi.read_text("not json at all\n")
+        assert rendered == "not json at all"
+
+    def test_message_then_fields_render_in_order(self):
+        raw = json.dumps({"message": "header", "score": 0.7, "ok": True}) + "\n"
+        rendered = asi.read_text(raw)
+        # Message first; then sorted fields.  Sorted is deterministic
+        # for prompt reproducibility.  Scalars (incl. booleans) round-trip
+        # via ``str(...)`` so a Python ``True`` renders as ``True`` —
+        # ``json.dumps`` is reserved for nested containers, where the
+        # repr-vs-JSON-literal distinction actually matters.
+        lines = rendered.splitlines()
+        assert lines[0] == "header"
+        assert "ok: True" in lines
+        assert "score: 0.7" in lines
+
+
+# ---------------------------------------------------------------------------
+# read() / clear()
+# ---------------------------------------------------------------------------
+
+
+class TestReadAndClear:
+    def test_read_missing_file_returns_empty(self, tmp_path):
+        assert asi.read(tmp_path / "does-not-exist.jsonl") == ""
+
+    def test_clear_removes_file(self, tmp_path):
+        target = tmp_path / "asi.jsonl"
+        target.write_text("anything\n")
+        asi.clear(target)
+        assert not target.exists()
+
+    def test_clear_missing_file_no_raise(self, tmp_path):
+        # Idempotent: clearing a non-existent path is fine.
+        asi.clear(tmp_path / "never-existed.jsonl")

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock
 
 
@@ -148,6 +149,30 @@ class TestRunEvaluatorSuccess:
         result = run_evaluator(candidate, config)
 
         assert "stderr" not in result.asi
+
+    def test_sets_helix_asi_log_env(self, mocker):
+        mock_run = mocker.patch("helix.executor.subprocess.run")
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        candidate = make_candidate()
+        config = make_config(score_parser="exitcode")
+
+        run_evaluator(candidate, config)
+
+        env = mock_run.call_args.kwargs["env"]
+        assert "HELIX_ASI_LOG" in env
+
+    def test_captures_helix_log_in_asi(self, tmp_path):
+        command = (
+            f"{sys.executable} -c "
+            "\"from helix import log; log('unique evaluator note', score=0.7)\""
+        )
+        candidate = make_candidate(str(tmp_path))
+        config = make_config(command=command, score_parser="exitcode")
+
+        result = run_evaluator(candidate, config)
+
+        assert "unique evaluator note" in result.asi["log"]
+        assert "score: 0.7" in result.asi["log"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_executor_security.py
+++ b/tests/unit/test_executor_security.py
@@ -344,6 +344,58 @@ class TestRunEvaluator:
         assert commands[:2] == [["python", "/runner/evaluate.py"], ["python", "extra.py"]]
         assert commands[2][:2] == ["sh", "-c"]
         assert ".helix_asi_log_" in commands[2][2]
+        # Capture command must use the absolute ``/workspace/...`` path
+        # so the cwd assumption inside the sidecar does not affect what
+        # the ``cat`` resolves.
+        assert "/workspace/.helix_asi_log_" in commands[2][2]
+
+    def test_sandboxed_evaluator_parses_helix_log_capture_into_asi(self, mocker):
+        """The trailing ``cat`` capture command's stdout is JSONL from
+        the evaluator's ``helix.log()`` calls.  The executor must run
+        it through :func:`helix.asi.read_text` and surface the
+        rendered notes under ``asi["log"]`` — this end-to-end check
+        protects against accidentally treating the capture stdout as
+        an ``extra_N`` entry or dropping it."""
+        mock_run = mocker.patch("helix.executor.run_sandboxed_commands")
+        mocker.patch(
+            "helix.executor.current_evaluator_sidecar_runtime",
+            return_value=MagicMock(),
+        )
+        # Two records simulating an evaluator that called
+        # ``helix.log("starting", phase="warmup")`` then
+        # ``helix.log(score=0.7)``.
+        capture_stdout = (
+            '{"message": "starting", "phase": "warmup"}\n'
+            '{"score": 0.7}\n'
+        )
+        mock_run.return_value = [
+            MagicMock(stdout="HELIX_RESULT=[]\n", stderr="", returncode=0),
+            MagicMock(stdout=capture_stdout, stderr="", returncode=0),
+        ]
+
+        candidate = make_candidate()
+        config = make_config(command="python /runner/evaluate.py")
+        config.evaluator.sidecar = EvaluatorSidecarConfig(
+            image="eval:latest",
+            runner_image="eval-runner:latest",
+            command="python -m server",
+            endpoint="http://helix-evaluator:8080/evaluate",
+        )
+        config = config.model_copy(
+            update={"sandbox": SandboxConfig(enabled=True, evaluator=True)}
+        )
+
+        result = run_evaluator(candidate, config)
+
+        # Notes were captured via the ``cat`` command and routed to
+        # ``asi["log"]`` (NOT exposed as ``extra_0``, which would
+        # mistakenly treat the capture as a user-provided extra
+        # command).
+        assert "log" in result.asi
+        assert "starting" in result.asi["log"]
+        assert "phase: warmup" in result.asi["log"]
+        assert "score: 0.7" in result.asi["log"]
+        assert "extra_0" not in result.asi
 
     def test_run_evaluator_uses_host_when_sandbox_enabled_but_evaluator_disabled(self, mocker):
         mock_host_run = mocker.patch("helix.executor.subprocess.run")

--- a/tests/unit/test_executor_security.py
+++ b/tests/unit/test_executor_security.py
@@ -322,6 +322,7 @@ class TestRunEvaluator:
         mock_run.return_value = [
             MagicMock(stdout="main", stderr="", returncode=0),
             MagicMock(stdout="extra", stderr="", returncode=0),
+            MagicMock(stdout="", stderr="", returncode=0),
         ]
 
         candidate = make_candidate()
@@ -333,11 +334,16 @@ class TestRunEvaluator:
             command="python -m server",
             endpoint="http://helix-evaluator:8080/evaluate",
         )
-        config = config.model_copy(update={"sandbox": SandboxConfig(enabled=True, evaluator=True)})
+        config = config.model_copy(
+            update={"sandbox": SandboxConfig(enabled=True, evaluator=True)}
+        )
 
         run_evaluator(candidate, config)
 
-        assert mock_run.call_args.args[0] == [["python", "/runner/evaluate.py"], ["python", "extra.py"]]
+        commands = mock_run.call_args.args[0]
+        assert commands[:2] == [["python", "/runner/evaluate.py"], ["python", "extra.py"]]
+        assert commands[2][:2] == ["sh", "-c"]
+        assert ".helix_asi_log_" in commands[2][2]
 
     def test_run_evaluator_uses_host_when_sandbox_enabled_but_evaluator_disabled(self, mocker):
         mock_host_run = mocker.patch("helix.executor.subprocess.run")

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -85,6 +85,20 @@ class TestBuildMutationPrompt:
         prompt = build_mutation_prompt("goal", er)
         assert "unique_stdout_xyz" in prompt
 
+    def test_hides_helix_result_machine_protocol_from_prompt(self):
+        er = make_eval_result(
+            asi={
+                "stdout": (
+                    "HELIX_RESULT=[[1.0, {\"task_completed\": true}]]\n"
+                    "human fallback line\n"
+                ),
+                "stderr": "",
+            }
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "human fallback line" in prompt
+        assert "HELIX_RESULT=" not in prompt
+
     def test_contains_stderr(self):
         er = make_eval_result(asi={"stdout": "", "stderr": "unique_stderr_abc"})
         prompt = build_mutation_prompt("goal", er)
@@ -121,6 +135,53 @@ class TestBuildMutationPrompt:
         er = make_eval_result(scores={})
         prompt = build_mutation_prompt("goal", er)
         assert "no scores recorded" in prompt
+
+    def test_renders_helix_log_notes(self):
+        er = make_eval_result(
+            asi={"stdout": "debug stdout", "stderr": "", "log": "note"}
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "## Evaluator Notes" in prompt
+        assert "note" in prompt
+
+    def test_suppresses_success_stdout_when_log_exists(self):
+        er = make_eval_result(
+            asi={"stdout": "debug stdout", "stderr": "debug stderr", "log": "note"}
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "note" in prompt
+        assert "debug stdout" not in prompt
+        assert "debug stderr" not in prompt
+
+    def test_suppresses_success_stdout_when_structured_diagnostics_exist(self):
+        er = EvalResult(
+            candidate_id="g0-s0",
+            scores={"pass_rate": 0.5},
+            asi={"stdout": "debug stdout", "stderr": "debug stderr"},
+            instance_scores={"ex_0": 1.0},
+            per_example_side_info=[{"note": "structured note"}],
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "structured note" in prompt
+        assert "debug stdout" not in prompt
+        assert "debug stderr" not in prompt
+
+    def test_includes_stdout_stderr_when_evaluator_failed(self):
+        er = EvalResult(
+            candidate_id="g0-s0",
+            scores={"pass_rate": 0.0},
+            asi={
+                "stdout": "debug stdout",
+                "stderr": "debug stderr",
+                "log": "note",
+                "_returncode": "1",
+            },
+            instance_scores={"ex_0": 0.0},
+            per_example_side_info=[{"note": "structured note"}],
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "debug stdout" in prompt
+        assert "debug stderr" in prompt
 
 
 class TestPerExampleDiagnostics:

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -183,6 +183,29 @@ class TestBuildMutationPrompt:
         assert "debug stdout" in prompt
         assert "debug stderr" in prompt
 
+    def test_returncode_sentinel_does_not_leak_into_prompt(self):
+        """``_returncode`` is a HELIX-internal sentinel inside ``asi``
+        (kept there to preserve the GEPA O.A. EvaluationBatch
+        interface).  The mutation prompt builder must filter it out of
+        the catch-all "Extra Evaluator Info" rendering — surfacing the
+        literal ``_returncode: 0`` would leak HELIX implementation
+        detail into the LLM's reflection context."""
+        er = EvalResult(
+            candidate_id="g0-s0",
+            scores={"pass_rate": 1.0},
+            asi={
+                "stdout": "",
+                "stderr": "",
+                "_returncode": "0",
+                "extra_0": "real-extra",
+            },
+            instance_scores={"ex_0": 1.0},
+        )
+        prompt = build_mutation_prompt("goal", er)
+        assert "_returncode" not in prompt
+        # Sanity: the genuine extra_N entry still renders.
+        assert "real-extra" in prompt
+
 
 class TestPerExampleDiagnostics:
     """``build_mutation_prompt`` renders ``eval_result.per_example_side_info``

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -355,6 +355,48 @@ def test_agent_syncs_changes_back_but_excludes_git_and_artifacts(
     assert not (source / ".helix_backend_stdout.txt").exists()
 
 
+def test_agent_sync_tolerates_inaccessible_workspace_paths(
+    tmp_path: Path, mocker, monkeypatch
+):
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "keep.py").write_text("old\n")
+    (source / ".gitignore").write_text("*.tmp\n")
+
+    workspace_ready = False
+    real_exists = Path.exists
+
+    def fake_exists(path: Path) -> bool:
+        if workspace_ready and path.name == ".gitignore" and "/workspace/" in str(path):
+            raise PermissionError("permission denied")
+        return real_exists(path)
+
+    def fake_run(args, **kwargs):
+        nonlocal workspace_ready
+        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+            workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
+            (workspace / "keep.py").write_text("new\n")
+            workspace_ready = True
+        return subprocess.CompletedProcess(args, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+
+    run_sandboxed_command(
+        ["claude", "-p", "prompt"],
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True),
+        scope="agent",
+        sync_back=True,
+        image="helix-test:latest",
+        agent_backend="claude",
+    )
+
+    assert (source / "keep.py").read_text() == "new\n"
+    assert (source / ".gitignore").read_text() == "*.tmp\n"
+
+
 def test_agent_copies_claude_transcript_from_auth_volume(tmp_path: Path, mocker):
     source = tmp_path / "candidate"
     source.mkdir()

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -458,6 +458,57 @@ def test_agent_copies_claude_transcript_from_auth_volume(tmp_path: Path, mocker)
     assert "helix-auth-claude:/home/node:ro" in copy_call
 
 
+def test_agent_sync_tolerates_inaccessible_backend_transcripts(
+    tmp_path: Path, mocker, monkeypatch
+):
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "main.py").write_text("old\n")
+
+    workspace_root: Path | None = None
+    real_exists = Path.exists
+
+    def fake_exists(path: Path) -> bool:
+        if (
+            workspace_root is not None
+            and path == workspace_root / ".helix_artifacts" / "backend_transcripts"
+        ):
+            raise PermissionError("permission denied")
+        return real_exists(path)
+
+    def fake_run(args, **kwargs):
+        nonlocal workspace_root
+        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+            workspace_root = Path(args[args.index("-v") + 1].split(":", 1)[0])
+            (workspace_root / "main.py").write_text("new\n")
+            blocked = workspace_root / ".helix_artifacts" / "backend_transcripts"
+            blocked.mkdir(parents=True, exist_ok=True)
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout='{"type":"result","session_id":"sess_123"}\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+
+    run_sandboxed_command(
+        ["claude", "-p", "prompt"],
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True),
+        scope="agent",
+        sync_back=True,
+        image="helix-test:latest",
+        agent_backend="claude",
+    )
+
+    assert (source / "main.py").read_text() == "new\n"
+    assert not (source / ".helix_artifacts" / "backend_transcripts").exists()
+
+
 def test_agent_sync_back_honors_omitted_paths(tmp_path: Path, mocker):
     source = tmp_path / "candidate"
     source.mkdir()


### PR DESCRIPTION
## Summary
- Add a general HELIX reserved metadata log channel for evaluator-visible messages.
- Thread reserved metadata logging through executor and mutator flows.
- Add unit coverage for executor and mutator reserved metadata log behavior.

## Scope check
- Branch is based on `origin/main` and contains one cherry-picked commit from `dea0314` (`a4c81bb`).
- Diff is limited to general HELIX reserved metadata/log channel files.
- Checked the diff for CaP-X/cap-x/robosuite/R1Pro/LIBERO/domain-specific prompt-filter terms; no matches.

## Tests
- `.venv/bin/ruff check .` (fails on existing unrelated `F841` in `examples/web_researcher/evaluate.py:248`)
- `.venv/bin/ruff check README.md src/helix/__init__.py src/helix/reserved metadata.py src/helix/executor.py src/helix/mutator.py tests/unit/test_executor.py tests/unit/test_executor_security.py tests/unit/test_mutator.py`
- `.venv/bin/pytest tests/unit` (690 passed)
