### PR TITLE
Address remaining review feedback from PR #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validation errors, pointing users at likely typos or misplaced keys.
 
 ### Changed
+- **BREAKING**: `evolution.cache_evaluation` now defaults to `False`
+  (previously `True`).  Matches GEPA Optimize Anything's conservative
+  cache_evaluation default
+  (`src/gepa/optimize_anything.py:476`).  When the cache *is* enabled,
+  entries are now keyed by candidate **content** (the worktree's
+  `HEAD^{tree}` SHA, with a clean-state guard) rather than HELIX's
+  lineage `candidate.id`, so equivalent candidates can reuse results
+  across re-derivations.  Configs that previously relied on cache hits
+  (e.g. resume scenarios that re-evaluate the seed) should set
+  `cache_evaluation = true` explicitly.
 - **BREAKING**: `score_parser = "helix_result"` now takes a **per-example**
   `HELIX_RESULT=[[score_0, side_info_0], [score_1, side_info_1], ...]`
   payload — one `[score, side_info]` pair per id in `helix_batch.json`.

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -882,14 +882,14 @@ def _inject_top_k_best_example_history(
     ``top_k_best_example_history``; it is rendered by the existing diagnostics
     prompt path without changing candidate/worktree semantics.
     """
-    if k <= 0 or not eval_result.instance_scores or not frontier._results:
+    if k <= 0 or not eval_result.instance_scores or not frontier.has_results():
         return eval_result
 
     example_ids = list(eval_result.instance_scores.keys())
     history_by_id: dict[str, list[dict[str, Any]]] = {}
     for eid in example_ids:
         rows: list[dict[str, Any]] = []
-        for cid, result in frontier._results.items():
+        for cid, result in frontier.iter_results():
             if eid in result.instance_scores:
                 rows.append(
                     {
@@ -904,13 +904,25 @@ def _inject_top_k_best_example_history(
     if not history_by_id:
         return eval_result
 
-    per_example = (
-        [dict(item) for item in eval_result.per_example_side_info]
-        if eval_result.per_example_side_info is not None
-        else [{} for _ in example_ids]
-    )
-    if len(per_example) != len(example_ids):
-        per_example = [{} for _ in example_ids]
+    if eval_result.per_example_side_info is None:
+        per_example: list[dict[str, Any]] = [{} for _ in example_ids]
+    else:
+        per_example = [dict(item) for item in eval_result.per_example_side_info]
+        if len(per_example) != len(example_ids):
+            # Length skew between ``instance_scores`` and ``per_example_side_info``
+            # almost certainly indicates an upstream bug (the two are positional
+            # over the same example id list).  Don't silently throw away the
+            # caller's diagnostics — warn loudly and rebuild empty so reflection
+            # still gets the top-K history rather than crashing.
+            logger.warning(
+                "per_example_side_info length (%d) does not match "
+                "instance_scores length (%d) for candidate %s; rebuilding "
+                "side_info from empty before injecting top_k history.",
+                len(per_example),
+                len(example_ids),
+                eval_result.candidate_id,
+            )
+            per_example = [{} for _ in example_ids]
 
     for idx, eid in enumerate(example_ids):
         history_rows = history_by_id.get(eid)

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import random
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -215,6 +216,28 @@ class ParetoFrontier:
     def frontier_type(self) -> FrontierType:
         """Selected Pareto dimensionality (GEPA parity)."""
         return self._frontier_type
+
+    # ------------------------------------------------------------------
+    # Read-only accessors — public surface over the append-only result
+    # store so callers don't need to reach into ``_results``.
+    # ------------------------------------------------------------------
+
+    def get_result(self, candidate_id: str) -> EvalResult | None:
+        """Return the stored EvalResult for ``candidate_id`` or None."""
+        return self._results.get(candidate_id)
+
+    def iter_results(self) -> Iterator[tuple[str, EvalResult]]:
+        """Yield ``(candidate_id, EvalResult)`` pairs for all known candidates.
+
+        Iteration order matches the underlying dict's insertion order, which
+        in turn mirrors the order in which candidates were ``add``-ed — useful
+        for diagnostics that want a stable replay of population history.
+        """
+        return iter(self._results.items())
+
+    def has_results(self) -> bool:
+        """True iff at least one candidate has been added with a result."""
+        return bool(self._results)
 
     # ------------------------------------------------------------------
     # Mutation helpers — mirrors GEPAState._update_pareto_front_for_val_id

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -6,6 +6,7 @@ import json
 import os
 import pickle
 import tempfile
+import time
 import warnings
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -275,18 +276,41 @@ def load_eval_cache(base_dir: Path) -> dict[Any, Any] | None:
         with open(target, "rb") as f:
             loaded = pickle.load(f)
     except Exception as exc:
+        quarantined = _quarantine_corrupt_cache(target, reason="unreadable")
         warnings.warn(
-            f"Ignoring unreadable eval cache at {target}: {type(exc).__name__}: {exc}",
+            f"Ignoring unreadable eval cache at {target}: "
+            f"{type(exc).__name__}: {exc}. Quarantined to {quarantined}.",
             RuntimeWarning,
             stacklevel=2,
         )
         return None
     if not isinstance(loaded, dict):
+        quarantined = _quarantine_corrupt_cache(target, reason="non-dict")
         warnings.warn(
             f"Ignoring eval cache at {target}: expected dict, got "
-            f"{type(loaded).__name__}.",
+            f"{type(loaded).__name__}. Quarantined to {quarantined}.",
             RuntimeWarning,
             stacklevel=2,
         )
         return None
     return loaded
+
+
+def _quarantine_corrupt_cache(target: Path, *, reason: str) -> Path:
+    """Move a corrupt eval cache file aside so the next save doesn't overwrite it.
+
+    Returns the destination path (or the original if rename failed — in which
+    case the file is left in place; the caller's warning will still surface
+    the underlying error).  We use a unique timestamped suffix so repeated
+    failed loads don't collide.
+    """
+    suffix = f".corrupt-{reason}-{int(time.time() * 1000)}"
+    dest = target.with_name(target.name + suffix)
+    try:
+        os.replace(target, dest)
+        return dest
+    except OSError:
+        # Best-effort: if we can't rename (e.g. cross-device, perms), leave
+        # the file in place.  The save path uses ``os.replace`` to overwrite
+        # atomically, so a future successful save still wins.
+        return target

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -119,6 +119,64 @@ def test_top_k_best_example_history_injection_preserves_side_info() -> None:
     ]
 
 
+def test_top_k_best_example_history_warns_on_side_info_length_skew(
+    caplog: Any,
+) -> None:
+    """A length mismatch between instance_scores and per_example_side_info
+    indicates an upstream bug; injection must warn (not silently drop the
+    user's diagnostics) before rebuilding empty.
+    """
+    import logging
+
+    frontier = ParetoFrontier()
+    cand_a = _make_candidate("cand-a")
+    frontier.add(cand_a, _make_result("cand-a", {"0": 0.5, "1": 0.7}))
+
+    # 2 examples but only 1 side_info dict — clearly skewed.
+    current = EvalResult(
+        candidate_id="cand-skewed",
+        scores={},
+        asi={},
+        instance_scores={"0": 0.0, "1": 0.0},
+        per_example_side_info=[{"trace": "lonely"}],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="helix.evolution"):
+        updated = _inject_top_k_best_example_history(current, frontier, k=1)
+
+    assert any(
+        "per_example_side_info length" in rec.message for rec in caplog.records
+    ), f"expected length-skew warning, got: {[r.message for r in caplog.records]}"
+    assert updated.per_example_side_info == [
+        {"top_k_best_example_history": [{"candidate_id": "cand-a", "score": 0.5}]},
+        {"top_k_best_example_history": [{"candidate_id": "cand-a", "score": 0.7}]},
+    ]
+
+
+def test_pareto_frontier_public_accessors_match_internal_state() -> None:
+    """``iter_results`` / ``get_result`` / ``has_results`` are the public
+    surface used by ``_inject_top_k_best_example_history``; pin their
+    contract so we don't regress to ``_results`` poking.
+    """
+    frontier = ParetoFrontier()
+    assert frontier.has_results() is False
+    assert frontier.get_result("missing") is None
+    assert list(frontier.iter_results()) == []
+
+    cand_a = _make_candidate("cand-a")
+    cand_b = _make_candidate("cand-b")
+    res_a = _make_result("cand-a", {"0": 0.1})
+    res_b = _make_result("cand-b", {"0": 0.9})
+    frontier.add(cand_a, res_a)
+    frontier.add(cand_b, res_b)
+
+    assert frontier.has_results() is True
+    assert frontier.get_result("cand-a") is res_a
+    assert frontier.get_result("cand-b") is res_b
+    # Insertion order preserved → diagnostics get a stable replay.
+    assert [cid for cid, _ in frontier.iter_results()] == ["cand-a", "cand-b"]
+
+
 def _make_minibatch_config(
     train_path: Path,
     *,

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -201,25 +201,40 @@ def test_eval_cache_load_returns_none_when_missing(tmp_path: Path) -> None:
 
 
 def test_eval_cache_load_tolerates_non_dict(tmp_path: Path) -> None:
-    """A corrupt eval_cache.pkl warns and resumes with an empty cache."""
+    """A corrupt eval_cache.pkl warns, quarantines, and resumes with an empty cache."""
     import pickle as _pickle
 
     helix_dir = tmp_path / ".helix"
     helix_dir.mkdir(parents=True)
-    (helix_dir / "eval_cache.pkl").write_bytes(_pickle.dumps(["not", "a", "dict"]))
+    target = helix_dir / "eval_cache.pkl"
+    target.write_bytes(_pickle.dumps(["not", "a", "dict"]))
 
-    with pytest.warns(RuntimeWarning, match="Ignoring eval cache"):
+    with pytest.warns(RuntimeWarning, match="Quarantined to "):
         assert load_eval_cache(tmp_path) is None
+
+    # The corrupt file must be moved aside (not deleted) so the user can
+    # post-mortem, and must not still occupy the canonical path (so the
+    # next save doesn't have to overwrite it implicitly).
+    assert not target.exists()
+    quarantined = list(helix_dir.glob("eval_cache.pkl.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_bytes() == _pickle.dumps(["not", "a", "dict"])
 
 
 def test_eval_cache_load_tolerates_unreadable_pickle(tmp_path: Path) -> None:
-    """Unreadable pickle bytes should not abort resume."""
+    """Unreadable pickle bytes should not abort resume; file is quarantined."""
     helix_dir = tmp_path / ".helix"
     helix_dir.mkdir(parents=True)
-    (helix_dir / "eval_cache.pkl").write_bytes(b"not a pickle")
+    target = helix_dir / "eval_cache.pkl"
+    target.write_bytes(b"not a pickle")
 
     with pytest.warns(RuntimeWarning, match="Ignoring unreadable eval cache"):
         assert load_eval_cache(tmp_path) is None
+
+    assert not target.exists()
+    quarantined = list(helix_dir.glob("eval_cache.pkl.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_bytes() == b"not a pickle"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Follow-up to merged PR #14 picking up the review items not covered by `cdc8336` / `fa7707c`.

- **Public `ParetoFrontier` accessors** (`iter_results`, `get_result`, `has_results`) and switch `_inject_top_k_best_example_history` to use them instead of reaching into `frontier._results`.
- **Warn on `per_example_side_info` length skew** instead of silently rebuilding to empty dicts. A length mismatch with `instance_scores` almost always indicates an upstream bug; silently dropping caller-supplied diagnostics hides it.
- **Quarantine corrupt `eval_cache.pkl`** payloads. On either an unreadable pickle or a non-dict payload, `load_eval_cache` now renames the file to a timestamped sibling (`eval_cache.pkl.corrupt-<reason>-<ms>`) before returning `None` so the corrupt bytes are recoverable for post-mortem and the next save isn't responsible for overwriting them.
- **CHANGELOG entry** for the `cache_evaluation` default flip (`True` → `False`) and content-addressed keying — flagged in review as user-visible but undocumented.
- **New tests**:
  - `ParetoFrontier` public accessors (empty + populated, insertion order).
  - `_inject_top_k_best_example_history` length-skew warning path.
  - Quarantine destination + bytes for both corrupt-cache load paths.

Skipped (intentionally): per-candidate memoization of `git rev-parse HEAD^{tree}`. Cost is bounded (≤2 subprocesses per candidate per evaluation cycle) and correct invalidation across worktree mutations is non-trivial; profiling can revisit if it shows up.

## Test plan
- [x] `pytest tests/` — 692 passed locally.
- [x] `ruff check` clean on touched files.
- [x] `mypy --strict` clean on touched source files.
- [x] CI: full ruff/mypy/pytest sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)