### PR TITLE
Fix protected directory evaluator manifests

### DIFF
--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -74,6 +74,10 @@ from helix.worktree import (
 
 logger = logging.getLogger(__name__)
 
+# NOTE: ``shutil.ignore_patterns`` uses ``fnmatch`` *basename* matching, not
+# gitignore semantics.  Add basename globs here only -- patterns like
+# ``**/build/`` or ``cache/**`` will not match.  If we ever need gitignore
+# semantics, switch to ``pathspec`` rather than extending this tuple.
 _PROTECTED_DIRECTORY_IGNORE_PATTERNS = (
     ".git",
     "__pycache__",
@@ -81,6 +85,10 @@ _PROTECTED_DIRECTORY_IGNORE_PATTERNS = (
     ".pytest_cache",
     ".mypy_cache",
     ".ruff_cache",
+)
+# Reusable matcher; the patterns are constant so we build it once.
+_PROTECTED_DIRECTORY_IGNORE_MATCHER = shutil.ignore_patterns(
+    *_PROTECTED_DIRECTORY_IGNORE_PATTERNS
 )
 
 
@@ -263,7 +271,7 @@ def _copy_protected_path(source: Path, destination: Path) -> None:
         shutil.copytree(
             source,
             destination,
-            ignore=shutil.ignore_patterns(*_PROTECTED_DIRECTORY_IGNORE_PATTERNS),
+            ignore=_PROTECTED_DIRECTORY_IGNORE_MATCHER,
         )
     elif source.is_symlink():
         os.symlink(os.readlink(source), destination)
@@ -296,26 +304,41 @@ def _refresh_and_snapshot_protected_evaluator_files(
 
 
 def _sha256_file(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+    """Streamed SHA-256 of ``path``.
+
+    Uses ``hashlib.file_digest`` (Python 3.11+) so large protected files
+    (e.g., evaluator dataset ``.jsonl`` files) are not buffered in memory.
+    """
+    with path.open("rb") as f:
+        return hashlib.file_digest(f, "sha256").hexdigest()
 
 
 def _iter_protected_manifest_files(
     source_path: Path,
     rel_path: str,
 ) -> list[tuple[str, Path]]:
-    """Return manifest entries under one protected file/directory."""
+    """Return manifest entries under one protected file/directory.
+
+    ``source_path`` is expected to already be a real path (callers resolve
+    symlinks before calling).  ``os.walk`` is used with ``followlinks=False``
+    (the default) so symlinks inside the directory are not traversed.
+    """
     if source_path.is_file():
         return [(rel_path, source_path)]
-    if not source_path.is_dir() or source_path.is_symlink():
+    if not source_path.is_dir():
         return []
 
-    ignore = shutil.ignore_patterns(*_PROTECTED_DIRECTORY_IGNORE_PATTERNS)
     entries: list[tuple[str, Path]] = []
     for dirpath_str, dirnames, filenames in os.walk(source_path):
-        ignored = ignore(dirpath_str, [*dirnames, *filenames])
+        ignored = _PROTECTED_DIRECTORY_IGNORE_MATCHER(
+            dirpath_str, [*dirnames, *filenames]
+        )
         dirnames[:] = sorted(name for name in dirnames if name not in ignored)
         for filename in sorted(name for name in filenames if name not in ignored):
             file_path = Path(dirpath_str) / filename
+            # Defensive against TOCTOU: ``os.walk`` already separated files
+            # from directories, but a concurrent unlink/rename could leave a
+            # stale name behind.
             if not file_path.is_file():
                 continue
             entry_path = Path(rel_path) / file_path.relative_to(source_path)
@@ -332,7 +355,12 @@ def _build_evaluator_integrity_manifest(
     baseline_root: Path,
     project_root: Path,
 ) -> dict[str, str]:
-    """Build {repo_relative_path: sha256} for protected evaluator files."""
+    """Build {repo_relative_path: sha256} for protected evaluator files.
+
+    Fails closed: an unreadable protected file raises ``HelixError`` rather
+    than silently being omitted from the manifest -- otherwise tamper
+    detection would not flag changes to that file on resume.
+    """
     manifest: dict[str, str] = {}
     for rel_path in _collect_protected_evaluator_paths(config, project_root):
         source_path = (baseline_root / rel_path).resolve()
@@ -343,14 +371,27 @@ def _build_evaluator_integrity_manifest(
                 baseline_root,
             )
             continue
-        for manifest_rel_path, file_path in _iter_protected_manifest_files(
-            source_path,
-            rel_path,
-        ):
+        entries = _iter_protected_manifest_files(source_path, rel_path)
+        if not entries and source_path.is_dir():
+            # Surface likely misconfigurations (e.g., a protected directory
+            # whose only contents match the ignore list).
+            logger.warning(
+                "Protected evaluator directory %s contributed 0 manifest "
+                "entries (every file matched the ignore list).",
+                rel_path,
+            )
+        for manifest_rel_path, file_path in entries:
             try:
                 manifest[manifest_rel_path] = _sha256_file(file_path)
-            except OSError:
-                logger.exception("Failed hashing protected evaluator file: %s", file_path)
+            except OSError as exc:
+                raise HelixError(
+                    f"Failed hashing protected evaluator file: {file_path}",
+                    operation="build evaluator integrity manifest",
+                    suggestion=(
+                        "Ensure the file is readable and not held open by "
+                        "another process before retrying."
+                    ),
+                ) from exc
     return manifest
 
 
@@ -387,22 +428,50 @@ def _load_evaluator_integrity_manifest(base_dir: Path) -> dict[str, str] | None:
 def _detect_evaluator_tamper(
     candidate: Candidate,
     manifest: dict[str, str],
+    config: HelixConfig | None = None,
+    project_root: Path | None = None,
 ) -> list[str]:
-    """Return protected paths that diverge from the frozen evaluator manifest."""
+    """Return protected paths that diverge from the frozen evaluator manifest.
+
+    Detects three classes of tamper:
+
+    1. Modification of a baseline-listed file (hash mismatch).
+    2. Deletion of a baseline-listed file.
+    3. *Addition* of a previously-unknown file inside a protected directory,
+       when ``config`` and ``project_root`` are supplied.  Without these
+       arguments only the first two classes are reported, preserving the
+       legacy contract for callers that don't have config in scope.
+    """
     if not manifest:
         return []
-    violations: list[str] = []
+    violations: set[str] = set()
     worktree_root = Path(candidate.worktree_path)
     for rel_path, expected_hash in manifest.items():
         candidate_path = worktree_root / rel_path
         if not candidate_path.exists() or not candidate_path.is_file():
-            violations.append(rel_path)
+            violations.add(rel_path)
             continue
         try:
             if _sha256_file(candidate_path) != expected_hash:
-                violations.append(rel_path)
+                violations.add(rel_path)
         except OSError:
-            violations.append(rel_path)
+            violations.add(rel_path)
+
+    if config is not None and project_root is not None:
+        known = set(manifest)
+        for protected_rel in _collect_protected_evaluator_paths(
+            config, project_root
+        ):
+            candidate_path = worktree_root / protected_rel
+            # Only directories can hold *new* files; single-file protected
+            # paths are fully covered by the manifest loop above.
+            if not candidate_path.is_dir() or candidate_path.is_symlink():
+                continue
+            for entry_rel, _ in _iter_protected_manifest_files(
+                candidate_path, protected_rel
+            ):
+                if entry_rel not in known:
+                    violations.add(entry_rel)
     return sorted(violations)
 
 
@@ -1576,7 +1645,10 @@ def _run_evolution_impl(
                             )
 
                         merge_tamper = _detect_evaluator_tamper(
-                            merged, evaluator_manifest
+                            merged,
+                            evaluator_manifest,
+                            config,
+                            project_root,
                         )
                         if merge_tamper:
                             # Evaluator-tamper reject happens PRE-eval — no
@@ -2218,7 +2290,9 @@ def _run_evolution_impl(
                 mutations_attempted += 1
                 live.update(mutations_attempted=mutations_attempted)
 
-                tampered_paths = _detect_evaluator_tamper(child, evaluator_manifest)
+                tampered_paths = _detect_evaluator_tamper(
+                    child, evaluator_manifest, config, project_root
+                )
                 if tampered_paths:
                     print_warning(
                         f"Mutation {child.id} touched protected evaluator files "

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -74,6 +74,15 @@ from helix.worktree import (
 
 logger = logging.getLogger(__name__)
 
+_PROTECTED_DIRECTORY_IGNORE_PATTERNS = (
+    ".git",
+    "__pycache__",
+    "*.pyc",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -254,14 +263,7 @@ def _copy_protected_path(source: Path, destination: Path) -> None:
         shutil.copytree(
             source,
             destination,
-            ignore=shutil.ignore_patterns(
-                ".git",
-                "__pycache__",
-                "*.pyc",
-                ".pytest_cache",
-                ".mypy_cache",
-                ".ruff_cache",
-            ),
+            ignore=shutil.ignore_patterns(*_PROTECTED_DIRECTORY_IGNORE_PATTERNS),
         )
     elif source.is_symlink():
         os.symlink(os.readlink(source), destination)
@@ -297,6 +299,30 @@ def _sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _iter_protected_manifest_files(
+    source_path: Path,
+    rel_path: str,
+) -> list[tuple[str, Path]]:
+    """Return manifest entries under one protected file/directory."""
+    if source_path.is_file():
+        return [(rel_path, source_path)]
+    if not source_path.is_dir() or source_path.is_symlink():
+        return []
+
+    ignore = shutil.ignore_patterns(*_PROTECTED_DIRECTORY_IGNORE_PATTERNS)
+    entries: list[tuple[str, Path]] = []
+    for dirpath_str, dirnames, filenames in os.walk(source_path):
+        ignored = ignore(dirpath_str, [*dirnames, *filenames])
+        dirnames[:] = sorted(name for name in dirnames if name not in ignored)
+        for filename in sorted(name for name in filenames if name not in ignored):
+            file_path = Path(dirpath_str) / filename
+            if not file_path.is_file():
+                continue
+            entry_path = Path(rel_path) / file_path.relative_to(source_path)
+            entries.append((entry_path.as_posix(), file_path))
+    return entries
+
+
 def _evaluator_manifest_path(base_dir: Path) -> Path:
     return base_dir / _EVALUATOR_MANIFEST_FILENAME
 
@@ -310,17 +336,21 @@ def _build_evaluator_integrity_manifest(
     manifest: dict[str, str] = {}
     for rel_path in _collect_protected_evaluator_paths(config, project_root):
         source_path = (baseline_root / rel_path).resolve()
-        if not source_path.exists() or not source_path.is_file():
+        if not source_path.exists():
             logger.warning(
-                "Skipping protected evaluator file %s: missing from baseline %s",
+                "Skipping protected evaluator path %s: missing from baseline %s",
                 rel_path,
                 baseline_root,
             )
             continue
-        try:
-            manifest[rel_path] = _sha256_file(source_path)
-        except OSError:
-            logger.exception("Failed hashing protected evaluator file: %s", source_path)
+        for manifest_rel_path, file_path in _iter_protected_manifest_files(
+            source_path,
+            rel_path,
+        ):
+            try:
+                manifest[manifest_rel_path] = _sha256_file(file_path)
+            except OSError:
+                logger.exception("Failed hashing protected evaluator file: %s", file_path)
     return manifest
 
 

--- a/tests/unit/test_evaluator_integrity.py
+++ b/tests/unit/test_evaluator_integrity.py
@@ -130,6 +130,102 @@ def test_manifest_recurses_protected_directories_and_ignores_cache_files(tmp_pat
     assert violations == ["datasets/train.jsonl"]
 
 
+def test_detects_new_files_added_under_protected_directory(tmp_path):
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    (baseline / "evaluate.py").write_text("print('ok')\n")
+    (baseline / "datasets").mkdir()
+    (baseline / "datasets" / "train.jsonl").write_text('{"id": 1}\n')
+
+    config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(
+            command="python evaluate.py",
+            protected_files=["datasets"],
+        ),
+    )
+
+    manifest = _build_evaluator_integrity_manifest(config, baseline, baseline)
+
+    candidate_dir = tmp_path / "candidate"
+    shutil.copytree(baseline, candidate_dir)
+    # Inject a brand-new file the manifest doesn't know about, plus an
+    # ignored cache file that should NOT count as a violation.
+    (candidate_dir / "datasets" / "leak.jsonl").write_text('{"leak": true}\n')
+    (candidate_dir / "datasets" / "__pycache__").mkdir()
+    (candidate_dir / "datasets" / "__pycache__" / "x.pyc").write_bytes(b"cache")
+
+    # Without config + project_root the legacy contract holds: only
+    # modifications/deletions are reported.
+    assert _detect_evaluator_tamper(_candidate(str(candidate_dir)), manifest) == []
+
+    # With config + project_root the new file is flagged; ignored caches
+    # are not.
+    violations = _detect_evaluator_tamper(
+        _candidate(str(candidate_dir)), manifest, config, baseline
+    )
+    assert violations == ["datasets/leak.jsonl"]
+
+
+def test_build_manifest_warns_for_directory_with_only_ignored_files(
+    tmp_path, caplog
+):
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    (baseline / "evaluate.py").write_text("print('ok')\n")
+    (baseline / "datasets" / "__pycache__").mkdir(parents=True)
+    (baseline / "datasets" / "__pycache__" / "ignored.pyc").write_bytes(b"cache")
+
+    config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(
+            command="python evaluate.py",
+            protected_files=["datasets"],
+        ),
+    )
+
+    with caplog.at_level("WARNING", logger="helix.evolution"):
+        manifest = _build_evaluator_integrity_manifest(config, baseline, baseline)
+
+    assert "datasets" in caplog.text
+    assert "0 manifest entries" in caplog.text
+    assert sorted(manifest) == ["evaluate.py"]
+
+
+def test_build_manifest_fails_closed_on_unreadable_protected_file(tmp_path):
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    (baseline / "evaluate.py").write_text("print('ok')\n")
+
+    config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(
+            command="python evaluate.py",
+            protected_files=["evaluate.py"],
+        ),
+    )
+
+    # Make the file unreadable; on POSIX this triggers ``PermissionError``
+    # (a subclass of ``OSError``) inside ``_sha256_file``.
+    target = baseline / "evaluate.py"
+    original_mode = target.stat().st_mode
+    target.chmod(0)
+    try:
+        if target.read_bytes() == b"":
+            pytest.skip("filesystem ignores chmod 0 (e.g. running as root)")
+    except PermissionError:
+        pass
+    else:
+        target.chmod(original_mode)
+        pytest.skip("filesystem ignores chmod 0 (e.g. running as root)")
+
+    try:
+        with pytest.raises(HelixError):
+            _build_evaluator_integrity_manifest(config, baseline, baseline)
+    finally:
+        target.chmod(original_mode)
+
+
 def test_manifest_roundtrip(tmp_path):
     manifest = {"evaluate.py": "abc123", "fixtures/goldens.json": "def456"}
     _write_evaluator_integrity_manifest(tmp_path, manifest)

--- a/tests/unit/test_evaluator_integrity.py
+++ b/tests/unit/test_evaluator_integrity.py
@@ -91,6 +91,45 @@ def test_detects_modified_and_deleted_evaluator_files(tmp_path):
     assert violations == ["evaluate.py", "fixtures/goldens.json"]
 
 
+def test_manifest_recurses_protected_directories_and_ignores_cache_files(tmp_path):
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    (baseline / "evaluate.py").write_text("print('ok')\n")
+    (baseline / "datasets" / "nested").mkdir(parents=True)
+    (baseline / "datasets" / "train.jsonl").write_text('{"id": 1}\n')
+    (baseline / "datasets" / "nested" / "eval.jsonl").write_text('{"id": 2}\n')
+    (baseline / "datasets" / "__pycache__").mkdir()
+    (baseline / "datasets" / "__pycache__" / "ignored.pyc").write_bytes(b"cache")
+    (baseline / "datasets" / ".pytest_cache").mkdir()
+    (baseline / "datasets" / ".pytest_cache" / "ignored").write_text("cache\n")
+
+    config = HelixConfig(
+        objective="test",
+        evaluator=EvaluatorConfig(
+            command="python evaluate.py",
+            protected_files=["datasets"],
+        ),
+    )
+
+    manifest = _build_evaluator_integrity_manifest(config, baseline, baseline)
+
+    assert sorted(manifest) == [
+        "datasets/nested/eval.jsonl",
+        "datasets/train.jsonl",
+        "evaluate.py",
+    ]
+
+    candidate_dir = tmp_path / "candidate"
+    shutil.copytree(baseline, candidate_dir)
+    (candidate_dir / "datasets" / "train.jsonl").write_text('{"id": 99}\n')
+    (candidate_dir / "datasets" / "__pycache__" / "ignored.pyc").write_bytes(
+        b"changed cache"
+    )
+
+    violations = _detect_evaluator_tamper(_candidate(str(candidate_dir)), manifest)
+    assert violations == ["datasets/train.jsonl"]
+
+
 def test_manifest_roundtrip(tmp_path):
     manifest = {"evaluate.py": "abc123", "fixtures/goldens.json": "def456"}
     _write_evaluator_integrity_manifest(tmp_path, manifest)
@@ -104,15 +143,15 @@ def test_refreshes_protected_files_and_directories_from_current_root(tmp_path):
     (project / "evaluate.py").write_text("fixed evaluator\n")
     (project / "splits" / "instance_ids").mkdir(parents=True)
     (project / "splits" / "train.yaml").write_text("seeds: [0, 1]\n")
-    (project / "splits" / "instance_ids" / "cube_lifting__0.json").write_text("{}\n")
-    (project / "splits" / "instance_ids" / "cube_lifting__1.json").write_text("{}\n")
+    (project / "splits" / "instance_ids" / "case_0.json").write_text("{}\n")
+    (project / "splits" / "instance_ids" / "case_1.json").write_text("{}\n")
 
     worktree = tmp_path / "worktree"
     worktree.mkdir()
     (worktree / "evaluate.py").write_text("stale evaluator\n")
     (worktree / "splits" / "instance_ids").mkdir(parents=True)
     (worktree / "splits" / "train.yaml").write_text("trials_per_task: 1\n")
-    (worktree / "splits" / "instance_ids" / "cube_lifting__0.json").write_text("{}\n")
+    (worktree / "splits" / "instance_ids" / "case_0.json").write_text("{}\n")
 
     config = HelixConfig(
         objective="test",
@@ -128,15 +167,15 @@ def test_refreshes_protected_files_and_directories_from_current_root(tmp_path):
     assert (worktree / "splits" / "train.yaml").read_text() == "seeds: [0, 1]\n"
     instance_ids = sorted((worktree / "splits" / "instance_ids").glob("*.json"))
     assert [path.name for path in instance_ids] == [
-        "cube_lifting__0.json",
-        "cube_lifting__1.json",
+        "case_0.json",
+        "case_1.json",
     ]
 
 
 def test_copy_protected_path_noops_when_source_and_destination_match(tmp_path, monkeypatch):
     source = tmp_path / "splits" / "instance_ids"
     source.mkdir(parents=True)
-    (source / "cube_lifting__0.json").write_text("{}\n")
+    (source / "case_0.json").write_text("{}\n")
 
     calls: list[Path] = []
 
@@ -149,7 +188,7 @@ def test_copy_protected_path_noops_when_source_and_destination_match(tmp_path, m
     _copy_protected_path(source, source)
 
     assert calls == []
-    assert (source / "cube_lifting__0.json").read_text() == "{}\n"
+    assert (source / "case_0.json").read_text() == "{}\n"
 
 
 def test_refresh_snapshot_normalizes_protected_file_baseline(tmp_path):


### PR DESCRIPTION
## Summary
- Recursively include regular files under protected evaluator directories in `.helix/evaluator_manifest.json` using stable repo-relative manifest keys.
- Reuse the protected-directory copy ignore patterns for manifest traversal so cache/tool artifacts such as `__pycache__`, `*.pyc`, `.pytest_cache`, `.mypy_cache`, and `.ruff_cache` are not hashed.
- Preserve existing protected-file hashing behavior and add focused evaluator-integrity coverage for directory recursion and ignored cache files.

## Root Cause
`_build_evaluator_integrity_manifest` collected protected paths correctly, but treated every protected path as a single regular file. Protected directories copied into candidate worktrees were skipped from the manifest, which produced warnings and left their contents out of tamper detection.

## Validation
- `uv run pytest tests/unit/test_evaluator_integrity.py -q`
- `uv run ruff check src/helix/evolution.py tests/unit/test_evaluator_integrity.py`
- `timeout 120s uv run mypy --strict src/helix/`
