### PR TITLE
Recover sandbox sync after userns remap

### DIFF
--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -362,14 +362,17 @@ def _safe_rmtree(path: Path, *, docker_image: str | None = None) -> None:
     except FileNotFoundError:
         return
     except OSError as first_exc:
-        if docker_image and (host_owner := _host_owner()):
-            _docker_chown_workspace(path, docker_image, host_owner)
+        if docker_image:
+            if host_owner := _host_owner():
+                _docker_chown_workspace(path, docker_image, host_owner)
+            else:
+                _docker_relax_workspace_permissions(path, docker_image)
             try:
                 shutil.rmtree(path)
                 return
             except OSError as second_exc:
                 logger.warning(
-                    "failed to clean sandbox temp dir %s after chown: %s",
+                    "failed to clean sandbox temp dir %s after permission recovery: %s",
                     path,
                     second_exc,
                 )
@@ -490,6 +493,47 @@ def _docker_chown_workspace(workspace: Path, image: str, owner: str) -> None:
             "-c",
             'find /workspace -path /workspace/.git -prune -o -exec chown -h "$0" {} +',
             owner,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_docker_host_env(),
+    )
+
+
+def _docker_relax_workspace_permissions(workspace: Path, image: str) -> None:
+    """Make a sandbox workspace readable/writable by the host after userns runs.
+
+    Rootless Docker and user-namespace remapping can make container-owned files
+    appear on the host as unmapped high UIDs. In that mode chowning to the host
+    UID from inside the container is not meaningful, but a root helper in the
+    same namespace can still relax mode bits on the bind mount before host-side
+    sync and cleanup.
+    """
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--workdir",
+            "/workspace",
+            "--user",
+            "root",
+            "--network",
+            "none",
+            "--security-opt",
+            "no-new-privileges",
+            "-v",
+            f"{workspace}:/workspace:rw",
+            image,
+            "sh",
+            "-c",
+            (
+                "find /workspace -path /workspace/.git -prune -o "
+                "-type d -exec chmod 0777 {} +; "
+                "find /workspace -path /workspace/.git -prune -o "
+                "-type f -exec chmod 0666 {} +"
+            ),
         ],
         check=False,
         capture_output=True,
@@ -927,6 +971,8 @@ def run_sandboxed_commands(
         finally:
             if host_owner := _host_owner():
                 _docker_chown_workspace(workspace, docker_image, host_owner)
+            else:
+                _docker_relax_workspace_permissions(workspace, docker_image)
         if sync_back:
             _sync_back_workspace(
                 workspace,

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -472,32 +472,67 @@ def _init_synthetic_git_repo(workspace: Path) -> None:
     )
 
 
-def _docker_chown_workspace(workspace: Path, image: str, owner: str) -> None:
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "--workdir",
-            "/workspace",
-            "--user",
-            "root",
-            "--network",
-            "none",
-            "--security-opt",
-            "no-new-privileges",
-            "-v",
-            f"{workspace}:/workspace:rw",
-            image,
-            "sh",
-            "-c",
-            'find /workspace -path /workspace/.git -prune -o -exec chown -h "$0" {} +',
-            owner,
-        ],
+def _run_workspace_helper(
+    workspace: Path,
+    image: str,
+    sh_command: str,
+    extra_args: list[str] | None = None,
+    *,
+    helper_name: str,
+) -> None:
+    """Run a one-shot ``docker run`` helper bind-mounting ``workspace``.
+
+    All workspace-recovery helpers share the same security flags (root user,
+    no network, no-new-privileges) and the same bind-mount, so factor the
+    boilerplate here. Failures are logged but never raised: callers want
+    best-effort recovery, and surfacing the exit status helps diagnose
+    otherwise-confusing downstream sync/cleanup errors.
+    """
+    args = [
+        "docker",
+        "run",
+        "--rm",
+        "--workdir",
+        "/workspace",
+        "--user",
+        "root",
+        "--network",
+        "none",
+        "--security-opt",
+        "no-new-privileges",
+        "-v",
+        f"{workspace}:/workspace:rw",
+        image,
+        "sh",
+        "-c",
+        sh_command,
+    ]
+    if extra_args:
+        args.extend(extra_args)
+    result = subprocess.run(
+        args,
         check=False,
         capture_output=True,
         text=True,
         env=_docker_host_env(),
+    )
+    if result.returncode != 0:
+        logger.warning(
+            "docker workspace helper %s failed for %s: rc=%s stderr=%s",
+            helper_name,
+            workspace,
+            result.returncode,
+            (result.stderr or "").strip(),
+        )
+
+
+def _docker_chown_workspace(workspace: Path, image: str, owner: str) -> None:
+    _run_workspace_helper(
+        workspace,
+        image,
+        'find /workspace -path /workspace/.git -prune -o -exec chown -h "$0" {} +',
+        extra_args=[owner],
+        helper_name="chown",
     )
 
 
@@ -508,37 +543,15 @@ def _docker_relax_workspace_permissions(workspace: Path, image: str) -> None:
     appear on the host as unmapped high UIDs. In that mode chowning to the host
     UID from inside the container is not meaningful, but a root helper in the
     same namespace can still relax mode bits on the bind mount before host-side
-    sync and cleanup.
+    sync and cleanup. ``a+rwX`` (capital ``X``) preserves existing executable
+    bits on regular files and keeps directories traversable, unlike a flat
+    ``0666``/``0777`` pair.
     """
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "--workdir",
-            "/workspace",
-            "--user",
-            "root",
-            "--network",
-            "none",
-            "--security-opt",
-            "no-new-privileges",
-            "-v",
-            f"{workspace}:/workspace:rw",
-            image,
-            "sh",
-            "-c",
-            (
-                "find /workspace -path /workspace/.git -prune -o "
-                "-type d -exec chmod 0777 {} +; "
-                "find /workspace -path /workspace/.git -prune -o "
-                "-type f -exec chmod 0666 {} +"
-            ),
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-        env=_docker_host_env(),
+    _run_workspace_helper(
+        workspace,
+        image,
+        "find /workspace -path /workspace/.git -prune -o -exec chmod a+rwX {} +",
+        helper_name="relax",
     )
 
 

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -23,13 +23,29 @@ from helix.sandbox import (
 
 
 def _is_workspace_chown(args: list[str]) -> bool:
+    """True for either workspace-recovery helper (chown or permission-relax).
+
+    Existing call sites use this predicate to filter out housekeeping
+    containers from the primary agent ``docker run``; both helpers share the
+    same ``find /workspace`` boilerplate. Use :func:`_is_workspace_chown_only`
+    or :func:`_is_workspace_permission_relax` when you need to distinguish
+    them.
+    """
     return args[:2] == ["docker", "run"] and any(
         "find /workspace -path /workspace/.git -prune" in item for item in args
     )
 
 
+def _is_workspace_chown_only(args: list[str]) -> bool:
+    return args[:2] == ["docker", "run"] and any(
+        "chown" in item and "find /workspace" in item for item in args
+    )
+
+
 def _is_workspace_permission_relax(args: list[str]) -> bool:
-    return args[:2] == ["docker", "run"] and any("chmod 0777" in item for item in args)
+    return args[:2] == ["docker", "run"] and any(
+        "chmod a+rwX" in item for item in args
+    )
 
 
 def test_resolve_sandbox_image_defaults_from_backend():
@@ -551,13 +567,95 @@ def test_agent_sync_recovers_rootless_workspace_permissions(tmp_path: Path, mock
     assert (source / "main.py").read_text() == "new\n"
     relax_calls = [call for call in calls if _is_workspace_permission_relax(call)]
     assert relax_calls
-    assert calls.index(relax_calls[0]) > next(
+    # The relax helper must run after the agent container exits and before
+    # host-side sync-back reads the workspace; verify ordering relative to the
+    # primary agent docker run.
+    agent_run_idx = next(
         i
         for i, call in enumerate(calls)
         if call[:2] == ["docker", "run"]
         and not _is_workspace_chown(call)
         and not _is_workspace_permission_relax(call)
     )
+    assert calls.index(relax_calls[0]) > agent_run_idx
+
+
+def test_agent_sync_skips_relax_when_host_owner_available(tmp_path: Path, mocker):
+    """When ``_host_owner`` returns a value, the chown path runs and the relax
+    helper must NOT be invoked (the two recovery branches are mutually
+    exclusive)."""
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "main.py").write_text("old\n")
+
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if (
+            args[:2] == ["docker", "run"]
+            and not _is_workspace_chown(args)
+            and not _is_workspace_permission_relax(args)
+        ):
+            workspace_root = Path(args[args.index("-v") + 1].split(":", 1)[0])
+            (workspace_root / "main.py").write_text("new\n")
+        return subprocess.CompletedProcess(args, 0, stdout="{}", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value="1000:1000")
+
+    run_sandboxed_command(
+        ["claude", "-p", "prompt"],
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True),
+        scope="agent",
+        sync_back=True,
+        image="helix-test:latest",
+        agent_backend="claude",
+    )
+
+    assert (source / "main.py").read_text() == "new\n"
+    assert not [call for call in calls if _is_workspace_permission_relax(call)]
+    assert [call for call in calls if _is_workspace_chown_only(call)]
+
+
+def test_safe_rmtree_uses_relax_helper_when_host_owner_missing(
+    tmp_path: Path, mocker
+):
+    """``_safe_rmtree`` must invoke the relax helper (not chown) when the host
+    owner is unavailable, then retry the rmtree."""
+    from helix.sandbox import _safe_rmtree
+
+    target = tmp_path / "doomed"
+    target.mkdir()
+    (target / "f").write_text("x")
+
+    rmtree_calls: list[Path] = []
+    original_rmtree = __import__("shutil").rmtree
+
+    def fake_rmtree(path, *args, **kwargs):
+        rmtree_calls.append(Path(path))
+        if len(rmtree_calls) == 1:
+            raise OSError("permission denied")
+        return original_rmtree(path, *args, **kwargs)
+
+    mocker.patch("helix.sandbox.shutil.rmtree", side_effect=fake_rmtree)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+
+    docker_calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        docker_calls.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+
+    _safe_rmtree(target, docker_image="helix-test:latest")
+
+    assert any(_is_workspace_permission_relax(call) for call in docker_calls)
+    assert not any(_is_workspace_chown_only(call) for call in docker_calls)
+    assert len(rmtree_calls) == 2  # initial failure + retry
 
 
 def test_agent_sync_back_honors_omitted_paths(tmp_path: Path, mocker):

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -28,6 +28,10 @@ def _is_workspace_chown(args: list[str]) -> bool:
     )
 
 
+def _is_workspace_permission_relax(args: list[str]) -> bool:
+    return args[:2] == ["docker", "run"] and any("chmod 0777" in item for item in args)
+
+
 def test_resolve_sandbox_image_defaults_from_backend():
     cfg = SandboxConfig(enabled=True)
     assert (
@@ -507,6 +511,53 @@ def test_agent_sync_tolerates_inaccessible_backend_transcripts(
 
     assert (source / "main.py").read_text() == "new\n"
     assert not (source / ".helix_artifacts" / "backend_transcripts").exists()
+
+
+def test_agent_sync_recovers_rootless_workspace_permissions(tmp_path: Path, mocker):
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "main.py").write_text("old\n")
+
+    calls: list[list[str]] = []
+    workspace_root: Path | None = None
+
+    def fake_run(args, **kwargs):
+        nonlocal workspace_root
+        calls.append(args)
+        if (
+            args[:2] == ["docker", "run"]
+            and not _is_workspace_chown(args)
+            and not _is_workspace_permission_relax(args)
+        ):
+            workspace_root = Path(args[args.index("-v") + 1].split(":", 1)[0])
+            (workspace_root / "main.py").write_text("new\n")
+        return subprocess.CompletedProcess(args, 0, stdout="{}", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+
+    run_sandboxed_command(
+        ["claude", "-p", "prompt"],
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True),
+        scope="agent",
+        sync_back=True,
+        image="helix-test:latest",
+        agent_backend="claude",
+    )
+
+    assert workspace_root is not None
+    assert (source / "main.py").read_text() == "new\n"
+    relax_calls = [call for call in calls if _is_workspace_permission_relax(call)]
+    assert relax_calls
+    assert calls.index(relax_calls[0]) > next(
+        i
+        for i, call in enumerate(calls)
+        if call[:2] == ["docker", "run"]
+        and not _is_workspace_chown(call)
+        and not _is_workspace_permission_relax(call)
+    )
 
 
 def test_agent_sync_back_honors_omitted_paths(tmp_path: Path, mocker):


### PR DESCRIPTION
## Summary
- Recover sandbox workspace readability before host-side sync-back when direct host ownership restoration is unavailable.
- Use a root helper container to relax workspace mode bits in user-namespace/rootless Docker environments.
- Reuse the same recovery path for temporary sandbox cleanup.

## Root Cause
Some Docker configurations remap container-owned files to host UIDs that the host process cannot read after the agent command exits. HELIX already skips direct host chown in those configurations, but without a fallback the subsequent host-side sync-back can preserve stale files or skip artifacts because the temporary workspace is inaccessible.

## Validation
- `uv run pytest tests/unit/test_sandbox.py -q`
- `uv run ruff check src/helix/sandbox.py tests/unit/test_sandbox.py`
- Manual Docker sync-back smoke test with a container-created file and restrictive directory permissions
