### PR TITLE
Propagate backend reasoning effort

### DIFF
--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -19,13 +19,16 @@ BACKENDS: tuple[BackendName, ...] = ("claude", "codex", "cursor", "gemini", "ope
 # backend-native CLI flag in ``helix.mutator``:
 #
 #   - ``claude``:    ``--effort <value>``   (Claude Code thinking budget)
+#   - ``codex``:     ``-c model_reasoning_effort=<value>`` (Codex CLI config)
 #   - ``opencode``:  ``--variant <value>``  (model variant selector)
 #   - others:        silently ignored (no equivalent CLI surface)
 #
 # The two registries below let the config layer fail fast on bad combinations
 # without hard-coding backend knowledge into ``HelixConfig``.
 
-EFFORT_AWARE_BACKENDS: frozenset[BackendName] = frozenset({"claude", "opencode"})
+EFFORT_AWARE_BACKENDS: frozenset[BackendName] = frozenset(
+    {"claude", "codex", "opencode"}
+)
 """Backends that propagate ``agent.effort`` to their underlying CLI."""
 
 # ``None`` here means "any string accepted" — we still let strange values
@@ -38,6 +41,7 @@ EFFORT_AWARE_BACKENDS: frozenset[BackendName] = frozenset({"claude", "opencode"}
 # until this map is updated; the value still passes through to the CLI.
 EFFORT_VALID_VALUES: dict[BackendName, frozenset[str] | None] = {
     "claude": frozenset({"low", "medium", "high"}),
+    "codex": frozenset({"minimal", "low", "medium", "high", "xhigh"}),
     "opencode": None,  # variant strings are model-specific; opencode validates them.
 }
 

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -599,9 +599,10 @@ def sandbox_logout(
     default=None,
     help=(
         "Override backend reasoning-effort level. Forwarded as --effort to "
-        "the 'claude' backend (low|medium|high) and as --variant to the "
-        "'opencode' backend; ignored by codex/cursor/gemini (a warning is "
-        "emitted when set on a backend that does not support it)."
+        "the 'claude' backend (low|medium|high), as model_reasoning_effort "
+        "to the 'codex' backend, and as --variant to the 'opencode' backend; "
+        "ignored by cursor/gemini (a warning is emitted when set on a backend "
+        "that does not support it)."
     ),
 )
 def evolve(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -571,7 +571,7 @@ def _validate_agent_effort(agent: AgentConfig) -> None:
 
     Two cases are surfaced:
 
-    1. **Backend ignores the field** (``codex`` / ``cursor`` / ``gemini``):
+    1. **Backend ignores the field** (``cursor`` / ``gemini``):
        ``effort`` is silently dropped by ``helix.mutator`` because those CLIs
        don't expose an equivalent flag.  Without a warning, users assume the
        knob is taking effect.

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -689,7 +689,7 @@ def _build_backend_args(
         # ``effort`` is the user-facing knob for reasoning-level / thinking
         # budget; the registry of backends that honor it lives in
         # ``helix.backends.EFFORT_AWARE_BACKENDS`` and must stay in sync
-        # with this branch (and the ``opencode`` branch below).
+        # with this branch (and the ``codex`` / ``opencode`` branches below).
         if config.effort:
             args.extend(["--effort", config.effort])
         if config.max_turns is not None:
@@ -706,6 +706,10 @@ def _build_backend_args(
         ]
         if config.model:
             args.extend(["--model", config.model])
+        if config.effort:
+            args.extend(
+                ["-c", f"model_reasoning_effort={json.dumps(config.effort)}"]
+            )
         args.append(_prompt_file_instruction(prompt_artifact_name))
         return args
 

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -707,6 +707,12 @@ def _build_backend_args(
         if config.model:
             args.extend(["--model", config.model])
         if config.effort:
+            # Codex CLI accepts runtime config overrides via ``-c key=value``
+            # where the value must be a valid TOML literal.  ``json.dumps``
+            # produces a JSON string (double-quoted, with ``\"`` escapes) which
+            # is valid TOML basic-string syntax for all printable ASCII — safe
+            # for any realistic effort value.  See ``codex exec --help`` for
+            # the full ``-c`` interface.
             args.extend(
                 ["-c", f"model_reasoning_effort={json.dumps(config.effort)}"]
             )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -262,10 +262,11 @@ class TestDirectModelConstruction:
 class TestAgentEffortValidation:
     """Surface obvious mismatches between ``agent.effort`` and ``agent.backend``.
 
-    HELIX forwards ``agent.effort`` to a backend-native CLI flag in
-    ``helix.mutator`` (``claude --effort``, ``opencode --variant``).  The
-    other backends silently ignore the field — without a warning the
-    setting looks like it's taking effect when it isn't.
+    HELIX forwards ``agent.effort`` to a backend-native CLI flag/config in
+    ``helix.mutator`` (``claude --effort``, ``codex -c
+    model_reasoning_effort=...``, ``opencode --variant``).  The other
+    backends silently ignore the field — without a warning the setting looks
+    like it's taking effect when it isn't.
     """
 
     def _base_kwargs(self):
@@ -281,13 +282,13 @@ class TestAgentEffortValidation:
         )
         assert [w for w in recwarn.list if issubclass(w.category, UserWarning)] == []
 
-    def test_effort_warns_on_ignoring_backend_codex(self, recwarn):
-        HelixConfig(
-            **self._base_kwargs(),
-            agent=AgentConfig(backend="codex", effort="high"),
-        )
-        warnings = [str(w.message) for w in recwarn.list if w.category is UserWarning]
-        assert any("does not propagate" in w and "Codex" in w for w in warnings), warnings
+    def test_effort_accepts_valid_value_on_codex(self, recwarn):
+        for value in ("minimal", "low", "medium", "high", "xhigh"):
+            HelixConfig(
+                **self._base_kwargs(),
+                agent=AgentConfig(backend="codex", effort=value),
+            )
+        assert [w for w in recwarn.list if issubclass(w.category, UserWarning)] == []
 
     def test_effort_warns_on_ignoring_backend_gemini(self, recwarn):
         HelixConfig(
@@ -321,6 +322,14 @@ class TestAgentEffortValidation:
         warnings = [str(w.message) for w in recwarn.list if w.category is UserWarning]
         assert any("not a recognized value" in w and "extreme" in w for w in warnings), warnings
 
+    def test_effort_warns_on_unknown_value_for_codex(self, recwarn):
+        HelixConfig(
+            **self._base_kwargs(),
+            agent=AgentConfig(backend="codex", effort="extreme"),
+        )
+        warnings = [str(w.message) for w in recwarn.list if w.category is UserWarning]
+        assert any("not a recognized value" in w and "extreme" in w for w in warnings), warnings
+
     def test_effort_does_not_warn_on_unrestricted_backend(self, recwarn):
         """opencode accepts arbitrary --variant strings; HELIX must not warn."""
         HelixConfig(
@@ -336,7 +345,7 @@ class TestAgentEffortValidation:
         with pytest.warns(UserWarning, match="does not propagate"):
             HelixConfig(
                 **self._base_kwargs(),
-                agent=AgentConfig(backend="codex", effort="high"),
+                agent=AgentConfig(backend="gemini", effort="high"),
             )
 
     def test_every_backend_has_effort_metadata(self):

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -684,7 +684,7 @@ class TestInvokeClaudeCode:
             stderr="",
             returncode=0,
         )
-        config = AgentConfig(backend="codex", model="gpt-5")
+        config = AgentConfig(backend="codex", model="gpt-5", effort="high")
 
         result, _ = invoke_claude_code("/tmp/wt", "the prompt", config)
 
@@ -694,10 +694,26 @@ class TestInvokeClaudeCode:
         assert "--dangerously-bypass-approvals-and-sandbox" in args_list
         assert "--model" in args_list
         assert "gpt-5" in args_list
+        assert "-c" in args_list
+        assert 'model_reasoning_effort="high"' in args_list
         assert "the prompt" not in args_list
         assert ".agent_task_prompt.md" in args_list[-1]
         assert "input" not in mock_run.call_args[1]
         assert result["events"][0]["thread_id"] == "thr_123"
+
+    def test_codex_effort_config_value_is_toml_escaped(self, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"thread.started","thread_id":"thr_123"}\n',
+            stderr="",
+            returncode=0,
+        )
+        config = AgentConfig(backend="codex", effort='high"quoted')
+
+        invoke_claude_code("/tmp/wt", "the prompt", config)
+
+        args_list = mock_run.call_args[0][0]
+        assert 'model_reasoning_effort="high\\"quoted"' in args_list
 
     def test_cursor_cli_args_use_stream_json(self, mocker):
         mock_run = mocker.patch("helix.mutator.subprocess.run")

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -701,7 +701,12 @@ class TestInvokeClaudeCode:
         assert "input" not in mock_run.call_args[1]
         assert result["events"][0]["thread_id"] == "thr_123"
 
-    def test_codex_effort_config_value_is_toml_escaped(self, mocker):
+    def test_codex_effort_config_value_is_json_quoted(self, mocker):
+        # Codex's -c flag accepts key=value pairs where the value must be a
+        # valid TOML literal.  We use json.dumps() to produce a JSON string
+        # (e.g. "high\"quoted"), which is also valid TOML basic-string syntax
+        # for any input that does not contain TOML-only escapes — safe for all
+        # realistic effort values.
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(
             stdout='{"type":"thread.started","thread_id":"thr_123"}\n',


### PR DESCRIPTION
## Summary
- Propagate `agent.effort` to `codex exec` via `-c model_reasoning_effort=<value>`.
- Mark Codex as effort-aware in backend validation, including recognized Codex effort values.
- Update CLI help text and focused tests for Codex effort propagation and TOML escaping.

## Validation
- `uv run --extra dev pytest tests/unit/test_mutator.py tests/unit/test_config.py`
- `uv run --extra dev ruff check src/helix/backends.py src/helix/config.py src/helix/cli.py src/helix/mutator.py tests/unit/test_config.py tests/unit/test_mutator.py`