### PR TITLE
Track rejected attempts and retry perfect skips

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,12 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Per-test 60s cap with thread-based timeout: kills any hanging test and
+# prints a stack trace at kill, so future hangs surface in seconds locally
+# instead of hours of CI runner time.  See commit 0f13530 for the precedent
+# (a now-fixed NB-2-style infinite loop that wedged CI for 24 minutes).
+timeout = 60
+timeout_method = "thread"
 markers = [
     "diff_harness: GEPA differential-testing harness (phases 2-4)",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ exclude = [
 [dependency-groups]
 dev = [
     "mypy>=1.20.0",
+    "pytest-timeout>=2.4.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -902,6 +902,258 @@ def log_cmd(project_dir: Path | None) -> None:
 
 
 # ---------------------------------------------------------------------------
+# attempts helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_attempts(base_dir: Path) -> list[dict[str, Any]]:
+    """Load all attempt records from base_dir/attempts/*.json.
+
+    Returns a list sorted by ``(generation, candidate_id)``.
+    Malformed files are skipped with a one-line warning to stderr.
+    """
+    attempts_dir = base_dir / "attempts"
+    if not attempts_dir.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for path in sorted(attempts_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+            records.append(data)
+        except Exception as exc:
+            click.echo(
+                f"[helix attempts] Warning: skipping malformed file {path}: {exc}",
+                err=True,
+            )
+    records.sort(
+        key=lambda r: (
+            r.get("attempt", {}).get("generation", 0),
+            r.get("candidate_id", ""),
+        )
+    )
+    return records
+
+
+def _load_skips(base_dir: Path) -> list[dict[str, Any]]:
+    """Load all skip records from base_dir/skips/g*.json.
+
+    Each file is a JSON list (NB-1 consolidated format).  Returns a flat
+    list sorted by generation.  Malformed files are skipped with a warning.
+    """
+    skips_dir = base_dir / "skips"
+    if not skips_dir.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for path in sorted(skips_dir.glob("g*.json")):
+        try:
+            data = json.loads(path.read_text())
+            if isinstance(data, list):
+                records.extend(data)
+            else:
+                # Pre-NB-1 single-record — wrap for uniform handling
+                records.append(data)
+        except Exception as exc:
+            click.echo(
+                f"[helix attempts] Warning: skipping malformed file {path}: {exc}",
+                err=True,
+            )
+    records.sort(key=lambda r: r.get("generation", 0))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# attempts
+# ---------------------------------------------------------------------------
+
+
+@cli.command("attempts")
+@click.option(
+    "--skips",
+    "show_skips",
+    is_flag=True,
+    default=False,
+    help="Show perfect-subsample skip records from .helix/skips/ instead of rejected attempts.",
+)
+@click.option(
+    "--generation",
+    "generation",
+    default=None,
+    type=int,
+    help="Filter to a specific generation number.",
+)
+@click.option(
+    "--stage",
+    "stage",
+    default=None,
+    type=click.Choice(["minibatch_gate", "train_gate", "val_stage"]),
+    help="Filter by rejection gate (attempts view only).",
+)
+@click.option(
+    "--reason",
+    "reason_substr",
+    default=None,
+    help="Filter by reason substring (matched against the reason field).",
+)
+@click.option(
+    "--cid",
+    "cid",
+    default=None,
+    help="Show full JSON detail for one attempt by candidate ID.",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON to stdout instead of a human table.",
+)
+@click.option(
+    "--path",
+    "helix_path",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Path to the .helix/ directory (defaults to ./.helix/).",
+)
+def attempts_cmd(
+    show_skips: bool,
+    generation: int | None,
+    stage: str | None,
+    reason_substr: str | None,
+    cid: str | None,
+    output_json: bool,
+    helix_path: Path | None,
+) -> None:
+    """Show rejected attempt records and perfect-subsample skip records.
+
+    By default lists all rejected mutation attempts from .helix/attempts/,
+    sorted chronologically.  Use --skips to view the skip-record surface
+    (.helix/skips/) instead.
+
+    Examples:
+
+    \b
+      helix attempts                        # all rejected attempts
+      helix attempts --generation 12        # only generation 12
+      helix attempts --stage minibatch_gate # only minibatch rejections
+      helix attempts --skips                # perfect-subsample skips
+      helix attempts --skips --generation 12
+      helix attempts --cid g12-s4           # full JSON for one attempt
+      helix attempts --json | jq '.[].attempt.reason'
+    """
+    base_dir = (helix_path if helix_path is not None else Path.cwd() / ".helix").resolve()
+
+    # ------------------------------------------------------------------ skips
+    if show_skips:
+        skips_dir = base_dir / "skips"
+        if not skips_dir.exists():
+            print_error(
+                f"No skips directory found at {skips_dir}.\n"
+                "Has helix run produced any perfect-subsample skips yet?"
+            )
+            raise SystemExit(1)
+
+        records = _load_skips(base_dir)
+
+        if generation is not None:
+            records = [r for r in records if r.get("generation") == generation]
+        if reason_substr is not None:
+            records = [r for r in records if reason_substr in r.get("reason", "")]
+
+        if output_json:
+            click.echo(json.dumps(records, indent=2))
+            return
+
+        table = Table(title="HELIX Skip Records", show_lines=True)
+        table.add_column("Gen", style="bold cyan", justify="right")
+        table.add_column("Parent", style="cyan")
+        table.add_column("Reason", style="yellow")
+
+        for rec in records:
+            table.add_row(
+                str(rec.get("generation", "")),
+                str(rec.get("parent_id", "")),
+                str(rec.get("reason", "")),
+            )
+
+        console.print(table)
+        if not records:
+            print_warning("No skip records match the given filters.")
+        return
+
+    # --------------------------------------------------------------- attempts
+    attempts_dir = base_dir / "attempts"
+    if not attempts_dir.exists():
+        print_error(
+            f"No attempts directory found at {attempts_dir}.\n"
+            "Has helix run produced any rejected attempts yet?"
+        )
+        raise SystemExit(1)
+
+    records = _load_attempts(base_dir)
+
+    # --cid: full detail for one attempt
+    if cid is not None:
+        match = next((r for r in records if r.get("candidate_id") == cid), None)
+        if match is None:
+            print_error(f"No attempt found with candidate_id={cid!r}.")
+            raise SystemExit(1)
+        click.echo(json.dumps(match, indent=2))
+        return
+
+    # Apply filters
+    if generation is not None:
+        records = [
+            r for r in records if r.get("attempt", {}).get("generation") == generation
+        ]
+    if stage is not None:
+        records = [
+            r for r in records if r.get("attempt", {}).get("reason") == stage
+        ]
+    if reason_substr is not None:
+        records = [
+            r for r in records
+            if reason_substr in r.get("attempt", {}).get("reason", "")
+        ]
+
+    if output_json:
+        click.echo(json.dumps(records, indent=2))
+        return
+
+    table = Table(title="HELIX Rejected Attempts", show_lines=True)
+    table.add_column("Gen", style="bold cyan", justify="right")
+    table.add_column("CID", style="cyan")
+    table.add_column("Stage")
+    table.add_column("Reason", style="yellow")
+    table.add_column("Worktree")
+
+    worktrees_dir = base_dir / "worktrees"
+    for rec in records:
+        attempt = rec.get("attempt", {})
+        rec_cid = rec.get("candidate_id", "")
+        gen_val = str(attempt.get("generation", ""))
+        stage_val = str(attempt.get("stage", ""))
+        reason_val = str(attempt.get("reason", ""))
+
+        # Augment reason display with aggregate score when available
+        instance_scores = rec.get("instance_scores", {})
+        if instance_scores:
+            agg = sum(instance_scores.values()) / len(instance_scores)
+            reason_display = f"{reason_val} (score={agg:.2f})"
+        else:
+            reason_display = reason_val
+
+        # Worktree presence check
+        wt = worktrees_dir / rec_cid
+        wt_display = str(wt) if wt.exists() else "removed"
+
+        table.add_row(gen_val, rec_cid, stage_val, reason_display, wt_display)
+
+    console.print(table)
+    if not records:
+        print_warning("No attempt records match the given filters.")
+
+
+# ---------------------------------------------------------------------------
 # resume
 # ---------------------------------------------------------------------------
 

--- a/src/helix/evaluator_manifest.py
+++ b/src/helix/evaluator_manifest.py
@@ -1,0 +1,374 @@
+"""Protected-evaluator-file SHA-256 manifest for tamper detection.
+
+This module owns two closely-related responsibilities:
+
+1. **Protected-file refresh** — copy the project's evaluator script(s) and
+   explicitly listed protected files into candidate worktrees so mutations
+   cannot alter them (functions ``_collect_protected_evaluator_paths``,
+   ``_copy_protected_path``, ``_refresh_protected_evaluator_files``,
+   ``_refresh_and_snapshot_protected_evaluator_files``).
+
+2. **Integrity manifest** — build a ``{repo_relative_path: sha256}`` map from
+   the seed worktree and detect changes in mutation/merge candidates
+   (functions ``_sha256_file`` … ``_detect_evaluator_tamper``).
+
+These helpers have no dependency on ``EvolutionState``, ``ParetoFrontier``, or
+the evolution loop.  They operate only on ``Path``, ``HelixConfig``, and
+``Candidate.worktree_path``, so they can be unit-tested in isolation without
+constructing any evolution-loop state.
+
+Used for tamper detection during sandboxed mutation: before any mutation or
+merge candidate is evaluated, :func:`_detect_evaluator_tamper` compares each
+file in the manifest (seeded from the baseline worktree) against the
+candidate's worktree to catch modifications, deletions, or additions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import shlex
+from pathlib import Path
+
+from helix.config import HelixConfig
+from helix.exceptions import HelixError
+from helix.population import Candidate
+from helix.worktree import snapshot_candidate
+
+logger = logging.getLogger(__name__)
+
+# NOTE: ``shutil.ignore_patterns`` uses ``fnmatch`` *basename* matching, not
+# gitignore semantics.  Add basename globs here only -- patterns like
+# ``**/build/`` or ``cache/**`` will not match.  If we ever need gitignore
+# semantics, switch to ``pathspec`` rather than extending this tuple.
+_PROTECTED_DIRECTORY_IGNORE_PATTERNS = (
+    ".git",
+    "__pycache__",
+    "*.pyc",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+)
+# Reusable matcher; the patterns are constant so we build it once.
+_PROTECTED_DIRECTORY_IGNORE_MATCHER = shutil.ignore_patterns(
+    *_PROTECTED_DIRECTORY_IGNORE_PATTERNS
+)
+
+_NO_SCRIPT_COMMANDS = {"make", "pytest"}
+_INTERPRETERS = {"python", "python3", "uv", "poetry", "node", "bash", "sh"}
+_SKIP_TOKENS = {"run"}
+_SCRIPT_SUFFIXES = (".py", ".sh", ".js", ".ts")
+# Shell wrappers whose command body (after -c/-lc/...) is opaque to path-level
+# validation — e.g. `bash -lc "cd /x && python evaluate.py"`.
+# Note: only the adjacent `{wrapper} {flag}` prefix is exempted. Forms like
+# `bash --login -c "..."` (separate tokens) fall through to the normal
+# script-path checks by design — extend _SHELL_COMMAND_FLAGS if that becomes
+# a real-world need.
+_SHELL_WRAPPERS = {"bash", "sh", "zsh", "fish", "dash"}
+_SHELL_COMMAND_FLAGS = {"-c", "-lc", "-ic", "-ilc", "-lic"}
+_EVALUATOR_MANIFEST_FILENAME = "evaluator_manifest.json"
+
+
+def _extract_script_token(tokens: list[str]) -> str | None:
+    """Return the most likely script token from a tokenized command."""
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token == "-m":
+            # `python -m module` has no script path token.
+            skip_next = True
+            continue
+        if token in _INTERPRETERS or token in _SKIP_TOKENS:
+            continue
+        if token.startswith("-"):
+            continue
+        return token
+    return None
+
+
+def _looks_like_script_file(path_token: str) -> bool:
+    """Heuristic for script-like file paths used by evaluator commands."""
+    if path_token.endswith("/"):
+        return False
+    return any(path_token.endswith(ext) for ext in _SCRIPT_SUFFIXES)
+
+
+def _to_repo_relative(path_token: str, project_root: Path) -> str | None:
+    """Normalize a path token to a repo-relative POSIX path when possible."""
+    project_root_resolved = project_root.resolve()
+    token_path = Path(path_token)
+    abs_path = (
+        token_path.resolve()
+        if token_path.is_absolute()
+        else (project_root_resolved / token_path).resolve()
+    )
+    try:
+        return abs_path.relative_to(project_root_resolved).as_posix()
+    except ValueError:
+        return None
+
+
+def _collect_protected_evaluator_paths(
+    config: HelixConfig, project_root: Path
+) -> list[str]:
+    """Collect repo-relative files that should stay immutable during evolution."""
+    protected: set[str] = set()
+
+    for cmd in [config.evaluator.command, *config.evaluator.extra_commands]:
+        try:
+            tokens = shlex.split(cmd)
+        except ValueError:
+            continue
+        if not tokens or tokens[0] in _NO_SCRIPT_COMMANDS:
+            continue
+        # Shell wrappers like `bash -c "..."` hide the real command inside an
+        # opaque body string; path-level validation cannot reason about it.
+        if (
+            tokens[0] in _SHELL_WRAPPERS
+            and len(tokens) >= 2
+            and tokens[1] in _SHELL_COMMAND_FLAGS
+        ):
+            continue
+        script_token = _extract_script_token(tokens)
+        if script_token is None or not _looks_like_script_file(script_token):
+            continue
+        rel = _to_repo_relative(script_token, project_root)
+        if rel is not None:
+            protected.add(rel)
+
+    for path_str in config.evaluator.protected_files:
+        rel = _to_repo_relative(path_str, project_root)
+        if rel is None:
+            raise HelixError(
+                f"evaluator.protected_files path is outside project root: {path_str}",
+                operation="resolve protected evaluator files",
+                suggestion="Use repo-relative paths under the project root.",
+            )
+        protected.add(rel)
+
+    return sorted(protected)
+
+
+def _copy_protected_path(source: Path, destination: Path) -> None:
+    """Refresh one protected file/directory in a candidate worktree."""
+    if source.resolve(strict=False) == destination.resolve(strict=False):
+        return
+
+    if destination.exists() or destination.is_symlink():
+        if destination.is_dir() and not destination.is_symlink():
+            shutil.rmtree(destination)
+        else:
+            destination.unlink()
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_dir() and not source.is_symlink():
+        shutil.copytree(
+            source,
+            destination,
+            ignore=_PROTECTED_DIRECTORY_IGNORE_MATCHER,
+        )
+    elif source.is_symlink():
+        os.symlink(os.readlink(source), destination)
+    else:
+        shutil.copy2(source, destination)
+
+
+def _refresh_protected_evaluator_files(
+    candidate: Candidate,
+    config: HelixConfig,
+    project_root: Path,
+) -> None:
+    """Copy current root protected evaluator/runtime files into a worktree."""
+    worktree_root = Path(candidate.worktree_path)
+    for rel_path in _collect_protected_evaluator_paths(config, project_root):
+        source = project_root / rel_path
+        if not source.exists() and not source.is_symlink():
+            continue
+        _copy_protected_path(source, worktree_root / rel_path)
+
+
+def _refresh_and_snapshot_protected_evaluator_files(
+    candidate: Candidate,
+    config: HelixConfig,
+    project_root: Path,
+) -> None:
+    """Normalize HELIX-owned protected-file refresh before backend mutation."""
+    _refresh_protected_evaluator_files(candidate, config, project_root)
+    snapshot_candidate(candidate, "helix: refresh protected evaluator files")
+
+
+def _sha256_file(path: Path) -> str:
+    """Streamed SHA-256 of ``path``.
+
+    Uses ``hashlib.file_digest`` (Python 3.11+) so large protected files
+    (e.g., evaluator dataset ``.jsonl`` files) are not buffered in memory.
+    """
+    with path.open("rb") as f:
+        return hashlib.file_digest(f, "sha256").hexdigest()
+
+
+def _iter_protected_manifest_files(
+    source_path: Path,
+    rel_path: str,
+) -> list[tuple[str, Path]]:
+    """Return manifest entries under one protected file/directory.
+
+    ``source_path`` is expected to already be a real path (callers resolve
+    symlinks before calling).  ``os.walk`` is used with ``followlinks=False``
+    (the default) so symlinks inside the directory are not traversed.
+    """
+    if source_path.is_file():
+        return [(rel_path, source_path)]
+    if not source_path.is_dir():
+        return []
+
+    entries: list[tuple[str, Path]] = []
+    for dirpath_str, dirnames, filenames in os.walk(source_path):
+        ignored = _PROTECTED_DIRECTORY_IGNORE_MATCHER(
+            dirpath_str, [*dirnames, *filenames]
+        )
+        dirnames[:] = sorted(name for name in dirnames if name not in ignored)
+        for filename in sorted(name for name in filenames if name not in ignored):
+            file_path = Path(dirpath_str) / filename
+            # Defensive against TOCTOU: ``os.walk`` already separated files
+            # from directories, but a concurrent unlink/rename could leave a
+            # stale name behind.
+            if not file_path.is_file():
+                continue
+            entry_path = Path(rel_path) / file_path.relative_to(source_path)
+            entries.append((entry_path.as_posix(), file_path))
+    return entries
+
+
+def _evaluator_manifest_path(base_dir: Path) -> Path:
+    return base_dir / _EVALUATOR_MANIFEST_FILENAME
+
+
+def _build_evaluator_integrity_manifest(
+    config: HelixConfig,
+    baseline_root: Path,
+    project_root: Path,
+) -> dict[str, str]:
+    """Build {repo_relative_path: sha256} for protected evaluator files.
+
+    Fails closed: an unreadable protected file raises ``HelixError`` rather
+    than silently being omitted from the manifest -- otherwise tamper
+    detection would not flag changes to that file on resume.
+    """
+    manifest: dict[str, str] = {}
+    for rel_path in _collect_protected_evaluator_paths(config, project_root):
+        source_path = (baseline_root / rel_path).resolve()
+        if not source_path.exists():
+            logger.warning(
+                "Skipping protected evaluator path %s: missing from baseline %s",
+                rel_path,
+                baseline_root,
+            )
+            continue
+        entries = _iter_protected_manifest_files(source_path, rel_path)
+        if not entries and source_path.is_dir():
+            # Surface likely misconfigurations (e.g., a protected directory
+            # whose only contents match the ignore list).
+            logger.warning(
+                "Protected evaluator directory %s contributed 0 manifest "
+                "entries (every file matched the ignore list).",
+                rel_path,
+            )
+        for manifest_rel_path, file_path in entries:
+            try:
+                manifest[manifest_rel_path] = _sha256_file(file_path)
+            except OSError as exc:
+                raise HelixError(
+                    f"Failed hashing protected evaluator file: {file_path}",
+                    operation="build evaluator integrity manifest",
+                    suggestion=(
+                        "Ensure the file is readable and not held open by "
+                        "another process before retrying."
+                    ),
+                ) from exc
+    return manifest
+
+
+def _write_evaluator_integrity_manifest(
+    base_dir: Path, manifest: dict[str, str]
+) -> None:
+    """Persist immutable evaluator manifest for resume."""
+    path = _evaluator_manifest_path(base_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"version": 1, "files": manifest}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _load_evaluator_integrity_manifest(base_dir: Path) -> dict[str, str] | None:
+    """Load persisted immutable evaluator manifest, if available."""
+    path = _evaluator_manifest_path(base_dir)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        logger.exception("Failed to read evaluator integrity manifest: %s", path)
+        return None
+    files = payload.get("files")
+    if not isinstance(files, dict):
+        return None
+    manifest: dict[str, str] = {}
+    for key, value in files.items():
+        if isinstance(key, str) and isinstance(value, str):
+            manifest[key] = value
+    return manifest
+
+
+def _detect_evaluator_tamper(
+    candidate: Candidate,
+    manifest: dict[str, str],
+    config: HelixConfig | None = None,
+    project_root: Path | None = None,
+) -> list[str]:
+    """Return protected paths that diverge from the frozen evaluator manifest.
+
+    Detects three classes of tamper:
+
+    1. Modification of a baseline-listed file (hash mismatch).
+    2. Deletion of a baseline-listed file.
+    3. *Addition* of a previously-unknown file inside a protected directory,
+       when ``config`` and ``project_root`` are supplied.  Without these
+       arguments only the first two classes are reported, preserving the
+       legacy contract for callers that don't have config in scope.
+    """
+    if not manifest:
+        return []
+    violations: set[str] = set()
+    worktree_root = Path(candidate.worktree_path)
+    for rel_path, expected_hash in manifest.items():
+        candidate_path = worktree_root / rel_path
+        if not candidate_path.exists() or not candidate_path.is_file():
+            violations.add(rel_path)
+            continue
+        try:
+            if _sha256_file(candidate_path) != expected_hash:
+                violations.add(rel_path)
+        except OSError:
+            violations.add(rel_path)
+
+    if config is not None and project_root is not None:
+        known = set(manifest)
+        for protected_rel in _collect_protected_evaluator_paths(
+            config, project_root
+        ):
+            candidate_path = worktree_root / protected_rel
+            # Only directories can hold *new* files; single-file protected
+            # paths are fully covered by the manifest loop above.
+            if not candidate_path.is_dir() or candidate_path.is_symlink():
+                continue
+            for entry_rel, _ in _iter_protected_manifest_files(
+                candidate_path, protected_rel
+            ):
+                if entry_rel not in known:
+                    violations.add(entry_rel)
+    return sorted(violations)

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -81,25 +81,29 @@ from helix.worktree import (
     remove_worktree,
     snapshot_candidate,
 )
+from helix.evaluator_manifest import (  # noqa: E402  (after helix.worktree intentionally)
+    # 14 moved symbols — re-exported for backward compatibility and internal use
+    _collect_protected_evaluator_paths,
+    _copy_protected_path,
+    _detect_evaluator_tamper,
+    _evaluator_manifest_path,
+    _extract_script_token,
+    _iter_protected_manifest_files,
+    _load_evaluator_integrity_manifest,
+    _looks_like_script_file,
+    _build_evaluator_integrity_manifest,
+    _refresh_and_snapshot_protected_evaluator_files,
+    _refresh_protected_evaluator_files,
+    _sha256_file,
+    _to_repo_relative,
+    _write_evaluator_integrity_manifest,
+    # Constants needed by _check_evaluator_script_exists (which stays in this module)
+    _NO_SCRIPT_COMMANDS,
+    _SHELL_COMMAND_FLAGS,
+    _SHELL_WRAPPERS,
+)
 
 logger = logging.getLogger(__name__)
-
-# NOTE: ``shutil.ignore_patterns`` uses ``fnmatch`` *basename* matching, not
-# gitignore semantics.  Add basename globs here only -- patterns like
-# ``**/build/`` or ``cache/**`` will not match.  If we ever need gitignore
-# semantics, switch to ``pathspec`` rather than extending this tuple.
-_PROTECTED_DIRECTORY_IGNORE_PATTERNS = (
-    ".git",
-    "__pycache__",
-    "*.pyc",
-    ".pytest_cache",
-    ".mypy_cache",
-    ".ruff_cache",
-)
-# Reusable matcher; the patterns are constant so we build it once.
-_PROTECTED_DIRECTORY_IGNORE_MATCHER = shutil.ignore_patterns(
-    *_PROTECTED_DIRECTORY_IGNORE_PATTERNS
-)
 
 
 # ---------------------------------------------------------------------------
@@ -526,103 +530,6 @@ def _reconcile_incomplete_attempts_on_resume(
     return True
 
 
-_NO_SCRIPT_COMMANDS = {"make", "pytest"}
-_INTERPRETERS = {"python", "python3", "uv", "poetry", "node", "bash", "sh"}
-_SKIP_TOKENS = {"run"}
-_SCRIPT_SUFFIXES = (".py", ".sh", ".js", ".ts")
-# Shell wrappers whose command body (after -c/-lc/...) is opaque to path-level
-# validation — e.g. `bash -lc "cd /x && python evaluate.py"`.
-# Note: only the adjacent `{wrapper} {flag}` prefix is exempted. Forms like
-# `bash --login -c "..."` (separate tokens) fall through to the normal
-# script-path checks by design — extend _SHELL_COMMAND_FLAGS if that becomes
-# a real-world need.
-_SHELL_WRAPPERS = {"bash", "sh", "zsh", "fish", "dash"}
-_SHELL_COMMAND_FLAGS = {"-c", "-lc", "-ic", "-ilc", "-lic"}
-_EVALUATOR_MANIFEST_FILENAME = "evaluator_manifest.json"
-
-
-def _extract_script_token(tokens: list[str]) -> str | None:
-    """Return the most likely script token from a tokenized command."""
-    skip_next = False
-    for token in tokens:
-        if skip_next:
-            skip_next = False
-            continue
-        if token == "-m":
-            # `python -m module` has no script path token.
-            skip_next = True
-            continue
-        if token in _INTERPRETERS or token in _SKIP_TOKENS:
-            continue
-        if token.startswith("-"):
-            continue
-        return token
-    return None
-
-
-def _looks_like_script_file(path_token: str) -> bool:
-    """Heuristic for script-like file paths used by evaluator commands."""
-    if path_token.endswith("/"):
-        return False
-    return any(path_token.endswith(ext) for ext in _SCRIPT_SUFFIXES)
-
-
-def _to_repo_relative(path_token: str, project_root: Path) -> str | None:
-    """Normalize a path token to a repo-relative POSIX path when possible."""
-    project_root_resolved = project_root.resolve()
-    token_path = Path(path_token)
-    abs_path = (
-        token_path.resolve()
-        if token_path.is_absolute()
-        else (project_root_resolved / token_path).resolve()
-    )
-    try:
-        return abs_path.relative_to(project_root_resolved).as_posix()
-    except ValueError:
-        return None
-
-
-def _collect_protected_evaluator_paths(
-    config: HelixConfig, project_root: Path
-) -> list[str]:
-    """Collect repo-relative files that should stay immutable during evolution."""
-    protected: set[str] = set()
-
-    for cmd in [config.evaluator.command, *config.evaluator.extra_commands]:
-        try:
-            tokens = shlex.split(cmd)
-        except ValueError:
-            continue
-        if not tokens or tokens[0] in _NO_SCRIPT_COMMANDS:
-            continue
-        # Shell wrappers like `bash -c "..."` hide the real command inside an
-        # opaque body string; path-level validation cannot reason about it.
-        if (
-            tokens[0] in _SHELL_WRAPPERS
-            and len(tokens) >= 2
-            and tokens[1] in _SHELL_COMMAND_FLAGS
-        ):
-            continue
-        script_token = _extract_script_token(tokens)
-        if script_token is None or not _looks_like_script_file(script_token):
-            continue
-        rel = _to_repo_relative(script_token, project_root)
-        if rel is not None:
-            protected.add(rel)
-
-    for path_str in config.evaluator.protected_files:
-        rel = _to_repo_relative(path_str, project_root)
-        if rel is None:
-            raise HelixError(
-                f"evaluator.protected_files path is outside project root: {path_str}",
-                operation="resolve protected evaluator files",
-                suggestion="Use repo-relative paths under the project root.",
-            )
-        protected.add(rel)
-
-    return sorted(protected)
-
-
 def _safe_remove_worktree(candidate: Candidate, *, label: str) -> None:
     """Remove ``candidate``'s worktree, warning on failure rather than raising.
 
@@ -637,226 +544,6 @@ def _safe_remove_worktree(candidate: Candidate, *, label: str) -> None:
         print_warning(
             f"Could not remove worktree for {label} {candidate.id}: {exc}"
         )
-
-
-def _copy_protected_path(source: Path, destination: Path) -> None:
-    """Refresh one protected file/directory in a candidate worktree."""
-    if source.resolve(strict=False) == destination.resolve(strict=False):
-        return
-
-    if destination.exists() or destination.is_symlink():
-        if destination.is_dir() and not destination.is_symlink():
-            shutil.rmtree(destination)
-        else:
-            destination.unlink()
-
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    if source.is_dir() and not source.is_symlink():
-        shutil.copytree(
-            source,
-            destination,
-            ignore=_PROTECTED_DIRECTORY_IGNORE_MATCHER,
-        )
-    elif source.is_symlink():
-        os.symlink(os.readlink(source), destination)
-    else:
-        shutil.copy2(source, destination)
-
-
-def _refresh_protected_evaluator_files(
-    candidate: Candidate,
-    config: HelixConfig,
-    project_root: Path,
-) -> None:
-    """Copy current root protected evaluator/runtime files into a worktree."""
-    worktree_root = Path(candidate.worktree_path)
-    for rel_path in _collect_protected_evaluator_paths(config, project_root):
-        source = project_root / rel_path
-        if not source.exists() and not source.is_symlink():
-            continue
-        _copy_protected_path(source, worktree_root / rel_path)
-
-
-def _refresh_and_snapshot_protected_evaluator_files(
-    candidate: Candidate,
-    config: HelixConfig,
-    project_root: Path,
-) -> None:
-    """Normalize HELIX-owned protected-file refresh before backend mutation."""
-    _refresh_protected_evaluator_files(candidate, config, project_root)
-    snapshot_candidate(candidate, "helix: refresh protected evaluator files")
-
-
-def _sha256_file(path: Path) -> str:
-    """Streamed SHA-256 of ``path``.
-
-    Uses ``hashlib.file_digest`` (Python 3.11+) so large protected files
-    (e.g., evaluator dataset ``.jsonl`` files) are not buffered in memory.
-    """
-    with path.open("rb") as f:
-        return hashlib.file_digest(f, "sha256").hexdigest()
-
-
-def _iter_protected_manifest_files(
-    source_path: Path,
-    rel_path: str,
-) -> list[tuple[str, Path]]:
-    """Return manifest entries under one protected file/directory.
-
-    ``source_path`` is expected to already be a real path (callers resolve
-    symlinks before calling).  ``os.walk`` is used with ``followlinks=False``
-    (the default) so symlinks inside the directory are not traversed.
-    """
-    if source_path.is_file():
-        return [(rel_path, source_path)]
-    if not source_path.is_dir():
-        return []
-
-    entries: list[tuple[str, Path]] = []
-    for dirpath_str, dirnames, filenames in os.walk(source_path):
-        ignored = _PROTECTED_DIRECTORY_IGNORE_MATCHER(
-            dirpath_str, [*dirnames, *filenames]
-        )
-        dirnames[:] = sorted(name for name in dirnames if name not in ignored)
-        for filename in sorted(name for name in filenames if name not in ignored):
-            file_path = Path(dirpath_str) / filename
-            # Defensive against TOCTOU: ``os.walk`` already separated files
-            # from directories, but a concurrent unlink/rename could leave a
-            # stale name behind.
-            if not file_path.is_file():
-                continue
-            entry_path = Path(rel_path) / file_path.relative_to(source_path)
-            entries.append((entry_path.as_posix(), file_path))
-    return entries
-
-
-def _evaluator_manifest_path(base_dir: Path) -> Path:
-    return base_dir / _EVALUATOR_MANIFEST_FILENAME
-
-
-def _build_evaluator_integrity_manifest(
-    config: HelixConfig,
-    baseline_root: Path,
-    project_root: Path,
-) -> dict[str, str]:
-    """Build {repo_relative_path: sha256} for protected evaluator files.
-
-    Fails closed: an unreadable protected file raises ``HelixError`` rather
-    than silently being omitted from the manifest -- otherwise tamper
-    detection would not flag changes to that file on resume.
-    """
-    manifest: dict[str, str] = {}
-    for rel_path in _collect_protected_evaluator_paths(config, project_root):
-        source_path = (baseline_root / rel_path).resolve()
-        if not source_path.exists():
-            logger.warning(
-                "Skipping protected evaluator path %s: missing from baseline %s",
-                rel_path,
-                baseline_root,
-            )
-            continue
-        entries = _iter_protected_manifest_files(source_path, rel_path)
-        if not entries and source_path.is_dir():
-            # Surface likely misconfigurations (e.g., a protected directory
-            # whose only contents match the ignore list).
-            logger.warning(
-                "Protected evaluator directory %s contributed 0 manifest "
-                "entries (every file matched the ignore list).",
-                rel_path,
-            )
-        for manifest_rel_path, file_path in entries:
-            try:
-                manifest[manifest_rel_path] = _sha256_file(file_path)
-            except OSError as exc:
-                raise HelixError(
-                    f"Failed hashing protected evaluator file: {file_path}",
-                    operation="build evaluator integrity manifest",
-                    suggestion=(
-                        "Ensure the file is readable and not held open by "
-                        "another process before retrying."
-                    ),
-                ) from exc
-    return manifest
-
-
-def _write_evaluator_integrity_manifest(
-    base_dir: Path, manifest: dict[str, str]
-) -> None:
-    """Persist immutable evaluator manifest for resume."""
-    path = _evaluator_manifest_path(base_dir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"version": 1, "files": manifest}
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True))
-
-
-def _load_evaluator_integrity_manifest(base_dir: Path) -> dict[str, str] | None:
-    """Load persisted immutable evaluator manifest, if available."""
-    path = _evaluator_manifest_path(base_dir)
-    if not path.exists():
-        return None
-    try:
-        payload = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        logger.exception("Failed to read evaluator integrity manifest: %s", path)
-        return None
-    files = payload.get("files")
-    if not isinstance(files, dict):
-        return None
-    manifest: dict[str, str] = {}
-    for key, value in files.items():
-        if isinstance(key, str) and isinstance(value, str):
-            manifest[key] = value
-    return manifest
-
-
-def _detect_evaluator_tamper(
-    candidate: Candidate,
-    manifest: dict[str, str],
-    config: HelixConfig | None = None,
-    project_root: Path | None = None,
-) -> list[str]:
-    """Return protected paths that diverge from the frozen evaluator manifest.
-
-    Detects three classes of tamper:
-
-    1. Modification of a baseline-listed file (hash mismatch).
-    2. Deletion of a baseline-listed file.
-    3. *Addition* of a previously-unknown file inside a protected directory,
-       when ``config`` and ``project_root`` are supplied.  Without these
-       arguments only the first two classes are reported, preserving the
-       legacy contract for callers that don't have config in scope.
-    """
-    if not manifest:
-        return []
-    violations: set[str] = set()
-    worktree_root = Path(candidate.worktree_path)
-    for rel_path, expected_hash in manifest.items():
-        candidate_path = worktree_root / rel_path
-        if not candidate_path.exists() or not candidate_path.is_file():
-            violations.add(rel_path)
-            continue
-        try:
-            if _sha256_file(candidate_path) != expected_hash:
-                violations.add(rel_path)
-        except OSError:
-            violations.add(rel_path)
-
-    if config is not None and project_root is not None:
-        known = set(manifest)
-        for protected_rel in _collect_protected_evaluator_paths(
-            config, project_root
-        ):
-            candidate_path = worktree_root / protected_rel
-            # Only directories can hold *new* files; single-file protected
-            # paths are fully covered by the manifest loop above.
-            if not candidate_path.is_dir() or candidate_path.is_symlink():
-                continue
-            for entry_rel, _ in _iter_protected_manifest_files(
-                candidate_path, protected_rel
-            ):
-                if entry_rel not in known:
-                    violations.add(entry_rel)
-    return sorted(violations)
 
 
 def _check_evaluator_script_exists(evaluator_command: str, project_root: Path) -> None:

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -10,6 +10,7 @@ import random as _random
 import shutil
 import shlex
 import subprocess
+import tempfile
 import threading
 import traceback
 from dataclasses import replace
@@ -308,6 +309,29 @@ def init_base_dir(base_dir: Path, config: HelixConfig) -> None:
         config_path.write_text("".join(lines))
 
 
+def _atomic_write_json(path: Path, data: Any) -> None:
+    """Write *data* as JSON to *path* atomically using a sibling temp file.
+
+    Uses ``tempfile.mkstemp`` + ``Path.replace()`` (atomic on POSIX) to avoid
+    partial-write corruption when a concurrent reader or a crash mid-write
+    could otherwise observe a truncated file.  The temp file is created in the
+    same directory as *path* so that ``replace()`` is an intra-filesystem
+    rename rather than a cross-device copy.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        Path(tmp).replace(path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 def _save_evaluation(base_dir: Path, result: EvalResult) -> None:
     """Persist an EvalResult to evaluations/<candidate_id>.json.
 
@@ -319,10 +343,7 @@ def _save_evaluation(base_dir: Path, result: EvalResult) -> None:
     pre-multi-axis shape.
     """
     eval_dir = base_dir / "evaluations"
-    eval_dir.mkdir(parents=True, exist_ok=True)
-    (eval_dir / f"{result.candidate_id}.json").write_text(
-        json.dumps(result.to_dict(), indent=2)
-    )
+    _atomic_write_json(eval_dir / f"{result.candidate_id}.json", result.to_dict())
 
 
 def _save_attempt_result(
@@ -344,7 +365,6 @@ def _save_attempt_result(
     resume/debugging instead of leaving lineage entries with no result artifact.
     """
     attempts_dir = base_dir / "attempts"
-    attempts_dir.mkdir(parents=True, exist_ok=True)
     payload = result.to_dict()
     payload["attempt"] = {
         "status": status,
@@ -354,34 +374,26 @@ def _save_attempt_result(
         "stage": stage,
         "example_ids": example_ids,
     }
-    (attempts_dir / f"{result.candidate_id}.json").write_text(
-        json.dumps(payload, indent=2)
-    )
+    _atomic_write_json(attempts_dir / f"{result.candidate_id}.json", payload)
 
 
 def _save_skip_record(
     base_dir: Path,
     *,
     generation: int,
-    parent_id: str,
-    reason: str,
-    eval_result: EvalResult,
+    records: list[dict],
 ) -> None:
-    """Persist a skip-only iteration record.
+    """Persist all per-proposal skip records for a generation as a JSON list.
 
+    All parents that triggered the perfect-subsample gate within the same
+    generation are written as a single list so that ``n_proposals > 1`` with
+    multiple perfect parents does not silently overwrite earlier records.
     Skip records are intentionally separate from candidate attempts: no child
     program exists, but the run should still explain why a generation has no
     candidate result.
     """
     skips_dir = base_dir / "skips"
-    skips_dir.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "generation": generation,
-        "parent_id": parent_id,
-        "reason": reason,
-        "parent_eval": eval_result.to_dict(),
-    }
-    (skips_dir / f"g{generation}.json").write_text(json.dumps(payload, indent=2))
+    _atomic_write_json(skips_dir / f"g{generation}.json", records)
 
 
 def _load_evaluation(base_dir: Path, candidate_id: str) -> EvalResult | None:
@@ -402,7 +414,14 @@ def _gen_from_id(candidate_id: str) -> int:
 
 
 def _proposal_counter_from_id(candidate_id: str) -> int:
-    """Parse the proposal counter from a candidate id like 'g3-s4'."""
+    """Parse the proposal counter from a candidate id like 'g3-s4'.
+
+    Returns 0 on parse failure (e.g., legacy or seed-only IDs that do not
+    match the ``gN-sN`` format).  Note that counter=0 is ambiguous with the
+    first valid proposal slot ``g0-s0``; callers that filter by
+    ``counter > 0`` intentionally exclude both parse failures and the zeroth
+    slot for that reason.
+    """
     try:
         return int(candidate_id.split("-")[1].lstrip("s"))
     except (IndexError, ValueError):
@@ -1962,6 +1981,8 @@ def _run_evolution_impl(
             live.current_usage = UsageStats()
             live.update(phase=f"Starting Generation {gen}")
 
+            # Snapshot before set_generation so rollback restores the
+            # pre-iteration value (ordering matters: capture first, mutate second).
             _iteration_start_generation = state.generation
             _iteration_start_mutation_counter = state.mutation_counter
             budget_api.set_generation(state, gen)
@@ -2564,6 +2585,10 @@ def _run_evolution_impl(
             proposal_parent_mb_results: list[EvalResult | None] = []
             semantic_skip_count = 0
             retryable_semantic_skip_count = 0
+            # Accumulate per-proposal skip records; written as a single JSON list
+            # after the loop so that n_proposals > 1 with multiple perfect parents
+            # does not silently overwrite earlier records (review NB-1).
+            _gen_skip_records: list[dict] = []
 
             for _p_idx, (_pre_ctx, (_mb_result, _n_uncached)) in enumerate(
                 zip(presample_contexts, parent_eval_results)
@@ -2643,13 +2668,12 @@ def _run_evolution_impl(
                     s >= config.evolution.perfect_score_threshold
                     for s in eval_for_mutate.instance_scores.values()
                 ):
-                    _save_skip_record(
-                        base_dir,
-                        generation=gen,
-                        parent_id=parent.id,
-                        reason="perfect_subsample",
-                        eval_result=eval_for_mutate,
-                    )
+                    _gen_skip_records.append({
+                        "generation": gen,
+                        "parent_id": parent.id,
+                        "reason": "perfect_subsample",
+                        "parent_eval": eval_for_mutate.to_dict(),
+                    })
                     print_info(
                         f"Iteration {gen}: all subsample scores perfect for "
                         f"parent {parent.id}; skipping proposal "
@@ -2666,6 +2690,11 @@ def _run_evolution_impl(
                 proposal_subsamples.append(subsample_ids)
                 proposal_parent_mb_results.append(parent_mb_result)
 
+            # Write all skip records for this generation as a single JSON list.
+            # Must come after the inner loop so every proposal's result is known.
+            if _gen_skip_records:
+                _save_skip_record(base_dir, generation=gen, records=_gen_skip_records)
+
             if _budget_break and not proposal_contexts:
                 print_warning("Budget exhausted mid-generation -- stopping.")
                 _save_state(state)
@@ -2681,6 +2710,9 @@ def _run_evolution_impl(
                 # but roll back visible progress counters so resume/in-process
                 # continuation tries this generation again with a fresh
                 # parent/minibatch.
+                # NOTE: state.i is intentionally NOT rolled back; the proposal
+                # counter advances unconditionally per GEPA engine.py:649 to
+                # give the batch sampler a fresh seed on retry.
                 budget_api.set_generation(state, _iteration_start_generation)
                 state.mutation_counter = _iteration_start_mutation_counter
                 _save_state(state)

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -488,22 +488,18 @@ def _reconcile_incomplete_attempts_on_resume(
 
     for candidate_id in sorted(incomplete_ids):
         wt_path = worktrees_dir / candidate_id
-        try:
-            remove_worktree(
-                Candidate(
-                    id=candidate_id,
-                    worktree_path=str(wt_path),
-                    branch_name=f"helix/{candidate_id}",
-                    generation=_gen_from_id(candidate_id),
-                    parent_id=None,
-                    parent_ids=[],
-                    operation="interrupted",
-                )
-            )
-        except Exception as exc:
-            print_warning(
-                f"Could not remove incomplete attempt worktree {candidate_id}: {exc}"
-            )
+        _safe_remove_worktree(
+            Candidate(
+                id=candidate_id,
+                worktree_path=str(wt_path),
+                branch_name=f"helix/{candidate_id}",
+                generation=_gen_from_id(candidate_id),
+                parent_id=None,
+                parent_ids=[],
+                operation="interrupted",
+            ),
+            label="orphan worktree from prior run",
+        )
 
     _remove_lineage_records(lineage_path, incomplete_ids)
     for candidate_id in incomplete_ids:
@@ -625,6 +621,22 @@ def _collect_protected_evaluator_paths(
         protected.add(rel)
 
     return sorted(protected)
+
+
+def _safe_remove_worktree(candidate: Candidate, *, label: str) -> None:
+    """Remove ``candidate``'s worktree, warning on failure rather than raising.
+
+    The nine rejection / cleanup paths in :func:`_run_evolution_impl` and
+    :func:`_reconcile_incomplete_attempts_on_resume` all need the same
+    "best-effort remove + warn" behaviour.  Extracting this avoids 9× copies
+    of the same try/except.
+    """
+    try:
+        remove_worktree(candidate)
+    except Exception as exc:
+        print_warning(
+            f"Could not remove worktree for {label} {candidate.id}: {exc}"
+        )
 
 
 def _copy_protected_path(source: Path, destination: Path) -> None:
@@ -1874,7 +1886,7 @@ def _run_evolution_impl(
                     source="seed_generation",
                 )
             except Exception:
-                remove_worktree(seed)
+                _safe_remove_worktree(seed, label="failed seed generation")
                 raise
             print_success("Seed generation complete.")
         else:
@@ -2193,12 +2205,7 @@ def _run_evolution_impl(
                                 f"Merge {merge_id} touched protected evaluator files "
                                 f"({', '.join(merge_tamper)}) -- rejecting."
                             )
-                            try:
-                                remove_worktree(merged)
-                            except Exception as _rm_exc:
-                                print_warning(
-                                    f"Could not remove worktree for rejected merge {merge_id}: {_rm_exc}"
-                                )
+                            _safe_remove_worktree(merged, label="tamper-rejected merge candidate")
                         else:
                             candidates[merged.id] = merged
                             record_entry(
@@ -2235,12 +2242,7 @@ def _run_evolution_impl(
                                     f"Merge {merge_id} produced a previously-seen "
                                     f"output (desc {merged_sha[:8]}) -- skipping."
                                 )
-                                try:
-                                    remove_worktree(merged)
-                                except Exception as _rm_exc:
-                                    print_warning(
-                                        f"Could not remove worktree for duplicate-desc merge {merge_id}: {_rm_exc}"
-                                    )
+                                _safe_remove_worktree(merged, label="duplicate-desc merge candidate")
                                 if merged.id in candidates:
                                     del candidates[merged.id]
                                 _save_state(state)
@@ -2414,12 +2416,7 @@ def _run_evolution_impl(
                                     f"Merge {merge_id} score {merge_score:.4f} < "
                                     f"max parent {required_score:.4f} -- rejecting."
                                 )
-                                try:
-                                    remove_worktree(merged)
-                                except Exception as _rm_exc:
-                                    print_warning(
-                                        f"Could not remove worktree for rejected merge {merge_id}: {_rm_exc}"
-                                    )
+                                _safe_remove_worktree(merged, label="score-rejected merge candidate")
                                 if merged.id in candidates:
                                     del candidates[merged.id]
 
@@ -2876,12 +2873,7 @@ def _run_evolution_impl(
                         f"Mutation {child.id} touched protected evaluator files "
                         f"({', '.join(tampered_paths)}) -- rejecting."
                     )
-                    try:
-                        remove_worktree(child)
-                    except Exception as _rm_exc:
-                        print_warning(
-                            f"Could not remove worktree for rejected candidate {child.id}: {_rm_exc}"
-                        )
+                    _safe_remove_worktree(child, label="tamper-rejected mutation candidate")
                     continue
 
                 candidates[child.id] = child
@@ -3003,12 +2995,7 @@ def _run_evolution_impl(
                             f"Minibatch gate: {child.id} rejected "
                             f"(sum {sum(_after):.4f} vs parent {sum(_before):.4f}) -- removing."
                         )
-                        try:
-                            remove_worktree(child)
-                        except Exception as _rm_exc:
-                            print_warning(
-                                f"Could not remove worktree for rejected candidate {child.id}: {_rm_exc}"
-                            )
+                        _safe_remove_worktree(child, label="minibatch-gate-rejected candidate")
                         del candidates[child.id]
                         continue
                     else:
@@ -3084,12 +3071,7 @@ def _run_evolution_impl(
                             f"Acceptance: {child.id} does not improve "
                             f"(child_sum={child_sum:.4f}, parent_sum={parent_sum:.4f}) -- removing."
                         )
-                        try:
-                            remove_worktree(child)
-                        except Exception as _rm_exc:
-                            print_warning(
-                                f"Could not remove worktree for rejected candidate {child.id}: {_rm_exc}"
-                            )
+                        _safe_remove_worktree(child, label="train-gate-rejected candidate")
                         del candidates[child.id]
                         continue
 
@@ -3163,13 +3145,7 @@ def _run_evolution_impl(
                             f"(sum {sum(_stage_after):.4f} vs parent "
                             f"{sum(_stage_before):.4f}) -- removing."
                         )
-                        try:
-                            remove_worktree(child)
-                        except Exception as _rm_exc:
-                            print_warning(
-                                f"Could not remove worktree for stage-rejected candidate "
-                                f"{child.id}: {_rm_exc}"
-                            )
+                        _safe_remove_worktree(child, label="val-stage-rejected candidate")
                         del candidates[child.id]
                         continue
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -381,7 +381,7 @@ def _save_skip_record(
     base_dir: Path,
     *,
     generation: int,
-    records: list[dict],
+    records: list[dict[str, Any]],
 ) -> None:
     """Persist all per-proposal skip records for a generation as a JSON list.
 
@@ -2588,7 +2588,7 @@ def _run_evolution_impl(
             # Accumulate per-proposal skip records; written as a single JSON list
             # after the loop so that n_proposals > 1 with multiple perfect parents
             # does not silently overwrite earlier records (review NB-1).
-            _gen_skip_records: list[dict] = []
+            _gen_skip_records: list[dict[str, Any]] = []
 
             for _p_idx, (_pre_ctx, (_mb_result, _n_uncached)) in enumerate(
                 zip(presample_contexts, parent_eval_results)

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1389,6 +1389,64 @@ def _inject_top_k_best_example_history(
     return eval_result
 
 
+def _run_full_val_eval(
+    candidate: Candidate,
+    state: EvolutionState,
+    *,
+    full_val_example_ids: list[str] | tuple[str, ...],
+    minibatch_cache: "MinibatchEvalCache[object, str] | None",
+    eval_cache: EvaluationCache | None,
+    config: HelixConfig,
+    project_root: Path,
+    source_batch: str,
+    source_single: str,
+) -> EvalResult:
+    """Full-val eval on whichever path (batch via cache OR single-task) the
+    config selects; charges the budget with the appropriate ``source`` tag.
+
+    The batch path calls :func:`_cached_evaluate_batch` (per-example cache,
+    GEPA parity).  The single-task path calls :func:`_cached_eval` (split-level
+    cache).  Charges via :func:`budget_api.charge_evaluation` with
+    ``source=source_batch`` on the batch path and ``source=source_single`` on
+    the single-task path.
+
+    The three :func:`_run_evolution_impl` / seed-eval full-val blocks are
+    structurally identical except for the candidate variable and ``source``
+    strings (§3 D3 of the scope report).  This helper eliminates that
+    duplication.  Callers are responsible for any pre-eval side effects (e.g.
+    the seed-eval path calls ``_refresh_protected_evaluator_files`` before
+    invoking this helper on the single-task branch).
+    """
+    if full_val_example_ids:
+        result, n_uncached = _cached_evaluate_batch(
+            candidate,
+            list(full_val_example_ids),
+            minibatch_cache,
+            config,
+            "val",
+            project_root,
+        )
+        result.candidate_id = candidate.id
+        budget_api.charge_evaluation(
+            state,
+            num_actual_examples=n_uncached,
+            candidate_id=candidate.id,
+            split="val",
+            source=source_batch,
+        )
+    else:
+        result, cached = _cached_eval(candidate, config, "val", eval_cache)
+        result.candidate_id = candidate.id
+        budget_api.charge_evaluation(
+            state,
+            was_cached=cached,
+            candidate_id=candidate.id,
+            split="val",
+            source=source_single,
+        )
+    return result
+
+
 def _full_val_example_ids(
     config: HelixConfig,
     val_loader: "HelixDataLoader | _RangeDataLoader | None" = None,
@@ -1914,35 +1972,23 @@ def _run_evolution_impl(
         # is None (single-task/no-example mode, e.g. circle_packing) we
         # cannot key the cache by example id, so we fall back to one evaluator
         # call (counted as one uncached metric call).
-        if full_val_example_ids:
-            _seed_example_ids = list(full_val_example_ids)
-            seed_result, _seed_num_actual = _cached_evaluate_batch(
-                seed,
-                _seed_example_ids,
-                minibatch_cache,
-                config,
-                "val",
-                project_root,
-            )
-            seed_result.candidate_id = seed.id
-            budget_api.charge_evaluation(
-                state,
-                num_actual_examples=_seed_num_actual,
-                candidate_id=seed.id,
-                split="val",
-                source="seed_val_batch",
-            )
-        else:
+        # Pre-refresh on the single-task branch (no example ids): the protected
+        # evaluator files must be current before _cached_eval reads them.  The
+        # batch branch goes through _cached_evaluate_batch which rewrites the
+        # worktree each call, so no pre-refresh is needed there.
+        if not full_val_example_ids:
             _refresh_protected_evaluator_files(seed, config, project_root)
-            seed_result, _seed_cached = _cached_eval(seed, config, "val", eval_cache)
-            seed_result.candidate_id = seed.id
-            budget_api.charge_evaluation(
-                state,
-                was_cached=_seed_cached,
-                candidate_id=seed.id,
-                split="val",
-                source="seed_val",
-            )
+        seed_result = _run_full_val_eval(
+            seed,
+            state,
+            full_val_example_ids=full_val_example_ids,
+            minibatch_cache=minibatch_cache,
+            eval_cache=eval_cache,
+            config=config,
+            project_root=project_root,
+            source_batch="seed_val_batch",
+            source_single="seed_val",
+        )
 
         _save_evaluation(base_dir, seed_result)
         frontier.add(seed, seed_result)
@@ -2357,39 +2403,17 @@ def _run_evolution_impl(
                                 # Budget accounting charges the uncached
                                 # full-val example count; single-task/no-example
                                 # evals still charge 0/1 metric calls via _cached_eval.
-                                if full_val_example_ids:
-                                    _full_val_ids = list(full_val_example_ids)
-                                    full_val_result, _full_n = _cached_evaluate_batch(
-                                        merged,
-                                        _full_val_ids,
-                                        minibatch_cache,
-                                        config,
-                                        "val",
-                                        project_root,
-                                    )
-                                    full_val_result.candidate_id = merged.id
-                                    budget_api.charge_evaluation(
-                                        state,
-                                        num_actual_examples=_full_n,
-                                        candidate_id=merged.id,
-                                        split="val",
-                                        source="merge_full_val_batch",
-                                    )
-                                else:
-                                    full_val_result, _full_val_cached = _cached_eval(
-                                        merged,
-                                        config,
-                                        "val",
-                                        eval_cache,
-                                    )
-                                    full_val_result.candidate_id = merged.id
-                                    budget_api.charge_evaluation(
-                                        state,
-                                        was_cached=_full_val_cached,
-                                        candidate_id=merged.id,
-                                        split="val",
-                                        source="merge_full_val",
-                                    )
+                                full_val_result = _run_full_val_eval(
+                                    merged,
+                                    state,
+                                    full_val_example_ids=full_val_example_ids,
+                                    minibatch_cache=minibatch_cache,
+                                    eval_cache=eval_cache,
+                                    config=config,
+                                    project_root=project_root,
+                                    source_batch="merge_full_val_batch",
+                                    source_single="merge_full_val",
+                                )
                                 _save_evaluation(base_dir, full_val_result)
 
                                 if budget_api.budget_exhausted(state, config):
@@ -3171,38 +3195,18 @@ def _run_evolution_impl(
                 # fall back to the legacy ``_cached_eval`` path keyed by
                 # ``(candidate_id, split)`` — single-task/no-example mode has no example
                 # ids to key on.
-                if full_val_example_ids:
-                    _val_example_ids = list(full_val_example_ids)
-                    val_result, _n = _cached_evaluate_batch(
-                        child,
-                        _val_example_ids,
-                        minibatch_cache,
-                        config,
-                        "val",
-                        project_root,
-                    )
-                    val_result.candidate_id = child.id
-                    _last_eval_result = val_result
-                    budget_api.charge_evaluation(
-                        state,
-                        num_actual_examples=_n,
-                        candidate_id=child.id,
-                        split="val",
-                        source="mutation_full_val_batch",
-                    )
-                else:
-                    val_result, _val_cached = _cached_eval(
-                        child, config, "val", eval_cache
-                    )
-                    val_result.candidate_id = child.id
-                    _last_eval_result = val_result
-                    budget_api.charge_evaluation(
-                        state,
-                        was_cached=_val_cached,
-                        candidate_id=child.id,
-                        split="val",
-                        source="mutation_full_val",
-                    )
+                val_result = _run_full_val_eval(
+                    child,
+                    state,
+                    full_val_example_ids=full_val_example_ids,
+                    minibatch_cache=minibatch_cache,
+                    eval_cache=eval_cache,
+                    config=config,
+                    project_root=project_root,
+                    source_batch="mutation_full_val_batch",
+                    source_single="mutation_full_val",
+                )
+                _last_eval_result = val_result
 
                 if budget_api.budget_exhausted(state, config):
                     print_warning("Budget exhausted mid-generation -- stopping.")

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -325,6 +325,65 @@ def _save_evaluation(base_dir: Path, result: EvalResult) -> None:
     )
 
 
+def _save_attempt_result(
+    base_dir: Path,
+    result: EvalResult,
+    *,
+    status: str,
+    reason: str,
+    parent_id: str | None,
+    generation: int,
+    stage: str,
+    example_ids: list[str] | None = None,
+) -> None:
+    """Persist a non-frontier attempt result without polluting evaluations/.
+
+    ``evaluations/`` is the accepted/full-evaluation surface used for frontier
+    reporting.  Rejected mutations can still consume a generation and useful
+    evaluator work, so keep their gating/stage results under ``attempts/`` for
+    resume/debugging instead of leaving lineage entries with no result artifact.
+    """
+    attempts_dir = base_dir / "attempts"
+    attempts_dir.mkdir(parents=True, exist_ok=True)
+    payload = result.to_dict()
+    payload["attempt"] = {
+        "status": status,
+        "reason": reason,
+        "parent_id": parent_id,
+        "generation": generation,
+        "stage": stage,
+        "example_ids": example_ids,
+    }
+    (attempts_dir / f"{result.candidate_id}.json").write_text(
+        json.dumps(payload, indent=2)
+    )
+
+
+def _save_skip_record(
+    base_dir: Path,
+    *,
+    generation: int,
+    parent_id: str,
+    reason: str,
+    eval_result: EvalResult,
+) -> None:
+    """Persist a skip-only iteration record.
+
+    Skip records are intentionally separate from candidate attempts: no child
+    program exists, but the run should still explain why a generation has no
+    candidate result.
+    """
+    skips_dir = base_dir / "skips"
+    skips_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "generation": generation,
+        "parent_id": parent_id,
+        "reason": reason,
+        "parent_eval": eval_result.to_dict(),
+    }
+    (skips_dir / f"g{generation}.json").write_text(json.dumps(payload, indent=2))
+
+
 def _load_evaluation(base_dir: Path, candidate_id: str) -> EvalResult | None:
     """Load a saved EvalResult, or None if the file is absent."""
     path = base_dir / "evaluations" / f"{candidate_id}.json"
@@ -1780,11 +1839,14 @@ def _run_evolution_impl(
         mutations_attempted = 0
         mutations_accepted = 0
 
-        for gen in range(start_gen, config.evolution.max_generations + 1):
+        gen = start_gen
+        while gen <= config.evolution.max_generations:
             live.gen = gen
             live.current_usage = UsageStats()
             live.update(phase=f"Starting Generation {gen}")
 
+            _iteration_start_generation = state.generation
+            _iteration_start_mutation_counter = state.mutation_counter
             budget_api.set_generation(state, gen)
             # GEPA parity (engine.py:649): bump ``state.i`` unconditionally at
             # the top of every iteration so the proposal counter — used by the
@@ -2021,6 +2083,7 @@ def _run_evolution_impl(
                                 if merged.id in candidates:
                                     del candidates[merged.id]
                                 _save_state(state)
+                                gen += 1
                                 continue
                             state.merge_description_triplets.append(_desc_triplet)
                             # GEPA parity (M5): merge acceptance evaluates merged on a
@@ -2206,6 +2269,7 @@ def _run_evolution_impl(
                 # failure, tamper reject) we drop into reflective mutation below.
                 if merge_attempted:
                     _save_state(state)
+                    gen += 1
                     continue
 
             elif config.evolution.merge_enabled:
@@ -2381,6 +2445,8 @@ def _run_evolution_impl(
             ] = []
             proposal_subsamples: list[list[str] | None] = []
             proposal_parent_mb_results: list[EvalResult | None] = []
+            semantic_skip_count = 0
+            retryable_semantic_skip_count = 0
 
             for _p_idx, (_pre_ctx, (_mb_result, _n_uncached)) in enumerate(
                 zip(presample_contexts, parent_eval_results)
@@ -2460,11 +2526,21 @@ def _run_evolution_impl(
                     s >= config.evolution.perfect_score_threshold
                     for s in eval_for_mutate.instance_scores.values()
                 ):
+                    _save_skip_record(
+                        base_dir,
+                        generation=gen,
+                        parent_id=parent.id,
+                        reason="perfect_subsample",
+                        eval_result=eval_for_mutate,
+                    )
                     print_info(
                         f"Iteration {gen}: all subsample scores perfect for "
                         f"parent {parent.id}; skipping proposal "
                         f"(GEPA reflective_mutation.py:308-327)."
                     )
+                    semantic_skip_count += 1
+                    if subsample_ids is not None:
+                        retryable_semantic_skip_count += 1
                     continue
 
                 proposal_contexts.append(
@@ -2477,6 +2553,22 @@ def _run_evolution_impl(
                 print_warning("Budget exhausted mid-generation -- stopping.")
                 _save_state(state)
                 break
+            if (
+                not proposal_contexts
+                and semantic_skip_count
+                and retryable_semantic_skip_count == semantic_skip_count
+            ):
+                # A perfect-subsample skip is not a candidate attempt.  Do not
+                # consume the visible generation/candidate slot; keep metric
+                # budget charges and the proposal counter from the parent eval,
+                # but roll back visible progress counters so resume/in-process
+                # continuation tries this generation again with a fresh
+                # parent/minibatch.
+                state.generation = _iteration_start_generation
+                state.mutation_counter = _iteration_start_mutation_counter
+                _save_state(state)
+                TRACE.emit(EventType.ITER_END, decision=f"{gen}:skip")
+                continue
 
             # ---- Step 2: Execute mutations (parallel if N > 1) ----
             set_phase(HelixPhase.MUTATION)
@@ -2716,6 +2808,16 @@ def _run_evolution_impl(
                         subsample_scores_after=_after,
                     )
                     if not acceptance.should_accept(_proposal):
+                        _save_attempt_result(
+                            base_dir,
+                            gating_result,
+                            status="rejected",
+                            reason="minibatch_gate",
+                            parent_id=_parent.id,
+                            generation=gen,
+                            stage="train_minibatch",
+                            example_ids=list(_subsample_ids),
+                        )
                         TRACE.emit(
                             EventType.ACCEPT_DECISION,
                             candidate_id=child.id,
@@ -2794,6 +2896,16 @@ def _run_evolution_impl(
                     if not acceptance.should_accept(_legacy_proposal):
                         parent_sum = sum(_legacy_before)
                         child_sum = sum(_legacy_after)
+                        _save_attempt_result(
+                            base_dir,
+                            gating_result,
+                            status="rejected",
+                            reason="train_gate",
+                            parent_id=_parent.id,
+                            generation=gen,
+                            stage="train",
+                            example_ids=None,
+                        )
                         print_warning(
                             f"Acceptance: {child.id} does not improve "
                             f"(child_sum={child_sum:.4f}, parent_sum={parent_sum:.4f}) -- removing."
@@ -2854,6 +2966,16 @@ def _run_evolution_impl(
                         subsample_scores_after=_stage_after,
                     )
                     if not acceptance.should_accept(_proposal):
+                        _save_attempt_result(
+                            base_dir,
+                            stage_result,
+                            status="rejected",
+                            reason="val_stage",
+                            parent_id=_parent.id,
+                            generation=gen,
+                            stage="val_stage",
+                            example_ids=list(stage_val_example_ids),
+                        )
                         TRACE.emit(
                             EventType.ACCEPT_DECISION,
                             candidate_id=child.id,
@@ -2977,6 +3099,7 @@ def _run_evolution_impl(
 
             _save_state(state)
             TRACE.emit(EventType.ITER_END, decision=str(gen))
+            gen += 1
 
     # ------------------------------------------------------------------
     # Return best

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -449,9 +449,16 @@ def _reconcile_incomplete_attempts_on_resume(
     for candidate_id, entry in lineage.items():
         if candidate_id in completed_ids:
             continue
-        if entry.operation not in {"mutation", "merge"}:
+        if entry.operation not in {"mutate", "mutation", "merge"}:
             continue
         if (worktrees_dir / candidate_id).exists():
+            incomplete_ids.add(candidate_id)
+
+    for wt_path in worktrees_dir.glob("g*-s*"):
+        candidate_id = wt_path.name
+        if candidate_id in completed_ids or candidate_id in lineage:
+            continue
+        if wt_path.is_dir():
             incomplete_ids.add(candidate_id)
 
     if not incomplete_ids:

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -2564,7 +2564,7 @@ def _run_evolution_impl(
                 # but roll back visible progress counters so resume/in-process
                 # continuation tries this generation again with a fresh
                 # parent/minibatch.
-                state.generation = _iteration_start_generation
+                budget_api.set_generation(state, _iteration_start_generation)
                 state.mutation_counter = _iteration_start_mutation_counter
                 _save_state(state)
                 TRACE.emit(EventType.ITER_END, decision=f"{gen}:skip")

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1532,6 +1532,23 @@ def run_evolution(
     base_dir: Path,
 ) -> HelixResult:
     """Run the HELIX evolutionary loop."""
+    # Mirror GEPA api.py:262-265: at least one stopping condition is required.
+    # Without this, perfect-skip + always-perfect data + no effective bound =
+    # a run that terminates only by the OS.  In HELIX, max_generations (loop
+    # bound) and max_evaluations (budget cap, <= 0 disables) are the two
+    # supported stopping conditions.  max_generations defaults to 10 and is
+    # always a positive int; this guard fires only if a caller explicitly sets
+    # it to <= 0 while leaving max_evaluations disabled.
+    if (
+        config.evolution.max_generations <= 0
+        and config.evolution.max_evaluations <= 0
+    ):
+        raise ValueError(
+            "At least one stopping condition is required: set "
+            "config.evolution.max_generations to a positive integer, or "
+            "config.evolution.max_evaluations > 0. "
+            "See GEPA api.py:262-265 for the upstream equivalent check."
+        )
     if config.sandbox.enabled and config.sandbox.evaluator:
         if config.evaluator.sidecar is None:
             raise HelixError(

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1975,16 +1975,22 @@ def _run_evolution_impl(
         mutations_attempted = 0
         mutations_accepted = 0
 
-        gen = start_gen
-        while gen <= config.evolution.max_generations:
+        gen = start_gen - 1
+        while gen < config.evolution.max_generations:
+            # GEPA parity (engine.py:649): increment generation UNCONDITIONALLY
+            # at the top of the loop body, before any proposal work.  GEPA
+            # advances ``state.i`` at line 649, before any proposal logic.
+            # Moving the increment here eliminates the helix-original rollback
+            # construct that caused the NB-2 infinite-retry scenario
+            # (always-perfect data + cached parent eval + no budget cap →
+            # gen never advances).  After this change there is no code path
+            # that skips or rewinds ``gen``; budget_api.advance_proposal_counter
+            # (which increments state.i) continues to run here unconditionally.
+            gen += 1
             live.gen = gen
             live.current_usage = UsageStats()
             live.update(phase=f"Starting Generation {gen}")
 
-            # Snapshot before set_generation so rollback restores the
-            # pre-iteration value (ordering matters: capture first, mutate second).
-            _iteration_start_generation = state.generation
-            _iteration_start_mutation_counter = state.mutation_counter
             budget_api.set_generation(state, gen)
             # GEPA parity (engine.py:649): bump ``state.i`` unconditionally at
             # the top of every iteration so the proposal counter — used by the
@@ -2221,7 +2227,6 @@ def _run_evolution_impl(
                                 if merged.id in candidates:
                                     del candidates[merged.id]
                                 _save_state(state)
-                                gen += 1
                                 continue
                             state.merge_description_triplets.append(_desc_triplet)
                             # GEPA parity (M5): merge acceptance evaluates merged on a
@@ -2407,7 +2412,6 @@ def _run_evolution_impl(
                 # failure, tamper reject) we drop into reflective mutation below.
                 if merge_attempted:
                     _save_state(state)
-                    gen += 1
                     continue
 
             elif config.evolution.merge_enabled:
@@ -2514,10 +2518,18 @@ def _run_evolution_impl(
             ) -> tuple[EvalResult | None, int]:
                 _parent, _pfr, _sub_ids, _new_id = pre_ctx
                 if _sub_ids is not None:
+                    # GEPA parity (reflective_mutation.py:268-269): parent
+                    # minibatch evals BYPASS the cache — pass ``None`` so that
+                    # every call goes to the real evaluator and charges the full
+                    # minibatch size toward budget.  The cache is reserved for
+                    # val-set full evaluations only (GEPA engine.py:154-173).
+                    # This prevents NB-2: without this, a cache-warm parent that
+                    # always scores perfectly charges 0 toward budget while gen
+                    # keeps advancing (Change 1), making budget the only guard.
                     _mb, _n_uncached = _cached_evaluate_batch(
                         _parent,
                         list(_sub_ids),
-                        minibatch_cache,
+                        None,  # bypass minibatch_cache — mirrors GEPA line 268
                         config,
                         "train",
                         project_root,
@@ -2704,17 +2716,13 @@ def _run_evolution_impl(
                 and semantic_skip_count
                 and retryable_semantic_skip_count == semantic_skip_count
             ):
-                # A perfect-subsample skip is not a candidate attempt.  Do not
-                # consume the visible generation/candidate slot; keep metric
-                # budget charges and the proposal counter from the parent eval,
-                # but roll back visible progress counters so resume/in-process
-                # continuation tries this generation again with a fresh
-                # parent/minibatch.
-                # NOTE: state.i is intentionally NOT rolled back; the proposal
-                # counter advances unconditionally per GEPA engine.py:649 to
-                # give the batch sampler a fresh seed on retry.
-                budget_api.set_generation(state, _iteration_start_generation)
-                state.mutation_counter = _iteration_start_mutation_counter
+                # Perfect-subsample skip: all parents scored perfectly on the
+                # minibatch so no mutation was attempted.  GEPA parity
+                # (engine.py:649, reflective_mutation.py:308-327): gen was
+                # already incremented unconditionally at the top of the loop,
+                # so state.generation is now set to the *new* gen value.  On
+                # resume the next iteration will be gen+1 — no rollback, no
+                # retry-same-generation infinite loop (NB-2 fix).
                 _save_state(state)
                 TRACE.emit(EventType.ITER_END, decision=f"{gen}:skip")
                 continue
@@ -3248,7 +3256,6 @@ def _run_evolution_impl(
 
             _save_state(state)
             TRACE.emit(EventType.ITER_END, decision=str(gen))
-            gen += 1
 
     # ------------------------------------------------------------------
     # Return best

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -401,6 +401,109 @@ def _gen_from_id(candidate_id: str) -> int:
         return 0
 
 
+def _proposal_counter_from_id(candidate_id: str) -> int:
+    """Parse the proposal counter from a candidate id like 'g3-s4'."""
+    try:
+        return int(candidate_id.split("-")[1].lstrip("s"))
+    except (IndexError, ValueError):
+        return 0
+
+
+def _remove_lineage_records(lineage_path: Path, candidate_ids: set[str]) -> None:
+    """Remove candidate ids from the raw lineage JSON array."""
+    if not lineage_path.exists() or not candidate_ids:
+        return
+    records = json.loads(lineage_path.read_text())
+    kept = [record for record in records if record.get("id") not in candidate_ids]
+    tmp_path = lineage_path.with_suffix(f"{lineage_path.suffix}.tmp")
+    tmp_path.write_text(json.dumps(kept, indent=2))
+    tmp_path.replace(lineage_path)
+
+
+def _reconcile_incomplete_attempts_on_resume(
+    *,
+    state: EvolutionState,
+    base_dir: Path,
+    worktrees_dir: Path,
+    lineage_path: Path,
+) -> bool:
+    """Discard interrupted live attempts so resume retries their visible slot.
+
+    A completed proposal has either an evaluation artifact, an attempt artifact,
+    or frontier membership.  If a lineage entry still has a worktree but none of
+    those completion markers, HELIX likely stopped between candidate creation
+    and final result persistence.  Remove only those live incomplete worktrees;
+    historical lineage-only entries without worktrees are left untouched because
+    they may come from older completed runs that predate attempt artifacts.
+    """
+    if not lineage_path.exists():
+        return False
+
+    lineage = load_lineage(lineage_path)
+    completed_ids = set(state.frontier)
+    for artifact_dir in (base_dir / "evaluations", base_dir / "attempts"):
+        if artifact_dir.exists():
+            completed_ids.update(path.stem for path in artifact_dir.glob("*.json"))
+
+    incomplete_ids: set[str] = set()
+    for candidate_id, entry in lineage.items():
+        if candidate_id in completed_ids:
+            continue
+        if entry.operation not in {"mutation", "merge"}:
+            continue
+        if (worktrees_dir / candidate_id).exists():
+            incomplete_ids.add(candidate_id)
+
+    if not incomplete_ids:
+        return False
+
+    first_generation = min(_gen_from_id(candidate_id) for candidate_id in incomplete_ids)
+    first_counter = min(_proposal_counter_from_id(candidate_id) for candidate_id in incomplete_ids)
+
+    for candidate_id in sorted(incomplete_ids):
+        wt_path = worktrees_dir / candidate_id
+        try:
+            remove_worktree(
+                Candidate(
+                    id=candidate_id,
+                    worktree_path=str(wt_path),
+                    branch_name=f"helix/{candidate_id}",
+                    generation=_gen_from_id(candidate_id),
+                    parent_id=None,
+                    parent_ids=[],
+                    operation="interrupted",
+                )
+            )
+        except Exception as exc:
+            print_warning(
+                f"Could not remove incomplete attempt worktree {candidate_id}: {exc}"
+            )
+
+    _remove_lineage_records(lineage_path, incomplete_ids)
+    for candidate_id in incomplete_ids:
+        state.instance_scores.pop(candidate_id, None)
+    state.frontier = [cid for cid in state.frontier if cid not in incomplete_ids]
+    state.active_frontier = {
+        objective: [cid for cid in ids if cid not in incomplete_ids]
+        for objective, ids in state.active_frontier.items()
+    }
+
+    completed_counters = [
+        _proposal_counter_from_id(candidate_id)
+        for candidate_id in completed_ids
+        if _proposal_counter_from_id(candidate_id) > 0
+    ]
+    max_completed_counter = max(completed_counters, default=0)
+    state.mutation_counter = max(max_completed_counter, first_counter - 1)
+    budget_api.set_generation(state, max(0, first_generation - 1))
+    print_warning(
+        "Removed incomplete attempt(s) from prior interruption: "
+        f"{', '.join(sorted(incomplete_ids))}. The next resume will retry "
+        f"generation {first_generation}."
+    )
+    return True
+
+
 _NO_SCRIPT_COMMANDS = {"make", "pytest"}
 _INTERPRETERS = {"python", "python3", "uv", "poetry", "node", "bash", "sh"}
 _SKIP_TOKENS = {"run"}
@@ -1657,6 +1760,13 @@ def _run_evolution_impl(
                 "Config hash differs from the saved state; resuming with the current "
                 "config while keeping the existing frontier and history."
             )
+        if _reconcile_incomplete_attempts_on_resume(
+            state=state,
+            base_dir=base_dir,
+            worktrees_dir=worktrees_dir,
+            lineage_path=lineage_path,
+        ):
+            _save_state(state)
         # Reconstruct in-memory frontier from persisted evaluations
         for cid in state.frontier:
             result = _load_evaluation(base_dir, cid)

--- a/tests/unit/test_attempts_cli.py
+++ b/tests/unit/test_attempts_cli.py
@@ -13,11 +13,9 @@ Tests the full flag surface:
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
-import pytest
 from click.testing import CliRunner
 
 from helix.cli import cli

--- a/tests/unit/test_attempts_cli.py
+++ b/tests/unit/test_attempts_cli.py
@@ -1,0 +1,401 @@
+"""Unit tests for `helix attempts` CLI subcommand.
+
+Tests the full flag surface:
+  - default table (all rejected attempts)
+  - --generation, --stage, --reason filters
+  - --cid detail view
+  - --json output
+  - --skips view and filters
+  - --path to a non-default .helix/ directory
+  - graceful error handling (missing dir, malformed file)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from helix.cli import cli
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_attempt(
+    helix_dir: Path,
+    cid: str,
+    *,
+    generation: int,
+    parent_id: str,
+    reason: str,
+    stage: str,
+    instance_scores: dict[str, float] | None = None,
+    example_ids: list[str] | None = None,
+) -> None:
+    """Write a synthetic attempt JSON file into helix_dir/attempts/."""
+    attempts_dir = helix_dir / "attempts"
+    attempts_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "candidate_id": cid,
+        "scores": {},
+        "instance_scores": instance_scores or {},
+        "asi": {},
+        "attempt": {
+            "status": "rejected",
+            "reason": reason,
+            "parent_id": parent_id,
+            "generation": generation,
+            "stage": stage,
+            "example_ids": example_ids,
+        },
+    }
+    (attempts_dir / f"{cid}.json").write_text(json.dumps(payload, indent=2))
+
+
+def _write_skip(
+    helix_dir: Path,
+    generation: int,
+    records: list[dict[str, Any]],
+) -> None:
+    """Write a synthetic skip JSON list file into helix_dir/skips/."""
+    skips_dir = helix_dir / "skips"
+    skips_dir.mkdir(parents=True, exist_ok=True)
+    (skips_dir / f"g{generation}.json").write_text(json.dumps(records, indent=2))
+
+
+def _make_helix_dir(tmp_path: Path) -> Path:
+    """Create a minimal .helix/ directory with 3 attempts and 2 skips."""
+    helix_dir = tmp_path / ".helix"
+
+    # Three attempts across generations 12, 13, 14
+    _write_attempt(
+        helix_dir,
+        "g12-s4",
+        generation=12,
+        parent_id="g11-s3",
+        reason="minibatch_gate",
+        stage="train_minibatch",
+        instance_scores={"ex1": 0.31, "ex2": 0.28},
+        example_ids=["ex1", "ex2"],
+    )
+    _write_attempt(
+        helix_dir,
+        "g13-s5",
+        generation=13,
+        parent_id="g12-s4",
+        reason="val_stage",
+        stage="val_stage",
+        instance_scores={"ex3": 0.42},
+        example_ids=["ex3"],
+    )
+    _write_attempt(
+        helix_dir,
+        "g14-s6",
+        generation=14,
+        parent_id="g13-s5",
+        reason="train_gate",
+        stage="train",
+        instance_scores={"ex4": 0.39},
+    )
+
+    # Two skips across generations 12 and 13
+    _write_skip(
+        helix_dir,
+        generation=12,
+        records=[
+            {
+                "generation": 12,
+                "parent_id": "g11-s3",
+                "reason": "perfect_subsample",
+                "parent_eval": {},
+            },
+            {
+                "generation": 12,
+                "parent_id": "g11-s4",
+                "reason": "perfect_subsample",
+                "parent_eval": {},
+            },
+        ],
+    )
+    _write_skip(
+        helix_dir,
+        generation=13,
+        records=[
+            {
+                "generation": 13,
+                "parent_id": "g12-s4",
+                "reason": "perfect_subsample",
+                "parent_eval": {},
+            }
+        ],
+    )
+
+    return helix_dir
+
+
+# ---------------------------------------------------------------------------
+# Table — attempts view
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptsTableDefault:
+    """helix attempts (no flags) shows all attempt records."""
+
+    def test_attempts_table_default_shows_all_attempts(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir)]
+        )
+        assert result.exit_code == 0, result.output
+        # All three CIDs must appear in the output
+        assert "g12-s4" in result.output
+        assert "g13-s5" in result.output
+        assert "g14-s6" in result.output
+
+    def test_attempts_table_filters_by_generation(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--generation", "12"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "g12-s4" in result.output
+        assert "g13-s5" not in result.output
+        assert "g14-s6" not in result.output
+
+    def test_attempts_table_filters_by_stage(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--stage", "val_stage"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "g13-s5" in result.output
+        assert "g12-s4" not in result.output
+        assert "g14-s6" not in result.output
+
+    def test_attempts_table_filters_by_reason_substring(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        # "minibatch" is a substring of "minibatch_gate"
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--reason", "minibatch"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "g12-s4" in result.output
+        assert "g13-s5" not in result.output
+        assert "g14-s6" not in result.output
+
+    def test_attempts_table_reason_shows_score(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--generation", "12"]
+        )
+        assert result.exit_code == 0, result.output
+        # instance_scores for g12-s4 are 0.31 and 0.28 → mean 0.295 ≈ 0.30
+        assert "score=" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --cid detail view
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptsCidDetail:
+    def test_attempts_cid_detail_view(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--cid", "g12-s4"]
+        )
+        assert result.exit_code == 0, result.output
+        # Output should be valid JSON
+        data = json.loads(result.output)
+        assert data["candidate_id"] == "g12-s4"
+        assert data["attempt"]["reason"] == "minibatch_gate"
+        assert data["attempt"]["generation"] == 12
+
+    def test_attempts_cid_missing_exits_nonzero(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--cid", "g99-s99"]
+        )
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# --json output
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptsJsonOutput:
+    def test_attempts_json_output_is_jq_friendly(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--json"]
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 3
+        # All keys from the on-disk JSON must be preserved
+        for record in data:
+            assert "candidate_id" in record
+            assert "attempt" in record
+            assert "instance_scores" in record
+            assert "reason" in record["attempt"]
+
+    def test_attempts_json_filtered_by_generation(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--json", "--generation", "13"]
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["candidate_id"] == "g13-s5"
+
+
+# ---------------------------------------------------------------------------
+# --skips view
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptsSkipsView:
+    def test_attempts_skips_view(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--skips"]
+        )
+        assert result.exit_code == 0, result.output
+        # 3 skip records total (2 for gen 12, 1 for gen 13)
+        assert "perfect_subsample" in result.output
+        assert "g11-s3" in result.output
+        assert "g11-s4" in result.output
+        assert "g12-s4" in result.output  # parent in gen 13 skip
+
+    def test_attempts_skips_filters_by_generation(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["attempts", "--path", str(helix_dir), "--skips", "--generation", "12"],
+        )
+        assert result.exit_code == 0, result.output
+        # Gen 12 has 2 skip records
+        assert "g11-s3" in result.output
+        assert "g11-s4" in result.output
+        # Gen 13 parent should NOT appear
+        assert "g12-s4" not in result.output
+
+    def test_attempts_skips_json_output(self, tmp_path: Path) -> None:
+        helix_dir = _make_helix_dir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--skips", "--json"]
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 3  # 2 for gen 12 + 1 for gen 13
+        for rec in data:
+            assert rec["reason"] == "perfect_subsample"
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptsErrorHandling:
+    def test_attempts_handles_missing_helix_dir(self, tmp_path: Path) -> None:
+        """Missing .helix/attempts/ → clean error, not a stack trace."""
+        helix_dir = tmp_path / ".helix"
+        # Do NOT create the helix dir at all
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir)]
+        )
+        assert result.exit_code != 0
+        # Should mention the path and be human-readable, not a traceback
+        assert "attempts" in result.output.lower() or "attempts" in (result.output + "").lower()
+        assert "Traceback" not in result.output
+
+    def test_attempts_handles_missing_skips_dir(self, tmp_path: Path) -> None:
+        """Missing .helix/skips/ with --skips → clean error."""
+        helix_dir = tmp_path / ".helix"
+        helix_dir.mkdir(parents=True)
+        # No skips/ subdirectory
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir), "--skips"]
+        )
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+
+    def test_attempts_handles_malformed_attempt_file(self, tmp_path: Path) -> None:
+        """Malformed attempt JSON is skipped with a warning; valid files still render."""
+        helix_dir = tmp_path / ".helix"
+        attempts_dir = helix_dir / "attempts"
+        attempts_dir.mkdir(parents=True)
+
+        # One valid attempt
+        _write_attempt(
+            helix_dir,
+            "g12-s4",
+            generation=12,
+            parent_id="g11-s3",
+            reason="minibatch_gate",
+            stage="train_minibatch",
+        )
+        # One malformed file
+        (attempts_dir / "bad.json").write_text("{ NOT VALID JSON !!!")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["attempts", "--path", str(helix_dir)]
+        )
+        # Should NOT crash
+        assert result.exit_code == 0, result.output
+        # Valid record must appear
+        assert "g12-s4" in result.output
+        # Warning emitted to stderr (mix_stderr=True by default in CliRunner)
+        assert "Warning" in result.output or "warning" in result.output.lower() or result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Help text
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptsHelp:
+    def test_attempts_help_shows_subcommand(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["attempts", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--skips" in result.output
+        assert "--generation" in result.output
+        assert "--stage" in result.output
+        assert "--reason" in result.output
+        assert "--cid" in result.output
+        assert "--json" in result.output
+        assert "--path" in result.output
+
+    def test_attempts_appears_in_top_level_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "attempts" in result.output

--- a/tests/unit/test_evaluator_integrity.py
+++ b/tests/unit/test_evaluator_integrity.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from helix.config import EvaluatorConfig, HelixConfig
-from helix.evolution import (
+from helix.evaluator_manifest import (
     _build_evaluator_integrity_manifest,
     _collect_protected_evaluator_paths,
     _detect_evaluator_tamper,

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -2353,7 +2353,13 @@ def test_sandboxed_run_starts_evaluator_sidecar(tmp_path: Path, all_mocks):
             evaluator=True,
             extra_hosts={"evaluator-endpoint": "10.0.0.1"},
         ),
-        evolution=EvolutionConfig(max_generations=0),
+        # max_evaluations=1: Change 3 guard requires at least one effective
+        # stopping condition.  max_generations=0 means the loop runs 0
+        # iterations (while gen < 0 is immediately False), but the guard
+        # requires max_evaluations > 0 when max_generations <= 0.
+        # max_evaluations=1 satisfies the guard; budget exhausts immediately
+        # at the first budget check if any iteration were to start.
+        evolution=EvolutionConfig(max_generations=0, max_evaluations=1),
     )
 
     run_evolution(config, tmp_path, tmp_path / ".helix")

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -401,15 +401,23 @@ class TestMinibatchGateIntegration:
         }
         assert set(attempt["instance_scores"]) == set(child_train_ids)
 
-    def test_perfect_minibatch_skip_retries_same_generation_slot(
+    def test_perfect_minibatch_skip_advances_generation(
         self, tmp_path: Path, all_mocks: dict[str, Any]
     ) -> None:
-        """Perfect minibatch skips do not burn a visible generation/candidate id."""
+        """Perfect minibatch skip advances gen unconditionally (GEPA engine.py:649).
+
+        After Change 1 (unconditional gen increment), a perfect-subsample skip
+        no longer rolls back to retry the same generation slot.  Gen was already
+        incremented at the top of the loop, so state.generation advances and the
+        next loop iteration starts at gen+1.  With max_generations=1, the loop
+        exits immediately after the one skip iteration — mutate is never called.
+
+        Regression for NB-2: before the fix, a perfect skip did NOT advance gen,
+        allowing an infinite retry when budget was also uncapped.
+        """
         train_path = _write_train_jsonl(tmp_path, n=4)
         seed = _make_candidate("g0-s0")
-        child = _make_candidate("g1-s1")
         all_mocks["create_seed_worktree"].return_value = seed
-        all_mocks["mutate"].return_value = child
 
         parent_train_calls = 0
 
@@ -424,11 +432,8 @@ class TestMinibatchGateIntegration:
             if split == "train" and instance_ids is not None:
                 if candidate.id == seed.id:
                     parent_train_calls += 1
-                    if parent_train_calls == 1:
-                        return _make_result(
-                            candidate.id, {i: 1.0 for i in instance_ids}
-                        )
-                    return _make_result(candidate.id, {i: 0.4 for i in instance_ids})
+                    # Always perfect — ensures perfect-skip fires every time.
+                    return _make_result(candidate.id, {i: 1.0 for i in instance_ids})
                 return _make_result(candidate.id, {i: 0.9 for i in instance_ids})
             if instance_ids is not None:
                 return _make_result(candidate.id, {i: 0.9 for i in instance_ids})
@@ -446,9 +451,11 @@ class TestMinibatchGateIntegration:
         config.evolution.perfect_score_threshold = 1.0
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
-        assert parent_train_calls == 2
-        all_mocks["mutate"].assert_called_once()
-        assert all_mocks["mutate"].call_args.kwargs["new_id"] == "g1-s1"
+        # Gen was already incremented at the top of the loop before the skip.
+        # After the skip, 1 < max_generations=1 is False → loop exits.
+        # mutate is never called because the only generation was a perfect skip.
+        assert parent_train_calls == 1
+        all_mocks["mutate"].assert_not_called()
         skip_path = tmp_path / ".helix" / "skips" / "g1.json"
         assert skip_path.exists()
         skip_records = json.loads(skip_path.read_text())
@@ -469,6 +476,12 @@ class TestMinibatchGateIntegration:
 
         Regression for NB-1: before the fix _save_skip_record was called once per
         proposal, each overwriting the previous file so only the last record survived.
+
+        After Change 1 (unconditional gen increment) and Change 2 (parent minibatch
+        bypasses cache), max_generations=1 naturally terminates after the one
+        perfect-skip iteration — no tight budget ceiling needed.  3 perfect proposals
+        in g1 produce 3 records in skips/g1.json, then gen advances to 2 which
+        exceeds max_generations=1, ending the run.
         """
         train_path = _write_train_jsonl(tmp_path, n=6)
         seed = _make_candidate("g0-s0")
@@ -488,23 +501,16 @@ class TestMinibatchGateIntegration:
 
         all_mocks["run_evaluator"].side_effect = run_eval
 
-        # cache_evaluation=False: prevents the parallel ThreadPoolExecutor
-        # (n_proposals=3) from calling _candidate_content_key → subprocess.run
-        # on fake worktree paths, which deadlocks in CI.  Without caching,
-        # each minibatch eval charges its real example count toward the budget.
-        # max_evaluations=13: seed val (6 examples) + 3 proposals × 2 examples
-        # = 12 budget units for one full iteration; 13 allows exactly one
-        # complete perfect-skip iteration (writing all 3 records) then breaks
-        # on the first proposal of the retry (14 ≥ 13) before overwriting the
-        # file.  Without this, always-perfect mock data + caching = ∞ loop
-        # (cached evals charge 0, budget never exhausts).
+        # Change 2: parent minibatch evals bypass the cache (pass None), so no
+        # subprocess.run on fake worktree paths in the parallel ThreadPoolExecutor
+        # (n_proposals=3).  Change 1: gen advances on skip, so max_generations=1
+        # naturally terminates after the one iteration — no tight budget ceiling.
         config = _make_minibatch_config(
             train_path,
             minibatch_size=2,
             max_generations=1,
-            max_evaluations=13,
+            max_evaluations=100,
             num_parallel_proposals=3,
-            cache_evaluation=False,
         )
         config.evolution.perfect_score_threshold = 1.0
         run_evolution(config, tmp_path, tmp_path / ".helix")
@@ -1827,12 +1833,17 @@ class TestParentEvalExceptionDoesNotAbortGeneration:
 
 
 class TestParentMinibatchBudgetCharge:
-    def test_budget_charge_counts_parent_minibatch_examples_and_skips_cache_hit(
+    def test_budget_charge_counts_parent_minibatch_examples_always_fresh(
         self, tmp_path: Path, all_mocks: dict[str, Any]
     ) -> None:
-        """Two back-to-back iterations on the same parent/minibatch overlap
-        charge N units for the fresh parent evaluator run and zero for the
-        later pure cache hit.
+        """Parent minibatch evals always charge the full minibatch size (GEPA
+        reflective_mutation.py:268-269 parity: minibatch path bypasses cache).
+
+        Change 2: ``_eval_parent`` now passes ``None`` instead of
+        ``minibatch_cache`` to ``_cached_evaluate_batch``, matching GEPA's
+        ``execute_proposal`` which calls ``adapter.evaluate(ctx.minibatch, ...)``
+        directly, never through the cache.  Both iterations therefore invoke the
+        evaluator subprocess for the parent and charge 2 budget units each.
         """
         train_path = _write_train_jsonl(tmp_path, n=2)  # 2 ids → minibatch always [0,1]
         seed = _make_candidate("g0-s0")
@@ -1866,9 +1877,9 @@ class TestParentMinibatchBudgetCharge:
 
         all_mocks["save_state"].side_effect = capture
 
-        # max_generations=2 so the parent (seed) is evaluated on [0,1] twice.
-        # On iter 2 the cache already contains seed's scores for ids 0 and 1,
-        # so no evaluator subprocess runs and no budget unit is charged.
+        # max_generations=2: the parent (seed) is evaluated on [0,1] in BOTH
+        # iterations because Change 2 bypasses the minibatch cache for parent
+        # evals, matching GEPA reflective_mutation.py:268.
         config = _make_minibatch_config(
             train_path,
             minibatch_size=2,
@@ -1877,8 +1888,8 @@ class TestParentMinibatchBudgetCharge:
         )
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
-        # The parent evaluator is invoked once: iter 1 is fresh, iter 2 is a
-        # full cache hit.
+        # The parent evaluator is invoked TWICE: both iter 1 and iter 2 are
+        # fresh evaluator calls (cache bypassed for parent minibatch evals).
         parent_call_count = sum(
             1
             for call in all_mocks["run_evaluator"].call_args_list
@@ -1887,15 +1898,14 @@ class TestParentMinibatchBudgetCharge:
             and (call.args[0] if call.args else call.kwargs.get("candidate")).id
             == seed.id
         )
-        assert parent_call_count == 1, (
-            f"Expected parent minibatch evaluator invoked exactly once "
-            f"(iter 1 only, iter 2 full cache hit), got {parent_call_count}"
+        assert parent_call_count == 2, (
+            f"Expected parent minibatch evaluator invoked twice "
+            f"(once per generation, cache bypassed per GEPA parity), got {parent_call_count}"
         )
 
         assert len(budget_snapshots) >= 2, "expected multiple save_state calls"
-        # The snapshots capture the fresh 2-example parent eval (+2), the
-        # rejected child evals (+2 each), and no charge for the second parent
-        # cache hit.
+        # Iter 1: +2 (parent) +2 (rejected child) = 4; Iter 2: +2 (parent) +2
+        # (rejected child) = 4.  Total delta >= 8, well above the >=6 floor.
         assert budget_snapshots[-1] - budget_snapshots[0] >= 6, (
             f"Budget delta {budget_snapshots[-1] - budget_snapshots[0]} "
             f"< 6 - per-example minibatch evaluations were not charged"
@@ -2396,3 +2406,87 @@ class TestResumeAttemptReconciliation:
         remove_mock.assert_not_called()
         remaining_ids = {record["id"] for record in json.loads(lineage_path.read_text())}
         assert remaining_ids == {"g0-s0", "g2-s2"}
+
+
+# ---------------------------------------------------------------------------
+# NB-2 regression: always-perfect data must terminate (GEPA parity)
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysPerfectDataTerminates:
+    """Regression for NB-2: always-perfect dataset + perfect_score_threshold set
+    must not produce an infinite loop.
+
+    Three GEPA-aligned guards independently prevent NB-2:
+      1. gen advances unconditionally at top of loop (Change 1, engine.py:649)
+      2. Parent minibatch eval bypasses cache — always charges budget (Change 2)
+      3. Mandatory stopping condition check (Change 3, api.py:262-265)
+
+    This test exercises the gen-advance guard (1) and budget guard (2) together:
+    max_generations=5 must be the loop exit trigger, with 5 skip records written.
+    """
+
+    def test_always_perfect_data_terminates_at_max_generations(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """1-example always-perfect dataset with max_generations=5 terminates
+        normally and writes one skip file per generation.
+
+        NB-2 regression: before Change 1, perfect-skip rolled back gen, so
+        the loop retried the same generation indefinitely when budget was
+        uncapped.  After Change 1, gen advances each iteration and the loop
+        exits after 5 iterations.
+        """
+        train_path = _write_train_jsonl(tmp_path, n=1)  # 1 example → always same id
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        # All evals return 1.0 → perfect-skip fires every iteration.
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if instance_ids is not None:
+                return _make_result(candidate.id, {i: 1.0 for i in instance_ids})
+            return _make_result(candidate.id, {"v1": 1.0})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=1,
+            max_generations=5,
+            max_evaluations=1000,  # generous budget — gen advance (Change 1) stops first
+        )
+        config.evolution.perfect_score_threshold = 1.0
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        skips_dir = tmp_path / ".helix" / "skips"
+
+        # Loop must have exited via max_generations (not budget), so state.generation >= 5.
+        import json as _json
+
+        # Verify a skip file was written for each generation 1-5.
+        for g in range(1, 6):
+            skip_path = skips_dir / f"g{g}.json"
+            assert skip_path.exists(), (
+                f"skips/g{g}.json missing — generation {g} was not processed "
+                f"(NB-2 regression: loop may have exited before reaching gen {g})"
+            )
+            recs = _json.loads(skip_path.read_text())
+            assert isinstance(recs, list)
+            assert len(recs) >= 1
+            assert recs[0]["generation"] == g
+            assert recs[0]["reason"] == "perfect_subsample"
+
+        # No 6th generation — the loop stopped at max_generations=5.
+        assert not (skips_dir / "g6.json").exists(), (
+            "skips/g6.json exists — loop ran past max_generations=5"
+        )
+
+        # mutate must never have been called (every generation was a perfect skip).
+        all_mocks["mutate"].assert_not_called()
+

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -2490,3 +2490,82 @@ class TestAlwaysPerfectDataTerminates:
         # mutate must never have been called (every generation was a perfect skip).
         all_mocks["mutate"].assert_not_called()
 
+
+# ---------------------------------------------------------------------------
+# Change 3: mandatory stopping condition validation (GEPA api.py:262-265)
+# ---------------------------------------------------------------------------
+
+
+class TestStoppingConditionValidation:
+    """Mirror GEPA api.py:262-265: run_evolution must raise ValueError when
+    no effective stopping condition is configured.
+
+    In helix, max_generations (loop bound, default 10) is the primary stop
+    and max_evaluations (budget cap, -1 = disabled) is secondary.  The guard
+    fires when both are ineffective (max_generations <= 0 AND
+    max_evaluations <= 0), preventing a run that terminates only by the OS.
+    """
+
+    def test_no_stop_condition_raises_value_error(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """max_generations=0 and max_evaluations=-1 → ValueError before loop."""
+        config = HelixConfig(
+            objective="no stop condition test",
+            evaluator=EvaluatorConfig(command="pytest -q"),
+            dataset=DatasetConfig(),
+            evolution=EvolutionConfig(
+                max_generations=0,   # loop bound disabled
+                max_evaluations=-1,  # budget cap disabled
+            ),
+        )
+        with pytest.raises(ValueError, match="stopping condition"):
+            run_evolution(config, tmp_path, tmp_path / ".helix")
+
+    def test_negative_max_generations_raises_value_error(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """max_generations=-1 and max_evaluations=0 → ValueError before loop."""
+        config = HelixConfig(
+            objective="no stop condition test",
+            evaluator=EvaluatorConfig(command="pytest -q"),
+            dataset=DatasetConfig(),
+            evolution=EvolutionConfig(
+                max_generations=-1,  # loop bound disabled
+                max_evaluations=0,   # also disabled
+            ),
+        )
+        with pytest.raises(ValueError, match="stopping condition"):
+            run_evolution(config, tmp_path, tmp_path / ".helix")
+
+    def test_valid_max_generations_does_not_raise(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """max_generations=1 with max_evaluations=-1 is valid — loop bound set."""
+        train_path = _write_train_jsonl(tmp_path, n=2)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = None  # no children; single iteration
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if instance_ids is not None:
+                return _make_result(candidate.id, {i: 0.5 for i in instance_ids})
+            return _make_result(candidate.id, {"v1": 0.5})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=2,
+            max_generations=1,
+            max_evaluations=-1,  # disabled — max_generations alone suffices
+        )
+        # Must NOT raise — max_generations=1 is a valid stopping condition.
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -2054,7 +2054,7 @@ class TestResumeAttemptReconciliation:
                         "id": "g1-s1",
                         "parent": "g0-s0",
                         "parents": ["g0-s0"],
-                        "operation": "mutation",
+                        "operation": "mutate",
                         "generation": 1,
                         "files_changed": ["solver.py"],
                     },
@@ -2096,6 +2096,55 @@ class TestResumeAttemptReconciliation:
         remaining_ids = {record["id"] for record in json.loads(lineage_path.read_text())}
         assert remaining_ids == {"g0-s0", "g1-s1"}
 
+    def test_orphan_worktree_without_lineage_is_removed(
+        self, tmp_path: Path, mocker: Any
+    ) -> None:
+        base_dir = tmp_path / ".helix"
+        worktrees_dir = base_dir / "worktrees"
+        evaluations_dir = base_dir / "evaluations"
+        lineage_path = base_dir / "lineage.json"
+        worktrees_dir.mkdir(parents=True)
+        evaluations_dir.mkdir(parents=True)
+        (worktrees_dir / "g5-s5").mkdir()
+        (evaluations_dir / "g1-s1.json").write_text("{}")
+        lineage_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "g1-s1",
+                        "parent": "g0-s0",
+                        "parents": ["g0-s0"],
+                        "operation": "mutate",
+                        "generation": 1,
+                        "files_changed": ["solver.py"],
+                    }
+                ]
+            )
+        )
+        state = EvolutionState(
+            generation=4,
+            frontier=["g1-s1"],
+            instance_scores={"g1-s1": {"x": 0.2}},
+            budget=BudgetState(),
+            config_hash="hash",
+            mutation_counter=4,
+        )
+        remove_mock = mocker.patch("helix.evolution.remove_worktree")
+
+        changed = _reconcile_incomplete_attempts_on_resume(
+            state=state,
+            base_dir=base_dir,
+            worktrees_dir=worktrees_dir,
+            lineage_path=lineage_path,
+        )
+
+        assert changed is True
+        assert state.generation == 4
+        assert state.mutation_counter == 4
+        remove_mock.assert_called_once()
+        remaining_ids = {record["id"] for record in json.loads(lineage_path.read_text())}
+        assert remaining_ids == {"g1-s1"}
+
     def test_historical_missing_worktree_entries_are_left_intact(
         self, tmp_path: Path, mocker: Any
     ) -> None:
@@ -2121,7 +2170,7 @@ class TestResumeAttemptReconciliation:
                         "id": "g2-s2",
                         "parent": "g0-s0",
                         "parents": ["g0-s0"],
-                        "operation": "mutation",
+                        "operation": "mutate",
                         "generation": 2,
                         "files_changed": ["solver.py"],
                     },

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -451,9 +451,194 @@ class TestMinibatchGateIntegration:
         assert all_mocks["mutate"].call_args.kwargs["new_id"] == "g1-s1"
         skip_path = tmp_path / ".helix" / "skips" / "g1.json"
         assert skip_path.exists()
-        skip = json.loads(skip_path.read_text())
-        assert skip["generation"] == 1
-        assert skip["reason"] == "perfect_subsample"
+        skip_records = json.loads(skip_path.read_text())
+        # Since NB-1 fix, skip records are always a list (one entry per proposal).
+        assert isinstance(skip_records, list)
+        assert len(skip_records) == 1
+        assert skip_records[0]["generation"] == 1
+        assert skip_records[0]["reason"] == "perfect_subsample"
+
+    # ------------------------------------------------------------------
+    # Test A: NB-1 regression — all proposals perfect, n_proposals=3
+    # ------------------------------------------------------------------
+
+    def test_multiple_perfect_skips_all_recorded_in_single_file(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """n_proposals=3, all parents perfect → skips/g1.json is a list of 3 records.
+
+        Regression for NB-1: before the fix _save_skip_record was called once per
+        proposal, each overwriting the previous file so only the last record survived.
+        """
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        # Perfect scores for every parent minibatch eval so all 3 proposals skip.
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if instance_ids is not None:
+                return _make_result(candidate.id, {i: 1.0 for i in instance_ids})
+            return _make_result(candidate.id, {"v1": 1.0})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=2,
+            max_generations=1,
+            max_evaluations=1000,
+            num_parallel_proposals=3,
+        )
+        config.evolution.perfect_score_threshold = 1.0
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        skip_path = tmp_path / ".helix" / "skips" / "g1.json"
+        assert skip_path.exists(), "skips/g1.json should be written"
+        records = json.loads(skip_path.read_text())
+        assert isinstance(records, list), "skip file must be a JSON list"
+        assert len(records) == 3, (
+            f"Expected 3 skip records (one per proposal), got {len(records)}"
+        )
+        for rec in records:
+            assert rec["generation"] == 1
+            assert rec["reason"] == "perfect_subsample"
+            assert "parent_id" in rec
+            assert "parent_eval" in rec
+
+    # ------------------------------------------------------------------
+    # Test B: train_gate rejection artifact
+    # ------------------------------------------------------------------
+
+    def test_train_gate_rejection_artifact(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Child that fails train_gate (no-minibatch mode) writes attempts/{cid}.json.
+
+        Mirrors test_rejected_minibatch_attempt_artifact but for the legacy
+        single-task train-gating path (train_path=None → subsample_ids is None).
+        """
+        # No train_path → single-task / no-minibatch mode; child goes through
+        # the full-train acceptance gate instead of the minibatch gate.
+        seed = _make_candidate("g0-s0")
+        child = _make_candidate("g1-s1")
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            # In no-minibatch mode instance_ids is always None.
+            if candidate.id == seed.id:
+                return _make_result(candidate.id, {"t": 0.9})
+            # Child scores worse → train_gate rejects it.
+            return _make_result(candidate.id, {"t": 0.3})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = HelixConfig(
+            objective="train gate test",
+            evaluator=EvaluatorConfig(command="pytest -q"),
+            dataset=DatasetConfig(),  # no train_path → no minibatch gate
+            evolution=EvolutionConfig(
+                max_generations=1,
+                max_evaluations=100,
+                perfect_score_threshold=None,
+                frontier_type="instance",
+            ),
+            worktree=WorktreeConfig(),
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        attempt_path = tmp_path / ".helix" / "attempts" / "g1-s1.json"
+        assert attempt_path.exists(), "attempts/g1-s1.json should be written on train_gate reject"
+        attempt = json.loads(attempt_path.read_text())
+        assert attempt["candidate_id"] == "g1-s1"
+        assert attempt["attempt"]["status"] == "rejected"
+        assert attempt["attempt"]["reason"] == "train_gate"
+        assert attempt["attempt"]["stage"] == "train"
+        assert attempt["attempt"]["parent_id"] == "g0-s0"
+        assert attempt["attempt"]["generation"] == 1
+        assert attempt["attempt"]["example_ids"] is None
+        # The worktree should have been removed on rejection.
+        assert all_mocks["remove_worktree"].called
+
+    # ------------------------------------------------------------------
+    # Test C: val_stage rejection artifact
+    # ------------------------------------------------------------------
+
+    def test_val_stage_rejection_artifact(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Child that passes minibatch but fails val_stage writes attempts/{cid}.json.
+
+        Mirrors test_rejected_minibatch_attempt_artifact but for the staged-val
+        gate (val_stage_size > 0) rejection path.
+        """
+        train_path = _write_train_jsonl(tmp_path, n=4)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = _make_candidate("g1-s1")
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if instance_ids is not None:
+                if split == "train":
+                    # Parent scores low on minibatch; child scores high → passes gate.
+                    if candidate.id == seed.id:
+                        return _make_result(candidate.id, {i: 0.1 for i in instance_ids})
+                    return _make_result(candidate.id, {i: 0.9 for i in instance_ids})
+                # val evals
+                if split == "val":
+                    if candidate.id == seed.id:
+                        # Seed full val — provides parent frontier result with val scores.
+                        return _make_result(
+                            candidate.id, {i: 0.8 for i in instance_ids}
+                        )
+                    # Child on val stage: scores worse than parent → val_stage rejects.
+                    return _make_result(candidate.id, {i: 0.1 for i in instance_ids})
+            return _make_result(candidate.id, {"v1": 0.5})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=2,
+            val_size=4,
+            val_stage_size=2,
+            max_generations=1,
+            max_evaluations=100,
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        attempt_path = tmp_path / ".helix" / "attempts" / "g1-s1.json"
+        assert attempt_path.exists(), "attempts/g1-s1.json should be written on val_stage reject"
+        attempt = json.loads(attempt_path.read_text())
+        assert attempt["candidate_id"] == "g1-s1"
+        assert attempt["attempt"]["status"] == "rejected"
+        assert attempt["attempt"]["reason"] == "val_stage"
+        assert attempt["attempt"]["stage"] == "val_stage"
+        assert attempt["attempt"]["parent_id"] == "g0-s0"
+        assert attempt["attempt"]["generation"] == 1
+        # example_ids should be the val stage ids (first val_stage_size=2 val ids).
+        assert attempt["attempt"]["example_ids"] is not None
+        assert len(attempt["attempt"]["example_ids"]) == 2
+        # Verify worktree cleaned up.
+        assert all_mocks["remove_worktree"].called
 
     def test_accepted_proposal_triggers_full_val_eval(
         self, tmp_path: Path, all_mocks: dict[str, Any]

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -382,6 +382,76 @@ class TestMinibatchGateIntegration:
         )
         # Remove worktree was called (rejection cleanup).
         assert all_mocks["remove_worktree"].called
+        attempt_path = tmp_path / ".helix" / "attempts" / "g1-s1.json"
+        assert attempt_path.exists()
+        attempt = json.loads(attempt_path.read_text())
+        child_train_ids = [
+            c[2] for c in calls if c[0] == "g1-s1" and c[1] == "train"
+        ][0]
+        assert attempt["candidate_id"] == "g1-s1"
+        assert attempt["attempt"] == {
+            "status": "rejected",
+            "reason": "minibatch_gate",
+            "parent_id": "g0-s0",
+            "generation": 1,
+            "stage": "train_minibatch",
+            "example_ids": child_train_ids,
+        }
+        assert set(attempt["instance_scores"]) == set(child_train_ids)
+
+    def test_perfect_minibatch_skip_retries_same_generation_slot(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Perfect minibatch skips do not burn a visible generation/candidate id."""
+        train_path = _write_train_jsonl(tmp_path, n=4)
+        seed = _make_candidate("g0-s0")
+        child = _make_candidate("g1-s1")
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].return_value = child
+
+        parent_train_calls = 0
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            nonlocal parent_train_calls
+            if split == "train" and instance_ids is not None:
+                if candidate.id == seed.id:
+                    parent_train_calls += 1
+                    if parent_train_calls == 1:
+                        return _make_result(
+                            candidate.id, {i: 1.0 for i in instance_ids}
+                        )
+                    return _make_result(candidate.id, {i: 0.4 for i in instance_ids})
+                return _make_result(candidate.id, {i: 0.9 for i in instance_ids})
+            if instance_ids is not None:
+                return _make_result(candidate.id, {i: 0.9 for i in instance_ids})
+            return _make_result(candidate.id, {"v1": 0.9})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=2,
+            val_size=2,
+            max_generations=1,
+            max_evaluations=100,
+        )
+        config.evolution.perfect_score_threshold = 1.0
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert parent_train_calls == 2
+        all_mocks["mutate"].assert_called_once()
+        assert all_mocks["mutate"].call_args.kwargs["new_id"] == "g1-s1"
+        skip_path = tmp_path / ".helix" / "skips" / "g1.json"
+        assert skip_path.exists()
+        skip = json.loads(skip_path.read_text())
+        assert skip["generation"] == 1
+        assert skip["reason"] == "perfect_subsample"
 
     def test_accepted_proposal_triggers_full_val_eval(
         self, tmp_path: Path, all_mocks: dict[str, Any]

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -488,12 +488,23 @@ class TestMinibatchGateIntegration:
 
         all_mocks["run_evaluator"].side_effect = run_eval
 
+        # cache_evaluation=False: prevents the parallel ThreadPoolExecutor
+        # (n_proposals=3) from calling _candidate_content_key → subprocess.run
+        # on fake worktree paths, which deadlocks in CI.  Without caching,
+        # each minibatch eval charges its real example count toward the budget.
+        # max_evaluations=13: seed val (6 examples) + 3 proposals × 2 examples
+        # = 12 budget units for one full iteration; 13 allows exactly one
+        # complete perfect-skip iteration (writing all 3 records) then breaks
+        # on the first proposal of the retry (14 ≥ 13) before overwriting the
+        # file.  Without this, always-perfect mock data + caching = ∞ loop
+        # (cached evals charge 0, budget never exhausts).
         config = _make_minibatch_config(
             train_path,
             minibatch_size=2,
             max_generations=1,
-            max_evaluations=1000,
+            max_evaluations=13,
             num_parallel_proposals=3,
+            cache_evaluation=False,
         )
         config.evolution.perfect_score_threshold = 1.0
         run_evolution(config, tmp_path, tmp_path / ".helix")

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -27,9 +27,11 @@ from helix.evolution import (
     HelixDataLoader,
     _inject_top_k_best_example_history,
     _make_data_loader,
+    _reconcile_incomplete_attempts_on_resume,
     run_evolution,
 )
 from helix.population import Candidate, EvalResult, ParetoFrontier
+from helix.state import BudgetState, EvolutionState
 
 
 # ---------------------------------------------------------------------------
@@ -2020,3 +2022,132 @@ class TestWholeCandidateBudget:
         assert budget_snapshots[0] == 1, (
             f"empty instance_scores must still charge 1, got {budget_snapshots[0]}"
         )
+
+
+class TestResumeAttemptReconciliation:
+    """Resume cleanup for attempts interrupted before result persistence."""
+
+    def test_live_incomplete_attempt_retries_same_visible_slot(
+        self, tmp_path: Path, mocker: Any
+    ) -> None:
+        base_dir = tmp_path / ".helix"
+        worktrees_dir = base_dir / "worktrees"
+        evaluations_dir = base_dir / "evaluations"
+        lineage_path = base_dir / "lineage.json"
+        worktrees_dir.mkdir(parents=True)
+        evaluations_dir.mkdir(parents=True)
+        (worktrees_dir / "g4-s4").mkdir()
+        (evaluations_dir / "g0-s0.json").write_text("{}")
+        (evaluations_dir / "g1-s1.json").write_text("{}")
+        lineage_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "g0-s0",
+                        "parent": None,
+                        "parents": [],
+                        "operation": "seed",
+                        "generation": 0,
+                        "files_changed": [],
+                    },
+                    {
+                        "id": "g1-s1",
+                        "parent": "g0-s0",
+                        "parents": ["g0-s0"],
+                        "operation": "mutation",
+                        "generation": 1,
+                        "files_changed": ["solver.py"],
+                    },
+                    {
+                        "id": "g4-s4",
+                        "parent": "g1-s1",
+                        "parents": ["g1-s1"],
+                        "operation": "mutation",
+                        "generation": 4,
+                        "files_changed": ["solver.py"],
+                    },
+                ]
+            )
+        )
+        state = EvolutionState(
+            generation=4,
+            frontier=["g0-s0", "g1-s1"],
+            instance_scores={"g0-s0": {"x": 0.1}, "g1-s1": {"x": 0.2}},
+            budget=BudgetState(),
+            config_hash="hash",
+            mutation_counter=4,
+            active_frontier={"x": ["g1-s1"]},
+        )
+        remove_mock = mocker.patch("helix.evolution.remove_worktree")
+
+        changed = _reconcile_incomplete_attempts_on_resume(
+            state=state,
+            base_dir=base_dir,
+            worktrees_dir=worktrees_dir,
+            lineage_path=lineage_path,
+        )
+
+        assert changed is True
+        assert state.generation == 3
+        assert state.mutation_counter == 3
+        assert state.frontier == ["g0-s0", "g1-s1"]
+        assert state.active_frontier == {"x": ["g1-s1"]}
+        remove_mock.assert_called_once()
+        remaining_ids = {record["id"] for record in json.loads(lineage_path.read_text())}
+        assert remaining_ids == {"g0-s0", "g1-s1"}
+
+    def test_historical_missing_worktree_entries_are_left_intact(
+        self, tmp_path: Path, mocker: Any
+    ) -> None:
+        base_dir = tmp_path / ".helix"
+        worktrees_dir = base_dir / "worktrees"
+        evaluations_dir = base_dir / "evaluations"
+        lineage_path = base_dir / "lineage.json"
+        worktrees_dir.mkdir(parents=True)
+        evaluations_dir.mkdir(parents=True)
+        (evaluations_dir / "g0-s0.json").write_text("{}")
+        lineage_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "g0-s0",
+                        "parent": None,
+                        "parents": [],
+                        "operation": "seed",
+                        "generation": 0,
+                        "files_changed": [],
+                    },
+                    {
+                        "id": "g2-s2",
+                        "parent": "g0-s0",
+                        "parents": ["g0-s0"],
+                        "operation": "mutation",
+                        "generation": 2,
+                        "files_changed": ["solver.py"],
+                    },
+                ]
+            )
+        )
+        state = EvolutionState(
+            generation=2,
+            frontier=["g0-s0"],
+            instance_scores={"g0-s0": {"x": 0.1}},
+            budget=BudgetState(),
+            config_hash="hash",
+            mutation_counter=2,
+        )
+        remove_mock = mocker.patch("helix.evolution.remove_worktree")
+
+        changed = _reconcile_incomplete_attempts_on_resume(
+            state=state,
+            base_dir=base_dir,
+            worktrees_dir=worktrees_dir,
+            lineage_path=lineage_path,
+        )
+
+        assert changed is False
+        assert state.generation == 2
+        assert state.mutation_counter == 2
+        remove_mock.assert_not_called()
+        remaining_ids = {record["id"] for record in json.loads(lineage_path.read_text())}
+        assert remaining_ids == {"g0-s0", "g2-s2"}

--- a/uv.lock
+++ b/uv.lock
@@ -162,7 +162,7 @@ wheels = [
 
 [[package]]
 name = "helix-evo"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -184,6 +184,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -202,7 +203,10 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "mypy", specifier = ">=1.20.0" }]
+dev = [
+    { name = "mypy", specifier = ">=1.20.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -554,6 +558,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Persist rejected proposal results under `.helix/attempts/` with structured metadata.
- Record perfect-score skip events under `.helix/skips/`.
- Retry perfect minibatch skips without consuming the visible generation/candidate slot.
- On resume, remove live incomplete attempt worktrees and orphaned attempt worktrees that have no result artifact, then rewind visible counters when needed so the interrupted generation can be retried.

## Why

Rejected proposals, skip-only iterations, and interrupted attempts currently make run histories harder to audit: a candidate id can appear in lineage without an inspectable result, or a generation can be consumed without a candidate artifact. This change separates those cases:

- rejected proposals are completed attempts and remain inspectable;
- semantic skips are logged but do not burn a candidate generation;
- interrupted live attempts are cleaned up on resume and retried rather than leaving a dangling slot.

## CLI

`helix attempts` is a new top-level subcommand that surfaces the `attempts/` and `skips/` artifacts from the command line:

```
helix attempts                          # list all rejected attempts (table)
helix attempts --skips                  # switch to skip-record view
helix attempts --generation N           # filter to one generation
helix attempts --stage <gate>           # minibatch_gate | train_gate | val_stage
helix attempts --reason <substr>        # filter by reason substring
helix attempts --cid <id>              # full JSON detail for one attempt
helix attempts --json                   # machine-readable JSON for jq piping
helix attempts --path <.helix-dir>     # point at a non-default .helix/ directory
```

## GEPA structural alignment

Three commits (0f13530d → 84a8e5b → f47067f) align helix with upstream GEPA on structural properties that prevent the NB-2 infinite-retry scenario. The CI hang in 0f13530d was a symptom of a genuine latent production bug; these changes close it structurally.

**Change 1 — Unconditional generation increment** (`84a8e5b`, mirrors GEPA `engine.py:649`)

`gen += 1` moved to top of the while-loop body, before any proposal work. Removed the helix-original generation rollback (`_iteration_start_generation` snapshot + `budget_api.set_generation(state, _iteration_start_generation)`) that caused NB-2. After this change, no code path skips or rewinds `gen`.

**Change 2 — Budget always charged on parent minibatch eval** (`84a8e5b`, mirrors GEPA `reflective_mutation.py:268-269`)

`_eval_parent` now passes `None` instead of `minibatch_cache` to `_cached_evaluate_batch`, matching GEPA's `execute_proposal` which calls `adapter.evaluate()` directly. Every parent minibatch eval charges the full minibatch size toward budget regardless of cache state. Removes the `cache_evaluation=False` + tight `max_evaluations=13` workaround from 0f13530d.

**Change 3 — Mandatory stopping condition** (`f47067f`, mirrors GEPA `api.py:262-265`)

`run_evolution` now raises `ValueError` when both `max_generations <= 0` and `max_evaluations <= 0`, matching GEPA's hard guard that prevents unbounded runs.

New tests: `TestAlwaysPerfectDataTerminates` (NB-2 regression), `TestStoppingConditionValidation` (Change 3 guard). Total: 815 unit tests, mypy --strict clean.

## Validation

- `uv run --extra dev pytest tests/unit/test_evolution_minibatch.py::TestResumeAttemptReconciliation tests/unit/test_budget.py::test_evolution_counter_mutations_route_through_budget_api -q`
- `uv run --extra dev pytest tests/unit/ -q`
- `uv run --extra dev pytest tests/unit/test_attempts_cli.py -v` (17 new tests)
- `uv run --extra dev ruff check src/helix/evolution.py tests/unit/test_evolution_minibatch.py`
- `git diff --check origin/main...HEAD`

---

## Refactor (R2+R3+R6)

Three mechanical code-reuse refactors applied on top of this PR per [helix-evolution-refactor-scope.md](https://github.com/KE7/helix/blob/codex/attempt-artifacts-perfect-skip/../../helix-evolution-refactor-scope.md) §§3 D5, 3 D3, 5 C1.  No logic changes; all 815 unit tests green on each commit.

| Commit | Refactor | Description | Net Δ evolution.py |
|---|---|---|---|
| `45041da` | R2 | Extract `_safe_remove_worktree` helper (9 try/except sites consolidated) | −24 LOC |
| `094837f` | R3 | Extract `_run_full_val_eval` helper (3 dual-path dispatch blocks unified) | +4 LOC |
| `02784c2` | R6 | Split out `src/helix/evaluator_manifest.py` (14 manifest+protected-file helpers, 0 evolution-state dependency) | −313 LOC |

**evolution.py total: 3,295 → 2,962 lines (−333 LOC)**

Anti-patterns from scope §9 were explicitly avoided (did not unify `_save_*`, did not extract `_charge_and_check_budget`, did not split `_run_evolution_impl` without naming the seam).