### PR TITLE
Remove backend tool allowlist config

### DIFF
--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -465,9 +465,6 @@ class AgentConfig(BaseModel):
     model: str | None = None
     effort: str | None = None
     max_turns: int | None = None
-    allowed_tools: list[str] = Field(
-        default_factory=lambda: ["Read", "Edit", "Write", "Bash", "Glob", "Grep"]
-    )
     background: str | None = None
 
 

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -674,15 +674,12 @@ def _build_backend_args(
 ) -> list[str]:
     backend = config.backend
     if backend == "claude":
-        tools_str = ",".join(config.allowed_tools)
         args = [
             "claude",
             "--dangerously-skip-permissions",
             "--print",
             "--output-format",
             "json",
-            "--allowedTools",
-            tools_str,
         ]
         if config.model:
             args.extend(["--model", config.model])

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -77,7 +77,6 @@ class TestLoadConfig:
 
             [agent]
             model = "claude-opus-4-5-20250514"
-            allowed_tools = ["Read", "Write"]
             background = "You are a coding expert."
 
             [worktree]
@@ -100,7 +99,6 @@ class TestLoadConfig:
         assert cfg.evolution.merge_enabled is False
         assert cfg.evolution.max_merge_invocations == 2
         assert cfg.agent.model == "claude-opus-4-5-20250514"
-        assert cfg.agent.allowed_tools == ["Read", "Write"]
         assert cfg.agent.background == "You are a coding expert."
 
         assert cfg.worktree.base_dir == "/tmp/worktrees"
@@ -147,7 +145,6 @@ class TestLoadConfig:
         # AgentConfig defaults
         assert cfg.agent.backend == "claude"
         assert cfg.agent.model is None
-        assert "Read" in cfg.agent.allowed_tools
         assert cfg.agent.background is None
 
         # WorktreeConfig defaults
@@ -241,12 +238,6 @@ class TestDirectModelConstruction:
             "changing this default, update this test AND the comment in "
             "config.py that cites the GEPA line."
         )
-
-    def test_claude_config_default_tools(self):
-        cfg = AgentConfig()
-        assert "Read" in cfg.allowed_tools
-        assert "Edit" in cfg.allowed_tools
-        assert "Bash" in cfg.allowed_tools
 
     def test_worktree_config_defaults(self):
         cfg = WorktreeConfig()

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -643,7 +643,7 @@ class TestInvokeClaudeCode:
     def test_cli_args_include_required_flags(self, mocker):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
-        config = AgentConfig(allowed_tools=["Read", "Edit"])
+        config = AgentConfig()
         invoke_claude_code("/tmp/wt", "the prompt", config)
 
         call_args = mock_run.call_args
@@ -654,8 +654,8 @@ class TestInvokeClaudeCode:
         assert "--print" in args_list
         assert "--output-format" in args_list
         assert "json" in args_list
-        assert "--allowedTools" in args_list
-        assert "Read,Edit" in args_list
+        assert "--allowedTools" not in args_list
+        assert "--allowed-tools" not in args_list
         assert "--model" not in args_list
         assert "--max-turns" not in args_list
         assert "the prompt" not in args_list


### PR DESCRIPTION
## Summary
- Remove the backend-specific tool allowlist setting from agent configuration.
- Let containerized mutation environments expose their native tool surface without HELIX filtering.
- Update config and mutator tests to reflect the simplified command construction.

## Rationale
The allowlist is a low-level backend concern that makes the default mutation path more restrictive than the underlying sandbox. With containerized mutation enabled, HELIX can rely on the sandbox boundary instead of constraining the agent tool list in config.

## Validation
- `uv run --extra dev pytest tests/unit/test_config.py tests/unit/test_mutator.py -q`
- `uv run --extra dev ruff check src/helix/config.py src/helix/mutator.py tests/unit/test_config.py tests/unit/test_mutator.py`
- `git diff --check origin/main...HEAD`
