### PR TITLE
Persist extended backend usage totals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist/
 .coverage
 htmlcov/
 .envrc
+.helix/

--- a/src/helix/budget.py
+++ b/src/helix/budget.py
@@ -39,6 +39,10 @@ class UsageDict(TypedDict, total=False):
 
     input_tokens: int
     output_tokens: int
+    cached_input_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+    reasoning_tokens: int
     cost_usd: float
 
 
@@ -125,9 +129,17 @@ def charge_llm_usage(
         return
     input_delta = int(usage.get("input_tokens", 0))
     output_delta = int(usage.get("output_tokens", 0))
+    cached_input_delta = int(usage.get("cached_input_tokens", 0))
+    cache_creation_delta = int(usage.get("cache_creation_input_tokens", 0))
+    cache_read_delta = int(usage.get("cache_read_input_tokens", 0))
+    reasoning_delta = int(usage.get("reasoning_tokens", 0))
     cost_delta = float(usage.get("cost_usd", 0.0))
     state.budget.input_tokens += input_delta
     state.budget.output_tokens += output_delta
+    state.budget.cached_input_tokens += cached_input_delta
+    state.budget.cache_creation_input_tokens += cache_creation_delta
+    state.budget.cache_read_input_tokens += cache_read_delta
+    state.budget.reasoning_tokens += reasoning_delta
     state.budget.cost_usd += cost_delta
     TRACE.emit(
         EventType.BUDGET_UPDATE,

--- a/src/helix/budget.py
+++ b/src/helix/budget.py
@@ -20,30 +20,11 @@ introduce a ``threading.Lock`` here first; otherwise concurrent
 from __future__ import annotations
 
 import warnings
-from collections.abc import Mapping
-from typing import Any, TypedDict
 
 from helix.config import HelixConfig
+from helix.display import UsageStats
 from helix.state import EvolutionState
 from helix.trace import TRACE, EventType
-
-
-class UsageDict(TypedDict, total=False):
-    """Subset of backend usage-payload fields read by ``charge_llm_usage``.
-
-    Pinning the keys makes the contract explicit at type-check time
-    without requiring callers to convert their existing
-    ``Candidate.usage: dict[str, Any]`` payloads.  ``charge_llm_usage``
-    accepts any read-only mapping so this remains backward-compatible.
-    """
-
-    input_tokens: int
-    output_tokens: int
-    cached_input_tokens: int
-    cache_creation_input_tokens: int
-    cache_read_input_tokens: int
-    reasoning_tokens: int
-    cost_usd: float
 
 
 def budget_exhausted(state: EvolutionState, config: HelixConfig) -> bool:
@@ -113,27 +94,27 @@ def charge_evaluation(
 
 def charge_llm_usage(
     state: EvolutionState,
-    usage: UsageDict | Mapping[str, Any] | None,
+    usage: UsageStats | None,
     *,
     candidate_id: str | None = None,
     source: str | None = None,
 ) -> None:
-    """Charge token and cost counters from a backend usage payload.
+    """Charge token and cost counters from a ``UsageStats`` payload.
 
-    Safe to call with ``None`` or an empty mapping; both short-circuit
-    without touching counters or emitting a trace event.  A non-empty
-    mapping with all-zero deltas still emits one ``BUDGET_UPDATE`` event
-    (the call indicates a real backend response was processed).
+    Safe to call with ``None``; short-circuits without touching counters
+    or emitting a trace event.  A non-None ``UsageStats`` with all-zero
+    deltas still emits one ``BUDGET_UPDATE`` event (the call indicates a
+    real backend response was processed).
     """
-    if not usage:
+    if usage is None:
         return
-    input_delta = int(usage.get("input_tokens", 0))
-    output_delta = int(usage.get("output_tokens", 0))
-    cached_input_delta = int(usage.get("cached_input_tokens", 0))
-    cache_creation_delta = int(usage.get("cache_creation_input_tokens", 0))
-    cache_read_delta = int(usage.get("cache_read_input_tokens", 0))
-    reasoning_delta = int(usage.get("reasoning_tokens", 0))
-    cost_delta = float(usage.get("cost_usd", 0.0))
+    input_delta = usage.input_tokens
+    output_delta = usage.output_tokens
+    cached_input_delta = usage.cached_input_tokens
+    cache_creation_delta = usage.cache_creation_input_tokens
+    cache_read_delta = usage.cache_read_input_tokens
+    reasoning_delta = usage.reasoning_tokens
+    cost_delta = usage.cost_usd
     state.budget.input_tokens += input_delta
     state.budget.output_tokens += output_delta
     state.budget.cached_input_tokens += cached_input_delta

--- a/src/helix/display.py
+++ b/src/helix/display.py
@@ -27,6 +27,10 @@ class UsageStats:
 
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    reasoning_tokens: int = 0
     num_turns: int = 0
     tool_event_count: int = 0
     tool_names: list[str] = field(default_factory=list)
@@ -36,6 +40,12 @@ class UsageStats:
         if isinstance(other, dict):
             self.input_tokens += int(other.get("input_tokens", 0))
             self.output_tokens += int(other.get("output_tokens", 0))
+            self.cached_input_tokens += int(other.get("cached_input_tokens", 0))
+            self.cache_creation_input_tokens += int(
+                other.get("cache_creation_input_tokens", 0)
+            )
+            self.cache_read_input_tokens += int(other.get("cache_read_input_tokens", 0))
+            self.reasoning_tokens += int(other.get("reasoning_tokens", 0))
             self.num_turns += int(other.get("num_turns", 0))
             self.tool_event_count += int(other.get("tool_event_count", 0))
             self.cost_usd += float(other.get("cost_usd", 0.0))
@@ -46,6 +56,10 @@ class UsageStats:
         else:
             self.input_tokens += other.input_tokens
             self.output_tokens += other.output_tokens
+            self.cached_input_tokens += other.cached_input_tokens
+            self.cache_creation_input_tokens += other.cache_creation_input_tokens
+            self.cache_read_input_tokens += other.cache_read_input_tokens
+            self.reasoning_tokens += other.reasoning_tokens
             self.num_turns += other.num_turns
             self.tool_event_count += other.tool_event_count
             self.cost_usd += other.cost_usd
@@ -136,9 +150,18 @@ def render_status_panel(
         [
             "[bold]Current Generation Usage:[/bold]",
             f"  Tokens: {current_usage.input_tokens:,} in / {current_usage.output_tokens:,} out",
-            f"  Turns : {current_usage.num_turns}",
         ]
     )
+    current_cache_tokens = (
+        current_usage.cached_input_tokens
+        + current_usage.cache_creation_input_tokens
+        + current_usage.cache_read_input_tokens
+    )
+    if current_cache_tokens:
+        lines.append(f"  Cache : {current_cache_tokens:,} input tokens")
+    if current_usage.reasoning_tokens:
+        lines.append(f"  Think : {current_usage.reasoning_tokens:,} tokens")
+    lines.append(f"  Turns : {current_usage.num_turns}")
 
     tools_str = f"{current_usage.tool_event_count}"
     if current_usage.tool_names:
@@ -157,9 +180,18 @@ def render_status_panel(
             "",
             "[bold]Cumulative Evolution Total:[/bold]",
             f"  Tokens: {cumulative_budget.input_tokens:,} in / {cumulative_budget.output_tokens:,} out",
-            f"  Cost  : [green]${cumulative_budget.cost_usd:.4f}[/green]",
         ]
     )
+    cumulative_cache_tokens = (
+        cumulative_budget.cached_input_tokens
+        + cumulative_budget.cache_creation_input_tokens
+        + cumulative_budget.cache_read_input_tokens
+    )
+    if cumulative_cache_tokens:
+        lines.append(f"  Cache : {cumulative_cache_tokens:,} input tokens")
+    if cumulative_budget.reasoning_tokens:
+        lines.append(f"  Think : {cumulative_budget.reasoning_tokens:,} tokens")
+    lines.append(f"  Cost  : [green]${cumulative_budget.cost_usd:.4f}[/green]")
 
     if config_evolution:
         cap = config_evolution.max_evaluations

--- a/src/helix/display.py
+++ b/src/helix/display.py
@@ -83,35 +83,18 @@ class UsageStats:
             session_id=d.get("session_id"),
         )
 
-    def add(self, other: UsageStats | dict[str, Any]) -> None:
-        if isinstance(other, dict):
-            self.input_tokens += int(other.get("input_tokens", 0))
-            self.output_tokens += int(other.get("output_tokens", 0))
-            self.cached_input_tokens += int(other.get("cached_input_tokens", 0))
-            self.cache_creation_input_tokens += int(
-                other.get("cache_creation_input_tokens", 0)
-            )
-            self.cache_read_input_tokens += int(other.get("cache_read_input_tokens", 0))
-            self.reasoning_tokens += int(other.get("reasoning_tokens", 0))
-            self.num_turns += int(other.get("num_turns", 0))
-            self.tool_event_count += int(other.get("tool_event_count", 0))
-            self.cost_usd += float(other.get("cost_usd", 0.0))
-            new_tools = other.get("tool_names", [])
-            if isinstance(new_tools, list):
-                for t in new_tools:
-                    self.tool_names.append(t)
-        else:
-            self.input_tokens += other.input_tokens
-            self.output_tokens += other.output_tokens
-            self.cached_input_tokens += other.cached_input_tokens
-            self.cache_creation_input_tokens += other.cache_creation_input_tokens
-            self.cache_read_input_tokens += other.cache_read_input_tokens
-            self.reasoning_tokens += other.reasoning_tokens
-            self.num_turns += other.num_turns
-            self.tool_event_count += other.tool_event_count
-            self.cost_usd += other.cost_usd
-            for t in other.tool_names:
-                self.tool_names.append(t)
+    def add(self, other: UsageStats) -> None:
+        self.input_tokens += other.input_tokens
+        self.output_tokens += other.output_tokens
+        self.cached_input_tokens += other.cached_input_tokens
+        self.cache_creation_input_tokens += other.cache_creation_input_tokens
+        self.cache_read_input_tokens += other.cache_read_input_tokens
+        self.reasoning_tokens += other.reasoning_tokens
+        self.num_turns += other.num_turns
+        self.tool_event_count += other.tool_event_count
+        self.cost_usd += other.cost_usd
+        for t in other.tool_names:
+            self.tool_names.append(t)
 
 
 class HelixPhase(Enum):
@@ -315,7 +298,7 @@ class HelixLiveDisplay:
     def update(
         self,
         phase: HelixPhase | str | None = None,
-        usage: UsageStats | dict[str, Any] | None = None,
+        usage: UsageStats | None = None,
         mutations_attempted: int | None = None,
         mutations_accepted: int | None = None,
     ) -> None:

--- a/src/helix/display.py
+++ b/src/helix/display.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from enum import Enum
 import threading
 from typing import TYPE_CHECKING, Any
@@ -35,6 +36,52 @@ class UsageStats:
     tool_event_count: int = 0
     tool_names: list[str] = field(default_factory=list)
     cost_usd: float = 0.0
+    session_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable plain dict of all UsageStats fields.
+
+        ``tool_names`` is returned as a fresh list copy to prevent external
+        mutation of the live list reference.
+        """
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cached_input_tokens": self.cached_input_tokens,
+            "cache_creation_input_tokens": self.cache_creation_input_tokens,
+            "cache_read_input_tokens": self.cache_read_input_tokens,
+            "reasoning_tokens": self.reasoning_tokens,
+            "num_turns": self.num_turns,
+            "tool_event_count": self.tool_event_count,
+            "tool_names": list(self.tool_names),
+            "cost_usd": self.cost_usd,
+            "session_id": self.session_id,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Any]) -> UsageStats:
+        """Construct a ``UsageStats`` from a plain dict, tolerating missing keys.
+
+        Coerces numeric fields defensively (mirrors the dict branch of
+        ``add``).  ``tool_names`` defaults to ``[]`` when absent or
+        non-list.  ``session_id`` is ``None`` when absent.
+        """
+        tool_names = d.get("tool_names", [])
+        if not isinstance(tool_names, list):
+            tool_names = []
+        return cls(
+            input_tokens=int(d.get("input_tokens", 0)),
+            output_tokens=int(d.get("output_tokens", 0)),
+            cached_input_tokens=int(d.get("cached_input_tokens", 0)),
+            cache_creation_input_tokens=int(d.get("cache_creation_input_tokens", 0)),
+            cache_read_input_tokens=int(d.get("cache_read_input_tokens", 0)),
+            reasoning_tokens=int(d.get("reasoning_tokens", 0)),
+            num_turns=int(d.get("num_turns", 0)),
+            tool_event_count=int(d.get("tool_event_count", 0)),
+            tool_names=list(tool_names),
+            cost_usd=float(d.get("cost_usd", 0.0)),
+            session_id=d.get("session_id"),
+        )
 
     def add(self, other: UsageStats | dict[str, Any]) -> None:
         if isinstance(other, dict):

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -410,44 +410,55 @@ def run_evaluator(
     # that ignore HELIX_INSTANCE_IDS will still have returned the whole
     # split, but the minibatch gate only looks at the requested subset.
     if instance_ids is not None:
-        filtered: dict[str, float] = {}
-        missing: list[str] = []
-        for eid in instance_ids:
-            eid_s = str(eid)
-            if eid_s in instance_scores:
-                filtered[eid_s] = instance_scores[eid_s]
-            else:
-                # Evaluator produced no result for this id → 0.0
-                filtered[eid_s] = 0.0
-                missing.append(eid_s)
-        if missing:
-            # Diagnostic: the silent zero-fill above used to hide evaluator
-            # bugs — most infamously an ``instance_scores`` dict keyed by
-            # aggregate metric names (``task__metric``) instead of the
-            # per-example ids HELIX writes to ``helix_batch.json``
-            # (``task__trialN``).  That mismatch made strict-improvement
-            # acceptance compare ``0.0 vs 0.0`` for 113 straight generations
-            # in one real run.  The per-example ``helix_result`` contract
-            # removes that class of bug at the parser level, but this
-            # warning is still useful defense in depth: e.g. when a user
-            # picks ``score_parser="exitcode"`` and then asks for a
-            # minibatch subset, every requested id lands here.
-            sample = missing[:5]
-            logger.warning(
-                "evaluator returned %d/%d missing instance_scores for "
-                "requested ids (sample: %r%s); these were filled with 0.0. "
-                "If you need per-id scores for the minibatch gate, use "
-                "score_parser='helix_result' (per-example contract — "
-                "HELIX reads helix_batch.json and zips it with your list "
-                "of [score, side_info] pairs).",
-                len(missing),
-                len(instance_ids),
-                sample,
-                ""
-                if len(missing) <= len(sample)
-                else f" ... +{len(missing) - len(sample)} more",
-            )
-        instance_scores = filtered
+        # ``exitcode`` is a global pass/fail parser: it returns
+        # ``{"success": score}`` as instance_scores rather than per-example
+        # ids.  Broadcasting the global result to all requested ids is
+        # correct here — a process that exits 0 passed for all examples; one
+        # that exits non-zero failed for all examples.  Without this
+        # broadcast every requested id lands in ``missing`` and gets filled
+        # with 0.0, causing spurious rejections when the evaluator exited 0.
+        if evaluator.score_parser == "exitcode":
+            global_score = instance_scores.get("success", 0.0)
+            instance_scores = {str(eid): global_score for eid in instance_ids}
+        else:
+            filtered: dict[str, float] = {}
+            missing: list[str] = []
+            for eid in instance_ids:
+                eid_s = str(eid)
+                if eid_s in instance_scores:
+                    filtered[eid_s] = instance_scores[eid_s]
+                else:
+                    # Evaluator produced no result for this id → 0.0
+                    filtered[eid_s] = 0.0
+                    missing.append(eid_s)
+            if missing:
+                # Diagnostic: the silent zero-fill above used to hide evaluator
+                # bugs — most infamously an ``instance_scores`` dict keyed by
+                # aggregate metric names (``task__metric``) instead of the
+                # per-example ids HELIX writes to ``helix_batch.json``
+                # (``task__trialN``).  That mismatch made strict-improvement
+                # acceptance compare ``0.0 vs 0.0`` for 113 straight generations
+                # in one real run.  The per-example ``helix_result`` contract
+                # removes that class of bug at the parser level, but this
+                # warning is still useful defense in depth: e.g. when a user
+                # picks ``score_parser="exitcode"`` and then asks for a
+                # minibatch subset, every requested id lands here.
+                sample = missing[:5]
+                logger.warning(
+                    "evaluator returned %d/%d missing instance_scores for "
+                    "requested ids (sample: %r%s); these were filled with 0.0. "
+                    "If you need per-id scores for the minibatch gate, use "
+                    "score_parser='helix_result' (per-example contract — "
+                    "HELIX reads helix_batch.json and zips it with your list "
+                    "of [score, side_info] pairs).",
+                    len(missing),
+                    len(instance_ids),
+                    sample,
+                    ""
+                    if len(missing) <= len(sample)
+                    else f" ... +{len(missing) - len(sample)} more",
+                )
+            instance_scores = filtered
 
     _result = EvalResult(
         candidate_id=candidate.id,

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1071,6 +1071,225 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> UsageStats:
     )
 
 
+# ---------------------------------------------------------------------------
+# Per-backend transcript tool-event counters
+# ---------------------------------------------------------------------------
+# Claude's ``--output-format json`` summary omits per-turn tool invocations;
+# the other backends either emit tool events in their JSONL stream with
+# types/fields that ``_normalise_usage_stats`` doesn't fully parse (wrong
+# key names, double-counted started+completed pairs, etc.).  Each function
+# below parses the backend's native format and returns an accurate
+# ``(count, names)`` pair.  ``_count_transcript_tool_events`` dispatches to
+# the right function and is called from ``_write_backend_artifacts`` /
+# ``_collect_backend_transcript_artifacts`` to patch ``usage`` after the fact.
+
+
+def _count_claude_transcript_tool_events(path: Path) -> tuple[int, list[str]]:
+    """Count tool invocations from a Claude JSONL transcript file.
+
+    Claude stores tool calls as ``type='assistant'`` events whose
+    ``message.content`` list contains items with ``type='tool_use'``.
+    The top-level ``type`` is never ``'tool_use'`` — it only appears
+    inside the nested ``message.content`` array.
+
+    Returns ``(0, [])`` when the file is missing or a line is malformed.
+    """
+    count = 0
+    names: list[str] = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                continue  # skip malformed lines
+            if not isinstance(event, dict) or event.get("type") != "assistant":
+                continue
+            message = event.get("message")
+            if not isinstance(message, dict):
+                continue
+            for item in message.get("content") or []:
+                if isinstance(item, dict) and item.get("type") == "tool_use":
+                    count += 1
+                    name = item.get("name")
+                    if isinstance(name, str) and name:
+                        names.append(name)
+    except OSError:
+        return 0, []
+    return count, names
+
+
+def _count_codex_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
+    """Count tool invocations from a Codex ``exec --json`` stdout artifact.
+
+    Codex emits ``item.completed`` events whose ``item.type`` is one of
+    ``command_execution`` (shell commands) or ``file_change`` (edits).
+    These types are not in ``_normalise_usage_stats``'s ``_TOOL_NODE_TYPES``
+    set, so the initial count is 0; this function provides the correct value.
+    """
+    count = 0
+    names: list[str] = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(event, dict) or event.get("type") != "item.completed":
+                continue
+            item = event.get("item", {})
+            if not isinstance(item, dict):
+                continue
+            itype = item.get("type", "")
+            if itype == "command_execution":
+                count += 1
+                names.append("exec_command")
+            elif itype == "file_change":
+                count += 1
+                names.append("apply_patch")
+    except OSError:
+        return 0, []
+    return count, names
+
+
+def _count_cursor_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
+    """Count tool invocations from a Cursor stream-json stdout artifact.
+
+    Cursor emits ``tool_call`` events with ``subtype`` values ``started``
+    and ``completed``.  Counting both would double the true count, so only
+    ``started`` events are counted.  The tool name is the first key of the
+    nested ``tool_call`` object (e.g. ``readToolCall``, ``editToolCall``).
+    """
+    count = 0
+    names: list[str] = []
+    _NAME_MAP: dict[str, str] = {
+        "readToolCall": "read",
+        "editToolCall": "edit",
+        "shellToolCall": "shell",
+        "writeToolCall": "write",
+        "searchToolCall": "search",
+        "deleteToolCall": "delete",
+        "listToolCall": "list",
+        "grepToolCall": "grep",
+    }
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") != "tool_call" or event.get("subtype") != "started":
+                continue
+            count += 1
+            tool_call = event.get("tool_call", {})
+            if isinstance(tool_call, dict):
+                for key in tool_call:
+                    key_str = str(key)
+                    names.append(_NAME_MAP.get(key_str, key_str))
+                    break
+            else:
+                names.append("unknown")
+    except OSError:
+        return 0, []
+    return count, names
+
+
+def _count_gemini_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
+    """Count tool invocations from a Gemini stream-json stdout artifact.
+
+    Gemini emits ``tool_use`` events (correctly counted by
+    ``_normalise_usage_stats``) but stores the tool name in ``tool_name``
+    rather than ``name``, so ``tool_names`` remains empty after the initial
+    parse.  This function provides both the count and the names.
+    """
+    count = 0
+    names: list[str] = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(event, dict) or event.get("type") != "tool_use":
+                continue
+            count += 1
+            name = event.get("tool_name")
+            if isinstance(name, str) and name:
+                names.append(name)
+    except OSError:
+        return 0, []
+    return count, names
+
+
+def _count_opencode_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
+    """Count tool invocations from an OpenCode ``--format json`` stdout artifact.
+
+    OpenCode emits ``tool_use`` events with the tool name in ``part.tool``
+    rather than a top-level ``name`` field.  This function extracts both
+    the accurate count and the tool names.
+    """
+    count = 0
+    names: list[str] = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(event, dict) or event.get("type") != "tool_use":
+                continue
+            count += 1
+            part = event.get("part", {})
+            if isinstance(part, dict):
+                name = part.get("tool")
+                if isinstance(name, str) and name:
+                    names.append(name)
+    except OSError:
+        return 0, []
+    return count, names
+
+
+# Dispatcher: maps backend name → per-backend counter function.
+_TRANSCRIPT_TOOL_COUNTERS: dict[str, Callable[[Path], tuple[int, list[str]]]] = {
+    "claude": _count_claude_transcript_tool_events,
+    "codex": _count_codex_stdout_tool_events,
+    "cursor": _count_cursor_stdout_tool_events,
+    "gemini": _count_gemini_stdout_tool_events,
+    "opencode": _count_opencode_stdout_tool_events,
+}
+
+
+def _count_transcript_tool_events(path: Path, backend: str) -> tuple[int, list[str]]:
+    """Dispatch to the per-backend transcript tool-event counter.
+
+    Returns ``(0, [])`` for unknown backends or when the file is missing /
+    corrupt.  Never raises.
+    """
+    counter = _TRANSCRIPT_TOOL_COUNTERS.get(backend)
+    if counter is None or not path.is_file():
+        return 0, []
+    try:
+        return counter(path)
+    except Exception:  # noqa: BLE001
+        return 0, []
+
+
 def _copy_local_claude_transcript(
     worktree_path: str,
     *,
@@ -1175,6 +1394,17 @@ def _collect_backend_transcript_artifacts(
         artifact_dir=artifact_dir,
         transcript_root=transcript_root,
     )
+    if artifact is not None and artifact.get("available"):
+        # Claude's ``--output-format json`` summary omits per-turn tool
+        # invocations.  Now that the transcript is on disk, read it and
+        # patch the ``usage`` object with the accurate counts.  Only
+        # applied when the summary gave 0 tool events to avoid overriding
+        # a non-zero value that a future Claude version might expose.
+        dst = Path(worktree_path) / Path(artifact["path"])
+        tc, tn = _count_transcript_tool_events(dst, "claude")
+        if tc > 0 and usage.tool_event_count == 0:
+            usage.tool_event_count = tc
+            usage.tool_names = list(tn)
     return [artifact] if artifact is not None else []
 
 
@@ -1193,6 +1423,17 @@ def _write_backend_artifacts(
         (wt / BACKEND_STDOUT_ARTIFACT_NAME).write_text(result.stdout or "")
         (wt / BACKEND_STDERR_ARTIFACT_NAME).write_text(result.stderr or "")
         usage = _normalise_usage_stats(parsed or {})
+        # For non-Claude backends the stdout JSONL IS the transcript; patch
+        # ``usage`` with backend-specific tool-event counts now that the
+        # stdout artifact is on disk.  Claude is handled separately inside
+        # ``_collect_backend_transcript_artifacts`` where the external
+        # transcript file is copied first.
+        if backend != "claude":
+            stdout_path = wt / BACKEND_STDOUT_ARTIFACT_NAME
+            tc, tn = _count_transcript_tool_events(stdout_path, backend)
+            if tc > 0:
+                usage.tool_event_count = tc
+                usage.tool_names = list(tn)
         transcript_artifacts = _collect_backend_transcript_artifacts(
             worktree_path,
             backend=backend,

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -994,6 +994,22 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> dict[str, Any]:
                     "cached",
                 ),
             ),
+            (
+                "cache_creation_input_tokens",
+                (
+                    "cache_creation_input_tokens",
+                    "cacheCreationInputTokens",
+                    "cacheCreation",
+                ),
+            ),
+            (
+                "cache_read_input_tokens",
+                (
+                    "cache_read_input_tokens",
+                    "cacheReadInputTokens",
+                    "cacheRead",
+                ),
+            ),
             ("reasoning_tokens", ("reasoning_tokens", "reasoningTokens", "thoughts")),
             (
                 "cost_usd",

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from helix.backends import BACKEND_AUTH_ENV, backend_display_name
+from helix.display import UsageStats
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, SandboxConfig
 from helix.exceptions import (
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 # ``(worktree_path, prompt, config) -> tuple[dict[str, Any], dict[str, Any]]``.
 # None (default) = unchanged production behavior.
 _MUTATOR_OVERRIDE: (
-    Callable[[str, str, AgentConfig], tuple[dict[str, Any], dict[str, Any]]] | None
+    Callable[[str, str, AgentConfig], tuple[dict[str, Any], UsageStats]] | None
 ) = None
 
 # ---------------------------------------------------------------------------
@@ -246,7 +247,7 @@ def generate_seed(
     worktree_path: str,
     prompt: str,
     config: "HelixConfig",
-) -> dict[str, Any]:
+) -> UsageStats:
     """Generate an initial seed candidate by invoking Claude Code once.
 
     Matches GEPA's ``_generate_seed_candidate`` pattern exactly:
@@ -921,17 +922,18 @@ def _coerce_number(value: Any) -> float | None:
     return None
 
 
-def _normalise_usage_stats(parsed: dict[str, Any]) -> dict[str, Any]:
-    usage: dict[str, Any] = {}
+def _normalise_usage_stats(parsed: dict[str, Any]) -> UsageStats:
+    # Collect raw values into a plain dict first; construct UsageStats at the end.
+    _d: dict[str, Any] = {}
     tool_event_count = 0
     tool_names: list[str] = []
     num_turns = 0
 
     # Claude Code returns num_turns and tool_use_count in the top-level object.
     if "num_turns" in parsed:
-        usage["num_turns"] = _coerce_number(parsed["num_turns"])
+        _d["num_turns"] = _coerce_number(parsed["num_turns"])
     if "tool_use_count" in parsed:
-        usage["tool_event_count"] = _coerce_number(parsed["tool_use_count"])
+        _d["tool_event_count"] = _coerce_number(parsed["tool_use_count"])
 
     # Recognise the exact node types that backends emit for tool/function
     # invocations. Substring matching on "call" is too loose -- it also fires
@@ -1016,15 +1018,15 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> dict[str, Any]:
                 ("cost_usd", "costUsd", "total_cost_usd", "totalCostUsd", "total"),
             ),
         ):
-            if key in usage:
+            if key in _d:
                 continue
             for alias in aliases:
                 if alias in node:
                     value = _coerce_number(node[alias])
                     if value is not None:
-                        usage[key] = value
+                        _d[key] = value
                         break
-        if "session_id" not in usage:
+        if "session_id" not in _d:
             for alias in (
                 "session_id",
                 "sessionId",
@@ -1035,26 +1037,38 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> dict[str, Any]:
             ):
                 value = node.get(alias)
                 if isinstance(value, str) and value:
-                    usage["session_id"] = value
+                    _d["session_id"] = value
                     break
-            if "session_id" not in usage:
+            if "session_id" not in _d:
                 value = node.get("sessionID")
                 if isinstance(value, str) and value:
-                    usage["session_id"] = value
-        if "cost_usd" not in usage:
+                    _d["session_id"] = value
+        if "cost_usd" not in _d:
             value = node.get("cost")
             coerced = _coerce_number(value)
             if coerced is not None:
-                usage["cost_usd"] = coerced
+                _d["cost_usd"] = coerced
 
-    if tool_event_count and "tool_event_count" not in usage:
-        usage["tool_event_count"] = tool_event_count
+    if tool_event_count and "tool_event_count" not in _d:
+        _d["tool_event_count"] = tool_event_count
     if tool_names:
-        usage["tool_names"] = tool_names
-    if num_turns and "num_turns" not in usage:
-        usage["num_turns"] = num_turns
+        _d["tool_names"] = tool_names
+    if num_turns and "num_turns" not in _d:
+        _d["num_turns"] = num_turns
 
-    return usage
+    return UsageStats(
+        input_tokens=int(_d.get("input_tokens", 0)),
+        output_tokens=int(_d.get("output_tokens", 0)),
+        cached_input_tokens=int(_d.get("cached_input_tokens", 0)),
+        cache_creation_input_tokens=int(_d.get("cache_creation_input_tokens", 0)),
+        cache_read_input_tokens=int(_d.get("cache_read_input_tokens", 0)),
+        reasoning_tokens=int(_d.get("reasoning_tokens", 0)),
+        num_turns=int(_d.get("num_turns", 0)),
+        tool_event_count=int(_d.get("tool_event_count", 0)),
+        tool_names=_d.get("tool_names", []),
+        cost_usd=float(_d.get("cost_usd", 0.0)),
+        session_id=_d.get("session_id"),
+    )
 
 
 def _copy_local_claude_transcript(
@@ -1133,14 +1147,14 @@ def _collect_backend_transcript_artifacts(
     worktree_path: str,
     *,
     backend: str,
-    usage: dict[str, Any],
+    usage: UsageStats,
     sandbox: SandboxConfig | None,
 ) -> list[dict[str, Any]]:
     if backend != "claude":
         return []
     if sandbox is not None and not sandbox.preserve_backend_transcripts:
         return []
-    session_id = usage.get("session_id")
+    session_id = usage.session_id
     if not isinstance(session_id, str) or not session_id:
         return []
     artifact_dir = (
@@ -1193,7 +1207,7 @@ def _write_backend_artifacts(
             "returncode": result.returncode,
             "stdout_artifact": BACKEND_STDOUT_ARTIFACT_NAME,
             "stderr_artifact": BACKEND_STDERR_ARTIFACT_NAME,
-            "usage": usage,
+            "usage": usage.to_dict(),
             "transcript_artifacts": transcript_artifacts,
             "parsed": parsed,
         }
@@ -1214,7 +1228,7 @@ def invoke_claude_code(
     fixed_env: dict[str, str] | None = None,
     sandbox: SandboxConfig | None = None,
     prompt_artifact_name: str = MUTATION_PROMPT_ARTIFACT_NAME,
-) -> tuple[dict[str, Any], dict[str, Any]]:
+) -> tuple[dict[str, Any], UsageStats]:
     """Invoke the configured backend CLI in *worktree_path*.
 
     Parameters

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -14,6 +14,7 @@ from dataclasses import asdict, dataclass, field
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal
 
+from helix.display import UsageStats
 
 if TYPE_CHECKING:
     from helix.state import BudgetState
@@ -48,7 +49,7 @@ class Candidate:
     parent_id: str | None
     parent_ids: list[str]
     operation: str
-    usage: dict[str, Any] = field(default_factory=dict)
+    usage: UsageStats = field(default_factory=UsageStats)
 
 
 @dataclass
@@ -210,7 +211,7 @@ class CandidateSummary:
             "generation": self.generation,
             "parents": self.parents,
             "operation": self.operation,
-            "usage": self.candidate.usage,
+            "usage": self.candidate.usage.to_dict(),
             "aggregate_score": self.aggregate_score,
             "sum_score": self.sum_score,
             "scores": self.scores,

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -35,6 +35,10 @@ class BudgetState:
     evaluations: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    reasoning_tokens: int = 0
     cost_usd: float = 0.0
 
 
@@ -215,6 +219,10 @@ def load_state(base_dir: Path) -> EvolutionState | None:
         evaluations=budget_data.get("evaluations", 0),
         input_tokens=budget_data.get("input_tokens", 0),
         output_tokens=budget_data.get("output_tokens", 0),
+        cached_input_tokens=budget_data.get("cached_input_tokens", 0),
+        cache_creation_input_tokens=budget_data.get("cache_creation_input_tokens", 0),
+        cache_read_input_tokens=budget_data.get("cache_read_input_tokens", 0),
+        reasoning_tokens=budget_data.get("reasoning_tokens", 0),
         cost_usd=budget_data.get("cost_usd", 0.0),
     )
 

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -215,6 +215,152 @@ def test_backend_usage_parsing_charges_llm_budget(
     assert state.budget.cost_usd == pytest.approx(expected_cost)
 
 
+@pytest.mark.parametrize(
+    ("backend", "stdout", "expected"),
+    [
+        pytest.param(
+            "claude",
+            json.dumps(
+                {
+                    "type": "result",
+                    "session_id": "claude-session",
+                    "usage": {
+                        "input_tokens": 11,
+                        "output_tokens": 7,
+                        "cache_creation_input_tokens": 13,
+                        "cache_read_input_tokens": 17,
+                        "cached_input_tokens": 19,
+                    },
+                    "reasoning_tokens": 5,
+                    "total_cost_usd": 0.31,
+                }
+            ),
+            {
+                "input_tokens": 11,
+                "output_tokens": 7,
+                "cache_creation_input_tokens": 13,
+                "cache_read_input_tokens": 17,
+                "cached_input_tokens": 19,
+                "reasoning_tokens": 5,
+            },
+            id="claude",
+        ),
+        pytest.param(
+            "codex",
+            "\n".join(
+                [
+                    '{"type":"session.started","session_id":"codex-session"}',
+                    (
+                        '{"type":"turn","usage":{"prompt_tokens":12,'
+                        '"completion_tokens":8,"cached_input_tokens":21,'
+                        '"reasoning_tokens":6,"total_cost_usd":0.32}}'
+                    ),
+                ]
+            ),
+            {
+                "input_tokens": 12,
+                "output_tokens": 8,
+                "cached_input_tokens": 21,
+                "reasoning_tokens": 6,
+            },
+            id="codex",
+        ),
+        pytest.param(
+            "cursor",
+            "\n".join(
+                [
+                    '{"type":"system","sessionId":"cursor-session"}',
+                    (
+                        '{"type":"assistant","usage":{"inputTokens":13,'
+                        '"outputTokens":9,"cachedTokens":22,'
+                        '"reasoningTokens":7,"costUsd":0.33}}'
+                    ),
+                ]
+            ),
+            {
+                "input_tokens": 13,
+                "output_tokens": 9,
+                "cached_input_tokens": 22,
+                "reasoning_tokens": 7,
+            },
+            id="cursor",
+        ),
+        pytest.param(
+            "gemini",
+            "\n".join(
+                [
+                    '{"type":"init","session_id":"gemini-session"}',
+                    (
+                        '{"type":"result","usageMetadata":{"prompt_tokens":14,'
+                        '"completion_tokens":10,"cachedTokens":23},'
+                        '"thoughts":8,"cost":0.34}'
+                    ),
+                ]
+            ),
+            {
+                "input_tokens": 14,
+                "output_tokens": 10,
+                "cached_input_tokens": 23,
+                "reasoning_tokens": 8,
+            },
+            id="gemini",
+        ),
+        pytest.param(
+            "opencode",
+            "\n".join(
+                [
+                    '{"type":"step_start","sessionID":"opencode-session"}',
+                    (
+                        '{"type":"step_finish","part":{"tokens":{"input":15,'
+                        '"output":11,"cached":24,"thoughts":9},"cost":0.35}}'
+                    ),
+                ]
+            ),
+            {
+                "input_tokens": 15,
+                "output_tokens": 11,
+                "cached_input_tokens": 24,
+                "reasoning_tokens": 9,
+            },
+            id="opencode",
+        ),
+    ],
+)
+def test_backend_usage_parsing_charges_extended_llm_budget(
+    backend: str,
+    stdout: str,
+    expected: dict[str, int],
+    tmp_path: Path,
+    mocker,
+) -> None:
+    assert backend in BACKENDS
+    worktree = tmp_path / backend
+    worktree.mkdir()
+    mock_run = mocker.patch("helix.mutator.subprocess.run")
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[_BACKEND_EXECUTABLE[backend]],
+        returncode=0,
+        stdout=stdout,
+        stderr="",
+    )
+    state = make_state()
+
+    _parsed, usage = invoke_claude_code(
+        str(worktree),
+        "read the prompt artifact",
+        AgentConfig(backend=backend),
+    )
+    budget.charge_llm_usage(
+        state,
+        usage,
+        candidate_id=f"{backend}-candidate",
+        source=backend,
+    )
+
+    for key, value in expected.items():
+        assert getattr(state.budget, key) == value
+
+
 def test_backend_usage_parsing_under_sandbox_charges_llm_budget(
     tmp_path: Path, mocker
 ) -> None:
@@ -275,12 +421,7 @@ def test_backend_usage_parsing_under_sandbox_charges_llm_budget(
 def test_backend_usage_parsing_extracts_cached_and_reasoning_tokens(
     tmp_path: Path, mocker
 ) -> None:
-    """Lock in parser support for cached_input_tokens and reasoning_tokens.
-
-    ``charge_llm_usage`` does not yet sum these into ``BudgetState``, but the
-    backend output parser exposes them via ``_normalise_usage_stats`` so a
-    future budget-API extension can rely on the alias map remaining intact.
-    """
+    """Lock in parser support for cached_input_tokens and reasoning_tokens."""
     worktree = tmp_path / "claude"
     worktree.mkdir()
     stdout = json.dumps(
@@ -314,6 +455,10 @@ def test_backend_usage_parsing_extracts_cached_and_reasoning_tokens(
     assert usage["cached_input_tokens"] == 3
     assert usage["reasoning_tokens"] == 5
     assert usage["cost_usd"] == pytest.approx(0.31)
+    state = make_state()
+    budget.charge_llm_usage(state, usage, candidate_id="c", source="claude")
+    assert state.budget.cached_input_tokens == 3
+    assert state.budget.reasoning_tokens == 5
 
 
 def test_charge_llm_usage_handles_empty_and_partial_payloads() -> None:
@@ -341,6 +486,10 @@ def test_charge_llm_usage_handles_empty_and_partial_payloads() -> None:
     )
     assert state.budget.input_tokens == 7
     assert state.budget.output_tokens == 0
+    assert state.budget.cached_input_tokens == 0
+    assert state.budget.cache_creation_input_tokens == 0
+    assert state.budget.cache_read_input_tokens == 0
+    assert state.budget.reasoning_tokens == 0
     assert state.budget.cost_usd == 0.0
 
 
@@ -351,7 +500,15 @@ def test_charge_llm_usage_emits_budget_update_event() -> None:
     with TRACE.record() as events:
         budget.charge_llm_usage(
             state,
-            {"input_tokens": 11, "output_tokens": 7, "cost_usd": 0.31},
+            {
+                "input_tokens": 11,
+                "output_tokens": 7,
+                "cached_input_tokens": 3,
+                "cache_creation_input_tokens": 5,
+                "cache_read_input_tokens": 7,
+                "reasoning_tokens": 13,
+                "cost_usd": 0.31,
+            },
             candidate_id="g1-s1",
             source="mutation",
         )
@@ -366,6 +523,10 @@ def test_charge_llm_usage_emits_budget_update_event() -> None:
     assert event.cost_usd_delta == pytest.approx(0.31)
     assert event.input_tokens == 11
     assert event.output_tokens == 7
+    assert state.budget.cached_input_tokens == 3
+    assert state.budget.cache_creation_input_tokens == 5
+    assert state.budget.cache_read_input_tokens == 7
+    assert state.budget.reasoning_tokens == 13
     assert event.cost_usd == pytest.approx(0.31)
 
 

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -18,6 +18,7 @@ from helix.config import (
     HelixConfig,
     SandboxConfig,
 )
+from helix.display import UsageStats
 from helix.mutator import invoke_claude_code
 from helix.state import BudgetState, EvolutionState
 from helix.trace import TRACE, EventType
@@ -450,37 +451,31 @@ def test_backend_usage_parsing_extracts_cached_and_reasoning_tokens(
         AgentConfig(backend="claude"),
     )
 
-    assert usage["input_tokens"] == 11
-    assert usage["output_tokens"] == 7
-    assert usage["cached_input_tokens"] == 3
-    assert usage["reasoning_tokens"] == 5
-    assert usage["cost_usd"] == pytest.approx(0.31)
+    assert usage.input_tokens == 11
+    assert usage.output_tokens == 7
+    assert usage.cached_input_tokens == 3
+    assert usage.reasoning_tokens == 5
+    assert usage.cost_usd == pytest.approx(0.31)
     state = make_state()
     budget.charge_llm_usage(state, usage, candidate_id="c", source="claude")
     assert state.budget.cached_input_tokens == 3
     assert state.budget.reasoning_tokens == 5
 
 
-def test_charge_llm_usage_handles_empty_and_partial_payloads() -> None:
-    """Regression guard for the early-return / default-zero paths."""
+def test_charge_llm_usage_handles_none_and_partial_payloads() -> None:
+    """Regression guard for the None short-circuit and partial UsageStats paths."""
     state = make_state()
 
-    # ``None`` usage: short-circuit, no mutation.
+    # ``None`` usage: short-circuit, no mutation, no trace event.
     budget.charge_llm_usage(state, None, candidate_id="c", source="x")
     assert state.budget.input_tokens == 0
     assert state.budget.output_tokens == 0
     assert state.budget.cost_usd == 0.0
 
-    # Empty dict: short-circuit (falsy), no mutation.
-    budget.charge_llm_usage(state, {}, candidate_id="c", source="x")
-    assert state.budget.input_tokens == 0
-    assert state.budget.output_tokens == 0
-    assert state.budget.cost_usd == 0.0
-
-    # Partial payload: only present keys are summed; absent keys default to 0.
+    # Partial payload: only provided fields matter; absent fields default to 0.
     budget.charge_llm_usage(
         state,
-        {"input_tokens": 7},
+        UsageStats(input_tokens=7),
         candidate_id="c",
         source="x",
     )
@@ -500,15 +495,15 @@ def test_charge_llm_usage_emits_budget_update_event() -> None:
     with TRACE.record() as events:
         budget.charge_llm_usage(
             state,
-            {
-                "input_tokens": 11,
-                "output_tokens": 7,
-                "cached_input_tokens": 3,
-                "cache_creation_input_tokens": 5,
-                "cache_read_input_tokens": 7,
-                "reasoning_tokens": 13,
-                "cost_usd": 0.31,
-            },
+            UsageStats(
+                input_tokens=11,
+                output_tokens=7,
+                cached_input_tokens=3,
+                cache_creation_input_tokens=5,
+                cache_read_input_tokens=7,
+                reasoning_tokens=13,
+                cost_usd=0.31,
+            ),
             candidate_id="g1-s1",
             source="mutation",
         )
@@ -561,8 +556,6 @@ def test_charge_llm_usage_none_is_silent_noop() -> None:
 
     with TRACE.record() as events:
         budget.charge_llm_usage(state, None, candidate_id="c", source="s")
-        # The empty-dict case is the same falsy short-circuit; pin it too.
-        budget.charge_llm_usage(state, {}, candidate_id="c", source="s")
 
     assert state.budget.input_tokens == 7
     assert state.budget.output_tokens == 11
@@ -571,13 +564,13 @@ def test_charge_llm_usage_none_is_silent_noop() -> None:
 
 
 def test_charge_llm_usage_zero_delta_still_emits_event() -> None:
-    """A non-empty usage dict with all-zero deltas should still emit one event.
+    """A UsageStats with all-zero deltas should still emit one event.
 
     Pins current behavior so a future "skip on zero" optimization is a
     deliberate, test-visible decision rather than an accidental change.
     """
     state = make_state()
-    usage = {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}
+    usage = UsageStats(input_tokens=0, output_tokens=0, cost_usd=0.0)
 
     with TRACE.record() as events:
         budget.charge_llm_usage(state, usage, candidate_id="c", source="mutation")

--- a/tests/unit/test_display.py
+++ b/tests/unit/test_display.py
@@ -1,0 +1,263 @@
+"""Unit tests for helix.display — UsageStats dataclass and helpers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from helix.display import UsageStats
+from helix.population import Candidate, CandidateSummary, EvalResult
+
+
+# ---------------------------------------------------------------------------
+# UsageStats.add
+# ---------------------------------------------------------------------------
+
+
+class TestUsageStatsAdd:
+    """Verify UsageStats.add accumulates all fields from another UsageStats."""
+
+    def test_add_accumulates_integer_fields(self) -> None:
+        stats = UsageStats()
+        stats.add(
+            UsageStats(
+                input_tokens=11,
+                output_tokens=7,
+                cached_input_tokens=3,
+                cache_creation_input_tokens=5,
+                cache_read_input_tokens=7,
+                reasoning_tokens=13,
+                num_turns=2,
+                tool_event_count=1,
+            )
+        )
+        assert stats.input_tokens == 11
+        assert stats.output_tokens == 7
+        assert stats.cached_input_tokens == 3
+        assert stats.cache_creation_input_tokens == 5
+        assert stats.cache_read_input_tokens == 7
+        assert stats.reasoning_tokens == 13
+        assert stats.num_turns == 2
+        assert stats.tool_event_count == 1
+
+    def test_add_accumulates_cost_usd(self) -> None:
+        stats = UsageStats(cost_usd=1.0)
+        stats.add(UsageStats(cost_usd=0.31))
+        assert stats.cost_usd == pytest.approx(1.31)
+
+    def test_add_accumulates_tool_names(self) -> None:
+        stats = UsageStats(tool_names=["Bash"])
+        stats.add(UsageStats(tool_names=["Read", "Edit"]))
+        assert stats.tool_names == ["Bash", "Read", "Edit"]
+
+    def test_add_twice_doubles_values(self) -> None:
+        base = UsageStats(input_tokens=10, output_tokens=5, cost_usd=0.1)
+        base.add(UsageStats(input_tokens=10, output_tokens=5, cost_usd=0.1))
+        assert base.input_tokens == 20
+        assert base.output_tokens == 10
+        assert base.cost_usd == pytest.approx(0.2)
+
+    def test_add_empty_stats_is_noop(self) -> None:
+        stats = UsageStats(input_tokens=42, cost_usd=3.14)
+        stats.add(UsageStats())
+        assert stats.input_tokens == 42
+        assert stats.cost_usd == pytest.approx(3.14)
+
+    def test_add_does_not_share_tool_names_list(self) -> None:
+        """add must not alias the other.tool_names list into self."""
+        other = UsageStats(tool_names=["Bash"])
+        stats = UsageStats()
+        stats.add(other)
+        # Mutating other afterward must not affect stats
+        other.tool_names.append("EXTRA")
+        assert "EXTRA" not in stats.tool_names
+
+
+# ---------------------------------------------------------------------------
+# UsageStats.to_dict / from_dict round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestUsageStatsSerialization:
+    """Verify to_dict/from_dict round-trips all 11 fields losslessly."""
+
+    def _full_stats(self) -> UsageStats:
+        return UsageStats(
+            input_tokens=100,
+            output_tokens=50,
+            cached_input_tokens=20,
+            cache_creation_input_tokens=10,
+            cache_read_input_tokens=30,
+            reasoning_tokens=5,
+            num_turns=3,
+            tool_event_count=7,
+            tool_names=["Bash", "Read", "Edit"],
+            cost_usd=1.23,
+            session_id="sess-abc123",
+        )
+
+    def test_to_dict_contains_all_11_fields(self) -> None:
+        d = self._full_stats().to_dict()
+        assert set(d.keys()) == {
+            "input_tokens",
+            "output_tokens",
+            "cached_input_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+            "reasoning_tokens",
+            "num_turns",
+            "tool_event_count",
+            "tool_names",
+            "cost_usd",
+            "session_id",
+        }
+
+    def test_round_trip_all_fields(self) -> None:
+        original = self._full_stats()
+        restored = UsageStats.from_dict(original.to_dict())
+        assert restored.input_tokens == original.input_tokens
+        assert restored.output_tokens == original.output_tokens
+        assert restored.cached_input_tokens == original.cached_input_tokens
+        assert restored.cache_creation_input_tokens == original.cache_creation_input_tokens
+        assert restored.cache_read_input_tokens == original.cache_read_input_tokens
+        assert restored.reasoning_tokens == original.reasoning_tokens
+        assert restored.num_turns == original.num_turns
+        assert restored.tool_event_count == original.tool_event_count
+        assert restored.tool_names == original.tool_names
+        assert restored.cost_usd == pytest.approx(original.cost_usd)
+        assert restored.session_id == original.session_id
+
+    def test_to_dict_tool_names_is_fresh_copy(self) -> None:
+        """to_dict must return a copy of tool_names, not the live reference."""
+        stats = UsageStats(tool_names=["Bash"])
+        d = stats.to_dict()
+        d["tool_names"].append("MUTATED")
+        assert stats.tool_names == ["Bash"], "to_dict must not alias the live list"
+
+    def test_round_trip_is_json_serializable(self) -> None:
+        d = self._full_stats().to_dict()
+        # Must not raise
+        encoded = json.dumps(d)
+        decoded = json.loads(encoded)
+        assert decoded["input_tokens"] == 100
+        assert decoded["session_id"] == "sess-abc123"
+
+    def test_from_dict_tolerates_missing_keys(self) -> None:
+        """from_dict must use dataclass defaults for absent keys."""
+        stats = UsageStats.from_dict({})
+        assert stats.input_tokens == 0
+        assert stats.output_tokens == 0
+        assert stats.cached_input_tokens == 0
+        assert stats.cache_creation_input_tokens == 0
+        assert stats.cache_read_input_tokens == 0
+        assert stats.reasoning_tokens == 0
+        assert stats.num_turns == 0
+        assert stats.tool_event_count == 0
+        assert stats.tool_names == []
+        assert stats.cost_usd == 0.0
+        assert stats.session_id is None
+
+    def test_from_dict_tolerates_non_list_tool_names(self) -> None:
+        """from_dict must fall back to [] when tool_names is not a list."""
+        stats = UsageStats.from_dict({"tool_names": "Bash"})
+        assert stats.tool_names == []
+        stats2 = UsageStats.from_dict({"tool_names": None})
+        assert stats2.tool_names == []
+        stats3 = UsageStats.from_dict({"tool_names": 42})
+        assert stats3.tool_names == []
+
+    def test_from_dict_coerces_numeric_types(self) -> None:
+        """from_dict must coerce int/float defensively."""
+        stats = UsageStats.from_dict(
+            {
+                "input_tokens": "11",   # str → int
+                "cost_usd": "0.31",     # str → float
+                "output_tokens": 7.9,   # float → int (truncates)
+            }
+        )
+        assert stats.input_tokens == 11
+        assert stats.cost_usd == pytest.approx(0.31)
+        assert stats.output_tokens == 7
+
+    def test_from_dict_session_id_none_when_absent(self) -> None:
+        stats = UsageStats.from_dict({"input_tokens": 5})
+        assert stats.session_id is None
+
+    def test_from_dict_session_id_preserved(self) -> None:
+        stats = UsageStats.from_dict({"session_id": "abc"})
+        assert stats.session_id == "abc"
+
+
+# ---------------------------------------------------------------------------
+# Regression: CandidateSummary.to_dict() → json.dumps (critical risk #2)
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateSummaryJsonSerialization:
+    """Regression guard for the TypeError that would occur pre-flip.
+
+    Pre-flip: Candidate.usage was dict[str, Any], passed directly as
+    "usage": self.candidate.usage in CandidateSummary.to_dict().
+    json.dumps accepted it transparently.
+
+    Post-flip: Candidate.usage is UsageStats; CandidateSummary.to_dict()
+    calls .to_dict() on it, so json.dumps sees a plain dict again.
+    This test would TypeError on the pre-flip code if Candidate.usage
+    were a UsageStats without the .to_dict() adapter.
+    """
+
+    def _make_candidate_summary(self) -> CandidateSummary:
+        candidate = Candidate(
+            id="g1-s1",
+            worktree_path="/tmp/helix/g1-s1",
+            branch_name="helix/g1-s1",
+            generation=1,
+            parent_id="g0-s0",
+            parent_ids=["g0-s0"],
+            operation="mutate",
+            usage=UsageStats(
+                input_tokens=42,
+                output_tokens=17,
+                cost_usd=0.07,
+                session_id="sess-xyz",
+            ),
+        )
+        eval_result = EvalResult(
+            candidate_id="g1-s1",
+            scores={"train": 0.8},
+            instance_scores={"i1": 0.8},
+            asi={},
+        )
+        return CandidateSummary(
+            candidate=candidate,
+            aggregate_score=eval_result.aggregate_score(),
+            sum_score=eval_result.sum_score(),
+            scores=eval_result.scores,
+            instance_scores=eval_result.instance_scores,
+            objective_scores=None,
+            parents=["g0-s0"],
+            operation="mutate",
+            generation=1,
+        )
+
+    def test_candidate_summary_to_dict_is_json_serializable(self) -> None:
+        """CandidateSummary.to_dict() must not raise TypeError at json.dumps."""
+        summary = self._make_candidate_summary()
+        d = summary.to_dict()
+        # Pre-flip this line would TypeError because UsageStats is not JSON-able
+        encoded = json.dumps(d)
+        decoded = json.loads(encoded)
+        assert decoded["id"] == "g1-s1"
+        assert decoded["usage"]["input_tokens"] == 42
+        assert decoded["usage"]["cost_usd"] == pytest.approx(0.07)
+        assert decoded["usage"]["session_id"] == "sess-xyz"
+
+    def test_usage_field_in_summary_is_serialized_dict(self) -> None:
+        """The 'usage' key in CandidateSummary.to_dict() must be a plain dict."""
+        summary = self._make_candidate_summary()
+        d = summary.to_dict()
+        assert isinstance(d["usage"], dict), (
+            "CandidateSummary.to_dict() must call .to_dict() on usage; "
+            f"got {type(d['usage'])!r}"
+        )

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -36,6 +36,7 @@ from helix.budget import (
     budget_exhausted,
     evaluation_budget_units as _evaluation_budget_units,
 )
+from helix.display import UsageStats
 from helix.evolution import (
     _load_evaluation,
     degrades,
@@ -566,7 +567,7 @@ class TestGatingInEvolutionLoop:
             parent_id=seed.id,
             parent_ids=[seed.id],
             operation="mutate",
-            usage={"input_tokens": 7, "output_tokens": 3, "cost_usd": 0.01},
+            usage=UsageStats(input_tokens=7, output_tokens=3, cost_usd=0.01),
         )
         all_mocks["create_seed_worktree"].return_value = seed
         all_mocks["mutate"].return_value = child
@@ -933,7 +934,7 @@ class TestLlmUsageBudgetIntegration:
         self, mocker, tmp_path, all_mocks
     ):
         seed = make_candidate("g0-s0")
-        usage = {"input_tokens": 21, "output_tokens": 12, "cost_usd": 0.41}
+        usage = UsageStats(input_tokens=21, output_tokens=12, cost_usd=0.41)
         mocker.patch("helix.evolution.create_empty_seed_worktree", return_value=seed)
         mocker.patch(
             "helix.evolution.build_seed_generation_prompt", return_value="<seed prompt>"
@@ -1046,7 +1047,7 @@ class TestLlmUsageBudgetIntegration:
     ):
         seed = make_candidate("g0-s0")
         child = make_candidate("g1-s1", generation=1)
-        child.usage = {"input_tokens": 22, "output_tokens": 13, "cost_usd": 0.42}
+        child.usage = UsageStats(input_tokens=22, output_tokens=13, cost_usd=0.42)
         all_mocks["create_seed_worktree"].return_value = seed
         all_mocks["mutate"].return_value = child
 
@@ -1085,7 +1086,7 @@ class TestLlmUsageBudgetIntegration:
         merged = make_candidate("g2-m1", generation=2)
         merged.operation = "merge"
         merged.parent_ids = ["g0-s0", "g1-s1"]
-        merged.usage = {"input_tokens": 23, "output_tokens": 14, "cost_usd": 0.43}
+        merged.usage = UsageStats(input_tokens=23, output_tokens=14, cost_usd=0.43)
         all_mocks["create_seed_worktree"].return_value = seed
         all_mocks["mutate"].return_value = child
         all_mocks["merge"].return_value = merged

--- a/tests/unit/test_evolution_seedless.py
+++ b/tests/unit/test_evolution_seedless.py
@@ -12,6 +12,7 @@ from helix.config import (
     HelixConfig,
     WorktreeConfig,
 )
+from helix.display import UsageStats
 from helix.evolution import run_evolution
 from helix.exceptions import MutationError
 from helix.population import Candidate, EvalResult
@@ -107,7 +108,7 @@ def seedless_mocks(mocker):
             "helix.evolution.build_seed_generation_prompt",
             return_value="<seed prompt>",
         ),
-        "generate_seed": mocker.patch("helix.evolution.generate_seed", return_value={}),
+        "generate_seed": mocker.patch("helix.evolution.generate_seed", return_value=UsageStats()),
         "run_evaluator": mocker.patch(
             "helix.evolution.run_evaluator",
             return_value=seed_result,

--- a/tests/unit/test_executor_zero_fill_warning.py
+++ b/tests/unit/test_executor_zero_fill_warning.py
@@ -1,20 +1,23 @@
-"""Tests for the zero-fill warning emitted by :func:`helix.executor.run_evaluator`.
+"""Tests for the post-filter applied by :func:`helix.executor.run_evaluator`.
 
-When HELIX asks the evaluator for per-example scores via ``instance_ids``
-but the parser's ``instance_scores`` does not cover every requested id,
-the executor silently fills the missing ids with ``0.0`` so the
-minibatch gate can complete.  Historically that silence hid the
-id-key-mismatch footgun — 113 generations of evolution once failed
-silently because the old ``helix_result`` contract required an id-keyed
-``side_info["scores"]`` dict and the evaluator keyed it by aggregate
-metric names instead.
+When HELIX asks the evaluator for per-example scores via ``instance_ids``,
+the executor maps the parser's ``instance_scores`` to only the requested ids.
+
+``exitcode`` is a global pass/fail parser: it broadcasts the global
+``"success"`` score to every requested example id rather than zero-filling
+(which was the pre-fix behaviour and caused spurious rejections when the
+evaluator exited 0).
+
+Every other parser goes through the existing post-filter; if an id is
+missing the executor zero-fills it with 0.0 and emits a warning so the
+mismatch is visible.  Historically that silence hid the id-key-mismatch
+footgun — 113 generations of evolution once failed silently because the old
+``helix_result`` contract required an id-keyed ``side_info["scores"]`` dict
+and the evaluator keyed it by aggregate metric names instead.
 
 The new per-example ``helix_result`` contract eliminates that specific
 footgun at the parser level (it raises on length mismatch), but the
-warning still has value as defense in depth for every other parser —
-e.g. ``score_parser="exitcode"`` combined with a minibatch
-``instance_ids`` subset, which can't produce per-id scores by
-construction and so zero-fills every requested id.
+warning still has value as defense in depth for every other parser.
 """
 
 from __future__ import annotations
@@ -75,12 +78,12 @@ def _mock_subprocess(stdout: str, returncode: int = 0, stderr: str = "") -> Magi
 
 
 class TestZeroFillWarning:
-    def test_warns_when_exitcode_parser_cannot_produce_per_id_scores(
+    def test_exitcode_broadcasts_success_to_all_instance_ids(
         self, tmp_path: Path, mocker, caplog: pytest.LogCaptureFixture
     ) -> None:
-        # ``exitcode`` parser returns ``{"success": 1.0}`` (single key) —
-        # not one entry per requested id.  The post-filter will zero-fill
-        # every requested id, and the warning must surface that.
+        # ``exitcode`` is a global pass/fail parser; when ``instance_ids``
+        # are requested the executor broadcasts the global "success" score
+        # to every id instead of zero-filling.  Exit 0 → 1.0 for all ids.
         mocker.patch(
             "helix.executor.subprocess.run",
             return_value=_mock_subprocess("ok\n", returncode=0),
@@ -97,25 +100,46 @@ class TestZeroFillWarning:
                 instance_ids=instance_ids,
             )
 
-        # All requested ids present in the post-filtered dict, all zero-filled.
+        # All requested ids present, all receiving the broadcasted 1.0.
         assert set(result.instance_scores.keys()) == set(instance_ids)
-        assert all(v == 0.0 for v in result.instance_scores.values())
+        assert all(v == 1.0 for v in result.instance_scores.values()), (
+            "exitcode exit-0 should broadcast 1.0 to all requested ids"
+        )
 
+        # No "missing instance_scores" warning — broadcast is intentional.
         warnings = [
             r for r in caplog.records
             if r.levelno == logging.WARNING
             and "missing instance_scores" in r.getMessage()
         ]
-        assert warnings, (
-            "Expected a 'missing instance_scores' warning when the parser "
-            "cannot produce id-keyed scores but a minibatch subset was requested"
+        assert not warnings, (
+            "exitcode broadcast must not emit a 'missing instance_scores' warning; "
+            f"got: {[r.getMessage() for r in warnings]}"
         )
-        msg = warnings[0].getMessage()
-        assert "4/4" in msg
-        # Sample of up to 5 ids appears in the log body.
-        assert "task__0" in msg
-        # Log nudges the user toward the fix.
-        assert "helix_result" in msg
+
+    def test_exitcode_broadcasts_failure_to_all_instance_ids(
+        self, tmp_path: Path, mocker
+    ) -> None:
+        # Exit non-zero → 0.0 broadcast to all ids.
+        mocker.patch(
+            "helix.executor.subprocess.run",
+            return_value=_mock_subprocess("FAIL\n", returncode=1),
+        )
+
+        candidate = _make_candidate(tmp_path)
+        instance_ids = ["ex0", "ex1", "ex2"]
+
+        result = run_evaluator(
+            candidate,
+            _make_config(score_parser="exitcode"),
+            split="train",
+            instance_ids=instance_ids,
+        )
+
+        assert set(result.instance_scores.keys()) == set(instance_ids)
+        assert all(v == 0.0 for v in result.instance_scores.values()), (
+            "exitcode exit-nonzero should broadcast 0.0 to all requested ids"
+        )
 
     def test_no_warning_when_parser_covers_all_ids(
         self, tmp_path: Path, mocker, caplog: pytest.LogCaptureFixture
@@ -150,14 +174,15 @@ class TestZeroFillWarning:
             f"parser's returned instance_scores; got: {[r.getMessage() for r in warnings]}"
         )
 
-    def test_warning_sample_truncates_to_five(
+    def test_warning_sample_truncates_to_five_for_non_exitcode_parsers(
         self, tmp_path: Path, mocker, caplog: pytest.LogCaptureFixture
     ) -> None:
-        # exitcode parser + many requested ids → all zero-filled; log
+        # json_accuracy returns an empty instance_scores when the JSON has no
+        # "instance_scores" key.  All 8 requested ids go missing → warning
         # must cap the sample list at 5 and surface the overflow count.
         mocker.patch(
             "helix.executor.subprocess.run",
-            return_value=_mock_subprocess("ok\n", returncode=0),
+            return_value=_mock_subprocess('{"accuracy": 0.5}\n', returncode=0),
         )
 
         candidate = _make_candidate(tmp_path)
@@ -166,7 +191,7 @@ class TestZeroFillWarning:
         with caplog.at_level(logging.WARNING, logger="helix.executor"):
             run_evaluator(
                 candidate,
-                _make_config(score_parser="exitcode"),
+                _make_config(score_parser="json_accuracy"),
                 split="train",
                 instance_ids=instance_ids,
             )

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1330,3 +1330,453 @@ def test_normalise_usage_stats_ignores_recall_and_callback(monkeypatch):
     result = _normalise_usage_stats(parsed)
     assert result.tool_event_count == 2
     assert result.tool_names == ["Read", "search"]
+
+
+# ---------------------------------------------------------------------------
+# Per-backend transcript tool-event counter tests
+# ---------------------------------------------------------------------------
+
+
+class TestCountClaudeTranscriptToolEvents:
+    """Tests for ``_count_claude_transcript_tool_events``."""
+
+    def _write_jsonl(self, path: Path, events: list[dict]) -> None:
+        path.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+    def test_counts_three_tool_use_events_with_two_distinct_names(
+        self, tmp_path: Path
+    ) -> None:
+        from helix.mutator import _count_claude_transcript_tool_events
+
+        transcript = tmp_path / "session.jsonl"
+        self._write_jsonl(
+            transcript,
+            [
+                # Non-assistant events are ignored
+                {"type": "user", "message": {"role": "user", "content": []}},
+                # First tool call
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "id": "t1", "name": "Read"},
+                        ],
+                    },
+                },
+                # Second tool call
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "id": "t2", "name": "Read"},
+                        ],
+                    },
+                },
+                # Third tool call (different name)
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "id": "t3", "name": "Edit"},
+                        ],
+                    },
+                },
+            ],
+        )
+
+        count, names = _count_claude_transcript_tool_events(transcript)
+
+        assert count == 3
+        assert names == ["Read", "Read", "Edit"]
+
+    def test_zero_events_when_no_tool_use(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_claude_transcript_tool_events
+
+        transcript = tmp_path / "session.jsonl"
+        self._write_jsonl(
+            transcript,
+            [
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "Done."}],
+                    },
+                }
+            ],
+        )
+
+        count, names = _count_claude_transcript_tool_events(transcript)
+
+        assert count == 0
+        assert names == []
+
+    def test_skips_malformed_lines(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_claude_transcript_tool_events
+
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text(
+            "NOT_JSON\n"
+            + json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "tool_use", "name": "Write"}],
+                    },
+                }
+            )
+            + "\n"
+            + "{bad json\n"
+        )
+
+        count, names = _count_claude_transcript_tool_events(transcript)
+
+        assert count == 1
+        assert names == ["Write"]
+
+    def test_missing_file_returns_zero(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_claude_transcript_tool_events
+
+        count, names = _count_claude_transcript_tool_events(
+            tmp_path / "nonexistent.jsonl"
+        )
+
+        assert count == 0
+        assert names == []
+
+
+class TestCountCodexStdoutToolEvents:
+    """Tests for ``_count_codex_stdout_tool_events``."""
+
+    def test_counts_command_execution_and_file_change(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_codex_stdout_tool_events
+
+        stdout = tmp_path / "stdout.jsonl"
+        stdout.write_text(
+            json.dumps({"type": "thread.started", "thread_id": "abc"}) + "\n"
+            + json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "command_execution", "command": "cat solver.py"},
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "Done"},
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "file_change",
+                        "changes": [{"path": "solver.py"}],
+                    },
+                }
+            )
+            + "\n"
+        )
+
+        count, names = _count_codex_stdout_tool_events(stdout)
+
+        assert count == 2
+        assert "exec_command" in names
+        assert "apply_patch" in names
+
+    def test_zero_when_no_tool_items(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_codex_stdout_tool_events
+
+        stdout = tmp_path / "stdout.jsonl"
+        stdout.write_text(
+            json.dumps({"type": "thread.started"}) + "\n"
+            + json.dumps({"type": "turn.completed"}) + "\n"
+        )
+
+        count, names = _count_codex_stdout_tool_events(stdout)
+
+        assert count == 0
+        assert names == []
+
+    def test_missing_file_returns_zero(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_codex_stdout_tool_events
+
+        count, names = _count_codex_stdout_tool_events(tmp_path / "nope.jsonl")
+
+        assert count == 0
+        assert names == []
+
+
+class TestCountCursorStdoutToolEvents:
+    """Tests for ``_count_cursor_stdout_tool_events``."""
+
+    def test_counts_only_started_events_not_completed(
+        self, tmp_path: Path
+    ) -> None:
+        from helix.mutator import _count_cursor_stdout_tool_events
+
+        stdout = tmp_path / "stdout.jsonl"
+        stdout.write_text(
+            # started → count
+            json.dumps(
+                {
+                    "type": "tool_call",
+                    "subtype": "started",
+                    "call_id": "c1",
+                    "tool_call": {"readToolCall": {"args": {"path": "f.py"}}},
+                }
+            )
+            + "\n"
+            # completed → skip
+            + json.dumps(
+                {
+                    "type": "tool_call",
+                    "subtype": "completed",
+                    "call_id": "c1",
+                    "tool_call": {"readToolCall": {}},
+                }
+            )
+            + "\n"
+            # started with editToolCall
+            + json.dumps(
+                {
+                    "type": "tool_call",
+                    "subtype": "started",
+                    "call_id": "c2",
+                    "tool_call": {"editToolCall": {"args": {}}},
+                }
+            )
+            + "\n"
+        )
+
+        count, names = _count_cursor_stdout_tool_events(stdout)
+
+        assert count == 2
+        assert names == ["read", "edit"]
+
+    def test_missing_file_returns_zero(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_cursor_stdout_tool_events
+
+        count, names = _count_cursor_stdout_tool_events(tmp_path / "nope.jsonl")
+
+        assert count == 0
+        assert names == []
+
+
+class TestCountGeminiStdoutToolEvents:
+    """Tests for ``_count_gemini_stdout_tool_events``."""
+
+    def test_counts_tool_use_and_extracts_tool_name(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_gemini_stdout_tool_events
+
+        stdout = tmp_path / "stdout.jsonl"
+        stdout.write_text(
+            json.dumps(
+                {
+                    "type": "tool_use",
+                    "tool_name": "read_file",
+                    "tool_id": "t1",
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "tool_result",
+                    "tool_id": "t1",
+                    "content": "...",
+                }
+            )
+            + "\n"  # tool_result → skip (not tool_use)
+            + json.dumps(
+                {
+                    "type": "tool_use",
+                    "tool_name": "write_file",
+                    "tool_id": "t2",
+                }
+            )
+            + "\n"
+        )
+
+        count, names = _count_gemini_stdout_tool_events(stdout)
+
+        assert count == 2
+        assert names == ["read_file", "write_file"]
+
+    def test_missing_file_returns_zero(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_gemini_stdout_tool_events
+
+        count, names = _count_gemini_stdout_tool_events(tmp_path / "nope.jsonl")
+
+        assert count == 0
+        assert names == []
+
+
+class TestCountOpencodeStdoutToolEvents:
+    """Tests for ``_count_opencode_stdout_tool_events``."""
+
+    def test_counts_tool_use_and_extracts_part_tool(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_opencode_stdout_tool_events
+
+        stdout = tmp_path / "stdout.jsonl"
+        stdout.write_text(
+            json.dumps(
+                {
+                    "type": "tool_use",
+                    "sessionID": "ses_abc",
+                    "part": {"type": "tool", "tool": "read", "callID": "c1"},
+                }
+            )
+            + "\n"
+            + json.dumps({"type": "text", "sessionID": "ses_abc"})
+            + "\n"  # text → skip
+            + json.dumps(
+                {
+                    "type": "tool_use",
+                    "sessionID": "ses_abc",
+                    "part": {"type": "tool", "tool": "write", "callID": "c2"},
+                }
+            )
+            + "\n"
+        )
+
+        count, names = _count_opencode_stdout_tool_events(stdout)
+
+        assert count == 2
+        assert names == ["read", "write"]
+
+    def test_missing_file_returns_zero(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_opencode_stdout_tool_events
+
+        count, names = _count_opencode_stdout_tool_events(tmp_path / "nope.jsonl")
+
+        assert count == 0
+        assert names == []
+
+
+class TestCountTranscriptToolEventsDispatcher:
+    """Tests for the ``_count_transcript_tool_events`` dispatcher."""
+
+    def test_unknown_backend_returns_zero(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_transcript_tool_events
+
+        f = tmp_path / "transcript.jsonl"
+        f.write_text("{}\n")
+
+        count, names = _count_transcript_tool_events(f, "unknown_backend")
+
+        assert count == 0
+        assert names == []
+
+    def test_missing_file_returns_zero_for_known_backend(
+        self, tmp_path: Path
+    ) -> None:
+        from helix.mutator import _count_transcript_tool_events
+
+        count, names = _count_transcript_tool_events(
+            tmp_path / "nonexistent.jsonl", "claude"
+        )
+
+        assert count == 0
+        assert names == []
+
+    def test_dispatches_to_claude_counter(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_transcript_tool_events
+
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "tool_use", "name": "Read"}],
+                    },
+                }
+            )
+            + "\n"
+        )
+
+        count, names = _count_transcript_tool_events(transcript, "claude")
+
+        assert count == 1
+        assert names == ["Read"]
+
+    def test_dispatches_to_gemini_counter(self, tmp_path: Path) -> None:
+        from helix.mutator import _count_transcript_tool_events
+
+        stdout = tmp_path / "stdout.jsonl"
+        stdout.write_text(
+            json.dumps({"type": "tool_use", "tool_name": "grep"}) + "\n"
+        )
+
+        count, names = _count_transcript_tool_events(stdout, "gemini")
+
+        assert count == 1
+        assert names == ["grep"]
+
+
+class TestTranscriptToolPatchesUsageInArtifact:
+    """Integration: after _write_backend_artifacts, tool counts are patched."""
+
+    def test_claude_tool_counts_patched_from_transcript(
+        self, tmp_path: Path, mocker, monkeypatch
+    ) -> None:
+        """tool_event_count and tool_names are populated from Claude JSONL transcript."""
+        from helix.mutator import (
+            BACKEND_TRANSCRIPT_ARTIFACT_DIR,
+            invoke_claude_code,
+        )
+
+        # Set up a fake transcript with 3 tool_use events
+        transcript_root = tmp_path / "claude-home" / ".claude" / "projects" / "-workspace"
+        transcript_root.mkdir(parents=True)
+        (transcript_root / "sess_tool.jsonl").write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "name": "Read"},
+                            {"type": "tool_use", "name": "Edit"},
+                        ],
+                    },
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "tool_use", "name": "Write"}],
+                    },
+                }
+            )
+            + "\n"
+        )
+        monkeypatch.setenv("HELIX_CLAUDE_TRANSCRIPT_ROOT", str(transcript_root))
+
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"result","session_id":"sess_tool"}\n',
+            stderr="",
+            returncode=0,
+        )
+
+        invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="claude"))
+
+        payload = json.loads((tmp_path / BACKEND_RESULT_ARTIFACT_NAME).read_text())
+        assert payload["usage"]["tool_event_count"] == 3, (
+            "tool_event_count should be patched from transcript (was 0 from summary JSON)"
+        )
+        assert payload["usage"]["tool_names"] == ["Read", "Edit", "Write"]
+        # Transcript artifact should also be present
+        assert len(payload["transcript_artifacts"]) == 1
+        assert payload["transcript_artifacts"][0]["available"] is True

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -771,6 +771,155 @@ class TestInvokeClaudeCode:
         assert payload["usage"]["session_id"] == "sess_123"
         assert payload["usage"]["tool_event_count"] == 1
 
+    @pytest.mark.parametrize(
+        ("backend", "stdout", "expected_usage"),
+        [
+            pytest.param(
+                "claude",
+                json.dumps(
+                    {
+                        "type": "result",
+                        "session_id": "claude-session",
+                        "usage": {
+                            "input_tokens": 11,
+                            "output_tokens": 7,
+                            "cache_creation_input_tokens": 13,
+                            "cache_read_input_tokens": 17,
+                            "cached_input_tokens": 19,
+                        },
+                        "reasoning_tokens": 5,
+                        "total_cost_usd": 0.31,
+                    }
+                ),
+                {
+                    "input_tokens": 11,
+                    "output_tokens": 7,
+                    "cache_creation_input_tokens": 13,
+                    "cache_read_input_tokens": 17,
+                    "cached_input_tokens": 19,
+                    "reasoning_tokens": 5,
+                    "cost_usd": 0.31,
+                    "session_id": "claude-session",
+                },
+                id="claude",
+            ),
+            pytest.param(
+                "codex",
+                "\n".join(
+                    [
+                        '{"type":"session.started","session_id":"codex-session"}',
+                        (
+                            '{"type":"turn","usage":{"prompt_tokens":12,'
+                            '"completion_tokens":8,"cached_input_tokens":21,'
+                            '"reasoning_tokens":6,"total_cost_usd":0.32}}'
+                        ),
+                    ]
+                ),
+                {
+                    "input_tokens": 12,
+                    "output_tokens": 8,
+                    "cached_input_tokens": 21,
+                    "reasoning_tokens": 6,
+                    "cost_usd": 0.32,
+                    "session_id": "codex-session",
+                },
+                id="codex",
+            ),
+            pytest.param(
+                "cursor",
+                "\n".join(
+                    [
+                        '{"type":"system","sessionId":"cursor-session"}',
+                        (
+                            '{"type":"assistant","usage":{"inputTokens":13,'
+                            '"outputTokens":9,"cachedTokens":22,'
+                            '"reasoningTokens":7,"costUsd":0.33}}'
+                        ),
+                    ]
+                ),
+                {
+                    "input_tokens": 13,
+                    "output_tokens": 9,
+                    "cached_input_tokens": 22,
+                    "reasoning_tokens": 7,
+                    "cost_usd": 0.33,
+                    "session_id": "cursor-session",
+                },
+                id="cursor",
+            ),
+            pytest.param(
+                "gemini",
+                "\n".join(
+                    [
+                        "MCP advisory preamble tolerated by the Gemini parser.",
+                        '{"type":"init","session_id":"gemini-session"}',
+                        (
+                            '{"type":"result","usageMetadata":{"prompt_tokens":14,'
+                            '"completion_tokens":10,"cachedTokens":23},'
+                            '"thoughts":8,"cost":0.34}'
+                        ),
+                    ]
+                ),
+                {
+                    "input_tokens": 14,
+                    "output_tokens": 10,
+                    "cached_input_tokens": 23,
+                    "reasoning_tokens": 8,
+                    "cost_usd": 0.34,
+                    "session_id": "gemini-session",
+                },
+                id="gemini",
+            ),
+            pytest.param(
+                "opencode",
+                "\n".join(
+                    [
+                        '{"type":"step_start","sessionID":"opencode-session"}',
+                        (
+                            '{"type":"step_finish","part":{"tokens":{"input":15,'
+                            '"output":11,"cached":24,"thoughts":9},"cost":0.35}}'
+                        ),
+                    ]
+                ),
+                {
+                    "input_tokens": 15,
+                    "output_tokens": 11,
+                    "cached_input_tokens": 24,
+                    "reasoning_tokens": 9,
+                    "cost_usd": 0.35,
+                    "session_id": "opencode-session",
+                },
+                id="opencode",
+            ),
+        ],
+    )
+    def test_backend_result_artifact_contains_extended_usage_for_each_backend(
+        self,
+        tmp_path: Path,
+        mocker,
+        backend: str,
+        stdout: str,
+        expected_usage: dict[str, float | int | str],
+    ):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(stdout=stdout, stderr="", returncode=0)
+
+        _parsed, returned_usage = invoke_claude_code(
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend=backend),
+        )
+
+        payload = json.loads((tmp_path / BACKEND_RESULT_ARTIFACT_NAME).read_text())
+        assert payload["backend"] == backend
+        assert payload["returncode"] == 0
+        assert payload["usage"] == returned_usage
+        for key, value in expected_usage.items():
+            if isinstance(value, float):
+                assert payload["usage"][key] == pytest.approx(value)
+            else:
+                assert payload["usage"][key] == value
+
     def test_claude_backend_artifacts_copy_local_transcript(
         self, tmp_path: Path, mocker, monkeypatch
     ):

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -913,7 +913,8 @@ class TestInvokeClaudeCode:
         payload = json.loads((tmp_path / BACKEND_RESULT_ARTIFACT_NAME).read_text())
         assert payload["backend"] == backend
         assert payload["returncode"] == 0
-        assert payload["usage"] == returned_usage
+        # payload["usage"] is the serialized dict; returned_usage is a UsageStats
+        assert payload["usage"] == returned_usage.to_dict()
         for key, value in expected_usage.items():
             if isinstance(value, float):
                 assert payload["usage"][key] == pytest.approx(value)
@@ -1327,5 +1328,5 @@ def test_normalise_usage_stats_ignores_recall_and_callback(monkeypatch):
         ],
     }
     result = _normalise_usage_stats(parsed)
-    assert result.get("tool_event_count") == 2
-    assert result.get("tool_names") == ["Read", "search"]
+    assert result.tool_event_count == 2
+    assert result.tool_names == ["Read", "search"]

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -52,7 +52,16 @@ def _make_full_state() -> EvolutionState:
             "g1-s1": {"task_a": 0.6, "task_b": 0.7},
             "g2-m1": {"task_a": 0.65, "task_b": 0.75},
         },
-        budget=BudgetState(evaluations=42),
+        budget=BudgetState(
+            evaluations=42,
+            input_tokens=100,
+            output_tokens=40,
+            cached_input_tokens=30,
+            cache_creation_input_tokens=20,
+            cache_read_input_tokens=10,
+            reasoning_tokens=5,
+            cost_usd=1.23,
+        ),
         config_hash="cfg-deadbeef",
         mutation_counter=2,
         merge_counter=1,
@@ -144,6 +153,10 @@ def test_load_legacy_state_populates_defaults(tmp_path: Path) -> None:
     assert loaded.generation == 1
     assert loaded.frontier == ["g0-s0"]
     assert loaded.budget.evaluations == 1
+    assert loaded.budget.cached_input_tokens == 0
+    assert loaded.budget.cache_creation_input_tokens == 0
+    assert loaded.budget.cache_read_input_tokens == 0
+    assert loaded.budget.reasoning_tokens == 0
 
 
 def test_load_state_rejects_newer_schema_version(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -162,7 +162,7 @@ wheels = [
 
 [[package]]
 name = "helix-evo"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Persist extended backend usage totals in \`state.json\` budget state.
- Aggregate cached input, cache creation/read input, and reasoning tokens from backend usage payloads.
- Cover the existing backend set with parser/accounting tests and artifact-level tests that verify \`.helix_backend_result.json\` contains the normalized usage fields.
- Show cache/reasoning totals in the live status panel when nonzero.

## UsageStats | dict Unification (added on top of original PR)

Executed Direction B from the scope report: `UsageStats` is now the canonical type for backend usage payloads everywhere; the `dict` path is retired.

### Changes (3 commits on top of original PR)

**Commit 1 — display.py: harden UsageStats (prep)**
- Add `session_id: str | None = None` field (critical risk #1: `_normalise_usage_stats` returns session_id; `_collect_backend_transcript_artifacts` reads it; without this field the flip silently breaks transcript artifact collection)
- Add `UsageStats.to_dict() -> dict[str, Any]` (all 11 fields; tool_names as fresh copy)
- Add `UsageStats.from_dict(d: Mapping[str, Any]) -> UsageStats` (tolerates missing keys, wrong types, absent tool_names)

**Commit 2 — flip Candidate.usage and all callsites**
- `population.py`: `Candidate.usage: dict[str, Any]` → `UsageStats`
- `population.py`: `CandidateSummary.to_dict()` → `"usage": self.candidate.usage.to_dict()` (critical risk #2: prevents `TypeError` at json.dumps boundary)
- `mutator.py`: `_normalise_usage_stats` returns `UsageStats`; session_id flows into `UsageStats.session_id`; `_collect_backend_transcript_artifacts` uses `usage.session_id`; `_write_backend_artifacts` serializes via `usage.to_dict()`; `invoke_claude_code` and `generate_seed` return annotations updated
- `budget.py`: `UsageDict` TypedDict deleted; `charge_llm_usage` accepts `UsageStats | None`; 7 `.get()` calls → attribute access
- `display.py`: `UsageStats.add` dict branch removed; `HelixLiveDisplay.update` narrowed
- All test fixtures updated: 3 dict literals in `test_evolution.py`, seedless mock in `test_evolution_seedless.py`, dict subscript access in `test_budget.py`, `_normalise_usage_stats` result access in `test_mutator.py`

**Commit 3 — new test_display.py (17 tests)**
- `TestUsageStatsAdd`: accumulates all fields, cost, tool_names; empty add is noop; no list aliasing
- `TestUsageStatsSerialization`: all-11-field round-trip; to_dict fresh copy; json-serializable; from_dict tolerates missing keys, non-list tool_names, string coercion, session_id
- `TestCandidateSummaryJsonSerialization`: regression guard for critical risk #2 — `CandidateSummary.to_dict() → json.dumps` must not TypeError

## Rationale
Backends can report important usage outside plain input/output token fields. Persisting those totals in state makes long-running sessions easier to inspect without re-reading every backend artifact. After the UsageStats unification, `mypy` can fully check `Candidate.usage` access everywhere, and `budget.py`'s 7 `.get()` calls become clean attribute reads.

## Validation
- `uv run --extra dev pytest tests/unit/ -q` → **814 passed** (797 pre-existing + 17 new)
- `uv run --extra dev ruff check src/helix/display.py src/helix/budget.py src/helix/population.py src/helix/mutator.py tests/unit/test_display.py` → all checks passed

## Test plan
- [x] `UsageStats.add` accumulates all 11 fields from a `UsageStats` argument
- [x] `UsageStats.to_dict()` round-trips through `UsageStats.from_dict()` losslessly for all 11 fields
- [x] `from_dict` tolerates missing keys, wrong types, missing `tool_names`
- [x] `CandidateSummary.to_dict()` → `json.dumps` succeeds without `TypeError` (critical risk #2 regression)
- [x] `session_id` field flows from `_normalise_usage_stats` through `UsageStats.session_id` to `_collect_backend_transcript_artifacts`
- [x] All 797 pre-existing unit tests continue to pass