### PR TITLE
refresh docs and replace architecture diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-05-13
+
+### Added
+- New CLI subcommand `helix attempts` — surfaces rejected attempt records and
+  perfect-skip events; supports filtering by `--generation`, `--stage`,
+  `--reason`, `--cid`; `--skips` flag to show only perfect-skip entries;
+  `--json` for machine-readable output. (PR #30)
+- New artifact directories `.helix/attempts/` and `.helix/skips/` — per-rejected-candidate
+  JSON files and per-generation perfect-skip event lists persisted alongside
+  `.helix/evaluations/` and `.helix/worktrees/`. (PR #30)
+- 5-backend `tool_event_count` / `tool_names` tracking in `UsageStats` —
+  normalised tool-use metrics for claude, codex, cursor, gemini, and opencode
+  backends extracted from transcript artifacts. (PR #32)
+- `session_id`, `to_dict`, `from_dict` helpers on `UsageStats`. (PR #32)
+- New module `src/helix/evaluator_manifest.py` — SHA-256 manifest for
+  protected evaluator files; refresh helpers for mutation and merge candidates.
+  (PR #30 refactor)
+
+### Changed
+- **GEPA structural alignment**: generation counter advances unconditionally per
+  GEPA spec — a perfect-subsample no longer rewinds the counter. Cache is also
+  bypassed when re-evaluating the parent's minibatch, ensuring consistent
+  parent-comparison semantics across resume scenarios. (PR #32)
+- `exitcode` score parser now broadcasts the success score to *all* instance
+  IDs in the batch, fixing a bug where only the first instance was populated
+  when using `exitcode` with multi-example runs. (PR #32)
+
+### Fixed
+- Mandatory stop-condition enforcement: `run_evolution` now raises `ValueError`
+  at startup if both `max_generations ≤ 0` and `max_evaluations ≤ 0`. Previously
+  a config with both set to negative values would loop indefinitely. (PR #32)
+- Resume reconciliation: incomplete attempts and orphaned worktrees from a
+  crashed run are cleaned up at resume time before the first new generation
+  starts. (PR #30)
+
 ## [0.2.1] - 2026-05-10
 
 > Note: 0.2.0 was published from a broken build and is superseded by this

--- a/README.md
+++ b/README.md
@@ -78,60 +78,81 @@ This is why a full solver module or a shrinkwrap of an ML kernel behave qualitat
 
 ## 🔄 How It Works
 
-```
-                              ┌──────────────────────┐
-                              │   Host HELIX Engine  │
-                              │  state, frontier,    │
-                              │  worktree copies     │
-                              └──────────┬───────────┘
-                                         │
-                    starts once per run  │
-                                         ▼
-                 ┌────────────────────────────────────────┐
-                 │ Private Evaluator Sidecar              │
-                 │ Docker network: helix-eval-*           │
-                 │ • benchmark code/data stay here        │
-                 │ • no published host ports              │
-                 │ • no agent auth volume                 │
-                 └───────────────────▲────────────────────┘
-                                     │ HTTP/RPC only
-                                     │
-          ┌──────────────────────────┴──────────────────────────┐
-          │                                                     │
-          ▼                                                     ▼
- ┌──────────────────────┐                              ┌──────────────────────┐
- │ Evaluator Runner     │                              │ Evaluator Runner     │
- │ short-lived Docker   │            ...               │ short-lived Docker   │
- │ • copied /workspace  │                              │ • copied /workspace  │
- │ • private eval net   │                              │ • private eval net   │
- │ • prints HELIX_RESULT│                              │ • prints HELIX_RESULT│
- └──────────┬───────────┘                              └──────────┬───────────┘
-            │                                                     │
-            └────────────── scores / ASI / stderr ────────────────┘
-                                         │
-                                         ▼
-                              ┌──────────────────────┐
-                              │ Select Parent        │
-                              │ Pareto + train gate  │
-                              └──────────┬───────────┘
-                                         │
-                                         ▼
-                 ┌────────────────────────────────────────┐
-                 │ Mutator Agent Container                │
-                 │ Docker network: normal agent egress    │
-                 │ • copied /workspace                    │
-                 │ • backend auth volume                  │
-                 │ • no evaluator network or endpoint     │
-                 │ • edits sync back after exit           │
-                 └───────────────────┬────────────────────┘
-                                     │
-                                     ▼
-                              ┌──────────────────────┐
-                              │ Gate / Pareto Update │
-                              │ Merge / Cleanup      │
-                              └──────────┬───────────┘
-                                         │
-                                         └── repeat generations
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '14px'}}}%%
+flowchart TD
+    classDef host fill:#dbeafe,stroke:#0072B2,color:#1a365d
+    classDef eval fill:#d1fae5,stroke:#009E73,color:#064e3b
+    classDef agent fill:#fef3c7,stroke:#E69F00,color:#78350f
+    classDef artifact fill:#fce7f3,stroke:#CC79A7,color:#500724
+    classDef dec fill:#ffffff,stroke:#6b7280,color:#374151
+    classDef ok fill:#f0fdf4,stroke:#009E73,color:#064e3b
+
+    %% ── Phase 1: Startup ─────────────────────────────────────────────────────────
+    CFG(["📄 helix.toml"]):::host
+    LOAD["Load & validate config\n⚠ ValueError if max_gen ≤ 0\nAND max_eval ≤ 0"]:::host
+    RES{"resume?"}:::dec
+    REC["Reconcile on resume:\ncleanup partial attempts\n& orphaned worktrees"]:::host
+    SEED["Evaluate seed candidate"]:::eval
+    FRONT["🏆 Pareto Frontier"]:::host
+
+    CFG --> LOAD --> RES
+    RES -->|yes| REC --> SEED
+    RES -->|no| SEED
+    SEED --> FRONT
+
+    %% ── Phase 2: Generation loop — select parent ─────────────────────────────────
+    SEL["Select parent\n(weighted by instance wins)"]:::host
+    FRONT --> SEL
+
+    %% ── Phase 3: Docker Sandbox — isolated execution ─────────────────────────────
+    subgraph DOCKER["🐳  Docker Sandbox  —  isolated execution environment"]
+        direction LR
+        subgraph ANET["  Agent Network  (normal egress)  "]
+            AGENT["Mutation / Merge Container\n──────────────────────────\nclaude · codex · cursor\ngemini · opencode\nAuth: helix-auth-BACKEND"]:::agent
+        end
+        subgraph ENET["  Private Evaluator Network  (helix-eval-*)  "]
+            ERUN["Eval Runners\n(short-lived,\ncopied workspace)"]:::eval
+            ESVC["Evaluator Sidecar\n(benchmark data\nno host ports)"]:::eval
+            ERUN -->|"HTTP/RPC"| ESVC
+        end
+    end
+    style DOCKER fill:#f8fafc,stroke:#64748b,color:#0f172a
+
+    SEL -->|"spawn mutation/merge"| AGENT
+    AGENT -->|"edits synced back"| GATE
+
+    %% ── Phase 4: Evaluate & update ───────────────────────────────────────────────
+    GATE["Train-set gate\n(minibatch eval)"]:::eval
+    AREC["Rejected attempt\n.helix/attempts/"]:::artifact
+    VEVAL["Full val eval"]:::eval
+    PERF{"all instances\nat perfect score?"}:::dec
+    SREC["Perfect-skip event\n.helix/skips/"]:::artifact
+    PUPD["Pareto update"]:::host
+    ADV["Advance gen counter\n(unconditionally)"]:::host
+    STOPDEC{"stop?"}:::dec
+    DONE(["✅  Evolution complete"]):::ok
+
+    GATE -->|"reject"| AREC
+    GATE -->|"pass"| VEVAL --> PERF
+    PERF -->|"perfect skip"| SREC
+    PERF -->|"no"| PUPD
+
+    AREC --> ADV
+    SREC --> ADV
+    PUPD --> ADV
+    ADV --> STOPDEC
+    STOPDEC -->|"next gen"| SEL
+    STOPDEC -->|"done"| DONE
+
+    %% ── .helix/ Artifact Store ───────────────────────────────────────────────────
+    ARTS[["💾 .helix/ Artifact Store\n─────────────────────────────────────\nstate.json · lineage.json · evaluations/\nworktrees/ · attempts/ · skips/\nbackend_transcripts/‹backend›/‹session›.jsonl"]]:::artifact
+    style ARTS fill:#fdf2f8,stroke:#CC79A7,color:#500724
+
+    PUPD -.->|"persist"| ARTS
+    VEVAL -.->|"persist"| ARTS
+    AREC -.-> ARTS
+    SREC -.-> ARTS
 ```
 
 **The loop in detail:**

--- a/README.md
+++ b/README.md
@@ -362,6 +362,9 @@ enabled = false
 max_generations = 20
 perfect_score_threshold = 1.0    # skip proposals whose instance_scores all reach this
 max_evaluations = -1             # evaluation budget cap (-1 = no cap)
+                                 # NOTE: at least one stopping condition is required —
+                                 # max_generations must be > 0 or max_evaluations must be > 0;
+                                 # setting both to ≤ 0 raises ValueError at evolution start.
 merge_enabled = false            # enable merge/crossover operations
 max_merge_invocations = 5        # total merge cap across entire run
 merge_val_overlap_floor = 5      # minimum val-set overlap for merge candidates
@@ -384,7 +387,6 @@ backend = "claude"               # "claude" | "codex" | "cursor" | "gemini" | "o
 # model = "sonnet"               # optional backend-specific model name
 effort = "medium"                # optional: "low" | "medium" | "high" | "xhigh" | "max"
 max_turns = 20
-allowed_tools = ["Read", "Edit", "Write", "Bash", "Glob", "Grep"]
 # background = "Only modify files under src/. Do not touch tests/ or config/."
 
 [sandbox]
@@ -596,6 +598,7 @@ stderr as fallback debug context.
 | `helix resume` | Resume a previously interrupted evolution run |
 | `helix clean` | Remove all worktrees and `.helix/` state (with confirmation) |
 | `helix log` | Show semantic mutation log — full trajectory with parent lineage |
+| `helix attempts` | Surface rejected attempt records and perfect-skip events from `.helix/attempts/` and `.helix/skips/` |
 
 ### `helix evolve` Options
 
@@ -606,7 +609,8 @@ stderr as fallback debug context.
 --evaluator TEXT     Override the evaluator command
 --generations INT   Override max_generations
 --no-merge          Disable merge operations
---model TEXT        Claude model (e.g. sonnet, opus, claude-sonnet-4-5)
+--backend BACKEND   Override the mutation backend [claude|codex|cursor|gemini|opencode]
+--model TEXT        Override the backend model (backend-specific naming)
 --effort LEVEL      Reasoning effort: low | medium | high | xhigh | max
 ```
 
@@ -643,20 +647,23 @@ Pack 26 non-overlapping circles in a unit square, maximizing sum of radii.
 │   ├── g0-s0/           # Seed
 │   ├── g1-m1/           # Gen 1 Mutation 1
 │   └── g2-x1/           # Gen 2 Merge 1
-└── evaluations/
-    └── g0-s0.json       # EvalResult per candidate
+├── evaluations/
+│   └── g0-s0.json       # EvalResult per candidate
+├── attempts/            # Per-rejected-candidate attempt records (JSON)
+└── skips/               # Per-generation perfect-skip event lists (JSON)
 ```
 
 ### Module Overview
 
 | Module | Role |
 |---|---|
-| `cli.py` | Click CLI — init, evolve, frontier, best, history, resume, clean, log |
+| `cli.py` | Click CLI — init, evolve, frontier, best, history, resume, clean, log, attempts |
 | `config.py` | TOML config parsing via Pydantic v2 |
 | `evolution.py` | Main generation loop with gating, merge, and termination on `max_generations` / `max_evaluations` |
 | `population.py` | `Candidate`, `EvalResult`, `ParetoFrontier` |
 | `worktree.py` | Git worktree lifecycle (create, clone, snapshot, remove) |
 | `executor.py` | Run evaluator commands |
+| `evaluator_manifest.py` | SHA-256 manifest for protected evaluator files; refresh helpers for mutation and merge candidates |
 | `mutator.py` | Backend mutation invocation with autonomous system prompt and HELIX usage artifacts |
 | `merger.py` | Backend merge/crossover between complementary candidates |
 | `lineage.py` | Ancestry graph tracking |

--- a/examples/circle_packing/README.md
+++ b/examples/circle_packing/README.md
@@ -33,10 +33,11 @@ The final score of **2.6360** was reached at **generation 14 of a 30-generation 
 >
 > *Achieved with **haiku + low reasoning effort + max_turns=20**, arguably the cheapest Claude setup available. Demonstrates HELIX can extract strong results from tiny budgets.*
 
-The exact `[claude]` block from `helix.toml` that produced the result:
+The exact `[agent]` block from `helix.toml` that produced the result:
 
 ```toml
-[claude]
+[agent]
+backend = "claude"
 model = "haiku"
 effort = "low"
 max_turns = 20

--- a/examples/circle_packing/helix.toml
+++ b/examples/circle_packing/helix.toml
@@ -14,9 +14,9 @@ max_generations = 30
 merge_enabled = false
 perfect_score_threshold = 100.0
 max_evaluations = 500
-max_claude_calls = 80
 
-[claude]
+[agent]
+backend = "claude"
 model = "haiku"
 effort = "low"
 max_turns = 20

--- a/skills/helix/SKILL.md
+++ b/skills/helix/SKILL.md
@@ -222,6 +222,8 @@ helix best --dir .
 helix best --export ./best-worktree --dir .
 helix history --dir .
 helix log --dir .
+helix attempts --dir .
+helix attempts --skips --dir .
 helix clean --dir .
 ```
 

--- a/skills/helix/references/run-debug.md
+++ b/skills/helix/references/run-debug.md
@@ -73,6 +73,8 @@ helix best
 helix best --export ./best-solution
 helix history
 helix log
+helix attempts
+helix attempts --skips
 ```
 
 Useful files:
@@ -80,10 +82,13 @@ Useful files:
 ```text
 .helix/
   config.toml
+  evaluator_manifest.json
   state.json
   helix.log
   log/*.json
   worktrees/gN-sN/
+  attempts/           (per-rejected-candidate JSON records)
+  skips/              (per-generation perfect-skip event lists)
 ```
 
 For backend diagnostics in a candidate worktree, inspect:

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1782,6 +1782,15 @@ def _run_evolution_impl(
             # through to reflective mutation.  HELIX previously ``continue``d
             # on every merge-gate entry regardless of attempt outcome, cutting
             # the effective mutation count by the merge-gate failure rate.
+            # GEPA-parity note: the *merge operator itself* (helix.merger.merge,
+            # invoked below) deliberately diverges from GEPA's deterministic
+            # text-component splicing (gepa/proposer/merge.py:155-203).  GEPA
+            # candidates are dict[str, str], so a syntactic per-component swap
+            # is well-defined; helix candidates are full git worktrees, where
+            # LLM-mediated file editing is the only viable approach.  Every
+            # surrounding piece — the trigger condition, parent selection,
+            # subsample selection, acceptance criterion, full-val post-eval, and
+            # rejection control flow — mirrors GEPA verbatim.
             merge_attempted = False
             if (
                 config.evolution.merge_enabled

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -2224,6 +2224,9 @@ def _run_evolution_impl(
                         split="train",
                     )
 
+                # g (gen) and s (mutation_counter) advance together under n_proposals=1
+                # / merge_disabled defaults. They diverge when n_proposals > 1 (multiple
+                # s-slots per gen) or when merge fires (gen advances without incrementing s).
                 new_id = budget_api.next_mutation_id(state, gen)
                 presample_contexts.append(
                     (parent, parent_frontier_result, subsample_ids, new_id)

--- a/src/helix/merger.py
+++ b/src/helix/merger.py
@@ -162,6 +162,16 @@ def merge(
     prompt, and invokes Claude Code.  Snapshots on success; removes the
     worktree and returns ``None`` on failure.
 
+    GEPA-parity note: this is the correct domain adaptation of GEPA's
+    text-component merge (``gepa/proposer/merge.py:155-203``) for HELIX's
+    full-codebase setting.  GEPA can splice ``dict[str, str]`` programs
+    deterministically by swapping components from each parent; HELIX
+    candidates are full git worktrees, where syntactic per-component swap
+    is undefined, so an LLM-mediated edit is the only viable approach.
+    The surrounding trigger / parent-selection / subsample / acceptance /
+    full-val logic in :mod:`helix.evolution` mirrors GEPA's
+    ``MergeProposer`` and ``GEPAEngine`` verbatim.
+
     Parameters
     ----------
     candidate_a:

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1,4 +1,4 @@
-"""HELIX mutator: applies code mutations to evolutionary candidates via Claude Code."""
+"""HELIX mutator: applies code mutations via agentic coding backends (claude, codex, cursor, gemini, opencode)."""
 
 from __future__ import annotations
 

--- a/src/helix/worktree.py
+++ b/src/helix/worktree.py
@@ -500,7 +500,7 @@ def clone_candidate(parent: Candidate, new_id: str, base_dir: Path) -> Candidate
     parent:
         The candidate to clone from.
     new_id:
-        Identifier for the new candidate (e.g. ``"g1-s0"``).
+        Identifier for the new candidate (e.g. ``"g1-s1"``).
     base_dir:
         Root directory for HELIX worktrees.
 


### PR DESCRIPTION
## Summary

Addresses all **P0 + P1 doc staleness** items from the post-PR #30/#32 audit, plus two P2 nits from the `gN-sN` naming investigation. Split into two commits for reviewability.

### Commit 1 — doc catchup (`74e942c`)

| Item | File(s) changed |
|------|----------------|
| P0-1 Fix invalid `[claude]` section in example config | `examples/circle_packing/helix.toml` |
| P0-2 Update embedded TOML snippet in example README | `examples/circle_packing/README.md` |
| P0-3 Remove invalid `allowed_tools` from README `[agent]` example | `README.md` |
| P0-4 Add `helix attempts` to CLI Reference table | `README.md` |
| P0-5 Add `## [0.2.2]` CHANGELOG section for PR #30 + PR #32 | `CHANGELOG.md` |
| P1-1 Add `attempts/` + `skips/` to `.helix/` filesystem layout | `README.md` |
| P1-2 Add `--backend` flag + fix `--model` description in CLI ref | `README.md` |
| P1-3 Add `evaluator_manifest.py` to Module Overview; add `attempts` to `cli.py` row | `README.md` |
| P1-4 Fix `mutator.py` module docstring (list all 5 backends) | `src/helix/mutator.py` |
| P1-5 Add `helix attempts`, `evaluator_manifest.json`, `attempts/`, `skips/` to run-debug skill | `skills/helix/references/run-debug.md` |
| P1-6 Add `helix attempts` commands to SKILL.md | `skills/helix/SKILL.md` |
| P1-7 Add mandatory stop condition note to `[evolution]` config block | `README.md` |
| P2 nit Fix docstring example `g1-s0` → `g1-s1` | `src/helix/worktree.py` |
| P2 nit Add comment explaining g/s counter divergence at `next_mutation_id` | `src/helix/evolution.py` |

### Commit 2 — architecture diagram (`c69da36`)

Replace the 55-line ASCII process-flow diagram with a professional **Mermaid `flowchart TD`** diagram (21 iterations).

**Content additions vs. old ASCII art:**
- All 5 mutation backends (claude · codex · cursor · gemini · opencode)
- Docker sandbox as inline subgraph: Agent Network + Private Evaluator Network
- Reconcile-on-resume path (cleanup partial attempts & orphaned worktrees)
- Mandatory stop condition (⚠ ValueError node)
- Perfect-skip branch → `.helix/skips/`
- All 7 `.helix/` subdirectories in the Artifact Store node
- Transcript flow: `backend_transcripts/‹backend›/‹session›.jsonl`

**Design:** TD layout, Okabe-Ito CVD-safe palette, exception paths LEFT / happy path RIGHT.

## Test plan

- [ ] `gh pr checks` green (pre-commit hooks passed locally on both commits)
- [ ] Mermaid diagram renders correctly in GitHub PR preview
- [ ] `examples/circle_packing/helix.toml` is valid TOML with `[agent]` section
- [ ] CHANGELOG `## [0.2.2]` section appears correctly formatted
- [ ] No behavior changes — all edits are documentation and comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)