### PR TITLE
perf(opencode): isolate per-proposal subprocess state to prevent SQLite WAL contention

### DIFF
--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -586,6 +586,10 @@ def _ignore_helix_artifacts(worktree_path: Path) -> None:
         BACKEND_STDERR_ARTIFACT_NAME,
         ".helix_artifacts/",
         "helix_batch.json",
+        # Per-candidate OpenCode SQLite state (XDG_DATA_HOME isolation).
+        # Each parallel opencode worker gets a fresh database here; keeps
+        # the candidate git tree free of opencode's session/session files.
+        ".helix_opencode_state/",
     ]
     existing = gitignore.read_text() if gitignore.exists() else ""
     to_append = [p for p in patterns if p not in existing]
@@ -1515,6 +1519,30 @@ def invoke_claude_code(
     _add_backend_auth_env(backend_env, backend)
     if backend == "gemini":
         backend_env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"
+    if backend == "opencode" and (sandbox is None or not sandbox.enabled):
+        # Per-candidate SQLite isolation for concurrent opencode subprocesses.
+        #
+        # OpenCode stores its session database at:
+        #   macOS: ~/Library/Application Support/opencode/opencode.db
+        #   Linux: $XDG_DATA_HOME/opencode/opencode.db  (default ~/.local/share/opencode/)
+        #
+        # When multiple proposals run in parallel (num_parallel_proposals > 1),
+        # every worker spawns a fresh `opencode run` subprocess that issues
+        # `PRAGMA journal_mode = WAL` against this shared database at startup.
+        # Concurrent WAL-mode requests on the same file produce:
+        #   "Failed to run the query 'PRAGMA journal_mode = WAL'"
+        # (observed in PR #34 E2E re-verify: g1-s1 lost to this error while g1-s2 succeeded).
+        #
+        # Fix: set XDG_DATA_HOME to a per-candidate directory.  OpenCode respects
+        # XDG_DATA_HOME and will create an isolated database at:
+        #   <worktree>/.helix_opencode_state/opencode/opencode.db
+        # Each parallel worker gets its own fresh database; no contention.
+        #
+        # The sandbox branch is excluded: container isolation already provides
+        # per-candidate filesystem separation, so XDG_DATA_HOME would be redundant.
+        opencode_state_dir = Path(worktree_path) / ".helix_opencode_state"
+        opencode_state_dir.mkdir(parents=True, exist_ok=True)
+        backend_env["XDG_DATA_HOME"] = str(opencode_state_dir)
     if sandbox is not None and sandbox.enabled:
         sandbox_image = resolve_sandbox_image(sandbox, backend)
         result = run_sandboxed_command(

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1780,3 +1780,127 @@ class TestTranscriptToolPatchesUsageInArtifact:
         # Transcript artifact should also be present
         assert len(payload["transcript_artifacts"]) == 1
         assert payload["transcript_artifacts"][0]["available"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: OpenCode per-candidate SQLite isolation (XDG_DATA_HOME)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeSubprocessIsolation:
+    """Verify that concurrent opencode subprocesses receive isolated XDG_DATA_HOME
+    values so each worker opens its own SQLite database and the shared-database
+    'PRAGMA journal_mode = WAL' contention observed in PR #34 cannot recur.
+    """
+
+    def test_opencode_subprocess_isolation_env_set(self, tmp_path: Path, mocker):
+        """invoke_claude_code sets XDG_DATA_HOME for opencode backend."""
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"result","sessionID":"ses_abc"}\n',
+            stderr="",
+            returncode=0,
+        )
+
+        invoke_claude_code(
+            str(tmp_path), "fix the bug", AgentConfig(backend="opencode")
+        )
+
+        call_kwargs = mock_run.call_args[1]
+        env = call_kwargs["env"]
+        assert "XDG_DATA_HOME" in env, (
+            "XDG_DATA_HOME must be set for opencode to isolate its SQLite database "
+            "from other concurrent opencode workers"
+        )
+        # Must point inside the candidate worktree so cleanup is automatic
+        xdg = env["XDG_DATA_HOME"]
+        assert xdg.startswith(str(tmp_path)), (
+            f"XDG_DATA_HOME={xdg!r} should be under the candidate worktree {tmp_path}"
+        )
+
+    def test_opencode_subprocess_isolation_unique_per_candidate(
+        self, tmp_path: Path, mocker
+    ):
+        """Two different candidates get different XDG_DATA_HOME values."""
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"result","sessionID":"ses_abc"}\n',
+            stderr="",
+            returncode=0,
+        )
+
+        wt_a = tmp_path / "g1-s1"
+        wt_b = tmp_path / "g1-s2"
+        wt_a.mkdir()
+        wt_b.mkdir()
+
+        invoke_claude_code(str(wt_a), "prompt", AgentConfig(backend="opencode"))
+        env_a = mock_run.call_args[1]["env"]["XDG_DATA_HOME"]
+
+        invoke_claude_code(str(wt_b), "prompt", AgentConfig(backend="opencode"))
+        env_b = mock_run.call_args[1]["env"]["XDG_DATA_HOME"]
+
+        assert env_a != env_b, (
+            "Each candidate worktree must produce a distinct XDG_DATA_HOME so their "
+            "opencode SQLite databases don't collide"
+        )
+
+    def test_opencode_subprocess_inherits_other_env(self, tmp_path: Path, mocker):
+        """Non-isolation env vars (PATH, HOME) are still present after XDG injection."""
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"result","sessionID":"ses_abc"}\n',
+            stderr="",
+            returncode=0,
+        )
+
+        invoke_claude_code(
+            str(tmp_path), "prompt", AgentConfig(backend="opencode"),
+            passthrough_env=["PATH", "HOME"],
+        )
+
+        env = mock_run.call_args[1]["env"]
+        # PATH and HOME are passed through from the parent process environment
+        import os
+        if "PATH" in os.environ:
+            assert "PATH" in env, "PATH must survive the env scrub for opencode"
+        if "HOME" in os.environ:
+            assert "HOME" in env, "HOME must survive the env scrub for opencode"
+        # And XDG_DATA_HOME is the *only* new opencode-specific addition
+        assert "XDG_DATA_HOME" in env
+
+    def test_opencode_isolation_not_applied_to_other_backends(
+        self, tmp_path: Path, mocker
+    ):
+        """XDG_DATA_HOME must NOT be injected for claude/codex/cursor/gemini."""
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+
+        for backend in ("claude", "codex", "cursor", "gemini"):
+            invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend=backend)
+            )
+            env = mock_run.call_args[1]["env"]
+            assert "XDG_DATA_HOME" not in env, (
+                f"XDG_DATA_HOME must not be injected for {backend} backend"
+            )
+
+    def test_opencode_isolation_dir_gitignored(self, tmp_path: Path, mocker):
+        """The per-candidate opencode state directory is added to .gitignore."""
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"result","sessionID":"ses_abc"}\n',
+            stderr="",
+            returncode=0,
+        )
+
+        invoke_claude_code(
+            str(tmp_path), "prompt", AgentConfig(backend="opencode")
+        )
+
+        gitignore_path = tmp_path / ".gitignore"
+        assert gitignore_path.exists(), ".gitignore must be created in the worktree"
+        gitignore_text = gitignore_path.read_text()
+        assert ".helix_opencode_state/" in gitignore_text, (
+            ".helix_opencode_state/ must be gitignored to keep it out of candidate history"
+        )


### PR DESCRIPTION
## Summary

- Fixes the SQLite WAL contention observed in the PR #34 E2E re-verify run where `g1-s1` failed with `"Failed to run the query 'PRAGMA journal_mode = WAL'"` while `g1-s2` succeeded — wasting one proposal slot
- Fix: set `XDG_DATA_HOME` to a per-candidate directory (`<worktree>/.helix_opencode_state/`) before invoking `opencode run`, giving each parallel worker its own isolated SQLite database
- 5 new unit tests; backend-exclusion test covers all 4 other backends (claude/codex/cursor/gemini)

## Background

**Depends on:** #34 (perf/architecture-d-atomic-worker)

When `num_parallel_proposals > 1` with `backend = "opencode"`, helix spawns concurrent `opencode run --format json` subprocesses. All share the same global SQLite database:
- macOS: `~/Library/Application Support/opencode/opencode.db`
- Linux: `$XDG_DATA_HOME/opencode/opencode.db`

Each subprocess issues `PRAGMA journal_mode = WAL` at startup. Concurrent requests on the same file produce the error seen in PR #34's re-verify.

**Root cause archaeology:** Confirmed via `opencode debug paths` that `XDG_DATA_HOME` changes the `data` directory (and therefore `opencode.db` path). Setting it per-candidate gives complete isolation.

**Reference:** PR #34 E2E re-verify report at `/Users/ke/helix-arch-d-e2e-reverify-report.md`:
> `g1-s1 status: Failed (SQLite WAL error — handled gracefully) ⚠️`

**OMAR comparison:** OMAR uses `OPENCODE_CONFIG_CONTENT` env var for MCP config injection per-session, but does NOT set `XDG_DATA_HOME`. OMAR runs opencode in interactive TUI mode (tmux panes), not headless `opencode run`, so it doesn't hit the cold-start WAL contention. The `XDG_DATA_HOME` isolation is helix-specific and implemented directly.

## Implementation

**`src/helix/mutator.py`** (~28 LOC including explanatory comment):

```python
if backend == "opencode" and (sandbox is None or not sandbox.enabled):
    # Per-candidate SQLite isolation for concurrent opencode subprocesses.
    # [20-line comment explaining the WAL contention root cause]
    opencode_state_dir = Path(worktree_path) / ".helix_opencode_state"
    opencode_state_dir.mkdir(parents=True, exist_ok=True)
    backend_env["XDG_DATA_HOME"] = str(opencode_state_dir)
```

Also adds `.helix_opencode_state/` to `_ignore_helix_artifacts` gitignore patterns.

## E2E Validation Results

Both runs used the `add_one` off-by-one fixture with `backend = "opencode"`, `score_parser = "exitcode"`, `frontier_type = "instance"`.

| Config | Workers | Acceptance | SQLite WAL errors | Cost |
|--------|---------|------------|-------------------|------|
| `n_proposals=2` | 2/2 ✅ | 100% | 0 ✅ | $0.00 |
| `n_proposals=3` | 3/3 ✅ | 100% | 0 ✅ | $0.00 |

Prior (PR #34 re-verify without this fix): `n_proposals=2` → 1/2 (g1-s1 SQLite WAL failure).

Per-candidate isolation confirmed: each worktree has `.helix_opencode_state/opencode/opencode.db`.

## Test Plan

- [x] `uv run pytest tests/unit -q` → 871 passed (866 pre-existing + 5 new)
- [x] `uv run mypy --strict src/helix/` → Success: no issues found in 29 source files
- [x] E2E `n_proposals=2` → 2/2 success, no SQLite WAL errors
- [x] E2E `n_proposals=3` → 3/3 success, no SQLite WAL errors
- [x] Reviewer verdict: APPROVE (opencode-harden-reviewer, `/Users/ke/helix-opencode-harden-review.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)