### PR TITLE
Stop crossing mini batch feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ merge_subsample_size = 5         # stratified val subsample size for merge accep
 max_workers = 8                  # thread-pool cap for parent-eval + mutation pools
                                  # (default: os.cpu_count(), or 32 if that returns None)
 num_parallel_proposals = 1       # parallel mutations per generation; "auto" resolves to max_workers // minibatch_size
-minibatch_size = 3               # train-set minibatch gate size
+minibatch_size = 3               # train-set minibatch size for reflective mutation
 cache_evaluation = true          # reuse per-instance evaluator results
 acceptance_criterion = "strict_improvement"
 val_stage_size = 0               # optional first-N val gate before full val

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -299,7 +299,7 @@ class EvolutionConfig(BaseModel):
     and parallel proposal settings.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     max_generations: int = 10
     perfect_score_threshold: float | None = None
@@ -334,7 +334,7 @@ class EvolutionConfig(BaseModel):
     minibatch_size: int = Field(
         default=3,
         description=(
-            "Number of training examples per minibatch acceptance test. "
+            "Number of training examples per reflective mutation. "
             "GEPA parity: ReflectionConfig.reflection_minibatch_size default."
         ),
     )

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1013,69 +1013,6 @@ def _cached_evaluate_batch(
     return merged, num_actual_evals
 
 
-def _inject_top_k_best_example_history(
-    eval_result: EvalResult,
-    frontier: ParetoFrontier,
-    *,
-    k: int = 3,
-) -> EvalResult:
-    """Attach per-example best-history context for reflection prompts.
-
-    Optimize Anything exposes top-performing example histories to reflection.
-    HELIX's compatible surface is a per-example ``side_info`` field named
-    ``top_k_best_example_history``; it is rendered by the existing diagnostics
-    prompt path without changing candidate/worktree semantics.
-    """
-    if k <= 0 or not eval_result.instance_scores or not frontier.has_results():
-        return eval_result
-
-    example_ids = list(eval_result.instance_scores.keys())
-    history_by_id: dict[str, list[dict[str, Any]]] = {}
-    for eid in example_ids:
-        rows: list[dict[str, Any]] = []
-        for cid, result in frontier.iter_results():
-            if eid in result.instance_scores:
-                rows.append(
-                    {
-                        "candidate_id": cid,
-                        "score": float(result.instance_scores[eid]),
-                    }
-                )
-        rows.sort(key=lambda row: row["score"], reverse=True)
-        if rows:
-            history_by_id[eid] = rows[:k]
-
-    if not history_by_id:
-        return eval_result
-
-    if eval_result.per_example_side_info is None:
-        per_example: list[dict[str, Any]] = [{} for _ in example_ids]
-    else:
-        per_example = [dict(item) for item in eval_result.per_example_side_info]
-        if len(per_example) != len(example_ids):
-            # Length skew between ``instance_scores`` and ``per_example_side_info``
-            # almost certainly indicates an upstream bug (the two are positional
-            # over the same example id list).  Don't silently throw away the
-            # caller's diagnostics — warn loudly and rebuild empty so reflection
-            # still gets the top-K history rather than crashing.
-            logger.warning(
-                "per_example_side_info length (%d) does not match "
-                "instance_scores length (%d) for candidate %s; rebuilding "
-                "side_info from empty before injecting top_k history.",
-                len(per_example),
-                len(example_ids),
-                eval_result.candidate_id,
-            )
-            per_example = [{} for _ in example_ids]
-
-    for idx, eid in enumerate(example_ids):
-        history_rows = history_by_id.get(eid)
-        if history_rows:
-            per_example[idx]["top_k_best_example_history"] = history_rows
-    eval_result.per_example_side_info = per_example
-    return eval_result
-
-
 def _run_full_val_eval(
     candidate: Candidate,
     state: EvolutionState,
@@ -2363,11 +2300,6 @@ def _run_evolution_impl(
                 # ---- Step W2: Build eval_for_mutate ----
                 assert _parent_eval is not None
                 _eval_for_mutate = _parent_eval
-
-                # Inject top-k history (read-only from frontier — safe in parallel)
-                _eval_for_mutate = _inject_top_k_best_example_history(
-                    _eval_for_mutate, frontier
-                )
 
                 # ---- Step W3: Skip-perfect check ----
                 # GEPA parity (reflective_mutation.py:308-327): fires on both

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -25,7 +25,6 @@ from helix.config import (
 )
 from helix.evolution import (
     HelixDataLoader,
-    _inject_top_k_best_example_history,
     _make_data_loader,
     _reconcile_incomplete_attempts_on_resume,
     run_evolution,
@@ -87,79 +86,8 @@ def _init_repo(path: Path) -> None:
     _git(["config", "user.email", "helix-test@noreply"], path)
 
 
-def test_top_k_best_example_history_injection_preserves_side_info() -> None:
-    """Reflection evals expose top-K per-example frontier history."""
-    frontier = ParetoFrontier()
-    cand_a = _make_candidate("cand-a")
-    cand_b = _make_candidate("cand-b")
-    frontier.add(cand_a, _make_result("cand-a", {"0": 0.2, "1": 0.9}))
-    frontier.add(cand_b, _make_result("cand-b", {"0": 0.8, "1": 0.4}))
-
-    current = EvalResult(
-        candidate_id="cand-current",
-        scores={},
-        asi={},
-        instance_scores={"0": 0.1, "1": 0.1},
-        per_example_side_info=[{"trace": "keep-0"}, {"trace": "keep-1"}],
-    )
-
-    updated = _inject_top_k_best_example_history(current, frontier, k=1)
-
-    assert updated.per_example_side_info == [
-        {
-            "trace": "keep-0",
-            "top_k_best_example_history": [
-                {"candidate_id": "cand-b", "score": 0.8}
-            ],
-        },
-        {
-            "trace": "keep-1",
-            "top_k_best_example_history": [
-                {"candidate_id": "cand-a", "score": 0.9}
-            ],
-        },
-    ]
-
-
-def test_top_k_best_example_history_warns_on_side_info_length_skew(
-    caplog: Any,
-) -> None:
-    """A length mismatch between instance_scores and per_example_side_info
-    indicates an upstream bug; injection must warn (not silently drop the
-    user's diagnostics) before rebuilding empty.
-    """
-    import logging
-
-    frontier = ParetoFrontier()
-    cand_a = _make_candidate("cand-a")
-    frontier.add(cand_a, _make_result("cand-a", {"0": 0.5, "1": 0.7}))
-
-    # 2 examples but only 1 side_info dict — clearly skewed.
-    current = EvalResult(
-        candidate_id="cand-skewed",
-        scores={},
-        asi={},
-        instance_scores={"0": 0.0, "1": 0.0},
-        per_example_side_info=[{"trace": "lonely"}],
-    )
-
-    with caplog.at_level(logging.WARNING, logger="helix.evolution"):
-        updated = _inject_top_k_best_example_history(current, frontier, k=1)
-
-    assert any(
-        "per_example_side_info length" in rec.message for rec in caplog.records
-    ), f"expected length-skew warning, got: {[r.message for r in caplog.records]}"
-    assert updated.per_example_side_info == [
-        {"top_k_best_example_history": [{"candidate_id": "cand-a", "score": 0.5}]},
-        {"top_k_best_example_history": [{"candidate_id": "cand-a", "score": 0.7}]},
-    ]
-
-
 def test_pareto_frontier_public_accessors_match_internal_state() -> None:
-    """``iter_results`` / ``get_result`` / ``has_results`` are the public
-    surface used by ``_inject_top_k_best_example_history``; pin their
-    contract so we don't regress to ``_results`` poking.
-    """
+    """``iter_results`` / ``get_result`` / ``has_results`` expose stable results."""
     frontier = ParetoFrontier()
     assert frontier.has_results() is False
     assert frontier.get_result("missing") is None
@@ -2568,8 +2496,6 @@ class TestStoppingConditionValidation:
         )
         # Must NOT raise — max_generations=1 is a valid stopping condition.
         run_evolution(config, tmp_path, tmp_path / ".helix")
-
-
 # ---------------------------------------------------------------------------
 # Atomic Proposal Worker Tests
 #
@@ -2992,4 +2918,3 @@ class TestAtomicProposalWorker:
             assert snapped is None or snapped.id != child.id, (
                 f"snapshot_candidate must not be called for tampered child {child.id}"
             )
-


### PR DESCRIPTION
## Summary

- remove automatic `top_k_best_example_history` injection from mutation prompts so reflection only sees the current minibatch feedback
- keep Helix on a single `evolution.minibatch_size` knob for reflective mutation minibatches
- update tests and README for the prompt-memory behavior

## Why

Historical information persists through the candidate artifacts and Pareto frontier, not through an accumulated feedback buffer. Helix was adding synthetic per-example frontier history to the prompt, which made reflection stateful across minibatches.

## Validation

- `uv run pytest tests/unit/ -q`
- `uv run mypy --strict src/helix/`