### PR TITLE
feat(cache): preserve per-(candidate, example) side_info across cache hits

### DIFF
--- a/src/helix/batch_sampler.py
+++ b/src/helix/batch_sampler.py
@@ -1,8 +1,8 @@
 """HELIX minibatch sampler — GEPA parity.
 
-Line-for-line port of
-  gepa.strategies.batch_sampler.EpochShuffledBatchSampler
-(see /tmp/gepa_eval_spec.md §2).
+Port of ``gepa.strategies.batch_sampler.EpochShuffledBatchSampler``
+(see ``src/gepa/strategies/batch_sampler.py`` in the public GEPA repo,
+``github.com/gepa-ai/gepa``).
 
 Also provides :class:`StratifiedBatchSampler`, which is a HELIX extension
 over EpochShuffledBatchSampler that guarantees each minibatch of size K

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -344,7 +344,7 @@ class EvolutionConfig(BaseModel):
             "Max parallel eval workers — bounds both the parent-eval and "
             "mutation ThreadPools in the num_parallel_proposals pipeline. "
             "GEPA parity: EngineConfig.max_workers "
-            "(/tmp/gepa-official/src/gepa/optimize_anything.py:485, "
+            "(src/gepa/optimize_anything.py:485, "
             "default os.cpu_count() or 32)."
         ),
     )
@@ -425,7 +425,7 @@ class EvolutionConfig(BaseModel):
         # GEPA parity: resolve ``num_parallel_proposals="auto"`` to
         # ``max(1, max_workers // minibatch_size)`` once at construction
         # time so every downstream consumer sees a plain int.  Mirrors
-        # /tmp/gepa-official/src/gepa/optimize_anything.py:1108-1116.
+        # GEPA src/gepa/optimize_anything.py:1108-1116.
         if self.num_parallel_proposals == "auto":
             self.num_parallel_proposals = max(
                 1, self.max_workers // max(1, self.minibatch_size)

--- a/src/helix/eval_cache.py
+++ b/src/helix/eval_cache.py
@@ -1,7 +1,21 @@
 """HELIX evaluation cache — GEPA parity.
 
-Line-for-line port of the cache layer described in
-/tmp/gepa_eval_spec.md §3 (originally at gepa/core/state.py:27-130).
+Port of the cache layer from GEPA's ``gepa/core/state.py:27-130``
+(public source at ``github.com/gepa-ai/gepa``), extended with a
+per-(candidate, example) ``side_info`` slot.
+
+The base GEPA ``CachedEvaluation`` stores only ``(output, score,
+objective_scores)``.  GEPA's ``OptimizeAnythingAdapter._eval_cache``
+(``gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py:92,
+200-216``) caches the richer ``(score, output, side_info)`` tuple in a
+*second* adapter-level cache, precisely because reflection prompts need
+the side_info to survive a cache hit.  HELIX has no analogous adapter
+cache — the engine-level cache is the only one — so we fold the
+side_info slot into ``CachedEvaluation`` here.  This preserves the
+LIBERO feedback signal (``evaluation_diagnostics``, ``judge_metrics``,
+``evaluator_error``, ``video_path``, ...) across cache hits, which is
+what reaches the mutator's ``## Diagnostics`` section
+(see ``helix.mutator._render_per_example_diagnostics``).
 """
 from __future__ import annotations
 
@@ -31,9 +45,20 @@ def _candidate_hash(candidate: dict[str, str]) -> CandidateHash:
 
 @dataclass
 class CachedEvaluation(Generic[RolloutOutput]):
+    """Per-(candidate, example) cached evaluation entry.
+
+    ``output``, ``score``, and ``objective_scores`` mirror GEPA's
+    base ``CachedEvaluation`` (``gepa/core/state.py:37-43``).  ``side_info``
+    is the HELIX-specific extension that lets per-example reflection
+    diagnostics (LIBERO feedback, evaluator error traces, judge metrics,
+    media references, ...) survive cache hits — see the module docstring
+    for the GEPA OptimizeAnythingAdapter precedent.
+    """
+
     output: RolloutOutput
     score: float
     objective_scores: dict[str, float] | None = None
+    side_info: dict[str, Any] | None = None
 
 
 @dataclass
@@ -41,8 +66,8 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
     _cache: dict[CacheKey, CachedEvaluation[RolloutOutput]] = field(
         default_factory=dict
     )
-    # Thread safety (audit-mutation §C4 / audit-budget-caching §C1): the
-    # parent-minibatch eval now runs inside a ThreadPoolExecutor (see
+    # Thread safety: the parent-minibatch eval runs inside a
+    # ThreadPoolExecutor (see
     # evolution.py parent-eval parallel stage), so concurrent readers/writers
     # can race on ``_cache``.  A single lock serialises every access.
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
@@ -60,10 +85,11 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         output: RolloutOutput,
         score: float,
         objective_scores: dict[str, float] | None = None,
+        side_info: dict[str, Any] | None = None,
     ) -> None:
         with self._lock:
             self._cache[(_candidate_hash(candidate), example_id)] = CachedEvaluation(
-                output, score, objective_scores
+                output, score, objective_scores, side_info
             )
 
     def get_batch(
@@ -95,6 +121,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         outputs: list[RolloutOutput],
         scores: list[float],
         objective_scores_list: list[dict[str, float]] | None = None,
+        side_info_list: list[dict[str, Any]] | None = None,
     ) -> None:
         h = _candidate_hash(candidate)
         with self._lock:
@@ -103,6 +130,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                     outputs[i],
                     scores[i],
                     objective_scores_list[i] if objective_scores_list else None,
+                    side_info_list[i] if side_info_list else None,
                 )
         TRACE.emit(
             EventType.CACHE_PUT,
@@ -117,14 +145,36 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         fetcher: Callable[[list[DataId]], Any],
         evaluator: Callable[
             [Any, dict[str, str]],
-            tuple[list[RolloutOutput], list[float], list[dict[str, float]] | None],
+            tuple[
+                list[RolloutOutput],
+                list[float],
+                list[dict[str, float]] | None,
+                list[dict[str, Any]] | None,
+            ],
         ],
     ) -> tuple[
         dict[DataId, RolloutOutput],
         dict[DataId, float],
         dict[DataId, dict[str, float]] | None,
+        dict[DataId, dict[str, Any]] | None,
         int,
     ]:
+        """Evaluate ``candidate`` on ``example_ids`` with per-example caching.
+
+        Evaluator return shape (4-tuple):
+
+          ``(outputs, scores, objective_scores, side_infos)``
+
+        ``objective_scores`` and ``side_infos`` are both optional
+        (``None`` allowed).  When provided they must be positional to
+        ``batch`` (length ``len(batch)``).
+
+        Returns ``(outputs_by_id, scores_by_id, objective_by_id,
+        side_info_by_id, num_actual_evals)``.  ``objective_by_id`` and
+        ``side_info_by_id`` are ``None`` when no entry — cached or
+        fresh — produced that axis; otherwise they cover the union of
+        cache-hit and fresh-miss ids for which the axis was non-empty.
+        """
         cached, uncached_ids = self.get_batch(candidate, example_ids)
         outputs_by_id: dict[DataId, RolloutOutput] = {
             eid: c.output for eid, c in cached.items()
@@ -133,14 +183,19 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
             eid: c.score for eid, c in cached.items()
         }
         objective_by_id: dict[DataId, dict[str, float]] | None = None
+        side_info_by_id: dict[DataId, dict[str, Any]] | None = None
         for eid, c in cached.items():
             if c.objective_scores is not None:
                 if objective_by_id is None:
                     objective_by_id = {}
                 objective_by_id[eid] = c.objective_scores
+            if c.side_info is not None:
+                if side_info_by_id is None:
+                    side_info_by_id = {}
+                side_info_by_id[eid] = c.side_info
         if uncached_ids:
             batch = fetcher(uncached_ids)
-            outputs, scores, obj_scores = evaluator(batch, candidate)
+            outputs, scores, obj_scores, side_infos = evaluator(batch, candidate)
             for idx, eid in enumerate(uncached_ids):
                 outputs_by_id[eid] = outputs[idx]
                 scores_by_id[eid] = scores[idx]
@@ -148,5 +203,22 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                     if objective_by_id is None:
                         objective_by_id = {}
                     objective_by_id[eid] = obj_scores[idx]
-            self.put_batch(candidate, uncached_ids, outputs, scores, obj_scores)
-        return outputs_by_id, scores_by_id, objective_by_id, len(uncached_ids)
+                if side_infos is not None:
+                    if side_info_by_id is None:
+                        side_info_by_id = {}
+                    side_info_by_id[eid] = side_infos[idx]
+            self.put_batch(
+                candidate,
+                uncached_ids,
+                outputs,
+                scores,
+                obj_scores,
+                side_infos,
+            )
+        return (
+            outputs_by_id,
+            scores_by_id,
+            objective_by_id,
+            side_info_by_id,
+            len(uncached_ids),
+        )

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -891,8 +891,7 @@ def _cached_evaluate_batch(
         return result, len(example_ids)
 
     # Cached branch — delegate to the GEPA-parity helper on the cache
-    # itself (helix.eval_cache.EvaluationCache.evaluate_with_cache_full,
-    # which is a line-for-line port of GEPA state.py:94-130).
+    # itself (helix.eval_cache.EvaluationCache.evaluate_with_cache_full).
     # Cache keys must remain stable across equivalent candidate content, but
     # train/val batches must not alias when they share positional ids like
     # "0", "1", ... .
@@ -900,15 +899,6 @@ def _cached_evaluate_batch(
         "content_key": _candidate_content_key(candidate),
         "split": split,
     }
-
-    # Closure side-channel: the cache stores ``(output, score, objective_scores)``
-    # per id but has no slot for freeform ``side_info``.  Collect fresh
-    # per-example side_info in a closure dict so we can attach it to the
-    # merged ``EvalResult`` below.  Cache-hit ids (not in this dict) get
-    # ``{}`` as their per_example_side_info slot — their prior side_info
-    # was consumed by the reflection prompt at their original eval time
-    # and is not round-tripped through the cache.
-    fresh_side_info_by_id: dict[str, dict[str, Any]] = {}
 
     def _fetcher(ids: list[str]) -> list[str]:
         # HELIX evaluators read batches off disk via helix_batch.json;
@@ -920,15 +910,20 @@ def _cached_evaluate_batch(
     def _evaluator(
         batch: list[str],
         _candidate: dict[str, str],
-    ) -> tuple[list[object], list[float], list[dict[str, float]] | None]:
+    ) -> tuple[
+        list[object],
+        list[float],
+        list[dict[str, float]] | None,
+        list[dict[str, Any]] | None,
+    ]:
         # Write a REDUCED helix_batch.json containing only the uncached
         # example ids, then invoke the evaluator subprocess.  Evaluators
         # read that file from cwd and filter their own dataset to exactly
         # these ids; run_evaluator additionally post-filters
         # instance_scores to ``batch`` in executor.py:245.
         # Per-worktree lock: see ``_worktree_lock`` — parent-minibatch
-        # parallelism (audit-mutation §C4) requires serialising the
-        # ``write_helix_batch`` + ``run_evaluator`` pair on a given worktree.
+        # parallelism requires serialising the ``write_helix_batch`` +
+        # ``run_evaluator`` pair on a given worktree.
         with _worktree_lock(candidate.worktree_path):
             _refresh_protected_evaluator_files(candidate, config, project_root)
             _write_helix_batch(candidate.worktree_path, batch)
@@ -955,26 +950,38 @@ def _cached_evaluate_batch(
         # ``EvaluationBatch.objective_scores`` parity
         # (``src/gepa/core/adapter.py:26``).  Feeds the multi-axis
         # Pareto frontier when ``evolution.frontier_type`` is
-        # ``"objective"``, ``"hybrid"``, or ``"cartesian"``.  The
-        # underlying ``EvaluationCache`` already has a slot for this
-        # (``put_batch(..., objective_scores_list=...)``); previously
-        # ``_evaluator`` returned ``None`` here and the multi-axis data
-        # was dropped on the cached path.
+        # ``"objective"``, ``"hybrid"``, or ``"cartesian"``.
         obj_list: list[dict[str, float]] | None = None
         if fresh.objective_scores is not None and len(fresh.objective_scores) == len(
             batch
         ):
             obj_list = [fresh.objective_scores[i] for i in range(len(batch))]
-        # Capture per-example side_info for the outer merge.  Only
-        # freshly-evaluated ids populate this; cache hits remain ``{}``.
+        # Thread per-example side_info through the cache.  GEPA's
+        # ``OptimizeAnythingAdapter._eval_cache`` stores side_info under
+        # ``(score, output, side_info)`` keys
+        # (``gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py:200-216``);
+        # we fold the same slot into ``CachedEvaluation.side_info`` so
+        # that on cache hits the reflection-feedstock (LIBERO
+        # ``evaluation_diagnostics`` / ``judge_metrics`` /
+        # ``evaluator_error`` / ``video_path``) re-materialises into the
+        # mutator's ``## Diagnostics`` section without re-running the
+        # evaluator.  Pre-extension behaviour gave cache-hit ids a ``{}``
+        # placeholder, which silently dropped the LIBERO feedback signal
+        # the second time a (candidate, example) pair was scored.
+        side_info_list: list[dict[str, Any]] | None = None
         if fresh.per_example_side_info is not None and len(
             fresh.per_example_side_info
         ) == len(batch):
-            for i, eid in enumerate(batch):
-                fresh_side_info_by_id[eid] = fresh.per_example_side_info[i]
-        return outputs, scores, obj_list
+            side_info_list = [fresh.per_example_side_info[i] for i in range(len(batch))]
+        return outputs, scores, obj_list, side_info_list
 
-    _, scores_by_id, objective_by_id, num_actual_evals = cache.evaluate_with_cache_full(
+    (
+        _,
+        scores_by_id,
+        objective_by_id,
+        side_info_by_id,
+        num_actual_evals,
+    ) = cache.evaluate_with_cache_full(
         cand_dict,
         example_ids,
         _fetcher,
@@ -997,9 +1004,9 @@ def _cached_evaluate_batch(
     if objective_by_id is not None:
         objective_scores_list = [objective_by_id.get(eid, {}) for eid in example_ids]
     per_example_side_info_list: list[dict[str, Any]] | None = None
-    if fresh_side_info_by_id:
+    if side_info_by_id is not None:
         per_example_side_info_list = [
-            fresh_side_info_by_id.get(eid, {}) for eid in example_ids
+            side_info_by_id.get(eid, {}) for eid in example_ids
         ]
 
     merged = EvalResult(
@@ -1374,7 +1381,7 @@ def _run_evolution_impl(
     # Use ``object`` for the output type parameter: HELIX only stores
     # per-(candidate, example) scores here, not rollout outputs.
     #
-    # GEPA parity (audit-rng-state-persist C1): on resume, restore the
+    # GEPA parity: on resume, restore the
     # cache contents from .helix/eval_cache.pkl when caching is enabled.
     # Mirrors GEPA's behaviour at gepa/core/state.py:683-687
     # (initialize_gepa_state) — when ``cache_evaluation`` is off we drop any
@@ -1432,7 +1439,7 @@ def _run_evolution_impl(
         evaluator_manifest = current_root_manifest
         _write_evaluator_integrity_manifest(base_dir, evaluator_manifest)
 
-    # GEPA parity (audit-rng-state-persist C1): bundle eval-cache persistence
+    # GEPA parity: bundle eval-cache persistence
     # with state.json writes.  GEPA's single ``GEPAState.save`` call pickles
     # the cache atomically alongside everything else (state.py:306-340); HELIX
     # routes the (candidate_id, example_id)-keyed companion pickle through
@@ -1618,7 +1625,7 @@ def _run_evolution_impl(
         frontier.add(seed, seed_result)
         _sync_frontier_state()
         state.instance_scores[seed.id] = seed_result.instance_scores
-        # GEPA parity (audit-rng-state-persist C/§3): record per-program
+        # GEPA parity: record per-program
         # discovery budget at the moment the program enters the frontier.
         # Mirrors GEPA core/state.py:537 (``num_metric_calls_by_discovery
         # .append(num_metric_calls_by_discovery_of_new_program)`` inside
@@ -1708,8 +1715,8 @@ def _run_evolution_impl(
             # previous acceptance).  If merge fires, skip mutation entirely
             # (``continue``).  This matches GEPA core/engine.py:664-737.
             # =============================================================
-            # GEPA parity (M2 fallthrough — audit-init-engine.md B3):
-            # merge_attempted tracks whether an actual merge eval happened this
+            # GEPA parity (M2 fallthrough): merge_attempted tracks
+            # whether an actual merge eval happened this
             # iteration.  GEPA engine.py:664-741 only ``continue``s past the
             # reflective mutation block when a merge is accepted (line 719) or
             # rejected (line 737) — i.e. after the merged candidate has been
@@ -1763,8 +1770,8 @@ def _run_evolution_impl(
                 # ``triplet is None`` — both paths now fall through to
                 # reflective mutation (GEPA engine.py:741-742).
                 #
-                # GEPA parity (merge-pairing audit D1, /tmp/audit_audit-merge-pairing.md:49-50):
-                # mirror GEPA ``merge.py:130-131`` — you need two siblings plus
+                # GEPA parity: mirror GEPA
+                # ``merge.py:130-131`` — you need two siblings plus
                 # one ancestor, so fewer than 3 total candidates can never
                 # yield a valid triplet.  Kept as an explicit guard for
                 # clarity; functionally equivalent to ``find_merge_triplet``
@@ -1775,8 +1782,7 @@ def _run_evolution_impl(
                 if len(lineage) < 3:
                     triplet = None
                 else:
-                    # GEPA parity (merge-pairing audit B1/B2,
-                    # /tmp/audit_audit-merge-pairing.md:10-22): push the
+                    # GEPA parity: push the
                     # "already-attempted pair" and "val-support overlap"
                     # filters INTO ``find_merge_triplet``'s retry loop so a
                     # blocked sample triggers resampling rather than bailing
@@ -1808,7 +1814,7 @@ def _run_evolution_impl(
                     )
 
                 if triplet is not None:
-                    # GEPA parity (merge-pairing audit C3, merge.py:94-95):
+                    # GEPA parity (merge.py:94-95):
                     # ``find_merge_triplet`` now returns the canonical
                     # ``(i, j)`` (lex-sorted), so ``cid_i <= cid_j`` always —
                     # the merge subprocess, attempted-pair ledger and the
@@ -1878,8 +1884,7 @@ def _run_evolution_impl(
                         )
                         if merge_tamper:
                             # Evaluator-tamper reject happens PRE-eval — no
-                            # merge was attempted in the GEPA sense
-                            # (audit-init-engine.md B3).  Fall through.
+                            # merge was attempted in the GEPA sense.  Fall through.
                             print_warning(
                                 f"Merge {merge_id} touched protected evaluator files "
                                 f"({', '.join(merge_tamper)}) -- rejecting."
@@ -1902,8 +1907,7 @@ def _run_evolution_impl(
                             # crashes (e.g. empty-commit), state is already
                             # persisted and resume can skip re-doing this merge.
                             _save_state(state)
-                            # GEPA parity (merge-pairing audit C1,
-                            # /tmp/audit_audit-merge-pairing.md:28-31): the
+                            # GEPA parity: the
                             # HEAD SHA of the snapshotted worktree is HELIX's
                             # port of GEPA's ``new_prog_desc`` (merge.py:195-203);
                             # content-addressed so two different triplets that
@@ -2020,8 +2024,7 @@ def _run_evolution_impl(
                             )
 
                             if merge_score >= required_score:
-                                # GEPA parity (merge-gate audit M3,
-                                # /tmp/audit_audit-merge-gate.md:10-32): after
+                                # GEPA parity: after
                                 # the subsample gate passes, run a FULL-valset
                                 # eval on the merged candidate and pass THAT
                                 # result (not the 5-id subsample) to
@@ -2063,8 +2066,8 @@ def _run_evolution_impl(
                                 state.instance_scores[merged.id] = (
                                     full_val_result.instance_scores
                                 )
-                                # GEPA parity (audit-rng-state-persist C/§3):
-                                # record per-program discovery budget at the
+                                # GEPA parity: record per-program
+                                # discovery budget at the
                                 # moment the merged program enters the
                                 # frontier.  GEPA core/state.py:537.
                                 budget_api.record_discovery_budget(state, merged.id)
@@ -2201,8 +2204,7 @@ def _run_evolution_impl(
                 # extra parallel proposal above (engine.py:408) — so the
                 # sampler always sees the right counter.  The parent-on-
                 # minibatch eval is deferred to §1b so that N parent evals
-                # overlap under ``num_parallel_proposals > 1``
-                # (audit-mutation §C4 MODERATE E).
+                # overlap under ``num_parallel_proposals > 1``.
                 subsample_ids: list[str] | None = None
                 if (
                     use_minibatch_gate
@@ -2718,7 +2720,7 @@ def _run_evolution_impl(
                     gating_result.candidate_id = child.id
                     _last_eval_result = gating_result
                     # Single-task/no-example mode still charges on train eval.
-                    # GEPA parity (MODERATE D — audit-mutation.md C3):
+                    # GEPA parity:
                     # same strict-sum acceptance criterion as minibatch path.
                     budget_api.charge_evaluation(
                         state, was_cached=_gating_cached, candidate_id=child.id,
@@ -2853,7 +2855,7 @@ def _run_evolution_impl(
                 frontier.add(child, val_result)
                 _sync_frontier_state()
                 state.instance_scores[child.id] = val_result.instance_scores
-                # GEPA parity (audit-rng-state-persist C/§3): record per-program
+                # GEPA parity: record per-program
                 # discovery budget at the moment the child enters the frontier.
                 # GEPA core/state.py:537.
                 budget_api.record_discovery_budget(state, child.id)

--- a/src/helix/lineage.py
+++ b/src/helix/lineage.py
@@ -125,7 +125,7 @@ def find_merge_triplet(
     GEPA parity (L1): improvement filter is non-strict (``>``) matching
     GEPA merge.py:59 — ancestor score must not exceed either candidate.
 
-    GEPA parity (merge-pairing audit B1/B2/C3, /tmp/audit_audit-merge-pairing.md):
+    GEPA parity:
     - Canonicalize ``(i, j)`` inside the sampling loop so downstream
       consumers (the merge subprocess, the attempted-pair ledger) always
       see a lex-sorted tuple.  Mirrors GEPA ``merge.py:94-95``
@@ -184,7 +184,7 @@ def find_merge_triplet(
         if i == j:
             continue
 
-        # GEPA parity (merge-pairing audit C3, merge.py:94-95): canonicalize
+        # GEPA parity (merge.py:94-95): canonicalize
         # pair so (i, j) and (j, i) land on the same (i, j) tuple for all
         # downstream consumers (merge subprocess arg order, attempted-pair
         # ledger, description-triplet dedup).  HELIX ids are strings, so
@@ -192,13 +192,13 @@ def find_merge_triplet(
         if j < i:
             i, j = j, i
 
-        # GEPA parity (merge-pairing audit B2, merge.py:147-148): skip
+        # GEPA parity (merge.py:147-148): skip
         # already-attempted pairs inside the retry loop instead of burning
         # the whole propose() call.
         if attempted_pairs is not None and (i, j) in attempted_pairs:
             continue
 
-        # GEPA parity (merge-pairing audit B1, merge.py:199-201): skip
+        # GEPA parity (merge.py:199-201): skip
         # pairs with insufficient val-support overlap inside the retry
         # loop.  This lets the next sample win instead of consuming the
         # whole generation on the first unlucky draw.

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shlex
 import subprocess
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from helix.backends import BACKEND_AUTH_ENV, backend_display_name
 from helix.display import UsageStats
@@ -21,6 +23,7 @@ from helix.exceptions import (
     print_helix_error,
 )
 from helix.executor import _scrub_environment
+from helix.redaction import redact_diagnostics
 from helix.sandbox import resolve_sandbox_image, run_sandboxed_command
 from helix.worktree import clone_candidate, snapshot_candidate, remove_worktree  # noqa: F401
 
@@ -335,6 +338,35 @@ def _render_side_info_value(value: Any, level: int) -> str:
     return str(value).strip() + "\n\n"
 
 
+# Keep paths out of prompts even when they are embedded in otherwise useful
+# evaluator feedback.  This is deliberately independent from the shared
+# value-aware redactor: an internal filesystem path is sensitive provenance,
+# not necessarily a configured secret value.
+_ABSOLUTE_FILESYSTEM_PATH = re.compile(
+    r"(?<![A-Za-z0-9_:])/(?:[^\s/]+/)*[^\s/]+"
+)
+_REDACTED_FILESYSTEM_PATH = "<filesystem-path>"
+
+
+def _redact_filesystem_paths(value: Any) -> Any:
+    """Recursively remove absolute filesystem paths from diagnostic values.
+
+    Dictionary keys deliberately remain unchanged: they name the diagnostic
+    signal, while only values can carry evaluator-local provenance.  This
+    function is called only while rendering prompts, after parsers and cache
+    handling have consumed the original evaluator result.
+    """
+    if isinstance(value, str):
+        return _ABSOLUTE_FILESYSTEM_PATH.sub(_REDACTED_FILESYSTEM_PATH, value)
+    if isinstance(value, dict):
+        return {key: _redact_filesystem_paths(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_filesystem_paths(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_filesystem_paths(item) for item in value)
+    return value
+
+
 def _render_per_example_diagnostics(
     example_ids: list[str],
     per_example_side_info: list[dict[str, Any]],
@@ -380,7 +412,8 @@ def _render_per_example_diagnostics(
     nested_level = min(key_header_level + 1, _MAX_MARKDOWN_HEADER_LEVEL)
 
     lines: list[str] = ["## Diagnostics"]
-    for eid, side_info in zip(example_ids, per_example_side_info):
+    for eid, raw_side_info in zip(example_ids, per_example_side_info):
+        side_info = cast(dict[str, Any], _redact_filesystem_paths(raw_side_info))
         lines.append("")
         lines.append(f"{example_hashes} Example {eid}")
         if not side_info:
@@ -406,6 +439,7 @@ def build_mutation_prompt(
     eval_result: EvalResult,
     background: str | None = None,
     max_turns: int | None = None,
+    secret_values: Iterable[object] = (),
 ) -> str:
     """Construct the mutation prompt for Claude Code."""
     scores_text = "\n".join(
@@ -458,14 +492,15 @@ def build_mutation_prompt(
             key_header_level=4,
         )
     elif eval_result.side_info is not None:
+        side_info = cast(dict[str, Any], _redact_filesystem_paths(eval_result.side_info))
         diag_lines = "\n".join(
-            f"  {k}: {v}" for k, v in sorted(eval_result.side_info.items())
+            f"  {k}: {v}" for k, v in sorted(side_info.items())
         )
         diagnostics_section = f"## Diagnostics\n{diag_lines}\n\n"
 
     bg = background or "(no additional background provided)"
 
-    return MUTATION_PROMPT_TEMPLATE.format(
+    prompt = MUTATION_PROMPT_TEMPLATE.format(
         system_prompt=AUTONOMOUS_SYSTEM_PROMPT,
         objective=objective,
         scores=scores_text,
@@ -475,6 +510,13 @@ def build_mutation_prompt(
         diagnostics_section=diagnostics_section,
         background=bg,
         turn_budget=_turn_budget_section(max_turns),
+    )
+    # The final prompt is the trust boundary.  Run both redactors here so
+    # evaluator values remain raw for parsing and cache parity, while every
+    # rendered diagnostic surface masks configured values and local paths.
+    return cast(
+        str,
+        redact_diagnostics(_redact_filesystem_paths(prompt), secret_values),
     )
 
 
@@ -1718,6 +1760,10 @@ def mutate(
         eval_result,
         background,
         config.agent.max_turns,
+        secret_values=_scrub_environment(
+            passthrough_env=config.passthrough_env,
+            fixed_env=config.env,
+        ).values(),
     )
 
     # Persist the rendered prompt to the worktree for post-hoc inspection:

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -15,7 +15,6 @@ minibatch gate whenever the evaluator keyed its dict by aggregate
 metric names (``task__metric``) instead of the per-example ids HELIX
 wrote to ``helix_batch.json`` (``task__trialN``): 113 generations of
 evolution were once wasted on exactly that zero-vs-zero footgun.
-See ``/tmp/gepa_audit_report.md`` for the full audit.
 
 Contract
 --------

--- a/src/helix/redaction.py
+++ b/src/helix/redaction.py
@@ -1,0 +1,65 @@
+"""Value-aware redaction for diagnostics rendered outside a trust boundary.
+
+The redactor protects a configured value only in its literal spelling or the
+JSON-string escaped spelling of that value.  It intentionally does not attempt
+to discover transformed, partial, or line-wrapped forms (for example base64,
+URL encoding, hexadecimal, or a token prefix): decoding arbitrary transforms
+is both incomplete and prone to false positives.  A known encoded environment
+value is protected when that exact encoded value is supplied to
+:meth:`DiagnosticRedactor.from_values`.
+
+Values shorter than eight characters and empty values are deliberately ignored
+to keep ordinary diagnostic text useful; this means sub-eight-character
+secrets are outside this utility's protection guarantee.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Final
+
+REDACTED_VALUE: Final = "<redacted>"
+_MIN_REDACTABLE_VALUE_LENGTH: Final = 8
+
+
+@dataclass(frozen=True)
+class DiagnosticRedactor:
+    """Replace configured secret values in strings and nested diagnostics."""
+
+    replacements: tuple[str, ...] = ()
+
+    @classmethod
+    def from_values(cls, values: Iterable[object]) -> DiagnosticRedactor:
+        """Build a redactor from configured values safe to match literally."""
+        literals = {
+            value
+            for value in values
+            if isinstance(value, str) and len(value) >= _MIN_REDACTABLE_VALUE_LENGTH
+        }
+        forms: set[str] = set(literals)
+        for value in literals:
+            forms.add(json.dumps(value, ensure_ascii=False)[1:-1])
+            forms.add(json.dumps(value, ensure_ascii=True)[1:-1])
+        return cls(tuple(sorted(forms, key=len, reverse=True)))
+
+    def redact(self, value: Any) -> Any:
+        """Return a recursively redacted copy, preserving keys and primitives."""
+        if isinstance(value, str):
+            redacted = value
+            for replacement in self.replacements:
+                redacted = redacted.replace(replacement, REDACTED_VALUE)
+            return redacted
+        if isinstance(value, dict):
+            return {key: self.redact(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [self.redact(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self.redact(item) for item in value)
+        return value
+
+
+def redact_diagnostics(value: Any, secret_values: Iterable[object]) -> Any:
+    """Convenience wrapper for one-off diagnostic rendering boundaries."""
+    return DiagnosticRedactor.from_values(secret_values).redact(value)

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -23,6 +23,15 @@ from helix.population import FrontierType
 # v0; ``load_state`` migrates by default-filling missing fields).
 SCHEMA_VERSION: int = 2
 
+# Schema version for the per-(candidate, example) eval cache pickle.
+# Bumped to 1 when ``CachedEvaluation`` gained a per-example ``side_info``
+# slot — pre-extension caches dropped the LIBERO reflection feedstock on
+# every hit, so a resume that silently kept them around would silently
+# keep dropping it.  ``load_eval_cache`` quarantines any payload without
+# this version (treated as schema 0) instead of loading it, so the next
+# eval pass repopulates the cache with the new slot filled.
+EVAL_CACHE_SCHEMA_VERSION: int = 1
+
 
 @dataclass
 class BudgetState:
@@ -267,13 +276,22 @@ def save_eval_cache(cache_dict: dict[Any, Any], base_dir: Path) -> None:
     ``MinibatchEvalCache._cache`` directly.  No-op semantics for an empty
     cache: the file is still written so that resume can reliably distinguish
     "cache disabled in last run" from "cache enabled but empty".
+
+    The payload is a ``{"schema_version": int, "entries": cache_dict}``
+    envelope rather than the bare cache dict — ``load_eval_cache`` rejects
+    older shapes so a pre-extension cache (no ``CachedEvaluation.side_info``
+    slot) is not silently revived.  See ``EVAL_CACHE_SCHEMA_VERSION``.
     """
     target = _eval_cache_path(base_dir)
     target.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=target.parent, suffix=".tmp")
+    payload: dict[str, Any] = {
+        "schema_version": EVAL_CACHE_SCHEMA_VERSION,
+        "entries": cache_dict,
+    }
     try:
         with os.fdopen(fd, "wb") as f:
-            pickle.dump(cache_dict, f)
+            pickle.dump(payload, f)
         os.replace(tmp_path, target)
     except Exception:
         try:
@@ -287,10 +305,19 @@ def load_eval_cache(base_dir: Path) -> dict[Any, Any] | None:
     """Load the per-(candidate, example) eval cache, or None if absent.
 
     GEPA parity: mirrors the cache-restore behaviour at
-    gepa/core/state.py:348-376.  Returns the raw dict so the
+    gepa/core/state.py:348-376.  Returns the raw entries dict so the
     caller can install it on a freshly constructed cache instance (the
     caller decides whether caching is enabled — see ``initialize_gepa_state``
     at gepa/core/state.py:683-687 for the equivalent gating).
+
+    Schema check: payloads without the current ``schema_version`` are
+    quarantined and treated as absent so the next eval pass repopulates
+    the cache.  This is deliberate, not "backwards compatibility": a
+    pre-extension cache (``CachedEvaluation`` without the ``side_info``
+    slot) silently reproduces the very LIBERO-reflection regression the
+    slot was added to fix, so silently keeping it on resume would
+    persist the bug.  The old payload is preserved on disk under a
+    timestamped suffix for diagnostics.
     """
     target = _eval_cache_path(base_dir)
     if not target.exists():
@@ -316,7 +343,35 @@ def load_eval_cache(base_dir: Path) -> dict[Any, Any] | None:
             stacklevel=2,
         )
         return None
-    return loaded
+    # Schema-version guard.  A payload without ``schema_version`` is a
+    # pre-extension cache (bare ``dict[CacheKey, CachedEvaluation]`` with
+    # no ``side_info`` slot); quarantine it so the next eval pass refills
+    # the new slot rather than silently losing the reflection feedstock.
+    version = loaded.get("schema_version") if "schema_version" in loaded else None
+    if version != EVAL_CACHE_SCHEMA_VERSION:
+        quarantined = _quarantine_corrupt_cache(
+            target, reason=f"schema-v{version}-expected-v{EVAL_CACHE_SCHEMA_VERSION}"
+        )
+        warnings.warn(
+            f"Ignoring eval cache at {target}: schema_version={version!r} "
+            f"does not match current {EVAL_CACHE_SCHEMA_VERSION}.  The next "
+            f"eval pass will repopulate the cache with the current shape.  "
+            f"Previous payload preserved at {quarantined}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
+    entries = loaded.get("entries")
+    if not isinstance(entries, dict):
+        quarantined = _quarantine_corrupt_cache(target, reason="malformed-envelope")
+        warnings.warn(
+            f"Ignoring eval cache at {target}: envelope missing 'entries' "
+            f"dict (got {type(entries).__name__}). Quarantined to {quarantined}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
+    return entries
 
 
 def _quarantine_corrupt_cache(target: Path, *, reason: str) -> Path:

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -15,8 +15,8 @@ from typing import Any
 from helix.population import FrontierType
 
 
-# GEPA parity (audit-rng-state-persist D1):
-# GEPA core/state.py:153 declares ``_VALIDATION_SCHEMA_VERSION: ClassVar[int] = 5``
+# GEPA parity: GEPA core/state.py:153 declares
+# ``_VALIDATION_SCHEMA_VERSION: ClassVar[int] = 5``
 # and migrates older state dicts on load (state.py:355-376).  HELIX previously
 # had no schema version on ``state.json``; subsequent bumps mark explicit
 # JSON-native schema additions (the unversioned predecessor is treated as
@@ -85,10 +85,10 @@ class EvolutionState:
     # Each entry is [cid_i, cid_j] sorted lexicographically.  Kept for
     # backward-compat with existing state files; the within-propose retry
     # filter in ``lineage.find_merge_triplet`` reads this set to short-
-    # circuit already-seen pairs (merge-pairing audit B2).
+    # circuit already-seen pairs.
     merge_attempted_pairs: list[list[str]] = field(default_factory=list)
-    # GEPA parity (merge-pairing audit C1, /tmp/audit_audit-merge-pairing.md:28-31):
-    # mirrors GEPA ``merges_performed[1]`` at gepa/proposer/merge.py:195-203.
+    # GEPA parity: mirrors GEPA ``merges_performed[1]`` at
+    # gepa/proposer/merge.py:195-203.
     # Each entry is [cid_i, cid_j, desc_hash] with cid_i <= cid_j
     # lexicographically and desc_hash = post-snapshot git SHA of the
     # merged worktree.  Blocks only the *same* (pair, output) triplet,
@@ -99,7 +99,7 @@ class EvolutionState:
     # Starts at -1 and is bumped to 0 before the first minibatch sample.
     # Mirrors GEPA ``state.i`` in core/state.py.
     i: int = -1
-    # GEPA parity (audit-rng-state-persist C/§3): per-program discovery budget.
+    # GEPA parity: per-program discovery budget.
     # GEPA tracks ``num_metric_calls_by_discovery: list[int]`` indexed by
     # program_idx (state.py:177, appended at state.py:537).  HELIX uses
     # candidate_id strings, so the dict keys by id and stores the value of
@@ -126,7 +126,7 @@ class EvolutionState:
     # a GEPA-style single pickled artifact: HELIX still persists worktrees,
     # evaluations, lineage, and state as separate artifacts.
     resume_semantics: dict[str, Any] = field(default_factory=dict)
-    # GEPA parity (audit-rng-state-persist D1): persisted schema version.
+    # GEPA parity: persisted schema version.
     # Mirrors GEPA core/state.py:182 / class-var :153.  Bumped when the
     # serialized schema changes; ``load_state`` migrates older payloads by
     # supplying defaults for any missing fields.
@@ -135,7 +135,7 @@ class EvolutionState:
 
 _STATE_FILENAME = "state.json"
 _STATE_DIR = ".helix"
-# GEPA parity (audit-rng-state-persist C1): companion pickle for the
+# GEPA parity: companion pickle for the
 # per-(candidate_hash, example_id) eval cache.  GEPA pickles the whole state
 # dict, which round-trips its tuple-keyed ``EvaluationCache._cache`` for free
 # (gepa/core/state.py:306-340).  HELIX persists state as JSON, which cannot
@@ -158,8 +158,8 @@ def save_state(state: EvolutionState, base_dir: Path) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
 
     data = {
-        # GEPA parity (audit-rng-state-persist D1): schema_version is written
-        # FIRST so a stripped/legacy state.json without it loads as v0 and
+        # GEPA parity: schema_version is written FIRST so a
+        # stripped/legacy state.json without it loads as v0 and
         # triggers the migration branch in ``load_state``.
         "schema_version": SCHEMA_VERSION,
         "generation": state.generation,
@@ -202,7 +202,7 @@ def load_state(base_dir: Path) -> EvolutionState | None:
     with open(target) as f:
         data = json.load(f)
 
-    # GEPA parity (audit-rng-state-persist D1): migrate older payloads.
+    # GEPA parity: migrate older payloads.
     # GEPA's analogue is ``GEPAState._upgrade_state_dict`` (state.py:402-420):
     # supply defaults for any missing fields, then bump the version stamp.
     # HELIX treats a missing ``schema_version`` as v0 (the unversioned
@@ -260,8 +260,8 @@ def load_state(base_dir: Path) -> EvolutionState | None:
 def save_eval_cache(cache_dict: dict[Any, Any], base_dir: Path) -> None:
     """Atomically pickle the per-(candidate, example) eval cache.
 
-    GEPA parity (audit-rng-state-persist C1): mirrors the cache-survival
-    behaviour of ``GEPAState.save`` at gepa/core/state.py:306-340.  HELIX
+    GEPA parity: mirrors the cache-survival behaviour of
+    ``GEPAState.save`` at gepa/core/state.py:306-340.  HELIX
     uses JSON for ``state.json`` (which cannot round-trip tuple keys), so the
     cache is written to a sibling pickle.  Caller should pass
     ``MinibatchEvalCache._cache`` directly.  No-op semantics for an empty
@@ -286,8 +286,8 @@ def save_eval_cache(cache_dict: dict[Any, Any], base_dir: Path) -> None:
 def load_eval_cache(base_dir: Path) -> dict[Any, Any] | None:
     """Load the per-(candidate, example) eval cache, or None if absent.
 
-    GEPA parity (audit-rng-state-persist C1): mirrors the cache-restore
-    behaviour at gepa/core/state.py:348-376.  Returns the raw dict so the
+    GEPA parity: mirrors the cache-restore behaviour at
+    gepa/core/state.py:348-376.  Returns the raw dict so the
     caller can install it on a freshly constructed cache instance (the
     caller decides whether caching is enabled — see ``initialize_gepa_state``
     at gepa/core/state.py:683-687 for the equivalent gating).

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -349,14 +349,14 @@ def load_eval_cache(base_dir: Path) -> dict[Any, Any] | None:
     # the new slot rather than silently losing the reflection feedstock.
     version = loaded.get("schema_version") if "schema_version" in loaded else None
     if version != EVAL_CACHE_SCHEMA_VERSION:
-        quarantined = _quarantine_corrupt_cache(
+        _quarantine_corrupt_cache(
             target, reason=f"schema-v{version}-expected-v{EVAL_CACHE_SCHEMA_VERSION}"
         )
         warnings.warn(
-            f"Ignoring eval cache at {target}: schema_version={version!r} "
-            f"does not match current {EVAL_CACHE_SCHEMA_VERSION}.  The next "
-            f"eval pass will repopulate the cache with the current shape.  "
-            f"Previous payload preserved at {quarantined}.",
+            f"Ignoring eval cache: schema_version={version!r} does not match "
+            f"current {EVAL_CACHE_SCHEMA_VERSION}. The next eval pass will "
+            f"repopulate the cache with the current shape; a diagnostic copy "
+            f"was retained.",
             RuntimeWarning,
             stacklevel=2,
         )

--- a/tests/unit/test_align_iteration.py
+++ b/tests/unit/test_align_iteration.py
@@ -1,18 +1,18 @@
-"""Regression tests for GEPA parity fixes on branch ``topic/align-iteration``.
+"""Regression tests for GEPA parity fixes on the iteration loop.
 
-Covers three audit findings:
+Three behaviours covered:
 
-- **M1** (audit-init-engine.md B1/B2, audit-mutation.md C1) — perfect-score
-  hitting the threshold skips ONE proposal (``continue``) instead of
-  terminating the run (``break``), and uses the GEPA per-example
-  ``all(s >= threshold)`` criterion instead of mean ``aggregate_score()``.
+- **Perfect-score skip** — perfect-score hitting the threshold skips
+  ONE proposal (``continue``) instead of terminating the run
+  (``break``), and uses the GEPA per-example ``all(s >= threshold)``
+  criterion instead of mean ``aggregate_score()``.
   GEPA reference: ``reflective_mutation.py:308-327``.
-- **M2** (audit-init-engine.md B3) — merge-branch fail-fast paths fall
-  through to reflective mutation instead of consuming the iteration.
-  Only an actually-evaluated merge (accepted or rejected) consumes the
+- **Merge fall-through** — merge-branch fail-fast paths fall through
+  to reflective mutation instead of consuming the iteration.  Only an
+  actually-evaluated merge (accepted or rejected) consumes the
   iteration.  GEPA reference: ``engine.py:664-741``.
-- **MODERATE D** (audit-mutation.md C3) — legacy (no-minibatch) mutation
-  gating uses sum-score acceptance only (GEPA ``engine.py:287-303`` /
+- **Legacy gating** — no-minibatch mutation gating uses sum-score
+  acceptance only (GEPA ``engine.py:287-303`` /
   ``reflective_mutation.py:420``); the old ``degrades()`` pre-check is
   removed so the legacy path matches the minibatch path.
 
@@ -37,7 +37,7 @@ from tests.unit.test_evolution import (  # type: ignore[import-untyped]
 
 
 class TestPerfectScoreContinues:
-    """GEPA parity (M1) — audit-init-engine.md B1.
+    """GEPA parity: perfect-score skips one proposal, not the whole run.
 
     Pre-fix: perfect-score set ``_budget_break=True`` + broke the inner loop,
     and the outer ``if _budget_break and not proposal_contexts: break`` exited
@@ -84,7 +84,7 @@ class TestPerfectScoreContinues:
     def test_perfect_score_uses_per_example_all_not_mean(
         self, mocker, tmp_path, all_mocks  # noqa: F811
     ):
-        """GEPA parity (M1) — audit-init-engine.md B2.
+        """GEPA parity: perfect-score uses per-example ``all(...)``, not the mean.
 
         Pre-fix: criterion was ``aggregate_score() >= threshold`` (mean),
         which fires on ``{0.5, 1.0, 1.0}`` at ``threshold=0.8`` because
@@ -130,7 +130,7 @@ class TestPerfectScoreContinues:
 
 
 class TestMergeFallthroughToMutation:
-    """GEPA parity (M2) — audit-init-engine.md B3.
+    """GEPA parity: merge fail-fast paths fall through to mutation.
 
     When the merge gate is entered but no merge is actually evaluated
     (no triplet, pair already attempted, overlap floor fails, merge op
@@ -145,7 +145,7 @@ class TestMergeFallthroughToMutation:
     ):
         """``merge()`` returns None (Claude Code / subprocess failure) →
         no merged candidate instantiated → no eval → GEPA falls through
-        to reflective mutation (audit-init-engine.md B3).
+        to reflective mutation.
 
         Pre-fix HELIX: ``print_error`` fell through to the end-of-merge
         ``save_state/update/continue`` at evolution.py ~1343 (INSIDE the
@@ -197,7 +197,7 @@ class TestMergeFallthroughToMutation:
             f"failure falls through); got {all_mocks['mutate'].call_count}. "
             f"Pre-fix: 1 (merge branch consumed gen 2 via the "
             f"end-of-merge `continue` even though ``merged is None`` "
-            f"meant no eval happened — audit-init-engine.md B3)."
+            f"meant no eval happened)."
         )
         # Sanity: merge was attempted (find_merge_triplet returned a
         # triplet, merge(...) was called), but returned None.
@@ -265,7 +265,7 @@ class TestMergeFallthroughToMutation:
 
 
 class TestLegacyGatingUsesSumOnly:
-    """GEPA parity (MODERATE D) — audit-mutation.md C3.
+    """GEPA parity: single acceptance path on sum-score.
 
     GEPA has a single acceptance path: ``should_accept(proposal, state)``
     on sum-score (engine.py:287-303, reflective_mutation.py:420).  HELIX's
@@ -288,7 +288,7 @@ class TestLegacyGatingUsesSumOnly:
             called.append(1)
             raise AssertionError(
                 "degrades() must NOT be called in legacy gating "
-                "(GEPA parity MODERATE D — audit-mutation.md C3)."
+                "(GEPA parity: sum-score acceptance only)."
             )
 
         monkeypatch.setattr(_evo, "degrades", _boom)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -80,7 +80,7 @@ class TestLoadConfig:
             background = "You are a coding expert."
 
             [worktree]
-            base_dir = "/tmp/worktrees"
+            base_dir = "/fake/worktrees"
             cleanup_dominated = false
         """)
 
@@ -101,7 +101,7 @@ class TestLoadConfig:
         assert cfg.agent.model == "claude-opus-4-5-20250514"
         assert cfg.agent.background == "You are a coding expert."
 
-        assert cfg.worktree.base_dir == "/tmp/worktrees"
+        assert cfg.worktree.base_dir == "/fake/worktrees"
         assert cfg.worktree.cleanup_dominated is False
 
     def test_agent_section_loads(self, tmp_path):

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -27,16 +27,16 @@ from helix.config import (
 
 class TestSeedlessConfigValPath:
     def test_val_path_none_falls_back_to_train_path(self):
-        cfg = SeedlessConfig(train_path=Path("/tmp/train.jsonl"))
+        cfg = SeedlessConfig(train_path=Path("/fake/train.jsonl"))
         assert cfg.val_path is None
-        assert cfg.effective_val_path == Path("/tmp/train.jsonl")
+        assert cfg.effective_val_path == Path("/fake/train.jsonl")
 
     def test_val_path_set_returns_val_path(self):
         cfg = SeedlessConfig(
-            train_path=Path("/tmp/train.jsonl"),
-            val_path=Path("/tmp/val.jsonl"),
+            train_path=Path("/fake/train.jsonl"),
+            val_path=Path("/fake/val.jsonl"),
         )
-        assert cfg.effective_val_path == Path("/tmp/val.jsonl")
+        assert cfg.effective_val_path == Path("/fake/val.jsonl")
 
     def test_both_none_returns_none(self):
         cfg = SeedlessConfig()
@@ -148,7 +148,7 @@ class TestEvolutionConfigNewFields:
         ``max(1, max_workers // minibatch_size)`` in model_post_init.
 
         Mirrors GEPA ``_resolve_num_parallel_proposals``
-        (/tmp/gepa-official/src/gepa/optimize_anything.py:1108-1116).
+        (src/gepa/optimize_anything.py:1108-1116).
         """
         cfg = EvolutionConfig(
             num_parallel_proposals="auto",
@@ -430,8 +430,8 @@ class TestTomlRoundTrip:
             command = "pytest"
 
             [seedless]
-            train_path = "/tmp/train.jsonl"
-            val_path = "/tmp/val.jsonl"
+            train_path = "/fake/train.jsonl"
+            val_path = "/fake/val.jsonl"
 
             [evolution]
             minibatch_size = 7
@@ -443,9 +443,9 @@ class TestTomlRoundTrip:
         """)
         )
         cfg = load_config(toml)
-        assert cfg.seedless.train_path == Path("/tmp/train.jsonl")
-        assert cfg.seedless.val_path == Path("/tmp/val.jsonl")
-        assert cfg.seedless.effective_val_path == Path("/tmp/val.jsonl")
+        assert cfg.seedless.train_path == Path("/fake/train.jsonl")
+        assert cfg.seedless.val_path == Path("/fake/val.jsonl")
+        assert cfg.seedless.effective_val_path == Path("/fake/val.jsonl")
         assert cfg.evolution.minibatch_size == 7
         assert cfg.evolution.max_workers == 3
         assert cfg.evolution.num_parallel_proposals == 2
@@ -463,18 +463,18 @@ class TestTomlRoundTrip:
             command = "pytest"
 
             [seedless]
-            train_path = "/tmp/train.jsonl"
+            train_path = "/fake/train.jsonl"
         """)
         )
         cfg = load_config(toml)
         assert cfg.seedless.val_path is None
-        assert cfg.seedless.effective_val_path == Path("/tmp/train.jsonl")
+        assert cfg.seedless.effective_val_path == Path("/fake/train.jsonl")
 
     def test_model_dump_roundtrip(self):
         cfg = HelixConfig(
             objective="Test",
             evaluator={"command": "pytest"},
-            seedless={"train_path": "/tmp/train.jsonl", "val_path": "/tmp/val.jsonl"},
+            seedless={"train_path": "/fake/train.jsonl", "val_path": "/fake/val.jsonl"},
             evolution={
                 "minibatch_size": 4,
                 "max_workers": 2,
@@ -485,8 +485,8 @@ class TestTomlRoundTrip:
         )
         dumped = cfg.model_dump()
         restored = HelixConfig.model_validate(dumped)
-        assert restored.seedless.val_path == Path("/tmp/val.jsonl")
-        assert restored.seedless.effective_val_path == Path("/tmp/val.jsonl")
+        assert restored.seedless.val_path == Path("/fake/val.jsonl")
+        assert restored.seedless.effective_val_path == Path("/fake/val.jsonl")
         assert restored.evolution.minibatch_size == 4
         assert restored.evolution.max_workers == 2
         assert restored.evolution.cache_evaluation is True

--- a/tests/unit/test_display.py
+++ b/tests/unit/test_display.py
@@ -210,7 +210,7 @@ class TestCandidateSummaryJsonSerialization:
     def _make_candidate_summary(self) -> CandidateSummary:
         candidate = Candidate(
             id="g1-s1",
-            worktree_path="/tmp/helix/g1-s1",
+            worktree_path="/fake/helix/g1-s1",
             branch_name="helix/g1-s1",
             generation=1,
             parent_id="g0-s0",

--- a/tests/unit/test_eval_cache.py
+++ b/tests/unit/test_eval_cache.py
@@ -15,6 +15,34 @@ def test_get_put_round_trip() -> None:
     assert entry.output == "hello"
     assert entry.score == 0.5
     assert entry.objective_scores == {"acc": 1.0}
+    # side_info defaults to None when not provided at put time.
+    assert entry.side_info is None
+
+
+def test_get_put_round_trip_with_side_info() -> None:
+    """``CachedEvaluation.side_info`` is the HELIX-specific extension
+    mirroring GEPA OptimizeAnythingAdapter._eval_cache's per-example
+    ``(score, output, side_info)`` tuple.  A cache hit must return the
+    side_info dict that was stored at put time so reflection prompts
+    keep the LIBERO feedback signal across iterations.
+    """
+    cache: EvaluationCache[str, int] = EvaluationCache()
+    cand = {"a": "1"}
+    payload = {
+        "evaluation_diagnostics": {"instance_id": "i7", "judge_metrics": {"q": 0.8}},
+        "video_path": "feedback/last_run/i7.mp4",
+    }
+    cache.put(
+        cand,
+        7,
+        output="hello",
+        score=0.5,
+        objective_scores={"acc": 1.0},
+        side_info=payload,
+    )
+    entry = cache.get(cand, 7)
+    assert entry is not None
+    assert entry.side_info == payload
 
 
 def test_get_batch_splits_cached_uncached() -> None:
@@ -49,6 +77,28 @@ def test_put_batch_stores_all_entries() -> None:
         assert e.output == out
         assert e.score == score
         assert e.objective_scores == {"m": m}
+        assert e.side_info is None
+
+
+def test_put_batch_stores_side_info_per_entry() -> None:
+    cache: EvaluationCache[str, int] = EvaluationCache()
+    cand = {"k": "v"}
+    side_infos = [
+        {"feedback": "ok", "judge_metrics": {"q": 0.9}},
+        {"feedback": "miss", "judge_metrics": {"q": 0.1}},
+    ]
+    cache.put_batch(
+        cand,
+        [1, 2],
+        ["a", "b"],
+        [0.1, 0.2],
+        objective_scores_list=[{"m": 1.0}, {"m": 2.0}],
+        side_info_list=side_infos,
+    )
+    for idx, eid in enumerate([1, 2]):
+        e = cache.get(cand, eid)
+        assert e is not None
+        assert e.side_info == side_infos[idx]
 
 
 def test_put_batch_no_objective_scores() -> None:
@@ -58,9 +108,12 @@ def test_put_batch_no_objective_scores() -> None:
     e = cache.get(cand, 1)
     assert e is not None
     assert e.objective_scores is None
+    assert e.side_info is None
 
 
 def test_evaluate_with_cache_full_calls_evaluator_only_for_uncached() -> None:
+    from typing import Any
+
     cache: EvaluationCache[str, int] = EvaluationCache()
     cand = {"k": "v"}
     # Pre-populate id=1
@@ -73,14 +126,19 @@ def test_evaluate_with_cache_full_calls_evaluator_only_for_uncached() -> None:
 
     def evaluator(
         batch: list[int], _c: dict[str, str]
-    ) -> tuple[list[str], list[float], list[dict[str, float]] | None]:
+    ) -> tuple[
+        list[str],
+        list[float],
+        list[dict[str, float]] | None,
+        list[dict[str, Any]] | None,
+    ]:
         calls.append(list(batch))
         outs = [f"out{eid}" for eid in batch]
         scores = [float(eid) / 10 for eid in batch]
         obj = [{"acc": float(eid)} for eid in batch]
-        return outs, scores, obj
+        return outs, scores, obj, None
 
-    outputs, scores, obj_by_id, n_uncached = cache.evaluate_with_cache_full(
+    outputs, scores, obj_by_id, si_by_id, n_uncached = cache.evaluate_with_cache_full(
         cand, [1, 2, 3], fetcher, evaluator
     )
 
@@ -90,9 +148,67 @@ def test_evaluate_with_cache_full_calls_evaluator_only_for_uncached() -> None:
     assert scores == {1: 0.9, 2: 0.2, 3: 0.3}
     assert obj_by_id is not None
     assert obj_by_id == {2: {"acc": 2.0}, 3: {"acc": 3.0}}
+    assert si_by_id is None  # evaluator returned None for side_infos
+
+
+def test_evaluate_with_cache_full_threads_side_info() -> None:
+    """``evaluate_with_cache_full`` routes per-example side_info both
+    into the cache (so future hits return it) and into the merged
+    ``side_info_by_id`` mapping returned to the caller.
+    """
+    from typing import Any
+
+    cache: EvaluationCache[str, int] = EvaluationCache()
+    cand = {"k": "v"}
+
+    def fetcher(ids: list[int]) -> list[int]:
+        return list(ids)
+
+    def evaluator(
+        batch: list[int], _c: dict[str, str]
+    ) -> tuple[
+        list[str],
+        list[float],
+        list[dict[str, float]] | None,
+        list[dict[str, Any]] | None,
+    ]:
+        outs = [f"out{eid}" for eid in batch]
+        scores = [float(eid) / 10 for eid in batch]
+        side_infos = [{"feedback": f"si-{eid}"} for eid in batch]
+        return outs, scores, None, side_infos
+
+    outputs, scores, obj_by_id, si_by_id, n_uncached = cache.evaluate_with_cache_full(
+        cand, [1, 2], fetcher, evaluator
+    )
+    assert n_uncached == 2
+    assert obj_by_id is None
+    assert si_by_id == {1: {"feedback": "si-1"}, 2: {"feedback": "si-2"}}
+
+    # Cache must have persisted the side_info so a second call hits it.
+    e1 = cache.get(cand, 1)
+    assert e1 is not None and e1.side_info == {"feedback": "si-1"}
+
+    # Second call: nothing fresh, side_info re-materialised from cache.
+    def evaluator_should_not_run(
+        batch: list[int], _c: dict[str, str]
+    ) -> tuple[
+        list[str],
+        list[float],
+        list[dict[str, float]] | None,
+        list[dict[str, Any]] | None,
+    ]:
+        raise AssertionError("evaluator must not run on full cache hit")
+
+    outputs2, scores2, obj_by_id2, si_by_id2, n_new = cache.evaluate_with_cache_full(
+        cand, [1, 2], fetcher, evaluator_should_not_run
+    )
+    assert n_new == 0
+    assert si_by_id2 == {1: {"feedback": "si-1"}, 2: {"feedback": "si-2"}}
 
 
 def test_evaluate_with_cache_full_second_call_fully_cached() -> None:
+    from typing import Any
+
     cache: EvaluationCache[str, int] = EvaluationCache()
     cand = {"k": "v"}
     calls: list[list[int]] = []
@@ -102,14 +218,19 @@ def test_evaluate_with_cache_full_second_call_fully_cached() -> None:
 
     def evaluator(
         batch: list[int], _c: dict[str, str]
-    ) -> tuple[list[str], list[float], list[dict[str, float]] | None]:
+    ) -> tuple[
+        list[str],
+        list[float],
+        list[dict[str, float]] | None,
+        list[dict[str, Any]] | None,
+    ]:
         calls.append(list(batch))
-        return [f"o{e}" for e in batch], [0.0 for _ in batch], None
+        return [f"o{e}" for e in batch], [0.0 for _ in batch], None, None
 
     cache.evaluate_with_cache_full(cand, [1, 2, 3], fetcher, evaluator)
     assert calls == [[1, 2, 3]]
 
-    outputs, scores, obj, n_new = cache.evaluate_with_cache_full(
+    outputs, scores, obj, si, n_new = cache.evaluate_with_cache_full(
         cand, [1, 2, 3], fetcher, evaluator
     )
     assert calls == [[1, 2, 3]]  # not called again
@@ -117,6 +238,7 @@ def test_evaluate_with_cache_full_second_call_fully_cached() -> None:
     assert outputs == {1: "o1", 2: "o2", 3: "o3"}
     assert scores == {1: 0.0, 2: 0.0, 3: 0.0}
     assert obj is None
+    assert si is None
 
 
 def test_candidate_hash_order_independent() -> None:

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -56,7 +56,7 @@ from helix.state import BudgetState, EvolutionState
 def make_candidate(cid: str = "g0-s0", generation: int = 0) -> Candidate:
     return Candidate(
         id=cid,
-        worktree_path=f"/tmp/helix/{cid}",
+        worktree_path=f"/fake/helix/{cid}",
         branch_name=f"helix/{cid}",
         generation=generation,
         parent_id=None,
@@ -192,7 +192,7 @@ def all_mocks(mocker):
         "record_entry": mocker.patch("helix.evolution.record_entry"),
         "generate_seed": mocker.patch("helix.evolution.generate_seed", return_value={}),
         "HelixLiveDisplay": mocker.patch("helix.evolution.HelixLiveDisplay"),
-        # GEPA parity (merge-pairing audit D1, /tmp/audit_audit-merge-pairing.md:49-50):
+        # GEPA parity (merge.py:130-131):
         # the merge branch now enforces GEPA's ``len(parent_program_for_candidate) < 3``
         # early-exit (merge.py:130-131), i.e. you need two siblings plus one
         # ancestor.  Provide a 3-entry dummy lineage by default so merge tests
@@ -561,7 +561,7 @@ class TestGatingInEvolutionLoop:
         seed = make_candidate("g0-s0")
         child = Candidate(
             id="g1-s1",
-            worktree_path="/tmp/helix/g1-s1",
+            worktree_path="/fake/helix/g1-s1",
             branch_name="helix/g1-s1",
             generation=1,
             parent_id=seed.id,
@@ -722,7 +722,7 @@ class TestGatingInEvolutionLoop:
         seed = make_candidate("g0-s0")
         child = Candidate(
             id="g1-s1",
-            worktree_path="/tmp/helix/g1-s1",
+            worktree_path="/fake/helix/g1-s1",
             branch_name="helix/g1-s1",
             generation=1,
             parent_id=seed.id,
@@ -731,7 +731,7 @@ class TestGatingInEvolutionLoop:
         )
         merged = Candidate(
             id="g2-m1",
-            worktree_path="/tmp/helix/g2-m1",
+            worktree_path="/fake/helix/g2-m1",
             branch_name="helix/g2-m1",
             generation=2,
             parent_id=seed.id,
@@ -1455,8 +1455,8 @@ class TestMergeBehavior:
             f"merge eval must route through val, saw splits: "
             f"{[s for s, _ in merged_eval_calls]}"
         )
-        # GEPA parity (merge-gate audit M3, /tmp/audit_audit-merge-gate.md:10-32):
-        # after the subsample gate passes, HELIX now runs a SECOND (full-val)
+        # GEPA parity: after the subsample gate
+        # passes, HELIX now runs a SECOND (full-val)
         # eval on the merged candidate mirroring GEPA ``engine.py:690`` →
         # ``_run_full_eval_and_add`` → ``_evaluate_on_valset``.  With
         # val_size=None (single-task/no-example mode) the full-val path falls through
@@ -1537,12 +1537,11 @@ class TestMergeBehavior:
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
         assert merged_eval_batches, "merged candidate was never evaluated"
-        # GEPA parity (merge-gate audit M3): the first merge eval is the
+        # GEPA parity: the first merge eval is the
         # subsample gate (exactly ``merge_subsample_size`` ids drawn from
         # the common val intersection); subsequent calls are the
-        # GEPA-aligned post-acceptance full-val pass
-        # (/tmp/audit_audit-merge-gate.md:10-32).  Assert only the first
-        # call against the subsample contract.
+        # GEPA-aligned post-acceptance full-val pass.  Assert only the
+        # first call against the subsample contract.
         first_batch = merged_eval_batches[0]
         assert len(first_batch) == 3, (
             f"merge subsample must use exactly merge_subsample_size ids, "
@@ -1680,7 +1679,7 @@ class TestMergeBehavior:
     def test_merge_accepted_entry_has_full_val_coverage(
         self, mocker, tmp_path, all_mocks
     ):
-        """GEPA parity (merge-gate audit M3, /tmp/audit_audit-merge-gate.md:10-32).
+        """GEPA parity (gepa/core/engine.py:688-696, full-val merge eval).
 
         Once the subsample gate passes, HELIX runs a SECOND (full-val)
         eval on the merged candidate and uses THAT result for
@@ -1815,7 +1814,7 @@ class TestMergeBehavior:
     def test_merge_attempted_pairs_stored_canonically(
         self, mocker, tmp_path, all_mocks
     ):
-        """GEPA parity (merge-pairing audit C3, merge.py:94-95).
+        """GEPA parity (merge.py:94-95).
 
         ``find_merge_triplet`` canonicalizes the sampled pair via lex sort
         before returning, so the attempted-pair ledger stores
@@ -1911,7 +1910,7 @@ class TestMergeBehavior:
     def test_merge_description_triplet_recorded_on_accept(
         self, mocker, tmp_path, all_mocks
     ):
-        """GEPA parity (merge-pairing audit C1, merge.py:195-203).
+        """GEPA parity (merge.py:195-203).
 
         Forward-direction test: an accepted merge records a
         ``(id1, id2, desc_hash)`` triplet in
@@ -2004,7 +2003,7 @@ class TestMergeBehavior:
         )
 
     def test_merge_gate_requires_three_candidates(self, mocker, tmp_path, all_mocks):
-        """GEPA parity (merge-pairing audit D1, merge.py:130-131).
+        """GEPA parity (merge.py:130-131).
 
         The ``len(parent_program_for_candidate) < 3`` early-exit means a
         run with only two recorded candidates (seed + one child) skips

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -41,7 +41,7 @@ from helix.state import BudgetState, EvolutionState
 def _make_candidate(cid: str = "g0-s0") -> Candidate:
     return Candidate(
         id=cid,
-        worktree_path=f"/tmp/helix/{cid}",
+        worktree_path=f"/fake/helix/{cid}",
         branch_name=f"helix/{cid}",
         generation=0,
         parent_id=None,
@@ -960,7 +960,7 @@ class TestCachedEvaluateBatch:
         write_batch_mock = mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/fake"),
         )
 
         assert run_eval_mock.call_count == 0, (
@@ -995,7 +995,7 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand_b, ["0", "1"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand_b, ["0", "1"], cache, self._trivial_config(), "train", Path("/fake"),
         )
 
         assert num_actual == 0
@@ -1165,7 +1165,7 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/fake"),
         )
 
         assert seen_instance_ids == [["0", "1", "2"]], (
@@ -1197,10 +1197,10 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         first, first_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/tmp"),
+            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/fake"),
         )
         second, second_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/tmp"),
+            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/fake"),
         )
 
         assert seen_instance_ids == [["0", "1"], ["0", "1"]]
@@ -1248,7 +1248,7 @@ class TestCachedEvaluateBatch:
         )
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/fake"),
         )
 
         # Evaluator called exactly once, with only the missing id.
@@ -1267,20 +1267,25 @@ class TestCachedEvaluateBatch:
 
     def test_partial_cache_hit_per_example_fields_merge(self, mocker: Any) -> None:
         """Partial-cache-hit merge of ``per_example_side_info`` and
-        ``objective_scores``.  Pins the closure side-channel design
-        from commit H (``_cached_evaluate_batch``):
+        ``objective_scores``.
 
-          * cache-hit positions get ``{}`` for per_example_side_info
-            (the cache has no slot for freeform side_info so the merge
-            can't round-trip it — their prior side_info was consumed
-            by the reflection prompt at their original eval time);
-          * fresh miss positions get the per_example_side_info dict
-            from the fresh EvalResult, zipped by id;
-          * ``objective_scores`` IS round-tripped through the cache
-            (it has a dedicated slot — see
-            ``eval_cache.CachedEvaluation.objective_scores``), so
-            cache-hit positions get back the previously-stored dict
-            and miss positions get the freshly-harvested dict.
+        Both axes now round-trip through the cache via dedicated
+        ``CachedEvaluation`` slots:
+
+          * ``objective_scores`` — original GEPA parity slot
+            (``gepa/core/state.py:37-43``).
+          * ``side_info`` — HELIX extension mirroring GEPA's
+            ``OptimizeAnythingAdapter._eval_cache`` at
+            ``gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py:200-216``,
+            which caches the per-example reflection feedstock alongside
+            score/output.  Without this slot a second visit to the same
+            (candidate, example) lost the LIBERO ``evaluation_diagnostics``
+            / ``judge_metrics`` / ``evaluator_error`` payload before it
+            reached the mutator's ``## Diagnostics`` section.
+
+        Cache-hit positions therefore return the dict that was stored
+        with ``put_batch(..., side_info_list=...)``, and fresh miss
+        positions get the dict from the live evaluator output.
         """
         from helix.eval_cache import EvaluationCache as MBCache
         from helix.evolution import _cached_evaluate_batch
@@ -1288,8 +1293,10 @@ class TestCachedEvaluateBatch:
         cache: MBCache[object, str] = MBCache[object, str]()
         cand = self._make_cand("cand-pcfm")
         cand_dict = {"content_key": cand.id, "split": "train"}
-        # Pre-populate ids "0" and "2" with both score AND
-        # objective_scores (the cache stores these natively).
+        # Pre-populate ids "0" and "2" with score + objective_scores +
+        # side_info.  The side_info payload mirrors the shape LIBERO's
+        # evaluator emits: ``evaluation_diagnostics`` with task metadata
+        # and ``judge_metrics`` axes.
         cache.put_batch(
             cand_dict,
             ["0", "2"],
@@ -1298,6 +1305,10 @@ class TestCachedEvaluateBatch:
             objective_scores_list=[
                 {"obj_alpha": 0.11, "obj_beta": 0.8},
                 {"obj_alpha": 0.33, "obj_beta": 0.1},
+            ],
+            side_info_list=[
+                {"evaluation_diagnostics": {"instance_id": "0", "judge_metrics": {"q": 0.9}}},
+                {"evaluation_diagnostics": {"instance_id": "2", "judge_metrics": {"q": 0.4}}},
             ],
         )
         # "1" is uncached — the evaluator is invoked with it only, and
@@ -1332,7 +1343,7 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/fake"),
         )
 
         # instance_scores merge: cached 0/2 + fresh 1 (established
@@ -1350,14 +1361,81 @@ class TestCachedEvaluateBatch:
             {"obj_alpha": 0.33, "obj_beta": 0.1},     # cached id "2"
         ]
 
-        # per_example_side_info: cache has no slot, so cache-hit
-        # positions get ``{}`` placeholder; the fresh miss position
-        # gets the dict we returned from fake_run.
+        # per_example_side_info now also round-trips: cache-hit
+        # positions return the dict stored at the original eval time
+        # (LIBERO feedback preserved); the fresh miss position gets
+        # the live evaluator output.
         assert result.per_example_side_info is not None
         assert result.per_example_side_info == [
-            {},                                                               # cached "0" → {}
-            {"trajectory": "fresh_trace_1", "rollout_id": "fresh__1"},         # fresh "1"
-            {},                                                               # cached "2" → {}
+            {"evaluation_diagnostics": {"instance_id": "0", "judge_metrics": {"q": 0.9}}},
+            {"trajectory": "fresh_trace_1", "rollout_id": "fresh__1"},
+            {"evaluation_diagnostics": {"instance_id": "2", "judge_metrics": {"q": 0.4}}},
+        ]
+
+    def test_partial_cache_hit_side_info_repopulated_after_fresh_eval(
+        self, mocker: Any
+    ) -> None:
+        """A fresh evaluation populates ``side_info`` in the cache so a
+        subsequent fully-cached lookup re-materialises the per-example
+        reflection feedstock without re-running the evaluator.
+
+        Mirrors GEPA's ``OptimizeAnythingAdapter._call_evaluator`` cache
+        store at
+        ``gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py:200-216``:
+        once a (candidate, example) has been evaluated, the adapter cache
+        returns the full ``(score, output, side_info)`` tuple on the next
+        hit — never re-running the evaluator just to recover side_info.
+        """
+        from helix.eval_cache import EvaluationCache as MBCache
+        from helix.evolution import _cached_evaluate_batch
+
+        cache: MBCache[object, str] = MBCache[object, str]()
+        cand = self._make_cand("cand-roundtrip")
+
+        call_count = {"n": 0}
+
+        def fake_run(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            call_count["n"] += 1
+            ids = list(instance_ids or [])
+            return EvalResult(
+                candidate_id=candidate.id,
+                scores={},
+                asi={},
+                instance_scores={eid: 0.42 for eid in ids},
+                per_example_side_info=[
+                    {"evaluation_diagnostics": {"instance_id": eid, "judge_metrics": {"q": 0.7}}}
+                    for eid in ids
+                ],
+                objective_scores=[{"obj": 0.42} for _ in ids],
+            )
+
+        mocker.patch("helix.evolution.run_evaluator", side_effect=fake_run)
+        mocker.patch("helix.evolution._write_helix_batch")
+
+        first, first_actual = _cached_evaluate_batch(
+            cand, ["a", "b"], cache, self._trivial_config(), "train", Path("/fake"),
+        )
+        assert first_actual == 2  # cold miss → both ids evaluated
+        assert call_count["n"] == 1
+
+        second, second_actual = _cached_evaluate_batch(
+            cand, ["a", "b"], cache, self._trivial_config(), "train", Path("/fake"),
+        )
+        assert second_actual == 0  # full hit → evaluator not invoked again
+        assert call_count["n"] == 1  # confirms run_evaluator was not called
+
+        # side_info survives the round-trip — LIBERO feedback signal is
+        # preserved on cache hits.
+        assert second.per_example_side_info == first.per_example_side_info
+        assert second.per_example_side_info == [
+            {"evaluation_diagnostics": {"instance_id": "a", "judge_metrics": {"q": 0.7}}},
+            {"evaluation_diagnostics": {"instance_id": "b", "judge_metrics": {"q": 0.7}}},
         ]
 
     def test_cache_populates_after_fresh_eval(self, mocker: Any) -> None:
@@ -1389,7 +1467,7 @@ class TestCachedEvaluateBatch:
 
         # First call: full miss → evaluator runs once.
         first_result, first_num_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], cache, cfg, "train", Path("/tmp"),
+            cand, ["0", "1"], cache, cfg, "train", Path("/fake"),
         )
         assert call_count["n"] == 1
         assert first_num_actual == 2
@@ -1397,7 +1475,7 @@ class TestCachedEvaluateBatch:
 
         # Second call with the same (candidate, ids): full hit → no re-run.
         second_result, second_num_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], cache, cfg, "train", Path("/tmp"),
+            cand, ["0", "1"], cache, cfg, "train", Path("/fake"),
         )
         assert call_count["n"] == 1, (
             "Evaluator must not be invoked a second time for cached ids"
@@ -1435,7 +1513,7 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0"], cache, self._trivial_config(), "val", Path("/tmp"),
+            cand, ["0"], cache, self._trivial_config(), "val", Path("/fake"),
         )
 
         assert seen_splits == ["val"]
@@ -1466,7 +1544,7 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/tmp"),
+            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/fake"),
         )
 
         assert seen_instance_ids == [["0", "1"]]
@@ -1523,8 +1601,8 @@ class TestWriteHelixBatchStringIds:
 
 
 # ---------------------------------------------------------------------------
-# MODERATE E (audit-mutation §C4) — parent minibatch eval runs in parallel
-# worker threads, matching GEPA core/engine.py:381-452 which submits
+# Parent minibatch eval runs in parallel worker threads, matching GEPA
+# core/engine.py:381-452 which submits
 # ``execute_proposal`` (reflective_mutation.py:239-285) — including
 # ``adapter.evaluate`` at :268 — to a ``ThreadPoolExecutor``.
 #
@@ -1539,7 +1617,7 @@ class TestParentMinibatchParallelism:
     ) -> None:
         """Under ``num_parallel_proposals > 1`` the N parent-minibatch evals
         must be dispatched to a ``ThreadPoolExecutor`` (call-count evidence
-        of concurrency per audit-mutation §C4 MODERATE E).
+        of concurrency).
 
         We cannot block on a barrier because parents share the same seed
         worktree and the per-worktree file-handoff lock correctly serialises

--- a/tests/unit/test_evolution_seedless.py
+++ b/tests/unit/test_evolution_seedless.py
@@ -27,7 +27,7 @@ from helix.state import BudgetState, EvolutionState
 def make_candidate(cid: str = "g0-s0", generation: int = 0) -> Candidate:
     return Candidate(
         id=cid,
-        worktree_path=f"/tmp/helix/{cid}",
+        worktree_path=f"/fake/helix/{cid}",
         branch_name=f"helix/{cid}",
         generation=generation,
         parent_id=None,
@@ -184,7 +184,7 @@ class TestRunEvolutionSeedless:
         """generate_seed must be called with the worktree_path of the seed candidate."""
         config = make_config(seedless=True)
         seed_cand = make_candidate("g0-s0")
-        seed_cand_wt = "/tmp/helix/g0-s0"
+        seed_cand_wt = "/fake/helix/g0-s0"
         seed_cand = Candidate(
             id="g0-s0",
             worktree_path=seed_cand_wt,

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -16,7 +16,7 @@ from helix.executor import run_evaluator
 # ---------------------------------------------------------------------------
 
 
-def make_candidate(worktree_path: str = "/tmp/fake-worktree") -> Candidate:
+def make_candidate(worktree_path: str = "/fake/fake-worktree") -> Candidate:
     return Candidate(
         id="cand-001",
         worktree_path=worktree_path,

--- a/tests/unit/test_executor_security.py
+++ b/tests/unit/test_executor_security.py
@@ -22,7 +22,7 @@ from helix.exceptions import EvaluatorError
 # ---------------------------------------------------------------------------
 
 
-def make_candidate(worktree_path: str = "/tmp/fake-worktree") -> Candidate:
+def make_candidate(worktree_path: str = "/fake/fake-worktree") -> Candidate:
     return Candidate(
         id="cand-001",
         worktree_path=worktree_path,

--- a/tests/unit/test_helix_result.py
+++ b/tests/unit/test_helix_result.py
@@ -7,8 +7,7 @@ BREAKING (pre-1.0): ``helix_result`` previously accepted one
 ``helix_batch.json``.  HELIX zips them into id-keyed
 ``instance_scores`` (for the minibatch gate) and stores the raw
 per-example side_info list on ``EvalResult`` for the reflection
-prompt.  See :mod:`helix.parsers.helix_result` and
-``/tmp/gepa_audit_report.md``.
+prompt.  See :mod:`helix.parsers.helix_result`.
 """
 
 from __future__ import annotations
@@ -31,7 +30,7 @@ from helix.mutator import build_mutation_prompt
 # ---------------------------------------------------------------------------
 
 
-def make_candidate(worktree_path: str | Path = "/tmp/fake-worktree") -> Candidate:
+def make_candidate(worktree_path: str | Path = "/fake/fake-worktree") -> Candidate:
     return Candidate(
         id="cand-001",
         worktree_path=str(worktree_path),

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -1,13 +1,12 @@
 """Unit tests for helix.lineage.find_merge_triplet.
 
 Ported from GEPA's merge pair-selection behavior
-(gepa/proposer/merge.py:87-115, 118-207).  Covers the post-align-merge
-changes spelled out in the merge-pairing audit
-(/tmp/audit_audit-merge-pairing.md):
+(gepa/proposer/merge.py:87-115, 118-207).  Three post-align-merge
+behaviours covered:
 
-- B1: overlap-floor filter moved INTO the retry loop.
-- B2: attempted-pair filter moved INTO the retry loop.
-- C3: canonical (lex-sorted) pair returned, mirroring GEPA
+- overlap-floor filter moved INTO the retry loop.
+- attempted-pair filter moved INTO the retry loop.
+- canonical (lex-sorted) pair returned, mirroring GEPA
   ``merge.py:94-95`` ``if j < i: i, j = j, i``.
 """
 
@@ -35,7 +34,7 @@ def _build_lineage(parents_by_id: dict[str, list[str]]) -> dict[str, LineageEntr
 
 
 class TestFindMergeTripletCanonicalization:
-    """GEPA parity (merge-pairing audit C3, merge.py:94-95).
+    """GEPA parity (merge.py:94-95).
 
     The sampled pair is lex-sorted inside ``find_merge_triplet`` so that
     ``(A, B)`` and ``(B, A)`` both surface as ``(A, B)`` regardless of the
@@ -68,7 +67,7 @@ class TestFindMergeTripletCanonicalization:
 
 
 class TestFindMergeTripletWithinRetryFilters:
-    """GEPA parity (merge-pairing audit B1+B2, merge.py:147-148, 199-201).
+    """GEPA parity (merge.py:147-148, 199-201).
 
     The attempted-pair and val-overlap filters live INSIDE the retry loop
     (``for _ in range(max_attempts)``).  A blocked sample resamples within

--- a/tests/unit/test_merger.py
+++ b/tests/unit/test_merger.py
@@ -33,7 +33,7 @@ def make_eval_result(
     )
 
 
-def make_candidate(cid: str = "g0-s0", worktree_path: str = "/tmp/wt") -> Candidate:
+def make_candidate(cid: str = "g0-s0", worktree_path: str = "/fake/wt") -> Candidate:
     return Candidate(
         id=cid,
         worktree_path=worktree_path,
@@ -111,14 +111,14 @@ class TestMerge:
         cb = make_candidate("g0-s1")
         config = make_config()
 
-        child = make_candidate("g1-m0", "/tmp/g1-m0")
+        child = make_candidate("g1-m0", "/fake/g1-m0")
         mocker.patch("helix.merger.clone_candidate", return_value=child)
         mocker.patch("helix.merger.get_diff", return_value="+x = 1")
         mocker.patch("helix.merger.invoke_claude_code", return_value=({"result": "ok"}, {}))
         mocker.patch("helix.merger.snapshot_candidate", return_value="abc123")
         mocker.patch("helix.merger.remove_worktree")
 
-        result = merge(ca, cb, "g1-m0", config, Path("/tmp"))
+        result = merge(ca, cb, "g1-m0", config, Path("/fake"))
 
         assert result is child
 
@@ -134,7 +134,7 @@ class TestMerge:
         mocker.patch("helix.merger.snapshot_candidate", return_value="sha")
         mocker.patch("helix.merger.remove_worktree")
 
-        result = merge(ca, cb, "g1-m0", config, Path("/tmp"))
+        result = merge(ca, cb, "g1-m0", config, Path("/fake"))
 
         assert result.operation == "merge"
 
@@ -150,7 +150,7 @@ class TestMerge:
         mocker.patch("helix.merger.snapshot_candidate", return_value="sha")
         mocker.patch("helix.merger.remove_worktree")
 
-        result = merge(ca, cb, "g1-m0", config, Path("/tmp"))
+        result = merge(ca, cb, "g1-m0", config, Path("/fake"))
 
         assert "g0-s0" in result.parent_ids
         assert "g0-s1" in result.parent_ids
@@ -170,7 +170,7 @@ class TestMerge:
         mock_remove = mocker.patch("helix.merger.remove_worktree")
         mocker.patch("helix.merger.snapshot_candidate")
 
-        result = merge(ca, cb, "g1-m0", config, Path("/tmp"))
+        result = merge(ca, cb, "g1-m0", config, Path("/fake"))
 
         assert result is None
         mock_remove.assert_called_once_with(child)
@@ -190,7 +190,7 @@ class TestMerge:
         mock_remove = mocker.patch("helix.merger.remove_worktree")
         mocker.patch("helix.merger.snapshot_candidate")
 
-        merge(ca, cb, "g1-m0", config, Path("/tmp"))
+        merge(ca, cb, "g1-m0", config, Path("/fake"))
 
         mock_remove.assert_called_once_with(child)
 
@@ -211,7 +211,7 @@ class TestMerge:
         mock_snapshot = mocker.patch("helix.merger.snapshot_candidate", return_value="sha")
         mocker.patch("helix.merger.remove_worktree")
 
-        result = merge(ca, cb, "g1-m0", config, Path("/tmp"))
+        result = merge(ca, cb, "g1-m0", config, Path("/fake"))
 
         # merge() returns the child but does NOT snapshot internally
         assert result is child
@@ -232,7 +232,7 @@ class TestMerge:
         mock_snapshot = mocker.patch("helix.merger.snapshot_candidate")
         mocker.patch("helix.merger.remove_worktree")
 
-        merge(ca, cb, "g1-m0", config, Path("/tmp"))
+        merge(ca, cb, "g1-m0", config, Path("/fake"))
 
         mock_snapshot.assert_not_called()
 
@@ -248,7 +248,7 @@ class TestMerge:
         mocker.patch("helix.merger.snapshot_candidate", return_value="sha")
         mocker.patch("helix.merger.remove_worktree")
 
-        merge(ca, cb, "g1-m0", config, Path("/tmp"), background="unique_context_xyz")
+        merge(ca, cb, "g1-m0", config, Path("/fake"), background="unique_context_xyz")
 
         prompt_arg = mock_invoke.call_args[0][1]
         assert "unique_context_xyz" in prompt_arg

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -43,7 +43,7 @@ def make_eval_result(
 
 def make_candidate(
     cid: str = "g0-s0",
-    worktree_path: str = "/tmp/fake-wt",
+    worktree_path: str = "/fake/fake-wt",
 ) -> Candidate:
     return Candidate(
         id=cid,
@@ -615,7 +615,7 @@ class TestInvokeClaudeCode:
             returncode=0,
         )
         config = AgentConfig()
-        result, usage = invoke_claude_code("/tmp/wt", "do something", config)
+        result, usage = invoke_claude_code("/fake/wt", "do something", config)
         assert result == payload
 
     def test_raises_on_nonzero_returncode(self, mocker):
@@ -627,7 +627,7 @@ class TestInvokeClaudeCode:
         )
         config = AgentConfig()
         with pytest.raises(MutationError, match="exited with code 1"):
-            invoke_claude_code("/tmp/wt", "do something", config)
+            invoke_claude_code("/fake/wt", "do something", config)
 
     def test_raises_on_invalid_json(self, mocker):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
@@ -638,13 +638,13 @@ class TestInvokeClaudeCode:
         )
         config = AgentConfig()
         with pytest.raises(MutationError, match="Failed to parse"):
-            invoke_claude_code("/tmp/wt", "do something", config)
+            invoke_claude_code("/fake/wt", "do something", config)
 
     def test_cli_args_include_required_flags(self, mocker):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
         config = AgentConfig()
-        invoke_claude_code("/tmp/wt", "the prompt", config)
+        invoke_claude_code("/fake/wt", "the prompt", config)
 
         call_args = mock_run.call_args
         args_list = call_args[0][0]
@@ -674,7 +674,7 @@ class TestInvokeClaudeCode:
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
         config = AgentConfig()
-        invoke_claude_code("/tmp/wt", "prompt", config)
+        invoke_claude_code("/fake/wt", "prompt", config)
         assert "timeout" not in mock_run.call_args[1]
 
     def test_codex_cli_args_include_required_flags(self, mocker):
@@ -686,7 +686,7 @@ class TestInvokeClaudeCode:
         )
         config = AgentConfig(backend="codex", model="gpt-5", effort="high")
 
-        result, _ = invoke_claude_code("/tmp/wt", "the prompt", config)
+        result, _ = invoke_claude_code("/fake/wt", "the prompt", config)
 
         args_list = mock_run.call_args[0][0]
         assert args_list[:2] == ["codex", "exec"]
@@ -715,7 +715,7 @@ class TestInvokeClaudeCode:
         )
         config = AgentConfig(backend="codex", effort='high"quoted')
 
-        invoke_claude_code("/tmp/wt", "the prompt", config)
+        invoke_claude_code("/fake/wt", "the prompt", config)
 
         args_list = mock_run.call_args[0][0]
         assert 'model_reasoning_effort="high\\"quoted"' in args_list
@@ -729,7 +729,7 @@ class TestInvokeClaudeCode:
         )
         config = AgentConfig(backend="cursor", model="gpt-5")
 
-        result, _ = invoke_claude_code("/tmp/wt", "the prompt", config)
+        result, _ = invoke_claude_code("/fake/wt", "the prompt", config)
 
         args_list = mock_run.call_args[0][0]
         assert args_list[:2] == ["cursor", "agent"]
@@ -738,7 +738,7 @@ class TestInvokeClaudeCode:
         assert "stream-json" in args_list
         assert "--yolo" in args_list
         assert "--workspace" in args_list
-        assert "/tmp/wt" in args_list
+        assert "/fake/wt" in args_list
         assert "the prompt" not in args_list
         assert ".agent_task_prompt.md" in args_list[-1]
         assert "input" not in mock_run.call_args[1]
@@ -989,7 +989,7 @@ class TestInvokeClaudeCode:
         )
         config = AgentConfig(backend="gemini")
 
-        result, _ = invoke_claude_code("/tmp/wt", "prompt", config)
+        result, _ = invoke_claude_code("/fake/wt", "prompt", config)
 
         assert result["events"][0]["type"] == "init"
         assert result["unparsable_lines"] == [
@@ -1008,7 +1008,7 @@ class TestInvokeClaudeCode:
         ],
     )
     def test_gemini_and_opencode_cli_args(
-        self, mocker, backend, expected_prefix, expected_flags
+        self, mocker, tmp_path: Path, backend, expected_prefix, expected_flags
     ):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(
@@ -1018,7 +1018,11 @@ class TestInvokeClaudeCode:
         )
         config = AgentConfig(backend=backend, model="test-model")
 
-        result, _ = invoke_claude_code("/tmp/wt", "the prompt", config)
+        # opencode materialises ``<worktree>/.helix_opencode_state`` for per-
+        # candidate SQLite isolation (mutator.py:1543), so this test needs a
+        # real, writable directory rather than the synthetic ``/fake/wt``
+        # path string the other backends tolerate.
+        result, _ = invoke_claude_code(str(tmp_path), "the prompt", config)
 
         args_list = mock_run.call_args[0][0]
         assert args_list[: len(expected_prefix)] == expected_prefix
@@ -1079,7 +1083,7 @@ class TestInvokeClaudeCode:
         )
         monkeypatch.setenv("CURSOR_API_KEY", "cursor-key")
 
-        invoke_claude_code("/tmp/wt", "prompt", AgentConfig(backend="cursor"))
+        invoke_claude_code("/fake/wt", "prompt", AgentConfig(backend="cursor"))
 
         assert mock_run.call_args.kwargs["env"]["CURSOR_API_KEY"] == "cursor-key"
 
@@ -1089,7 +1093,7 @@ class TestInvokeClaudeCode:
         monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://wrong")
 
         invoke_claude_code(
-            "/tmp/wt",
+            "/fake/wt",
             "prompt",
             AgentConfig(),
             passthrough_env=["ANTHROPIC_BASE_URL"],
@@ -1125,7 +1129,7 @@ class TestMutate:
         mocker.patch("helix.mutator.snapshot_candidate", return_value="abc123")
         mocker.patch("helix.mutator.remove_worktree")
 
-        result = mutate(parent, er, "g1-s0", config, Path("/tmp"))
+        result = mutate(parent, er, "g1-s0", config, Path("/fake"))
 
         assert result is child
 
@@ -1142,7 +1146,7 @@ class TestMutate:
         mocker.patch("helix.mutator.snapshot_candidate", return_value="sha")
         mocker.patch("helix.mutator.remove_worktree")
 
-        result = mutate(parent, er, "g1-s0", config, Path("/tmp"))
+        result = mutate(parent, er, "g1-s0", config, Path("/fake"))
         assert result.operation == "mutate"
 
     def test_returns_none_on_mutation_error(self, tmp_path: Path, mocker):
@@ -1161,7 +1165,7 @@ class TestMutate:
         mock_remove = mocker.patch("helix.mutator.remove_worktree")
         mocker.patch("helix.mutator.snapshot_candidate")
 
-        result = mutate(parent, er, "g1-s0", config, Path("/tmp"))
+        result = mutate(parent, er, "g1-s0", config, Path("/fake"))
 
         assert result is None
         mock_remove.assert_called_once_with(child)
@@ -1182,7 +1186,7 @@ class TestMutate:
         mock_remove = mocker.patch("helix.mutator.remove_worktree")
         mocker.patch("helix.mutator.snapshot_candidate")
 
-        mutate(parent, er, "g1-s0", config, Path("/tmp"))
+        mutate(parent, er, "g1-s0", config, Path("/fake"))
 
         mock_remove.assert_called_once_with(child)
 
@@ -1206,7 +1210,7 @@ class TestMutate:
         )
         mocker.patch("helix.mutator.remove_worktree")
 
-        result = mutate(parent, er, "g1-s0", config, Path("/tmp"))
+        result = mutate(parent, er, "g1-s0", config, Path("/fake"))
 
         # mutate() returns the child but does NOT snapshot internally
         assert result is child
@@ -1228,7 +1232,7 @@ class TestMutate:
         mock_snapshot = mocker.patch("helix.mutator.snapshot_candidate")
         mocker.patch("helix.mutator.remove_worktree")
 
-        mutate(parent, er, "g1-s0", config, Path("/tmp"))
+        mutate(parent, er, "g1-s0", config, Path("/fake"))
 
         mock_snapshot.assert_not_called()
 
@@ -1247,7 +1251,7 @@ class TestMutate:
         mocker.patch("helix.mutator.snapshot_candidate", return_value="sha")
         mocker.patch("helix.mutator.remove_worktree")
 
-        mutate(parent, er, "g1-s0", config, Path("/tmp"), background="special context")
+        mutate(parent, er, "g1-s0", config, Path("/fake"), background="special context")
 
         prompt_arg = mock_invoke.call_args[0][1]
         assert "special context" in prompt_arg

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -358,6 +358,55 @@ class TestPerExampleDiagnostics:
         assert "top-down" in prompt
         assert "centered" in prompt
 
+    def test_redacts_filesystem_paths_recursively_without_losing_feedback(self):
+        """Prompt rendering must not disclose evaluator-local paths.
+
+        The evaluator/cache path deliberately retains the raw side-info for
+        parsing and resume fidelity.  Only the mutation-prompt boundary is
+        sanitised, recursively, so useful keys and non-sensitive feedback
+        still reach the mutator.
+        """
+        er = self._make(
+            per_example_side_info=[
+                {
+                    "video_path": "/private/evaluator/videos/run-1.mp4",
+                    "evaluation_diagnostics": {
+                        "evaluator_error": (
+                            "decoder failed at /private/evaluator/logs/run-1.txt"
+                        ),
+                        "judge_metrics": {"quality": 0.75},
+                        "auth_message": "token=credential-value-12345",
+                    },
+                }
+            ],
+            instance_scores={"ex_0": 0.0},
+        )
+
+        prompt = build_mutation_prompt(
+            "goal", er, secret_values=["credential-value-12345"]
+        )
+
+        assert "/private/evaluator/videos/run-1.mp4" not in prompt
+        assert "/private/evaluator/logs/run-1.txt" not in prompt
+        # Key names and useful non-sensitive feedback survive redaction.
+        assert "video_path" in prompt
+        assert "evaluator_error" in prompt
+        assert "decoder failed at" in prompt
+        assert "judge_metrics" in prompt
+        assert "0.75" in prompt
+        # The shared value-aware redactor keeps the diagnostic key and
+        # surrounding message while masking only the configured value.
+        assert "auth_message" in prompt
+        assert "token=<redacted>" in prompt
+        assert "credential-value-12345" not in prompt
+        # Rendering must not mutate the raw evaluator result that cache and
+        # parser paths use for resume fidelity.
+        assert er.per_example_side_info is not None
+        assert (
+            er.per_example_side_info[0]["video_path"]
+            == "/private/evaluator/videos/run-1.mp4"
+        )
+
     def test_list_values_render_as_item_headers(self):
         """GEPA ``render_value`` parity: a list value renders each
         element under ``##### Item N`` sub-headers (h5 under the h4

--- a/tests/unit/test_mutator_seedless.py
+++ b/tests/unit/test_mutator_seedless.py
@@ -93,14 +93,14 @@ class TestGenerateSeed:
         mock_result = {"result": "ok", "subtype": "success"}
 
         with patch("helix.mutator.invoke_claude_code", return_value=(mock_result, {})) as mock_invoke:
-            generate_seed("/tmp/fake-wt", "some prompt", config)
+            generate_seed("/fake/fake-wt", "some prompt", config)
 
         mock_invoke.assert_called_once()
 
     def test_passes_worktree_path_to_invoke(self):
         """generate_seed must pass the worktree_path as first arg to invoke_claude_code."""
         config = make_config()
-        worktree_path = "/tmp/my-seed-worktree"
+        worktree_path = "/fake/my-seed-worktree"
 
         with patch("helix.mutator.invoke_claude_code", return_value=({}, {})) as mock_invoke:
             generate_seed(worktree_path, "prompt text", config)
@@ -114,7 +114,7 @@ class TestGenerateSeed:
         prompt = "my seed generation prompt"
 
         with patch("helix.mutator.invoke_claude_code", return_value=({}, {})) as mock_invoke:
-            generate_seed("/tmp/wt", prompt, config)
+            generate_seed("/fake/wt", prompt, config)
 
         args, kwargs = mock_invoke.call_args
         assert args[1] == prompt
@@ -124,7 +124,7 @@ class TestGenerateSeed:
         config = make_config()
 
         with patch("helix.mutator.invoke_claude_code", return_value=({}, {})) as mock_invoke:
-            generate_seed("/tmp/wt", "prompt", config)
+            generate_seed("/fake/wt", "prompt", config)
 
         args, kwargs = mock_invoke.call_args
         assert args[2] is config.agent
@@ -140,7 +140,7 @@ class TestGenerateSeed:
 
         with patch("helix.mutator.invoke_claude_code", side_effect=exc):
             with pytest.raises(MutationError) as exc_info:
-                generate_seed("/tmp/wt", "prompt", config)
+                generate_seed("/fake/wt", "prompt", config)
 
         # Must be the exact same exception (no wrapping, no retry)
         assert exc_info.value is exc
@@ -158,7 +158,7 @@ class TestGenerateSeed:
 
         with patch("helix.mutator.invoke_claude_code", side_effect=failing_invoke):
             with pytest.raises(MutationError):
-                generate_seed("/tmp/wt", "prompt", config)
+                generate_seed("/fake/wt", "prompt", config)
 
         assert call_count == 1, f"Expected exactly 1 call, got {call_count} (retry loop detected!)"
 
@@ -168,6 +168,6 @@ class TestGenerateSeed:
         mock_usage = {"input_tokens": 100}
 
         with patch("helix.mutator.invoke_claude_code", return_value=({"subtype": "success"}, mock_usage)):
-            result = generate_seed("/tmp/wt", "prompt", config)
+            result = generate_seed("/fake/wt", "prompt", config)
 
         assert result == mock_usage

--- a/tests/unit/test_parser_helix_result.py
+++ b/tests/unit/test_parser_helix_result.py
@@ -5,8 +5,8 @@ evaluator emits a list of ``[score_i, side_info_i]`` pairs positional
 to the ids in ``helix_batch.json``.  HELIX zips them into the id-keyed
 ``instance_scores`` the minibatch gate needs and stores the
 per-example side_info list on :class:`helix.population.EvalResult` for
-the reflection prompt.  See :mod:`helix.parsers.helix_result` and
-``/tmp/gepa_audit_report.md`` for the GEPA parity rationale.
+the reflection prompt.  See :mod:`helix.parsers.helix_result` for the
+GEPA parity rationale.
 
 The parser is strict by design: any deviation from the contract raises
 :class:`EvaluatorError` rather than silently falling back.  The footgun

--- a/tests/unit/test_population.py
+++ b/tests/unit/test_population.py
@@ -16,7 +16,7 @@ from helix.population import Candidate, EvalResult, ParetoFrontier
 def make_candidate(cid: str, generation: int = 0) -> Candidate:
     return Candidate(
         id=cid,
-        worktree_path=f"/tmp/{cid}",
+        worktree_path=f"/fake/{cid}",
         branch_name=f"branch-{cid}",
         generation=generation,
         parent_id=None,

--- a/tests/unit/test_population_multi_axis_frontier.py
+++ b/tests/unit/test_population_multi_axis_frontier.py
@@ -40,7 +40,7 @@ from helix.population import (
 def _make_candidate(cid: str) -> Candidate:
     return Candidate(
         id=cid,
-        worktree_path=f"/tmp/{cid}",
+        worktree_path=f"/fake/{cid}",
         branch_name=f"branch-{cid}",
         generation=0,
         parent_id=None,

--- a/tests/unit/test_rate_limit_fixes.py
+++ b/tests/unit/test_rate_limit_fixes.py
@@ -91,7 +91,7 @@ class TestFix2RateLimitDiagnostics:
             operation="Claude Code invocation",
             phase="subprocess exit",
             command="claude --print -p ...",
-            cwd="/tmp/worktree",
+            cwd="/fake/worktree",
             stdout="",
             stderr="Error: 529 overloaded",
             exit_code=529,
@@ -100,7 +100,7 @@ class TestFix2RateLimitDiagnostics:
         assert err.operation == "Claude Code invocation"
         assert err.phase == "subprocess exit"
         assert err.command == "claude --print -p ..."
-        assert err.cwd == "/tmp/worktree"
+        assert err.cwd == "/fake/worktree"
         assert err.stdout == ""
         assert err.stderr == "Error: 529 overloaded"
         assert err.exit_code == 529
@@ -119,13 +119,13 @@ class TestFix2RateLimitDiagnostics:
 
         config = AgentConfig()
         with pytest.raises(RateLimitError) as exc_info:
-            invoke_claude_code("/tmp/wt", "test prompt", config)
+            invoke_claude_code("/fake/wt", "test prompt", config)
 
         err = exc_info.value
         assert err.exit_code == 1
         assert err.stderr == "Error: 529 overloaded please retry"
         assert err.stdout == ""
-        assert err.cwd == "/tmp/wt"
+        assert err.cwd == "/fake/wt"
         assert err.command != ""
         assert err.suggestion != ""
 
@@ -144,11 +144,11 @@ class TestFix2RateLimitDiagnostics:
 
         config = AgentConfig()
         with pytest.raises(RateLimitError) as exc_info:
-            invoke_claude_code("/tmp/wt", "test prompt", config)
+            invoke_claude_code("/fake/wt", "test prompt", config)
 
         err = exc_info.value
         assert err.exit_code == 0
-        assert err.cwd == "/tmp/wt"
+        assert err.cwd == "/fake/wt"
         assert err.command != ""
         assert err.suggestion != ""
 
@@ -159,7 +159,7 @@ class TestFix2RateLimitDiagnostics:
             operation="invoke",
             phase="exit",
             command="claude -p ...",
-            cwd="/tmp",
+            cwd="/fake",
             stdout="out",
             stderr="rate limit exceeded",
             exit_code=1,
@@ -170,7 +170,7 @@ class TestFix2RateLimitDiagnostics:
         assert "invoke" in full
         assert "exit" in full
         assert "claude -p ..." in full
-        assert "/tmp" in full
+        assert "/fake" in full
         assert "out" in full
         assert "rate limit exceeded" in full
         assert "retry later" in full
@@ -311,7 +311,7 @@ class TestFix4FileLogging:
             operation="mutate g1-s0",
             phase="subprocess exit",
             command="claude --print -p ...",
-            cwd="/tmp/wt",
+            cwd="/fake/wt",
             stdout="some stdout text",
             stderr="some stderr text",
             exit_code=1,
@@ -343,7 +343,7 @@ class TestFix4FileLogging:
             operation="Claude Code invocation",
             phase="subprocess exit",
             command="claude --print -p test",
-            cwd="/tmp/wt",
+            cwd="/fake/wt",
             stdout="",
             stderr="Error: 529 overloaded",
             exit_code=529,

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -1,0 +1,39 @@
+"""Tests for the shared diagnostic rendering redactor."""
+
+from __future__ import annotations
+
+import json
+
+from helix.redaction import REDACTED_VALUE, DiagnosticRedactor, redact_diagnostics
+
+
+def test_redacts_substrings_and_json_encoded_values_recursively():
+    secret = 'sk-secret-47-"quoted"'
+    encoded_secret = json.dumps(secret)[1:-1]
+    redactor = DiagnosticRedactor.from_values([secret])
+
+    value = {
+        "credential": f"prefix {secret} suffix",
+        "nested": [f'{{"token": "{encoded_secret}"}}'],
+    }
+
+    redacted = redactor.redact(value)
+
+    assert redacted == {
+        "credential": f"prefix {REDACTED_VALUE} suffix",
+        "nested": [f'{{"token": "{REDACTED_VALUE}"}}'],
+    }
+    assert "credential" in redacted
+    assert secret not in str(redacted)
+
+
+def test_short_and_empty_values_do_not_over_redact_unrelated_output():
+    output = "low battery; yellow light; unremarkable diagnostics"
+
+    assert redact_diagnostics(output, ["", "low", "yellow"]) == output
+
+
+def test_non_string_values_are_preserved():
+    value = {"count": 3, "enabled": True, "nothing": None}
+
+    assert redact_diagnostics(value, ["sk-secret-47"]) == value

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -188,8 +188,8 @@ def test_load_state_rejects_newer_schema_version(tmp_path: Path) -> None:
 def test_eval_cache_pickle_roundtrip(tmp_path: Path) -> None:
     """save_eval_cache → load_eval_cache must round-trip the tuple-keyed dict.
 
-    Audit ref: C1 — JSON cannot encode tuple keys; we use a sibling pickle
-    so the per-(candidate_hash, example_id) cache survives crash/resume the
+    JSON cannot encode tuple keys; we use a sibling pickle so the
+    per-(candidate_hash, example_id) cache survives crash/resume the
     same way GEPA's pickled state does (gepa/core/state.py:306-340, 348-376).
     """
     cache: MinibatchEvalCache[object, str] = MinibatchEvalCache[object, str]()
@@ -211,7 +211,7 @@ def test_eval_cache_pickle_roundtrip(tmp_path: Path) -> None:
 def test_eval_cache_load_returns_none_when_missing(tmp_path: Path) -> None:
     """load_eval_cache must return None when no companion pickle exists.
 
-    Audit ref: C1 — fresh runs (no prior state) should not raise.
+    Fresh runs (no prior state) should not raise.
     """
     assert load_eval_cache(tmp_path) is None
 
@@ -235,6 +235,80 @@ def test_eval_cache_load_tolerates_non_dict(tmp_path: Path) -> None:
     quarantined = list(helix_dir.glob("eval_cache.pkl.corrupt-*"))
     assert len(quarantined) == 1
     assert quarantined[0].read_bytes() == _pickle.dumps(["not", "a", "dict"])
+
+
+def test_eval_cache_load_rejects_pre_extension_payload(tmp_path: Path) -> None:
+    """A pre-``side_info`` cache (bare ``dict[CacheKey, CachedEvaluation]``
+    without the schema-versioned envelope) must be quarantined, not silently
+    loaded.  The pre-extension shape silently dropped the LIBERO reflection
+    feedstock on every cache hit (every cached entry's ``side_info`` would
+    be ``None``), so reviving it on resume would reproduce the very
+    regression the ``side_info`` slot was added to fix.
+    """
+    import pickle as _pickle
+
+    helix_dir = tmp_path / ".helix"
+    helix_dir.mkdir(parents=True)
+    target = helix_dir / "eval_cache.pkl"
+    # Bare dict, no envelope, no schema_version — exactly what previous
+    # versions of HELIX wrote.
+    legacy_payload = {
+        ("hash_a", "task_0"): "anything",
+        ("hash_b", "task_1"): "anything",
+    }
+    target.write_bytes(_pickle.dumps(legacy_payload))
+
+    with pytest.warns(RuntimeWarning, match="schema_version"):
+        assert load_eval_cache(tmp_path) is None
+
+    # The legacy file is moved aside (not deleted) so the user can inspect it.
+    assert not target.exists()
+    quarantined = list(helix_dir.glob("eval_cache.pkl.corrupt-schema-*"))
+    assert len(quarantined) == 1
+    assert _pickle.loads(quarantined[0].read_bytes()) == legacy_payload
+
+
+def test_eval_cache_load_rejects_wrong_schema_version(tmp_path: Path) -> None:
+    """A payload with an unrecognised ``schema_version`` is also quarantined.
+    Covers the forward-compat case where a future HELIX wrote a v2 cache and
+    the user resumed under a v1 binary.
+    """
+    import pickle as _pickle
+
+    helix_dir = tmp_path / ".helix"
+    helix_dir.mkdir(parents=True)
+    target = helix_dir / "eval_cache.pkl"
+    future_payload = {"schema_version": 999, "entries": {}}
+    target.write_bytes(_pickle.dumps(future_payload))
+
+    with pytest.warns(RuntimeWarning, match="schema_version=999"):
+        assert load_eval_cache(tmp_path) is None
+
+    assert not target.exists()
+    quarantined = list(helix_dir.glob("eval_cache.pkl.corrupt-schema-*"))
+    assert len(quarantined) == 1
+
+
+def test_eval_cache_load_rejects_malformed_envelope(tmp_path: Path) -> None:
+    """The envelope must carry an ``entries`` dict.  A versioned payload
+    that lost the entries (corruption mid-write, etc.) is quarantined.
+    """
+    import pickle as _pickle
+
+    from helix.state import EVAL_CACHE_SCHEMA_VERSION
+
+    helix_dir = tmp_path / ".helix"
+    helix_dir.mkdir(parents=True)
+    target = helix_dir / "eval_cache.pkl"
+    bad_payload = {"schema_version": EVAL_CACHE_SCHEMA_VERSION, "entries": "not-a-dict"}
+    target.write_bytes(_pickle.dumps(bad_payload))
+
+    with pytest.warns(RuntimeWarning, match="malformed-envelope"):
+        assert load_eval_cache(tmp_path) is None
+
+    assert not target.exists()
+    quarantined = list(helix_dir.glob("eval_cache.pkl.corrupt-malformed-envelope-*"))
+    assert len(quarantined) == 1
 
 
 def test_eval_cache_load_tolerates_unreadable_pickle(tmp_path: Path) -> None:

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -281,8 +281,13 @@ def test_eval_cache_load_rejects_wrong_schema_version(tmp_path: Path) -> None:
     future_payload = {"schema_version": 999, "entries": {}}
     target.write_bytes(_pickle.dumps(future_payload))
 
-    with pytest.warns(RuntimeWarning, match="schema_version=999"):
+    with pytest.warns(RuntimeWarning, match="schema_version=999") as recorded:
         assert load_eval_cache(tmp_path) is None
+
+    warning = str(recorded[0].message)
+    assert str(target) not in warning
+    assert str(helix_dir) not in warning
+    assert "diagnostic copy was retained" in warning
 
     assert not target.exists()
     quarantined = list(helix_dir.glob("eval_cache.pkl.corrupt-schema-*"))

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -1,7 +1,7 @@
 """Unit tests for GEPA-aligned state persistence.
 
-Covers the additions called out in /tmp/audit_audit-rng-state-persist.md
-(MODERATE_DIVERGENCE — schema thin vs GEPA):
+Covers the GEPA-parity state-persistence schema (HELIX was thinner than
+GEPA):
 
 * C1 — per-(candidate, example) eval cache survives save → load round-trip
   (GEPA core/state.py:185, 306-340, 348-376, 683-687).
@@ -80,7 +80,7 @@ def _make_full_state() -> EvolutionState:
 def test_state_roundtrip_preserves_all_fields(tmp_path: Path) -> None:
     """save_state → load_state must deep-equal the original on every field.
 
-    Audit ref: /tmp/audit_audit-rng-state-persist.md C/§3 + D1.
+    Covers per-program discovery budget + schema version persistence.
     """
     state = _make_full_state()
     save_state(state, tmp_path)
@@ -122,7 +122,7 @@ def _write_legacy_state_json(base_dir: Path) -> None:
     legacy = {
         # Note: deliberately omits "schema_version" and
         # "num_metric_calls_by_discovery".  Mirrors the on-disk format that
-        # existed before audit-rng-state-persist D1 was addressed.
+        # existed before the schema-version field was added.
         "generation": 1,
         "frontier": ["g0-s0"],
         "instance_scores": {"g0-s0": {"task_a": 0.5}},


### PR DESCRIPTION
## Summary

Preserves per-example evaluator `side_info` across evaluation-cache hits so useful mutation feedback remains available on resume and repeated examples.

## Disclosure fixes

- The raw evaluator result and cache remain unchanged for parsing and cache fidelity. At mutation-prompt rendering, diagnostics are recursively sanitised to replace absolute filesystem paths while retaining keys and non-sensitive feedback.
- Configured environment values are redacted at the same final prompt boundary using the shared value-aware redactor. It preserves dictionary keys and non-sensitive values.
- Cache schema-mismatch warnings now report the version mismatch and retained diagnostic copy without exposing filesystem paths.

## Shared component

`src/helix/redaction.py` is cherry-picked from PR #47, which owns it; merge #47 first or this commit will appear twice in history. This PR uses that module unchanged for configured secret values. The local prompt-boundary sanitiser separately covers filesystem paths, which are provenance data rather than configured secret values.

## Test plan

- [x] `uv sync --extra dev`
- [x] `uv run pytest tests/unit -q` — 880 passed
- [x] `uv run mypy --strict src/helix/` — clean
- [x] Regression coverage: nested side-info paths do not reach the prompt; raw evaluator data remains unchanged; useful keys and non-sensitive values survive; configured values are masked; schema-mismatch warnings contain no absolute paths.
