### PR TITLE
ci: publish multi-arch (amd64+arm64) Docker images via native runners

### DIFF
--- a/.github/workflows/publish-runners.yml
+++ b/.github/workflows/publish-runners.yml
@@ -11,14 +11,75 @@ env:
   IMAGE_PREFIX: ghcr.io/ke7/helix-evo-runner
 
 jobs:
-  publish-base:
-    name: Build and publish base runner image
-    runs-on: ubuntu-latest
+  # ── 1. Build base image, one job per arch, push by digest ─────────────────
+  build-base:
+    name: Build base image (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/base.Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}-base,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── 2. Merge both arch digests into a single multi-arch manifest ──────────
+  merge-base:
+    name: Merge base image manifests
+    runs-on: ubuntu-latest
+    needs: build-base
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-base-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -37,19 +98,17 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{version}}
 
-      - name: Build and publish base
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/base.Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create and push merged manifest list
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_PREFIX }}-base@sha256:%s ' *)
 
-  publish-backends:
-    name: Build and publish backend runner images
-    runs-on: ubuntu-latest
-    needs: publish-base
+  # ── 3. Build each backend (5 images × 2 arches = 10 jobs), push by digest ─
+  build-backends:
+    name: Build ${{ matrix.image.name }} (${{ matrix.platform }})
+    needs: merge-base
     permissions:
       contents: read
       packages: write
@@ -67,9 +126,90 @@ jobs:
             dockerfile: docker/gemini.Dockerfile
           - name: opencode
             dockerfile: docker/opencode.Dockerfile
-
+        platform:
+          - linux/amd64
+          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Choose base tag
+        id: base-tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push backend by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}-base:${{ steps.base-tag.outputs.value }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image.name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── 4. Merge each backend's 2 arch digests into a multi-arch manifest ─────
+  merge-backends:
+    name: Merge ${{ matrix.image.name }} image manifests
+    needs: build-backends
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: claude
+          - name: codex
+          - name: cursor
+          - name: gemini
+          - name: opencode
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image.name }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -88,31 +228,18 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{version}}
 
-      - name: Choose base tag
-        id: base-tag
-        shell: bash
+      - name: Create and push merged manifest list
+        working-directory: /tmp/digests
         run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
-            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=latest" >> "$GITHUB_OUTPUT"
-          fi
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }}@sha256:%s ' *)
 
-      - name: Build and publish backend
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.image.dockerfile }}
-          push: true
-          build-args: |
-            BASE_IMAGE=${{ env.IMAGE_PREFIX }}-base:${{ steps.base-tag.outputs.value }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
+  # ── 5. Smoke-test every published image on the native amd64 runner ────────
   verify:
     name: Verify published runner images
     runs-on: ubuntu-latest
-    needs: publish-backends
+    needs: merge-backends
     permissions:
       packages: read
     strategy:


### PR DESCRIPTION
## Summary

The `publish-runners` workflow previously built and pushed **amd64-only images** because `docker/setup-qemu-action`, `docker/setup-buildx-action`, and the `platforms:` key were all absent from every `docker/build-push-action` step. Apple Silicon users on macOS pull the amd64 image and run it under Rosetta 2 / QEMU emulation.

This PR refactors the workflow to publish true multi-arch (linux/amd64 + linux/arm64) manifest lists using a **native-runner** build+merge pattern. Native runners (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) avoid the ~3-5× QEMU slowdown that would otherwise plague the backend images' npm install steps.

## Job graph

```
build-base       (2 jobs:  amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm)
     |              each builds helix-evo-runner-base, pushes by digest
     v
merge-base       (1 job:   combines the 2 digests into a multi-arch manifest list)
     |
     v
build-backends   (10 jobs: 5 backends × 2 arches; builds against the merged base)
     |
     v
merge-backends   (5 jobs:  one per backend; combines its 2 arch digests)
     |
     v
verify           (smoke-tests every published image, unchanged)
```

## Verification after release tag

After the next `v*` tag triggers this workflow:

```bash
docker buildx imagetools inspect ghcr.io/ke7/helix-evo-runner-base:latest
# Must show:
#   MediaType: application/vnd.oci.image.index.v1+json
#   Platform:  linux/amd64
#   Platform:  linux/arm64

# From Apple Silicon (was returning x86_64 under Rosetta before):
docker pull ghcr.io/ke7/helix-evo-runner-claude:latest
docker run --rm ghcr.io/ke7/helix-evo-runner-claude:latest uname -m
# Expected: aarch64
```

## Reviewer pass (16 criteria, all PASS)

- YAML syntactic correctness, `on:` trigger unchanged, `env:` block preserved, permissions preserved
- Job graph `needs:` chain correct, `ubuntu-24.04-arm` runner name correct
- `build-backends` 2D matrix (`image × platform + include` for runner pinning) expands to exactly 10 jobs
- `push-by-digest=true,name-canonical=true,push=true` on build steps (no `tags:` key on build)
- Digest artifact upload/download naming consistent across all build/merge pairs
- `docker buildx imagetools create` jq invocation correct; tag scheme preserved (`latest`/`ref/tag`/`semver`)
- `verify` job preserved + retargeted at `merge-backends`
- `fail-fast: false` on both build matrices
- No accidental `load: true`
- Per-Dockerfile arm64 sanity checked (Cursor installer detects arm64; claude/codex/gemini/opencode Dockerfiles have no x86-only hard-codings)
- Backward compat: amd64 pullers still get amd64 transparently (multi-arch manifest list serves both arches)

S1 polish applied (removed unused `actions/checkout@v6` from `merge-base` and `merge-backends` — saves ~10-15s per merge run). S2 deferred (adding OCI labels via metadata-action in build jobs is cosmetic; images are functional without).

## Root-cause report

See `/Users/ke/helix-arm64-image-debug.md` §6 for the design rationale (native-arm64-runner vs QEMU emulation trade-off) and full diagnostic evidence (manifest inspect output, config blob arch=amd64 confirmation).