### PR TITLE
Cache per-example side info

### DIFF
--- a/src/helix/eval_cache.py
+++ b/src/helix/eval_cache.py
@@ -34,6 +34,7 @@ class CachedEvaluation(Generic[RolloutOutput]):
     output: RolloutOutput
     score: float
     objective_scores: dict[str, float] | None = None
+    side_info: dict[str, Any] | None = None
 
 
 @dataclass
@@ -60,10 +61,11 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         output: RolloutOutput,
         score: float,
         objective_scores: dict[str, float] | None = None,
+        side_info: dict[str, Any] | None = None,
     ) -> None:
         with self._lock:
             self._cache[(_candidate_hash(candidate), example_id)] = CachedEvaluation(
-                output, score, objective_scores
+                output, score, objective_scores, side_info
             )
 
     def get_batch(
@@ -95,6 +97,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         outputs: list[RolloutOutput],
         scores: list[float],
         objective_scores_list: list[dict[str, float]] | None = None,
+        side_info_list: list[dict[str, Any]] | None = None,
     ) -> None:
         h = _candidate_hash(candidate)
         with self._lock:
@@ -103,6 +106,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                     outputs[i],
                     scores[i],
                     objective_scores_list[i] if objective_scores_list else None,
+                    side_info_list[i] if side_info_list else None,
                 )
         TRACE.emit(
             EventType.CACHE_PUT,
@@ -117,12 +121,18 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         fetcher: Callable[[list[DataId]], Any],
         evaluator: Callable[
             [Any, dict[str, str]],
-            tuple[list[RolloutOutput], list[float], list[dict[str, float]] | None],
+            tuple[
+                list[RolloutOutput],
+                list[float],
+                list[dict[str, float]] | None,
+                list[dict[str, Any]] | None,
+            ],
         ],
     ) -> tuple[
         dict[DataId, RolloutOutput],
         dict[DataId, float],
         dict[DataId, dict[str, float]] | None,
+        dict[DataId, dict[str, Any]] | None,
         int,
     ]:
         cached, uncached_ids = self.get_batch(candidate, example_ids)
@@ -138,9 +148,15 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                 if objective_by_id is None:
                     objective_by_id = {}
                 objective_by_id[eid] = c.objective_scores
+        side_info_by_id: dict[DataId, dict[str, Any]] | None = None
+        for eid, c in cached.items():
+            if c.side_info is not None:
+                if side_info_by_id is None:
+                    side_info_by_id = {}
+                side_info_by_id[eid] = c.side_info
         if uncached_ids:
             batch = fetcher(uncached_ids)
-            outputs, scores, obj_scores = evaluator(batch, candidate)
+            outputs, scores, obj_scores, side_infos = evaluator(batch, candidate)
             for idx, eid in enumerate(uncached_ids):
                 outputs_by_id[eid] = outputs[idx]
                 scores_by_id[eid] = scores[idx]
@@ -148,5 +164,16 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                     if objective_by_id is None:
                         objective_by_id = {}
                     objective_by_id[eid] = obj_scores[idx]
-            self.put_batch(candidate, uncached_ids, outputs, scores, obj_scores)
-        return outputs_by_id, scores_by_id, objective_by_id, len(uncached_ids)
+                if side_infos is not None:
+                    if side_info_by_id is None:
+                        side_info_by_id = {}
+                    side_info_by_id[eid] = side_infos[idx]
+            self.put_batch(
+                candidate,
+                uncached_ids,
+                outputs,
+                scores,
+                obj_scores,
+                side_infos,
+            )
+        return outputs_by_id, scores_by_id, objective_by_id, side_info_by_id, len(uncached_ids)

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -901,15 +901,6 @@ def _cached_evaluate_batch(
         "split": split,
     }
 
-    # Closure side-channel: the cache stores ``(output, score, objective_scores)``
-    # per id but has no slot for freeform ``side_info``.  Collect fresh
-    # per-example side_info in a closure dict so we can attach it to the
-    # merged ``EvalResult`` below.  Cache-hit ids (not in this dict) get
-    # ``{}`` as their per_example_side_info slot — their prior side_info
-    # was consumed by the reflection prompt at their original eval time
-    # and is not round-tripped through the cache.
-    fresh_side_info_by_id: dict[str, dict[str, Any]] = {}
-
     def _fetcher(ids: list[str]) -> list[str]:
         # HELIX evaluators read batches off disk via helix_batch.json;
         # the "batch" handed to the evaluator callable is just the list
@@ -920,7 +911,12 @@ def _cached_evaluate_batch(
     def _evaluator(
         batch: list[str],
         _candidate: dict[str, str],
-    ) -> tuple[list[object], list[float], list[dict[str, float]] | None]:
+    ) -> tuple[
+        list[object],
+        list[float],
+        list[dict[str, float]] | None,
+        list[dict[str, Any]] | None,
+    ]:
         # Write a REDUCED helix_batch.json containing only the uncached
         # example ids, then invoke the evaluator subprocess.  Evaluators
         # read that file from cwd and filter their own dataset to exactly
@@ -965,16 +961,24 @@ def _cached_evaluate_batch(
             batch
         ):
             obj_list = [fresh.objective_scores[i] for i in range(len(batch))]
-        # Capture per-example side_info for the outer merge.  Only
-        # freshly-evaluated ids populate this; cache hits remain ``{}``.
+        # Capture per-example side_info for the cache.  This is keyed by the
+        # same (candidate hash, example id) pair as scores/objectives, so a
+        # later cache hit can render exactly the diagnostics for the selected
+        # examples instead of dropping them or reusing unrelated batch logs.
+        side_info_list: list[dict[str, Any]] | None = None
         if fresh.per_example_side_info is not None and len(
             fresh.per_example_side_info
         ) == len(batch):
-            for i, eid in enumerate(batch):
-                fresh_side_info_by_id[eid] = fresh.per_example_side_info[i]
-        return outputs, scores, obj_list
+            side_info_list = [fresh.per_example_side_info[i] for i in range(len(batch))]
+        return outputs, scores, obj_list, side_info_list
 
-    _, scores_by_id, objective_by_id, num_actual_evals = cache.evaluate_with_cache_full(
+    (
+        _,
+        scores_by_id,
+        objective_by_id,
+        side_info_by_id,
+        num_actual_evals,
+    ) = cache.evaluate_with_cache_full(
         cand_dict,
         example_ids,
         _fetcher,
@@ -997,9 +1001,9 @@ def _cached_evaluate_batch(
     if objective_by_id is not None:
         objective_scores_list = [objective_by_id.get(eid, {}) for eid in example_ids]
     per_example_side_info_list: list[dict[str, Any]] | None = None
-    if fresh_side_info_by_id:
+    if side_info_by_id is not None:
         per_example_side_info_list = [
-            fresh_side_info_by_id.get(eid, {}) for eid in example_ids
+            side_info_by_id.get(eid, {}) for eid in example_ids
         ]
 
     merged = EvalResult(

--- a/tests/unit/test_eval_cache.py
+++ b/tests/unit/test_eval_cache.py
@@ -9,12 +9,20 @@ def test_get_put_round_trip() -> None:
     cache: EvaluationCache[str, int] = EvaluationCache()
     cand = {"a": "1", "b": "2"}
     assert cache.get(cand, 7) is None
-    cache.put(cand, 7, output="hello", score=0.5, objective_scores={"acc": 1.0})
+    cache.put(
+        cand,
+        7,
+        output="hello",
+        score=0.5,
+        objective_scores={"acc": 1.0},
+        side_info={"trace": "cached"},
+    )
     entry = cache.get(cand, 7)
     assert entry is not None
     assert entry.output == "hello"
     assert entry.score == 0.5
     assert entry.objective_scores == {"acc": 1.0}
+    assert entry.side_info == {"trace": "cached"}
 
 
 def test_get_batch_splits_cached_uncached() -> None:
@@ -38,17 +46,19 @@ def test_put_batch_stores_all_entries() -> None:
         ["a", "b", "c"],
         [0.1, 0.2, 0.3],
         [{"m": 1.0}, {"m": 2.0}, {"m": 3.0}],
+        [{"log": "a"}, {"log": "b"}, {"log": "c"}],
     )
-    for eid, out, score, m in [
-        (10, "a", 0.1, 1.0),
-        (20, "b", 0.2, 2.0),
-        (30, "c", 0.3, 3.0),
+    for eid, out, score, m, log in [
+        (10, "a", 0.1, 1.0, "a"),
+        (20, "b", 0.2, 2.0, "b"),
+        (30, "c", 0.3, 3.0, "c"),
     ]:
         e = cache.get(cand, eid)
         assert e is not None
         assert e.output == out
         assert e.score == score
         assert e.objective_scores == {"m": m}
+        assert e.side_info == {"log": log}
 
 
 def test_put_batch_no_objective_scores() -> None:
@@ -58,6 +68,7 @@ def test_put_batch_no_objective_scores() -> None:
     e = cache.get(cand, 1)
     assert e is not None
     assert e.objective_scores is None
+    assert e.side_info is None
 
 
 def test_evaluate_with_cache_full_calls_evaluator_only_for_uncached() -> None:
@@ -73,14 +84,20 @@ def test_evaluate_with_cache_full_calls_evaluator_only_for_uncached() -> None:
 
     def evaluator(
         batch: list[int], _c: dict[str, str]
-    ) -> tuple[list[str], list[float], list[dict[str, float]] | None]:
+    ) -> tuple[
+        list[str],
+        list[float],
+        list[dict[str, float]] | None,
+        list[dict[str, str]] | None,
+    ]:
         calls.append(list(batch))
         outs = [f"out{eid}" for eid in batch]
         scores = [float(eid) / 10 for eid in batch]
         obj = [{"acc": float(eid)} for eid in batch]
-        return outs, scores, obj
+        side_info = [{"feedback": f"log{eid}"} for eid in batch]
+        return outs, scores, obj, side_info
 
-    outputs, scores, obj_by_id, n_uncached = cache.evaluate_with_cache_full(
+    outputs, scores, obj_by_id, side_info_by_id, n_uncached = cache.evaluate_with_cache_full(
         cand, [1, 2, 3], fetcher, evaluator
     )
 
@@ -90,6 +107,10 @@ def test_evaluate_with_cache_full_calls_evaluator_only_for_uncached() -> None:
     assert scores == {1: 0.9, 2: 0.2, 3: 0.3}
     assert obj_by_id is not None
     assert obj_by_id == {2: {"acc": 2.0}, 3: {"acc": 3.0}}
+    assert side_info_by_id == {
+        2: {"feedback": "log2"},
+        3: {"feedback": "log3"},
+    }
 
 
 def test_evaluate_with_cache_full_second_call_fully_cached() -> None:
@@ -102,14 +123,24 @@ def test_evaluate_with_cache_full_second_call_fully_cached() -> None:
 
     def evaluator(
         batch: list[int], _c: dict[str, str]
-    ) -> tuple[list[str], list[float], list[dict[str, float]] | None]:
+    ) -> tuple[
+        list[str],
+        list[float],
+        list[dict[str, float]] | None,
+        list[dict[str, str]] | None,
+    ]:
         calls.append(list(batch))
-        return [f"o{e}" for e in batch], [0.0 for _ in batch], None
+        return (
+            [f"o{e}" for e in batch],
+            [0.0 for _ in batch],
+            None,
+            [{"feedback": f"log{e}"} for e in batch],
+        )
 
     cache.evaluate_with_cache_full(cand, [1, 2, 3], fetcher, evaluator)
     assert calls == [[1, 2, 3]]
 
-    outputs, scores, obj, n_new = cache.evaluate_with_cache_full(
+    outputs, scores, obj, side_info, n_new = cache.evaluate_with_cache_full(
         cand, [1, 2, 3], fetcher, evaluator
     )
     assert calls == [[1, 2, 3]]  # not called again
@@ -117,6 +148,11 @@ def test_evaluate_with_cache_full_second_call_fully_cached() -> None:
     assert outputs == {1: "o1", 2: "o2", 3: "o3"}
     assert scores == {1: 0.0, 2: 0.0, 3: 0.0}
     assert obj is None
+    assert side_info == {
+        1: {"feedback": "log1"},
+        2: {"feedback": "log2"},
+        3: {"feedback": "log3"},
+    }
 
 
 def test_candidate_hash_order_independent() -> None:

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -1267,13 +1267,9 @@ class TestCachedEvaluateBatch:
 
     def test_partial_cache_hit_per_example_fields_merge(self, mocker: Any) -> None:
         """Partial-cache-hit merge of ``per_example_side_info`` and
-        ``objective_scores``.  Pins the closure side-channel design
-        from commit H (``_cached_evaluate_batch``):
+        ``objective_scores``:
 
-          * cache-hit positions get ``{}`` for per_example_side_info
-            (the cache has no slot for freeform side_info so the merge
-            can't round-trip it — their prior side_info was consumed
-            by the reflection prompt at their original eval time);
+          * cache-hit positions get their own cached side_info by id;
           * fresh miss positions get the per_example_side_info dict
             from the fresh EvalResult, zipped by id;
           * ``objective_scores`` IS round-tripped through the cache
@@ -1298,6 +1294,10 @@ class TestCachedEvaluateBatch:
             objective_scores_list=[
                 {"obj_alpha": 0.11, "obj_beta": 0.8},
                 {"obj_alpha": 0.33, "obj_beta": 0.1},
+            ],
+            side_info_list=[
+                {"trajectory": "cached_trace_0", "rollout_id": "cached__0"},
+                {"trajectory": "cached_trace_2", "rollout_id": "cached__2"},
             ],
         )
         # "1" is uncached — the evaluator is invoked with it only, and
@@ -1350,14 +1350,13 @@ class TestCachedEvaluateBatch:
             {"obj_alpha": 0.33, "obj_beta": 0.1},     # cached id "2"
         ]
 
-        # per_example_side_info: cache has no slot, so cache-hit
-        # positions get ``{}`` placeholder; the fresh miss position
-        # gets the dict we returned from fake_run.
+        # per_example_side_info round-trips by example id through the cache;
+        # the fresh miss position gets the dict we returned from fake_run.
         assert result.per_example_side_info is not None
         assert result.per_example_side_info == [
-            {},                                                               # cached "0" → {}
+            {"trajectory": "cached_trace_0", "rollout_id": "cached__0"},       # cached "0"
             {"trajectory": "fresh_trace_1", "rollout_id": "fresh__1"},         # fresh "1"
-            {},                                                               # cached "2" → {}
+            {"trajectory": "cached_trace_2", "rollout_id": "cached__2"},       # cached "2"
         ]
 
     def test_cache_populates_after_fresh_eval(self, mocker: Any) -> None:


### PR DESCRIPTION
## Summary
- cache per-example side_info alongside cached scores and objective scores
- reconstruct per_example_side_info by requested example id on cache hits and partial hits
- prevents cached evaluations from dropping feedback diagnostics for selected examples

## Behavior
Evaluator-specific log/feedback content is still produced by the evaluator. HELIX now owns the cache/indexing/persistence path for the per-example side_info that feeds mutation prompts.

## Tests
- `PYTHONPATH=$PWD/src /work/ke/research/helix/.venv/bin/python -m pytest tests/unit/test_eval_cache.py tests/unit/test_evolution_minibatch.py`
- `codex review --commit HEAD` attempted, but Codex CLI could not inspect due `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.
