### PR TITLE
Add grouped stratified minibatch sampling

### DIFF
--- a/src/helix/batch_sampler.py
+++ b/src/helix/batch_sampler.py
@@ -113,14 +113,15 @@ class EpochShuffledBatchSampler(Generic[DataId]):
 
 
 class StratifiedBatchSampler(Generic[DataId]):
-    """Task-stratified minibatch sampler.
+    """Group-stratified minibatch sampler.
 
-    Each epoch is pre-shuffled such that every minibatch of size ``K`` is a
-    slice of ``K`` instances drawn from ``K`` distinct groups (per
-    ``group_fn``).  This guarantees task diversity within every minibatch,
-    which helps reflection-style evolutionary search reason about
-    generalisation instead of overfitting to whichever task happens to
-    dominate a random batch.
+    By default, each epoch is pre-shuffled such that every minibatch of size
+    ``K`` is a slice of ``K`` instances drawn from ``K`` distinct groups (per
+    ``group_fn``).  When ``num_sampled_groups`` and ``num_examples_per_group`` are
+    set, each batch instead contains ``num_sampled_groups`` groups with
+    ``num_examples_per_group`` instances from each group.  This guarantees task
+    diversity, or deliberate same-group multi-example sampling, within every
+    minibatch.
 
     Design notes:
 
@@ -128,8 +129,8 @@ class StratifiedBatchSampler(Generic[DataId]):
       *within* each group, then interleave across groups round-robin.  The
       resulting flat schedule (``self.shuffled_ids``) has the property that
       any contiguous window of ``minibatch_size`` indices begins at a
-      multiple of ``minibatch_size`` and touches ``minibatch_size`` distinct
-      groups — as long as at least ``minibatch_size`` groups exist.
+      multiple of the effective minibatch size and touches the requested
+      number of distinct groups — as long as enough groups exist.
     - Per-round rotation: when ``num_groups > minibatch_size``, each round
       drops the trailing ``num_groups % minibatch_size`` groups (padding
       would re-introduce a group collision).  We rotate ``group_keys`` by
@@ -143,13 +144,13 @@ class StratifiedBatchSampler(Generic[DataId]):
       round, dropping any trailing remainder rather than padding with
       duplicates (padding would re-introduce a group collision within the
       final minibatch).
-    - Fallback: when ``len(groups) < minibatch_size``, a stratified minibatch
-      is impossible, so the sampler transparently delegates to an internal
-      :class:`EpochShuffledBatchSampler` for GEPA parity semantics.
+    - Fallback: when ``len(groups) < num_sampled_groups``, a stratified
+      minibatch is impossible, so the sampler transparently delegates to an
+      internal :class:`EpochShuffledBatchSampler` for GEPA parity semantics.
 
     Invariants:
-      S1. Every returned minibatch of size ``m`` contains exactly ``m``
-          distinct group keys (when ``num_groups >= m``).
+      S1. Every returned minibatch contains exactly ``m`` distinct group keys
+          and ``t`` examples per group (when ``num_groups >= m``).
       S2. Within an epoch each instance is yielded at most once.  In each
           round of the round-robin interleave, only the first
           ``whole_rounds_per_round = (num_groups // m) * m`` entries are
@@ -167,8 +168,25 @@ class StratifiedBatchSampler(Generic[DataId]):
         minibatch_size: int,
         group_fn: Callable[[DataId], str],
         rng: random.Random | None = None,
+        num_sampled_groups: int | None = None,
+        num_examples_per_group: int | None = None,
     ) -> None:
+        if num_sampled_groups is not None and num_sampled_groups < 1:
+            raise ValueError(
+                "num_sampled_groups must be >= 1 "
+                f"(got {num_sampled_groups})"
+            )
+        if num_examples_per_group is not None and num_examples_per_group < 1:
+            raise ValueError(
+                "num_examples_per_group must be >= 1 "
+                f"(got {num_examples_per_group})"
+            )
         self.minibatch_size = minibatch_size
+        self.num_sampled_groups = (
+            minibatch_size if num_sampled_groups is None else num_sampled_groups
+        )
+        self.num_examples_per_group = 1 if num_examples_per_group is None else num_examples_per_group
+        self.effective_minibatch_size = self.num_sampled_groups * self.num_examples_per_group
         self.group_fn = group_fn
         self.rng = rng if rng is not None else random.Random(0)
         self.shuffled_ids: list[DataId] = []
@@ -194,10 +212,10 @@ class StratifiedBatchSampler(Generic[DataId]):
         num_groups = len(group_keys)
 
         # Fallback path: not enough groups to guarantee stratification.
-        if num_groups < self.minibatch_size:
+        if num_groups < self.num_sampled_groups:
             if self._fallback is None:
                 self._fallback = EpochShuffledBatchSampler[DataId](
-                    minibatch_size=self.minibatch_size, rng=self.rng
+                    minibatch_size=self.effective_minibatch_size, rng=self.rng
                 )
             # Keep schedule empty so next_minibatch_ids delegates.
             self.shuffled_ids = []
@@ -224,21 +242,36 @@ class StratifiedBatchSampler(Generic[DataId]):
         # before slicing rotates which group lands in the trimmed slot
         # across rounds, so no group is starved within an epoch when
         # ``num_groups > m`` and ``num_groups % m != 0``.
-        max_rounds = max(len(buckets[k]) for k in group_keys)
-        m = self.minibatch_size
+        max_rounds = max(
+            len(buckets[k]) // self.num_examples_per_group for k in group_keys
+        )
+        m = self.num_sampled_groups
+        t = self.num_examples_per_group
         whole_rounds_per_round = (num_groups // m) * m
         trimmed: list[DataId] = []
         for r in range(max_rounds):
             offset = r % num_groups
             rotated_keys = group_keys[offset:] + group_keys[:offset]
-            round_slice = [buckets[k][r] for k in rotated_keys if r < len(buckets[k])]
+            round_slice: list[DataId] = []
+            for k in rotated_keys:
+                start = r * t
+                end = start + t
+                if end <= len(buckets[k]):
+                    round_slice.extend(buckets[k][start:end])
             # Take at most whole_rounds_per_round entries, then clip to a
-            # multiple of m in case this round is partial.
-            keep = min(len(round_slice), whole_rounds_per_round)
-            keep -= keep % m
+            # whole number of stratified batches in case this round is partial.
+            keep_groups = min(len(round_slice) // t, whole_rounds_per_round)
+            keep_groups -= keep_groups % m
+            keep = keep_groups * t
             trimmed.extend(round_slice[:keep])
 
         self.shuffled_ids = trimmed
+        if len(self.shuffled_ids) < self.effective_minibatch_size:
+            if self._fallback is None:
+                self._fallback = EpochShuffledBatchSampler[DataId](
+                    minibatch_size=self.effective_minibatch_size, rng=self.rng
+                )
+            self.shuffled_ids = []
 
     def next_minibatch_ids(
         self, loader: DataLoader[DataId], state: _SamplerState
@@ -254,7 +287,7 @@ class StratifiedBatchSampler(Generic[DataId]):
         if self._fallback is not None and trainset_size == self.last_trainset_size:
             return self._fallback.next_minibatch_ids(loader, state)
 
-        base_idx = state.i * self.minibatch_size
+        base_idx = state.i * self.effective_minibatch_size
         curr_epoch = (
             0 if self.epoch == -1 else base_idx // max(len(self.shuffled_ids), 1)
         )
@@ -271,10 +304,10 @@ class StratifiedBatchSampler(Generic[DataId]):
         if not self.shuffled_ids and self._fallback is not None:
             return self._fallback.next_minibatch_ids(loader, state)
 
-        assert len(self.shuffled_ids) >= self.minibatch_size
-        assert len(self.shuffled_ids) % self.minibatch_size == 0
+        assert len(self.shuffled_ids) >= self.effective_minibatch_size
+        assert len(self.shuffled_ids) % self.effective_minibatch_size == 0
         base_idx = base_idx % len(self.shuffled_ids)
-        end_idx = base_idx + self.minibatch_size
+        end_idx = base_idx + self.effective_minibatch_size
         assert end_idx <= len(self.shuffled_ids)
         _ids = self.shuffled_ids[base_idx:end_idx]
         TRACE.emit(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -382,6 +382,24 @@ class EvolutionConfig(BaseModel):
             "minibatch_size are available."
         ),
     )
+    num_sampled_groups: int | None = Field(
+        default=None,
+        description=(
+            "Optional stratified sampler group count. When set with "
+            "num_examples_per_group, each minibatch contains num_sampled_groups "
+            "groups and num_examples_per_group examples from each selected group. "
+            "Unset preserves the legacy stratified behavior of "
+            "minibatch_size distinct groups with one example each."
+        ),
+    )
+    num_examples_per_group: int | None = Field(
+        default=None,
+        description=(
+            "Optional stratified sampler example count per sampled group. Must "
+            "be set together with num_sampled_groups. The effective minibatch "
+            "cardinality becomes num_sampled_groups * num_examples_per_group."
+        ),
+    )
     group_key_separator: str = Field(
         default="__",
         description=(
@@ -453,6 +471,26 @@ class EvolutionConfig(BaseModel):
                 "evolution.group_key_separator must be a non-empty string "
                 "when evolution.batch_sampler='stratified' "
                 f"(got {self.group_key_separator!r})"
+            )
+        if (self.num_sampled_groups is None) != (self.num_examples_per_group is None):
+            raise ValueError(
+                "evolution.num_sampled_groups and evolution.num_examples_per_group "
+                "must be set together"
+            )
+        if self.num_sampled_groups is not None and self.batch_sampler != "stratified":
+            raise ValueError(
+                "evolution.num_sampled_groups and evolution.num_examples_per_group "
+                "require evolution.batch_sampler='stratified'"
+            )
+        if self.num_sampled_groups is not None and self.num_sampled_groups < 1:
+            raise ValueError(
+                "evolution.num_sampled_groups must be >= 1 "
+                f"(got {self.num_sampled_groups})"
+            )
+        if self.num_examples_per_group is not None and self.num_examples_per_group < 1:
+            raise ValueError(
+                "evolution.num_examples_per_group must be >= 1 "
+                f"(got {self.num_examples_per_group})"
             )
 
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -198,6 +198,8 @@ def _resume_semantics(config: HelixConfig) -> dict[str, Any]:
             "acceptance_criterion": config.evolution.acceptance_criterion,
             "minibatch_size": config.evolution.minibatch_size,
             "batch_sampler": config.evolution.batch_sampler,
+            "num_sampled_groups": config.evolution.num_sampled_groups,
+            "num_examples_per_group": config.evolution.num_examples_per_group,
             "group_key_separator": config.evolution.group_key_separator,
             "val_stage_size": config.evolution.val_stage_size,
             "merge_enabled": config.evolution.merge_enabled,
@@ -1361,6 +1363,8 @@ def _run_evolution_impl(
                 minibatch_size=config.evolution.minibatch_size,
                 group_fn=_group_fn,
                 rng=rng,
+                num_sampled_groups=config.evolution.num_sampled_groups,
+                num_examples_per_group=config.evolution.num_examples_per_group,
             )
         else:
             batch_sampler = EpochShuffledBatchSampler[str](

--- a/tests/unit/test_batch_sampler.py
+++ b/tests/unit/test_batch_sampler.py
@@ -151,6 +151,40 @@ def test_stratified_minibatch_contains_k_distinct_groups() -> None:
         )
 
 
+def test_stratified_num_sampled_groups_one_samples_multiple_examples_from_same_group() -> None:
+    """A stratified minibatch may now pick one group and several examples."""
+    ids = [f"{g}__trial_{i}" for g in ("a", "b", "c") for i in range(5)]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3,
+        group_fn=_group_by_prefix,
+        rng=random.Random(0),
+        num_sampled_groups=1,
+        num_examples_per_group=4,
+    )
+
+    for i in range(6):
+        batch = sampler.next_minibatch_ids(loader, _State(i=i))
+        assert len(batch) == 4
+        groups = {_group_by_prefix(eid) for eid in batch}
+        assert len(groups) == 1
+        assert len(set(batch)) == 4
+
+
+def test_stratified_legacy_defaults_still_use_minibatch_size_distinct_groups() -> None:
+    ids = [f"{g}__{i}" for g in ("a", "b", "c", "d") for i in range(2)]
+    loader = _Loader(ids)
+    sampler = StratifiedBatchSampler(
+        minibatch_size=3,
+        group_fn=_group_by_prefix,
+        rng=random.Random(5),
+    )
+
+    batch = sampler.next_minibatch_ids(loader, _State(i=0))
+    assert len(batch) == 3
+    assert len({_group_by_prefix(eid) for eid in batch}) == 3
+
+
 def test_stratified_epoch_covers_all_instances() -> None:
     """Each full epoch should emit every instance exactly once (balanced groups)."""
     ids = ["a__0", "a__1", "b__0", "b__1", "c__0", "c__1"]

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -114,6 +114,8 @@ class TestEvolutionConfigNewFields:
         assert cfg.cache_evaluation is False
         assert cfg.acceptance_criterion == "strict_improvement"
         assert cfg.val_stage_size is None
+        assert cfg.num_sampled_groups is None
+        assert cfg.num_examples_per_group is None
 
     def test_acceptance_criterion_accepts_improvement_or_equal(self):
         cfg = EvolutionConfig(acceptance_criterion="improvement_or_equal")
@@ -135,6 +137,9 @@ class TestEvolutionConfigNewFields:
             cache_evaluation=True,
             acceptance_criterion="improvement_or_equal",
             val_stage_size=50,
+            batch_sampler="stratified",
+            num_sampled_groups=1,
+            num_examples_per_group=4,
         )
         assert cfg.minibatch_size == 5
         assert cfg.max_workers == 4
@@ -142,6 +147,32 @@ class TestEvolutionConfigNewFields:
         assert cfg.cache_evaluation is True
         assert cfg.acceptance_criterion == "improvement_or_equal"
         assert cfg.val_stage_size == 50
+        assert cfg.num_sampled_groups == 1
+        assert cfg.num_examples_per_group == 4
+
+    def test_group_example_sampling_fields_must_be_paired(self):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(num_sampled_groups=1)
+        with pytest.raises(ValidationError):
+            EvolutionConfig(num_examples_per_group=2)
+
+    def test_group_example_sampling_fields_reject_non_positive(self):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(
+                batch_sampler="stratified",
+                num_sampled_groups=0,
+                num_examples_per_group=2,
+            )
+        with pytest.raises(ValidationError):
+            EvolutionConfig(
+                batch_sampler="stratified",
+                num_sampled_groups=1,
+                num_examples_per_group=0,
+            )
+
+    def test_group_example_sampling_requires_stratified_sampler(self):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(num_sampled_groups=1, num_examples_per_group=2)
 
     def test_num_parallel_proposals_auto_resolves(self):
         """GEPA parity: ``num_parallel_proposals="auto"`` resolves to
@@ -435,11 +466,14 @@ class TestTomlRoundTrip:
 
             [evolution]
             minibatch_size = 7
+            batch_sampler = "stratified"
             max_workers = 3
             num_parallel_proposals = 2
             cache_evaluation = true
             acceptance_criterion = "improvement_or_equal"
             val_stage_size = 50
+            num_sampled_groups = 1
+            num_examples_per_group = 4
         """)
         )
         cfg = load_config(toml)
@@ -452,6 +486,8 @@ class TestTomlRoundTrip:
         assert cfg.evolution.cache_evaluation is True
         assert cfg.evolution.acceptance_criterion == "improvement_or_equal"
         assert cfg.evolution.val_stage_size == 50
+        assert cfg.evolution.num_sampled_groups == 1
+        assert cfg.evolution.num_examples_per_group == 4
 
     def test_toml_val_path_omitted_falls_back(self, tmp_path):
         toml = tmp_path / "helix.toml"
@@ -477,10 +513,13 @@ class TestTomlRoundTrip:
             seedless={"train_path": "/tmp/train.jsonl", "val_path": "/tmp/val.jsonl"},
             evolution={
                 "minibatch_size": 4,
+                "batch_sampler": "stratified",
                 "max_workers": 2,
                 "cache_evaluation": True,
                 "acceptance_criterion": "improvement_or_equal",
                 "val_stage_size": 25,
+                "num_sampled_groups": 1,
+                "num_examples_per_group": 2,
             },
         )
         dumped = cfg.model_dump()
@@ -492,3 +531,5 @@ class TestTomlRoundTrip:
         assert restored.evolution.cache_evaluation is True
         assert restored.evolution.acceptance_criterion == "improvement_or_equal"
         assert restored.evolution.val_stage_size == 25
+        assert restored.evolution.num_sampled_groups == 1
+        assert restored.evolution.num_examples_per_group == 2


### PR DESCRIPTION
## Summary
- add generic grouped stratified sampling controls to HELIX
- support selecting N groups and M examples per group while preserving legacy stratified defaults
- persist the new sampler semantics in resume compatibility metadata

## Example
```toml
[evolution]
batch_sampler = "stratified"
num_sampled_groups = 1
num_examples_per_group = 4
```

## Tests
- `PYTHONPATH=$PWD/src /work/ke/research/helix/.venv/bin/python -m pytest tests/unit/test_batch_sampler.py tests/unit/test_config_new_fields.py`
- `codex review --commit HEAD` attempted, but Codex CLI could not inspect due `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.
