### PR TITLE
feat: add durable parallel P×N proposal batches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,13 @@ jobs:
       - run: uv sync --all-extras
       - name: Verify Docker daemon
         run: docker info
+      - name: Build sandbox fixture image
+        run: >-
+          docker build
+          --tag helix-parallel-sandbox-fixture:local
+          --file tests/integration/parallel-sandbox.Dockerfile
+          tests/integration
       - name: Run parallel sandbox integration test
+        env:
+          HELIX_DOCKER_TEST_IMAGE: helix-parallel-sandbox-fixture:local
         run: uv run pytest -m docker_integration tests/integration/test_parallel_sandbox.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      docker_integration:
+        description: Run the daemon-backed parallel sandbox integration test
+        required: false
+        default: false
+        type: boolean
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,3 +25,23 @@ jobs:
       - run: uv sync --all-extras
       - run: uv run pytest tests/unit/ -q
       - run: uv run mypy --strict src/helix/
+
+  # Opt-in because this builds a small local fixture image and starts real
+  # containers. Unit/type checks remain the required default PR path.
+  docker-integration:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_integration }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --all-extras
+      - name: Verify Docker daemon
+        run: docker info
+      - name: Run parallel sandbox integration test
+        run: uv run pytest -m docker_integration tests/integration/test_parallel_sandbox.py -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- P×N proposal batches: `num_parallel_proposals` selects P parent slots and
+  the new `mutations_per_parent` creates N independently sampled children per
+  slot. Parent selection is with replacement and task application remains
+  deterministic regardless of worker completion order.
+- Proposal selection modes `all_improvements`, `best_improvement`, and `top_k`
+  (with validated `proposal_top_k`) after ordered child minibatch evaluation.
+- Batch-aware state, trace, cleanup, and resume metadata for every planned
+  proposal slot, including interrupted-batch reconciliation.
+- Opt-in, manually dispatched Docker integration CI on Python 3.11 and 3.12 for
+  the daemon-backed parallel sandbox smoke test.
+
+### Changed
+- Existing `num_parallel_proposals = K` configurations now use the unified K×1
+  scheduler. Omitting `mutations_per_parent` remains behaviorally equivalent to
+  N=1; the default remains 1×1.
+- Candidate evaluation and multi-turn coding-agent work use bounded concurrent
+  batches rather than literal model-API batching. One global `max_workers` cap
+  bounds active candidate work and Docker containers within each phase.
+- Evaluation caps are checked before batch dispatch. All completed in-flight
+  uncached work is charged, so an admitted phase with U uncached metric units
+  can overshoot by at most `max(0, U - 1)` units.
+
 ## [0.2.2] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This is why a full solver module or a shrinkwrap of an ML kernel behave qualitat
 | 🔧 | **Tool access during mutation** | The configured backend can read, grep, run tests, inspect the codebase, and use the web mid-mutation |
 | ✅ | **Self-verification** | Mutations verify themselves by running commands before committing |
 | 📊 | **Pareto frontier** | Instance-level Pareto selection across test cases — no single metric bottleneck |
-| ⚡ | **Parallel evaluation** | Worktrees are isolated → parallel proposals via `ThreadPoolExecutor` (GEPA parity, bounded by `evolution.max_workers`) |
+| ⚡ | **Parallel proposal batches** | Select P parents and sample N isolated mutations per parent; one global `evolution.max_workers` cap bounds candidate work |
 | 🔀 | **Merge / crossover** | Combine two frontier candidates that excel on different instances |
 | 💾 | **State persistence & resume** | Crash-safe — resume from any generation with `helix resume` |
 | 🚦 | **Gated mutations** | Train-set gating rejects regressions before Pareto evaluation |
@@ -390,9 +390,12 @@ merge_enabled = false            # enable merge/crossover operations
 max_merge_invocations = 5        # total merge cap across entire run
 merge_val_overlap_floor = 5      # minimum val-set overlap for merge candidates
 merge_subsample_size = 5         # stratified val subsample size for merge acceptance (GEPA parity)
-max_workers = 8                  # thread-pool cap for parent-eval + mutation pools
+max_workers = 8                  # global candidate-worker cap across batched phases
                                  # (default: os.cpu_count(), or 32 if that returns None)
-num_parallel_proposals = 1       # parallel mutations per generation; "auto" resolves to max_workers // minibatch_size
+num_parallel_proposals = 1       # P: parent-selection attempts; "auto" resolves to max_workers // minibatch_size
+mutations_per_parent = 1         # N: independently sampled mutations per selected parent
+proposal_selection = "all_improvements" # "all_improvements" | "best_improvement" | "top_k"
+# proposal_top_k = 2             # required only for proposal_selection = "top_k"
 minibatch_size = 3               # train-set minibatch size for reflective mutation
 cache_evaluation = true          # reuse per-instance evaluator results
 acceptance_criterion = "strict_improvement"
@@ -421,6 +424,77 @@ skip_special_files = true        # skip FIFOs/sockets/devices during workspace s
 [worktree]
 base_dir = ".helix/worktrees"
 ```
+
+### Parallel Proposal Batches
+
+HELIX plans proposals as a P×N batch. `num_parallel_proposals` is **P**, the
+number of parent-selection attempts, and `mutations_per_parent` is **N**, the
+number of independently sampled mutations for each selected parent. The
+default remains `P=1, N=1`; one step plans at most `P * N` children.
+
+| Shape | Meaning | Example |
+|---|---|---|
+| **1×1** | Select one parent and create one mutation. | Defaults; no batch expansion. |
+| **1×N** | Select one parent once and create N sibling mutations, each with its own minibatch, ID, and worktree. | `num_parallel_proposals = 1`, `mutations_per_parent = 4` |
+| **P×1** | Make P independent parent-selection attempts and create one mutation for each. | `num_parallel_proposals = 4`, `mutations_per_parent = 1` |
+| **P×N** | Make P parent-selection attempts and create N sibling mutations per selected slot. | P=2 and N=3 plans six children in parent-major order. |
+
+Parent selection is **with replacement**. If two selection attempts return the
+same candidate, they remain two parent groups; HELIX does not collapse them.
+Tasks and candidate IDs are reserved in deterministic parent-major order
+(`p0/n0`, `p0/n1`, ..., `p1/n0`, ...). Worker completion order cannot change
+IDs, lineage, selection ties, or persisted order.
+
+After child minibatch scores are available, `proposal_selection` controls which
+passing improvements continue to full validation:
+
+- `all_improvements` keeps every passing improvement (the default).
+- `best_improvement` keeps the single largest score improvement.
+- `top_k` keeps the largest `proposal_top_k` passing improvements, with stable
+  task order breaking equal-score ties. `proposal_top_k` must be in `1..P*N`
+  and is valid only with `top_k`.
+
+Integer P, N, and `max_workers` must be at least one; `proposal_top_k` must be
+at least one when set.
+
+This is bounded concurrency, not literal model-API batching. HELIX backends are
+multi-turn coding CLI processes, so each mutation still runs in its own
+worktree and, when sandboxing is enabled, its own short-lived container. Parent
+evaluation, mutation, child scoring, and eligible full validation share the
+same global `max_workers` bound. `P*N` may exceed that bound; excess work waits
+in deterministic task order. With a Docker evaluator sidecar, size the daemon
+for one long-lived sidecar plus at most `max_workers` active short-lived
+agent/evaluator containers. Optional `[sandbox]` `cpus`, `memory`, and
+`pids_limit` values apply to **each** short-lived container, so provision for up
+to `max_workers` times those per-container limits; unset CPU/memory values leave
+Docker's daemon defaults in effect. The sidecar is a separate long-lived
+container and is not covered by those short-lived-container limits.
+
+Evaluation budget is charged for every completed uncached evaluation, including
+work that was already in flight when the cap was reached. A cached example
+costs zero units; an uncached example costs one, and an uncached no-example
+evaluator call costs one. HELIX checks `max_evaluations` before dispatching an
+evaluation phase, rather than cancelling sibling work after dispatch. If an
+admitted phase contains `U` total uncached evaluation units, its maximum
+in-flight overshoot is `max(0, U - 1)` units (the worst case starts at one unit
+below the cap). For a cache-cold minibatch phase, `U` is at most
+`P*N*minibatch_size`; for full validation it is at most
+`S*dataset.val_size`, where `S` is the number selected (`S <= P*N`, `S <= 1`
+for `best_improvement`, and `S <= proposal_top_k` for `top_k`). Cache hits,
+deduplicated parent evaluations, skipped perfect parents, and failed mutations
+reduce actual use. Increasing P or N therefore consumes a fixed evaluation
+budget faster even though the cap remains a dispatch boundary rather than a
+hard cancellation boundary.
+
+Existing `num_parallel_proposals = K` configurations are already the **K×1**
+case: omitting N is identical to setting `mutations_per_parent = 1`, including
+for `num_parallel_proposals = "auto"`. There is no legacy scheduler or
+deprecation path. Existing state files still load; missing batch metadata is
+interpreted as K×1. New state checkpoints persist the batch shape, task slots,
+selection mode, and terminal/cleanup status so an interrupted batch can
+reconcile every reserved ID and worktree without double charging or inserting a
+candidate twice. Changing P, N, or selection semantics while resuming an
+in-progress run is rejected; start a clean run when changing those settings.
 
 ### Docker Sandboxing
 
@@ -541,11 +615,11 @@ rejected before evaluation.
 
 ### Per-example Parallelism Inside the Evaluator
 
-HELIX parallelises across proposals (`num_parallel_proposals`) and across
-worktrees, but each evaluator invocation sees one candidate and a batch of
-instance ids as a single subprocess. Per-example parallelism — evaluating
-multiple ids of one candidate concurrently — lives **inside the evaluator**,
-not inside HELIX's engine.
+HELIX parallelises across the P×N proposal tasks and their isolated
+worktrees, up to the global `max_workers` cap. Each evaluator invocation still
+sees one candidate and a batch of instance ids as a single subprocess.
+Per-example parallelism — evaluating multiple ids of one candidate concurrently
+— lives **inside the evaluator**, not inside HELIX's engine.
 
 This is a deliberate architectural split: GEPA's reference adapter fans out
 per-example in-process, which is essentially free; HELIX's subprocess model

--- a/README.md
+++ b/README.md
@@ -489,12 +489,14 @@ hard cancellation boundary.
 Existing `num_parallel_proposals = K` configurations are already the **K×1**
 case: omitting N is identical to setting `mutations_per_parent = 1`, including
 for `num_parallel_proposals = "auto"`. There is no legacy scheduler or
-deprecation path. Existing state files still load; missing batch metadata is
-interpreted as K×1. New state checkpoints persist the batch shape, task slots,
-selection mode, and terminal/cleanup status so an interrupted batch can
-reconcile every reserved ID and worktree without double charging or inserting a
-candidate twice. Changing P, N, or selection semantics while resuming an
-in-progress run is rejected; start a clean run when changing those settings.
+deprecation path. Existing state files still load, and N defaults to one when
+their configuration omitted it. New state checkpoints persist each active
+batch's P×N shape, task slots, selection result, and terminal/cleanup status so
+resume reconciles that saved batch before planning more work, without double
+charging or inserting a candidate twice. P, N, selection mode, and worker count
+govern only future batches, so they may be changed between resumes; start a
+clean run instead when you need controlled comparisons between scheduler
+settings.
 
 ### Docker Sandboxing
 

--- a/docs/parallel-proposals-plan.md
+++ b/docs/parallel-proposals-plan.md
@@ -1,0 +1,422 @@
+# HELIX Parallel Proposals Work Plan
+
+## Objective
+
+Add GEPA-style P-by-N proposal batches to HELIX while preserving HELIX's
+worktree, coding-agent, evaluator, Docker sandbox, budget, cache, lineage, and
+resume guarantees.
+
+- `P` is the number of parent-selection attempts from the frontier per
+  optimization step.
+- `N` is the number of independently sampled reflective mutations for each
+  selected parent.
+- A full step plans at most `P * N` child proposals.
+- Parent selection is with replacement. GEPA PR #330 does not guarantee that
+  the `P` selected candidate IDs are distinct.
+- Reflection failures, missing diagnostics, perfect-parent skips, and security
+  rejection can reduce the number of evaluated children below `P * N`.
+
+## Ground Truth
+
+### GEPA PR #314
+
+- PR: <https://github.com/gepa-ai/gepa/pull/314>
+- Merge-base: `85a2d428e549aec0460f427cfd0d160178f2dbbf`
+- Head: `0c4213f9c5f227a717f4943e7a62f54b7513166b`
+- It added `num_parallel_proposals` and a three-phase lifecycle:
+  sequential prepare, threaded execute, sequential apply.
+- It represented only a flat proposal width. It did not model parent groups or
+  N sibling mutations for one selected parent.
+- Its final aggregate diff did not add tests under `tests/`.
+
+### GEPA PR #330
+
+- PR: <https://github.com/gepa-ai/gepa/pull/330>
+- Merge-base: `234970ac898b1c22a9012a15c72948f498994ebd`
+- Head: `b86c64a26a1e0f618324e2c9f433f83e7291c848`
+- Commit `71f7b4bcbf5f7d48d2f7d421645b6424d3fd4a31` explicitly reverts
+  PR #314's proposal-level `ThreadPoolExecutor` design.
+- It adds `ProposalTask`, `SingleMutationSampling`, `SameParentSampling`,
+  `IndependentSampling`, `PxNSampling`, `AllImprovements`,
+  `BestImprovement`, `TopKImprovements`, and optional adapter
+  `batch_evaluate` support.
+- The final PR path samples tasks, deduplicates and batch-evaluates parents,
+  reflects per task, batch-evaluates surviving children, selects improvements,
+  then performs full validation and state insertion sequentially.
+- The final PR has 11 focused tests, not the 14 stated in its description.
+  Its full branch validation was 487 passed, 3 skipped, with Pyright clean.
+- Its default batch evaluator is sequential. True cross-candidate overlap is
+  delegated to an adapter or custom batch evaluator.
+- Reflection requests in the final PR are sequential, despite the later blog's
+  description of one model batch.
+- Budget checks remain at the iteration boundary, so a batch can overshoot the
+  metric-call limit.
+
+### GEPA Blog Contract
+
+- Blog: <https://jialin-blog.gepa-docs-staging.pages.dev/blog/2026/06/30/parallel-proposals/>
+- Source commit: `0b82286307a1a0c0555b82cd912d6a600f61c99e`
+- The article defines `P` parents and `N` mutations per parent, for `P * N`
+  planned children per step.
+- The article's throughput results and model/evaluator batching claims describe
+  the later v0.1.4 design and are not all implemented or tested by PR #330.
+
+### Current HELIX
+
+- Branch `feat/parallel-proposals` starts at
+  `394a1b7dbbfbcb8362449c01661584cdec626f87`, the same commit as `main`
+  and `origin/main` when the branch was created.
+- `EvolutionConfig.num_parallel_proposals` is a flat width. The evolution loop
+  calls `frontier.select_parent()` once per slot and creates one mutation for
+  that selected parent. Its observable shape is `P=K, N=1`, not general P*N.
+- Current atomic workers already overlap parent evaluation, agent mutation,
+  tamper detection, and child minibatch evaluation with a bounded
+  `ThreadPoolExecutor`. Results are restored to sampled order before sequential
+  state mutation.
+- Each mutation has a candidate-specific Git worktree. Sandboxed coding-agent
+  and evaluator commands use candidate-specific `/workspace` mounts and Docker
+  `--rm`, so bounded concurrent containers are the natural HELIX realization
+  of proposal batching.
+- OpenCode already gets a candidate-specific state directory, preventing SQLite
+  WAL contention between concurrent proposal workers.
+- No GEPA package is a HELIX dependency. Parity must be implemented against
+  HELIX's own contracts rather than by importing GEPA.
+- Current validation baseline: 867 unit tests pass and strict mypy passes for
+  29 source files. `ruff check src/` currently reports seven pre-existing F401
+  findings in `src/helix/evolution.py`; CI does not run Ruff.
+- The current Pydantic model accepts invalid zero/negative values for
+  `max_workers` and `num_parallel_proposals`; the new design must close that
+  gap.
+
+## Required Semantics
+
+1. One step selects `P` parent slots in deterministic frontier RNG order.
+2. Each selected slot samples `N` minibatches and reserves `N` stable candidate
+   IDs before any concurrent work begins.
+3. Task order is parent-major: `(p0,n0)`, `(p0,n1)`, ..., `(p1,n0)`, ... .
+4. Completion order never changes IDs, lineage order, selection tie-breaking,
+   logs, or persisted state.
+5. Parent and child evaluations use one cross-candidate batch abstraction. The
+   Docker implementation may realize that batch as multiple bounded container
+   calls; it must preserve positional result alignment.
+6. Proposal generation uses one isolated worktree/container per child and is
+   bounded by the same global worker limit.
+7. Selection runs only after all available child minibatch evaluations return.
+8. Full-validation work for selected proposals may run concurrently, but
+   frontier, lineage, budget, trace, cache, and state updates are applied in
+   deterministic selected order.
+9. `P=1, N=1` preserves existing behavior.
+10. A failure in one proposal slot does not discard successful siblings unless
+    the error is an existing run-fatal security/configuration error.
+
+## Configuration Design
+
+Use one P*N scheduler and extend the existing flat `[evolution]` contract:
+
+```toml
+[evolution]
+num_parallel_proposals = 2       # P, parent-selection attempts
+mutations_per_parent = 2         # N, mutations for each selected parent
+proposal_selection = "all_improvements"
+# proposal_top_k = 2             # required only for selection = "top_k"
+```
+
+The existing field becomes P because that is what the current loop already
+does: it selects one parent for each of K slots. N defaults to one. Therefore
+every existing `num_parallel_proposals=K` configuration is exactly the K-by-1
+case of the new scheduler; there is no legacy runtime branch, adapter, or
+deprecation path.
+
+Rules:
+
+- Defaults are `num_parallel_proposals=1`, `mutations_per_parent=1`, and
+  `proposal_selection="all_improvements"`.
+- Existing `num_parallel_proposals="auto"` resolution produces P and still
+  lands on P-by-1 when N is omitted.
+- Supported selection values are `all_improvements`, `best_improvement`, and
+  `top_k`.
+- `proposal_top_k` must be within `1..P*N`; it is rejected for other selection
+  modes.
+- `max_workers`, integer P, N, and K must all be at least one.
+- `P*N` may exceed `max_workers`; tasks queue behind the worker bound.
+
+Internally define strategy protocols and built-ins, but keep TOML declarative.
+P*N sampling covers the three useful shapes without extra user-facing modes:
+`1x1` single, `1xN` same-parent, and `Px1` independent.
+
+## Baby-Step Implementation
+
+### Step 1: Lock the configuration contract
+
+Files:
+
+- `src/helix/config.py`
+- `tests/unit/test_config_new_fields.py`
+- `skills/helix/references/toml.md`
+
+Work:
+
+- Add N and selection fields to `EvolutionConfig` and validate the effective
+  P*N configuration.
+- Treat the existing `num_parallel_proposals` value as P in the unified
+  scheduler; N defaults to one.
+- Reject invalid zero/negative P, N, `top_k`, and `max_workers` values.
+- Document that old K-slot runs are the K-by-1 case.
+
+Gate: configuration tests and strict mypy pass before runtime changes.
+
+### Step 2: Introduce typed proposal tasks and strategies
+
+Files:
+
+- new `src/helix/proposals.py`
+- new `tests/unit/test_proposals.py`
+
+Work:
+
+- Add immutable `ProposalTask` with batch index, parent group index, mutation
+  index, parent candidate, minibatch IDs, and reserved child ID.
+- Add typed proposal outcomes for skipped, failed, tampered, evaluated, and
+  selected states.
+- Add P*N sampling and three selection implementations.
+- Preserve stable input order and stable first-on-tie behavior.
+
+Gate: all 11 GEPA PR #330 strategy/fallback/default tests are represented in
+HELIX, adapted to HELIX candidate and score types.
+
+### Step 3: Extract an ordered cross-candidate evaluation batch
+
+Files:
+
+- `src/helix/executor.py`
+- `src/helix/eval_cache.py`
+- `tests/unit/test_executor.py`
+- `tests/unit/test_eval_cache.py`
+
+Work:
+
+- Add a typed batch item and `run_evaluator_batch` API.
+- Bound execution by `max_workers`, store results by input index, and validate
+  exact result cardinality.
+- Deduplicate only identical candidate-content plus identical split/minibatch
+  keys. Do not deduplicate by candidate ID alone.
+- Return per-item failures without losing sibling results; preserve existing
+  fatal exception classes.
+- Keep candidate-specific `helix_batch.json` writes behind the existing
+  worktree lock.
+
+Gate: reverse completion order still yields input-order results and exact
+budget/cache accounting.
+
+### Step 4: Replace flat context preparation with P*N planning
+
+Files:
+
+- `src/helix/evolution.py`
+- `src/helix/budget.py`
+- `src/helix/batch_sampler.py`
+- `tests/unit/test_evolution_minibatch.py`
+
+Work:
+
+- Select P parent slots sequentially.
+- For each slot, sample N minibatches and reserve N IDs sequentially.
+- Snapshot all read-only task context before workers start.
+- Use the new parent evaluation batch and preserve the perfect-parent skip.
+- Keep the current default and K-by-1 behavior byte-for-byte where
+  persistence formats permit.
+
+Gate: `P=2,N=3` produces six tasks, exactly two parent selections, parent
+mapping `[A,A,A,B,B,B]`, six stable IDs, and three minibatches per group.
+
+### Step 5: Run isolated mutation workers as one bounded batch
+
+Files:
+
+- `src/helix/evolution.py`
+- `src/helix/mutator.py`
+- `src/helix/worktree.py`
+- `src/helix/sandbox.py`
+- `tests/unit/test_mutator.py`
+- `tests/unit/test_sandbox.py`
+
+Work:
+
+- Reuse HELIX's candidate-specific worktree and Docker container isolation.
+- Submit surviving mutation tasks to a bounded pool and restore sampled order.
+- Retain per-candidate OpenCode state isolation.
+- Preserve per-slot handling for rate limits, agent failures, tamper rejection,
+  worktree cleanup, and usage capture.
+- Do not claim literal model-API batching: current HELIX backends are coding
+  CLI subprocesses. The supported batch implementation is bounded concurrent
+  isolated agent containers.
+
+Gate: two mutation tasks are simultaneously active, use different worktrees
+and state directories, and leave no test containers behind.
+
+### Step 6: Batch child scoring, select, then apply deterministically
+
+Files:
+
+- `src/helix/evolution.py`
+- `src/helix/population.py`
+- `src/helix/eval_policy.py`
+- `tests/unit/test_evolution_minibatch.py`
+
+Work:
+
+- Batch child minibatch evaluation.
+- Build ordered proposal records with before/after scores and parent metadata.
+- Run the configured selection strategy once. Avoid GEPA PR #330's double call
+  to potentially stateful acceptance criteria.
+- Batch full-validation evaluation for selected children when safe.
+- Apply successful results sequentially in selected order.
+- Clean every unselected, rejected, failed, and tampered child worktree.
+
+Gate: completion-order permutations produce identical frontier, lineage,
+candidate IDs, budget, and selected results.
+
+### Step 7: Make persistence and observability batch-aware
+
+Files:
+
+- `src/helix/state.py`
+- `src/helix/evolution.py`
+- `src/helix/trace.py`
+- `src/helix/display.py`
+- `tests/unit/test_resume.py`
+- `tests/unit/test_state_persistence.py`
+- `tests/unit/test_display.py`
+
+Work:
+
+- Persist per-task records rather than GEPA PR #330's first-task-only summary.
+- Record batch ID, P, N, task index, parent group, mutation index, child ID,
+  status, score delta, selection result, and cleanup result.
+- Save before task execution and after deterministic application.
+- Extend interrupted-batch reconciliation to all planned worktrees and IDs.
+- Define batch budget semantics explicitly: check before dispatch, account all
+  completed in-flight work, and document/test the maximum permitted overshoot.
+
+Gate: interruption after a subset of workers completes can resume without ID
+collision, double charge, orphan worktree, or duplicate frontier insertion.
+
+### Step 8: Documentation, migration, and release validation
+
+Files:
+
+- `README.md`
+- `skills/helix/references/toml.md`
+- `skills/helix/references/gepa-migration.md`
+- `CHANGELOG.md`
+- `.github/workflows/ci.yml` or a new Docker integration workflow
+
+Work:
+
+- Document P and N with `1x1`, `1xN`, `Px1`, and `PxN` examples.
+- Explain that parents are selected with replacement.
+- Explain worker caps, Docker resource usage, budget acceleration/overshoot,
+  selection, and how existing K-by-1 configurations extend to P*N.
+- Add an opt-in Docker-daemon integration job with a small local fixture image.
+- Keep the default at single mutation.
+
+Gate: clean install, unit suite, strict typing, and daemon-backed Docker smoke
+all pass on Python 3.11 and 3.12.
+
+## Test Matrix
+
+### GEPA PR #330 parity tests
+
+1. Single mutation creates one task.
+2. Same-parent sampling creates N tasks for one selected parent with N sampled
+   minibatches.
+3. Independent sampling calls parent selection P times.
+4. P*N sampling with `P=2,N=3` creates six tasks and two parent selections.
+5. All-improvements keeps every proposal passing acceptance.
+6. Best-improvement keeps the largest score delta.
+7. Best-improvement returns empty when none pass.
+8. Top-K returns the K largest passing deltas in stable order.
+9. Default evaluation-batch fallback preserves count, order, and call count.
+10. Default sampling is `1x1`.
+11. Default selection is all-improvements.
+
+### HELIX additions
+
+- Validation: zero/negative P, N, K, and `max_workers`; `"auto"` resolution;
+  invalid `top_k` combinations.
+- Shape: compare `1x4` and `4x1`; equal child count but different selector calls
+  and parent grouping.
+- Parent replacement: duplicate parent selections remain two groups and do not
+  collapse N siblings incorrectly.
+- True overlap: use `threading.Barrier`/`Event`, not sleeps alone, to prove
+  simultaneous mutation and distinct-worktree child evaluation.
+- Worker cap: peak active tasks is both at least two when capacity permits and
+  never above `max_workers`.
+- Ordering: force reverse completion and assert stable IDs, lineage, selection
+  ties, persisted task order, and logs.
+- Deduplication: identical parent-content/minibatch work executes once; different
+  minibatches or content do not deduplicate.
+- Cardinality: malformed batch result lengths fail clearly before state apply.
+- Partial failure: parent eval, mutation, child eval, rate limit, and container
+  failure in one slot do not discard successful siblings.
+- Security: tampered children are never snapshotted/selected and their worktrees
+  are removed.
+- Selection cleanup: unselected and acceptance-rejected children are persisted
+  as attempts and cleaned.
+- Budget: exact parent/child/full-val charges, cache hits, in-flight overshoot
+  bound, and early truncation when the batch cannot start.
+- Cache: concurrent reads/writes and deduplicated results remain deterministic.
+- State: all-improvements can insert multiple children without frontier races.
+- Determinism: repeated runs with the same seed match despite different worker
+  completion schedules.
+- Resume: interruption before dispatch, mid-worker, after evaluation, and
+  mid-apply produces no double charge, duplicate lineage, ID collision, or
+  orphan worktree.
+- Trace/display: every P*N slot has a terminal status; no first-task-only
+  observability.
+- Docker unit seam: candidate-specific mounts, sidecar visibility to workers,
+  `--rm`, and per-proposal OpenCode state.
+- Docker integration: two real sandbox containers overlap, produce isolated
+  outputs, and leave no containers behind.
+- Compatibility: omitted N and explicit `N=1` produce the same K-by-1 trace,
+  lineage, budget, frontier, and persisted state for every existing K value.
+
+## Validation Commands
+
+```bash
+uv run pytest tests/unit/test_proposals.py -q
+uv run pytest tests/unit/test_config_new_fields.py \
+  tests/unit/test_evolution_minibatch.py \
+  tests/unit/test_executor.py tests/unit/test_eval_cache.py \
+  tests/unit/test_mutator.py tests/unit/test_sandbox.py \
+  tests/unit/test_resume.py tests/unit/test_state_persistence.py -q
+uv run pytest tests/unit/ -q
+uv run mypy --strict src/helix/
+uv run ruff check src/ tests/unit/test_proposals.py
+```
+
+The Ruff gate should distinguish new findings from the seven pre-existing F401
+findings in `src/helix/evolution.py`, or those findings should be fixed in a
+separate preparatory commit.
+
+For Docker integration, add a marked test and run it only when `docker info`
+succeeds:
+
+```bash
+uv run pytest -m docker_integration tests/integration/test_parallel_sandbox.py -q
+```
+
+## Definition of Done
+
+- Users can express P and N independently in TOML.
+- `P=2,N=3` demonstrably plans six stable child slots from two parent-selection
+  attempts.
+- Concurrent coding-agent/evaluator containers are globally bounded and
+  isolated.
+- Sampling, selection, evaluation, persistence, and cleanup are deterministic
+  regardless of worker completion order.
+- Per-slot failure does not corrupt sibling results or global state.
+- Budget and resume semantics are documented and tested.
+- All 11 GEPA PR #330 parity tests and the HELIX-specific matrix pass.
+- The existing 867-test baseline does not regress.
+- Strict mypy and daemon-backed Docker smoke pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,4 +83,5 @@ timeout = 60
 timeout_method = "thread"
 markers = [
     "diff_harness: GEPA differential-testing harness (phases 2-4)",
+    "docker_integration: requires a real Docker daemon and local fixture image",
 ]

--- a/skills/helix/references/gepa-migration.md
+++ b/skills/helix/references/gepa-migration.md
@@ -11,6 +11,7 @@ HELIX project.
 - Single-Task GEPA Mode
 - Multi-Objective Migration
 - Config Translation Example
+- Parallel Proposal Migration
 - Candidate Representation
 - Dataset ID Strategy
 - Docker Sandbox In Migration
@@ -53,7 +54,9 @@ Migration usually means:
 | `side_info` / trajectory | per-example `side_info` in `HELIX_RESULT` |
 | `side_info["scores"]` objective metrics | reserved `side_info["scores"]` dict |
 | `reflection_minibatch_size` | `[evolution].minibatch_size` |
-| `num_parallel_proposals` | `[evolution].num_parallel_proposals` |
+| `num_parallel_proposals` | `[evolution].num_parallel_proposals` (P parent-selection attempts) |
+| mutations per selected parent | `[evolution].mutations_per_parent` (N, default 1) |
+| proposal result selection | `[evolution].proposal_selection`, optional `proposal_top_k` |
 | `max_metric_calls` | `[evolution].max_evaluations` |
 | `frontier_type` | `[evolution].frontier_type` |
 | `cache_evaluation` | `[evolution].cache_evaluation` |
@@ -193,6 +196,7 @@ HELIX:
 [evolution]
 max_evaluations = 500
 num_parallel_proposals = 4
+mutations_per_parent = 1
 max_workers = 32
 frontier_type = "hybrid"
 cache_evaluation = true
@@ -200,6 +204,71 @@ minibatch_size = 3
 merge_enabled = true
 max_merge_invocations = 5
 ```
+
+The explicit `mutations_per_parent = 1` above shows the compatibility mapping:
+an existing four-proposal GEPA/HELIX configuration remains four independent
+parent-selection attempts and one mutation per selected slot.
+
+## Parallel Proposal Migration
+
+HELIX treats `num_parallel_proposals` as P and `mutations_per_parent` as N. A
+step plans at most `P*N` children:
+
+| Desired shape | HELIX configuration | Parent selection |
+|---|---|---|
+| 1×1 | `P=1, N=1` | Once |
+| 1×N, same-parent siblings | `P=1, N=N` | Once; N independent minibatches/mutations |
+| P×1, independent attempts | `P=P, N=1` | P times |
+| P×N | `P=P, N=N` | P times; N children per selected slot |
+
+Selection is with replacement, as in GEPA's P-slot sampling contract. The same
+frontier candidate may therefore appear in multiple parent groups. Do not
+deduplicate those groups in a migrated evaluator or downstream analysis:
+parent-major task order and the group index are part of lineage and resume
+state.
+
+For a two-by-three batch that keeps only the best two improvements:
+
+```toml
+[evolution]
+num_parallel_proposals = 2
+mutations_per_parent = 3
+proposal_selection = "top_k"
+proposal_top_k = 2
+max_workers = 4
+```
+
+The other selection modes are `all_improvements` (default) and
+`best_improvement`. `top_k` requires `proposal_top_k` in `1..P*N`; the field is
+rejected for the other modes.
+
+`max_workers` is a global candidate-worker cap, not an API batch size. HELIX
+runs bounded concurrent coding CLI processes and evaluator subprocesses, each
+against a candidate-specific worktree. In Docker mode that means at most
+`max_workers` active short-lived proposal/evaluator containers for the current
+phase, plus the optional long-lived evaluator sidecar. Tasks beyond the cap
+queue. This differs from systems whose adapter sends one literal batched model
+request. Optional `[sandbox]` `cpus`, `memory`, and `pids_limit` limits apply to
+each short-lived container, so peak configured CPU/memory demand can scale by
+`max_workers`; the sidecar remains a separate long-lived container.
+
+Parallel width accelerates metric-call consumption. Cached examples cost zero;
+each completed uncached example costs one, and an uncached no-example call costs
+one. HELIX admits work at an evaluation-phase boundary and accounts every
+completed in-flight sibling. For an admitted phase containing `U` uncached
+units, the hard worst-case overshoot is `max(0, U - 1)`. Without cache hits, a
+P×N minibatch phase has `U <= P*N*minibatch_size`; selected full validation
+has `U <= S*val_size`, with S bounded by the selection mode. Plan
+`max_evaluations` for that boundary behavior instead of assuming running work
+will be cancelled exactly at the cap.
+
+Omitting `mutations_per_parent` is exactly N=1, so every existing K-wide config
+and `"auto"` resolution remains K×1. Legacy state files without batch records
+load as K×1. New checkpoints record every planned slot and cleanup result;
+resume reconciles all reserved IDs/worktrees and does not recharge completed
+work or reinsert selected candidates. P, N, and proposal-selection settings are
+resume semantics: do not change them inside an existing run directory. Start a
+new run when changing batch shape or selection policy.
 
 ## Candidate Representation
 

--- a/skills/helix/references/gepa-migration.md
+++ b/skills/helix/references/gepa-migration.md
@@ -264,11 +264,12 @@ will be cancelled exactly at the cap.
 
 Omitting `mutations_per_parent` is exactly N=1, so every existing K-wide config
 and `"auto"` resolution remains K×1. Legacy state files without batch records
-load as K×1. New checkpoints record every planned slot and cleanup result;
-resume reconciles all reserved IDs/worktrees and does not recharge completed
-work or reinsert selected candidates. P, N, and proposal-selection settings are
-resume semantics: do not change them inside an existing run directory. Start a
-new run when changing batch shape or selection policy.
+still load, with N defaulting to one when omitted. New checkpoints record every
+planned slot and cleanup result; resume reconciles the saved active batch and
+all reserved IDs/worktrees without recharging completed work or reinserting a
+selected candidate. P, N, proposal selection, and worker count affect future
+batches rather than the meaning of saved scores, so a resumed run may change
+them. Use a new run directory when comparing scheduler settings experimentally.
 
 ## Candidate Representation
 

--- a/skills/helix/references/toml.md
+++ b/skills/helix/references/toml.md
@@ -123,7 +123,10 @@ perfect_score_threshold = 1.0
 max_evaluations = -1
 
 minibatch_size = 3
-num_parallel_proposals = 4  # or "auto"
+num_parallel_proposals = 4    # P — parent-selection attempts (int >= 1, or "auto")
+mutations_per_parent = 1      # N — mutations per selected parent (int >= 1)
+proposal_selection = "all_improvements"  # all_improvements | best_improvement | top_k
+# proposal_top_k = 2          # required only for proposal_selection = "top_k"; 1..P*N
 max_workers = 32
 cache_evaluation = true
 acceptance_criterion = "strict_improvement"
@@ -146,9 +149,23 @@ Important choices:
   `optimize_anything`'s multi-axis intent.
 - Non-`instance` frontiers need `score_parser = "helix_result"` and
   per-example `side_info["scores"]`.
-- `num_parallel_proposals` controls concurrent agent mutations per generation.
-  Keep it low for expensive agent backends.
-- `max_workers` bounds evaluation/mutation thread pools.
+- `num_parallel_proposals` is `P`: the number of parent-selection attempts per
+  step in the unified P×N proposal scheduler. `mutations_per_parent` is `N`: the
+  number of independent reflective mutations sampled for each selected parent. A
+  step plans at most `P * N` children. Keep both low for expensive agent
+  backends. Integer `P` and `N` must each be `>= 1`; `P` also accepts `"auto"`,
+  which resolves to `max(1, max_workers // minibatch_size)`.
+- `mutations_per_parent` defaults to `1`, so an existing `num_parallel_proposals
+  = K` run is exactly the K-by-1 case (`P=K, N=1`) — the same parent-per-slot
+  behavior as before, with no legacy runtime branch or migration.
+- `proposal_selection` chooses which evaluated children survive: `all_improvements`
+  (default) keeps every proposal that passes acceptance, `best_improvement` keeps
+  the single largest score delta, and `top_k` keeps the `proposal_top_k` largest
+  passing deltas.
+- `proposal_top_k` is required only when `proposal_selection = "top_k"` and must
+  be within `1..P*N`; it is rejected for the other selection modes.
+- `max_workers` bounds evaluation/mutation thread pools and must be `>= 1`.
+  `P*N` may exceed `max_workers`; the extra tasks queue behind the worker bound.
 - Enable `merge_enabled` only when candidate changes can be meaningfully merged.
 
 ## Agent

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -325,10 +325,47 @@ class EvolutionConfig(BaseModel):
     num_parallel_proposals: int | Literal["auto"] = Field(
         default=1,
         description=(
-            "Number of concurrent mutation proposals per iteration. "
+            "P — number of parent-selection attempts per iteration in the "
+            "unified P*N proposal scheduler. This is the same value the "
+            "current loop already uses: it selects one parent per slot, so "
+            "an existing num_parallel_proposals=K run is exactly the K-by-1 "
+            "case (P=K, N=1); there is no legacy runtime branch. "
             "GEPA parity: EngineConfig.num_parallel_proposals. "
             "Set to 'auto' to derive from max_workers // minibatch_size, "
-            "matching GEPA's optimize_anything._resolve_num_parallel_proposals."
+            "matching GEPA's optimize_anything._resolve_num_parallel_proposals. "
+            "Integer values must be >= 1."
+        ),
+    )
+    mutations_per_parent: int = Field(
+        default=1,
+        description=(
+            "N — number of independently sampled reflective mutations for "
+            "each selected parent in the unified P*N proposal scheduler. A "
+            "full step plans at most num_parallel_proposals * "
+            "mutations_per_parent (P*N) children. Defaults to 1, so every "
+            "existing num_parallel_proposals=K configuration lands on the "
+            "K-by-1 case with the existing behavior preserved. Must be >= 1."
+        ),
+    )
+    proposal_selection: Literal[
+        "all_improvements", "best_improvement", "top_k"
+    ] = Field(
+        default="all_improvements",
+        description=(
+            "Selection strategy applied to the evaluated child proposals of "
+            "one step. 'all_improvements' (default) keeps every proposal that "
+            "passes the acceptance gate; 'best_improvement' keeps the single "
+            "largest score delta; 'top_k' keeps the proposal_top_k largest "
+            "passing deltas in stable order."
+        ),
+    )
+    proposal_top_k: int | None = Field(
+        default=None,
+        description=(
+            "Number of proposals kept when proposal_selection='top_k'. "
+            "Required only for that mode and must be within 1..P*N "
+            "(num_parallel_proposals * mutations_per_parent). Rejected for "
+            "the other selection modes."
         ),
     )
     minibatch_size: int = Field(
@@ -440,13 +477,61 @@ class EvolutionConfig(BaseModel):
     )
 
     def model_post_init(self, __context: object) -> None:
-        # GEPA parity: resolve ``num_parallel_proposals="auto"`` to
-        # ``max(1, max_workers // minibatch_size)`` once at construction
-        # time so every downstream consumer sees a plain int.  Mirrors
+        # ``max_workers`` bounds every eval/mutation pool and feeds the
+        # ``num_parallel_proposals="auto"`` derivation, so validate it first.
+        # The prior Pydantic model accepted invalid zero/negative values; the
+        # unified P*N scheduler closes that gap.
+        if self.max_workers < 1:
+            raise ValueError(
+                f"evolution.max_workers must be >= 1 (got {self.max_workers})"
+            )
+        # Resolve P (``num_parallel_proposals``) to a plain int.  The existing
+        # value *is* P in the unified P*N scheduler: the current loop already
+        # selects one parent per slot, so ``num_parallel_proposals=K`` is the
+        # K-by-1 case.  GEPA parity: resolve ``"auto"`` to
+        # ``max(1, max_workers // minibatch_size)`` once at construction time
+        # so every downstream consumer sees a plain int.  Mirrors
         # /tmp/gepa-official/src/gepa/optimize_anything.py:1108-1116.
-        if self.num_parallel_proposals == "auto":
-            self.num_parallel_proposals = max(
-                1, self.max_workers // max(1, self.minibatch_size)
+        raw_p = self.num_parallel_proposals
+        if isinstance(raw_p, int):
+            if raw_p < 1:
+                raise ValueError(
+                    "evolution.num_parallel_proposals must be >= 1 "
+                    f"(got {raw_p})"
+                )
+            effective_p = raw_p
+        else:  # "auto"
+            effective_p = max(1, self.max_workers // max(1, self.minibatch_size))
+            self.num_parallel_proposals = effective_p
+        # ``mutations_per_parent`` is N; N defaults to 1 so omitting it keeps
+        # the K-by-1 behavior byte-for-byte.
+        if self.mutations_per_parent < 1:
+            raise ValueError(
+                "evolution.mutations_per_parent must be >= 1 "
+                f"(got {self.mutations_per_parent})"
+            )
+        # ``proposal_top_k`` is required and bounded to 1..P*N only for the
+        # ``top_k`` selection strategy; it is rejected for the other modes.
+        effective_pn = effective_p * self.mutations_per_parent
+        if self.proposal_selection == "top_k":
+            if self.proposal_top_k is None:
+                raise ValueError(
+                    "evolution.proposal_top_k is required when "
+                    "evolution.proposal_selection='top_k'"
+                )
+            if not 1 <= self.proposal_top_k <= effective_pn:
+                raise ValueError(
+                    "evolution.proposal_top_k must be within "
+                    f"1..{effective_pn} (P*N = num_parallel_proposals * "
+                    "mutations_per_parent) when "
+                    "evolution.proposal_selection='top_k' "
+                    f"(got {self.proposal_top_k})"
+                )
+        elif self.proposal_top_k is not None:
+            raise ValueError(
+                "evolution.proposal_top_k is only valid when "
+                "evolution.proposal_selection='top_k' (got "
+                f"proposal_selection={self.proposal_selection!r})"
             )
         if self.val_stage_size is not None and self.val_stage_size < 0:
             raise ValueError(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -347,17 +347,17 @@ class EvolutionConfig(BaseModel):
             "K-by-1 case with the existing behavior preserved. Must be >= 1."
         ),
     )
-    proposal_selection: Literal[
-        "all_improvements", "best_improvement", "top_k"
-    ] = Field(
-        default="all_improvements",
-        description=(
-            "Selection strategy applied to the evaluated child proposals of "
-            "one step. 'all_improvements' (default) keeps every proposal that "
-            "passes the acceptance gate; 'best_improvement' keeps the single "
-            "largest score delta; 'top_k' keeps the proposal_top_k largest "
-            "passing deltas in stable order."
-        ),
+    proposal_selection: Literal["all_improvements", "best_improvement", "top_k"] = (
+        Field(
+            default="all_improvements",
+            description=(
+                "Selection strategy applied to the evaluated child proposals of "
+                "one step. 'all_improvements' (default) keeps every proposal that "
+                "passes the acceptance gate; 'best_improvement' keeps the single "
+                "largest score delta; 'top_k' keeps the proposal_top_k largest "
+                "passing deltas in stable order."
+            ),
+        )
     )
     proposal_top_k: int | None = Field(
         default=None,
@@ -496,8 +496,7 @@ class EvolutionConfig(BaseModel):
         if isinstance(raw_p, int):
             if raw_p < 1:
                 raise ValueError(
-                    "evolution.num_parallel_proposals must be >= 1 "
-                    f"(got {raw_p})"
+                    f"evolution.num_parallel_proposals must be >= 1 (got {raw_p})"
                 )
             effective_p = raw_p
         else:  # "auto"

--- a/src/helix/display.py
+++ b/src/helix/display.py
@@ -14,7 +14,7 @@ from rich.table import Table
 
 if TYPE_CHECKING:
     from helix.population import EvalResult, ParetoFrontier
-    from helix.state import BudgetState
+    from helix.state import BudgetState, ProposalBatchRecord
     from helix.config import EvolutionConfig
 
 
@@ -113,6 +113,7 @@ class HelixPhase(Enum):
     MERGE = "Merging candidates"
     PARETO_UPDATE = "Updating Pareto frontier"
     CLEANUP = "Cleaning up dominated candidates"
+    PROPOSAL_BATCH = "Applying proposal batch"
 
 
 # Module-level console that persists across calls
@@ -393,6 +394,72 @@ def render_generation(
         border_style="blue",
     )
     console.print(panel)
+
+
+def render_proposal_batch_table(
+    batch: "ProposalBatchRecord",
+    *,
+    require_terminal: bool = True,
+) -> Table:
+    """Build a parent-major per-slot batch summary table.
+
+    Completed batch rendering is deliberately strict: by default a missing
+    terminal status or cleanup result raises rather than silently omitting the
+    slot.  Set ``require_terminal=False`` only for a live/in-progress view.
+    """
+    batch.validate_plan()
+    if require_terminal:
+        nonterminal = [task.task_index for task in batch.tasks if not task.is_terminal()]
+        if nonterminal:
+            raise ValueError(
+                f"Cannot render completed proposal batch {batch.batch_id!r}; "
+                "nonterminal slots: "
+                + ", ".join(str(index) for index in nonterminal)
+            )
+
+    table = Table(
+        title=(
+            f"Proposal Batch {batch.batch_id} "
+            f"({batch.p}×{batch.n}, {len(batch.tasks)} slots)"
+        ),
+        show_header=True,
+        header_style="bold magenta",
+        show_lines=True,
+    )
+    table.add_column("Slot", justify="right", no_wrap=True)
+    table.add_column("Parent", style="cyan", no_wrap=True)
+    table.add_column("Child", style="cyan", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Δ", justify="right", no_wrap=True)
+    table.add_column("Selection", no_wrap=True)
+    table.add_column("Cleanup", no_wrap=True)
+
+    status_styles = {
+        "applied": "green bold",
+        "rejected": "yellow",
+        "skipped": "yellow",
+        "failed": "red bold",
+        "tampered": "red bold",
+        "interrupted": "red",
+    }
+    for task in batch.tasks:
+        status_style = status_styles.get(task.status, "dim")
+        delta = "—" if task.score_delta is None else f"{task.score_delta:+.4f}"
+        table.add_row(
+            f"{task.task_index} ({task.parent_group},{task.mutation_index})",
+            task.parent_id,
+            task.child_id,
+            f"[{status_style}]{task.status}[/{status_style}]",
+            delta,
+            task.selection,
+            task.cleanup,
+        )
+    return table
+
+
+def render_proposal_batch(batch: "ProposalBatchRecord") -> None:
+    """Print a terminal summary containing every planned proposal slot."""
+    console.print(render_proposal_batch_table(batch))
 
 
 def render_frontier_table(

--- a/src/helix/display.py
+++ b/src/helix/display.py
@@ -409,12 +409,13 @@ def render_proposal_batch_table(
     """
     batch.validate_plan()
     if require_terminal:
-        nonterminal = [task.task_index for task in batch.tasks if not task.is_terminal()]
+        nonterminal = [
+            task.task_index for task in batch.tasks if not task.is_terminal()
+        ]
         if nonterminal:
             raise ValueError(
                 f"Cannot render completed proposal batch {batch.batch_id!r}; "
-                "nonterminal slots: "
-                + ", ".join(str(index) for index in nonterminal)
+                "nonterminal slots: " + ", ".join(str(index) for index in nonterminal)
             )
 
     table = Table(

--- a/src/helix/eval_cache.py
+++ b/src/helix/eval_cache.py
@@ -19,6 +19,21 @@ RolloutOutput = TypeVar("RolloutOutput")
 CacheKey: TypeAlias = tuple[CandidateHash, Any]  # (hash, example_id)
 
 
+@dataclass(frozen=True, slots=True)
+class EvaluationBatchKey:
+    """Identity of one evaluator request for cross-candidate deduplication.
+
+    Candidate lineage ids are deliberately absent.  Two requests may share
+    work only when their evaluation-relevant content, dataset split, and exact
+    ordered minibatch are all identical.  Minibatch order is significant
+    because evaluator side information is positional to ``helix_batch.json``.
+    """
+
+    content_key: str
+    split: str
+    instance_ids: tuple[str, ...] | None
+
+
 def _candidate_hash(candidate: dict[str, str]) -> CandidateHash:
     """Deterministic hash of a candidate dict (order-independent over keys).
 
@@ -99,6 +114,13 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         objective_scores_list: list[dict[str, float]] | None = None,
         side_info_list: list[dict[str, Any]] | None = None,
     ) -> None:
+        _validate_batch_cardinality(
+            example_ids,
+            outputs,
+            scores,
+            objective_scores_list,
+            side_info_list,
+        )
         h = _candidate_hash(candidate)
         with self._lock:
             for i, eid in enumerate(example_ids):
@@ -157,6 +179,13 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         if uncached_ids:
             batch = fetcher(uncached_ids)
             outputs, scores, obj_scores, side_infos = evaluator(batch, candidate)
+            _validate_batch_cardinality(
+                uncached_ids,
+                outputs,
+                scores,
+                obj_scores,
+                side_infos,
+            )
             for idx, eid in enumerate(uncached_ids):
                 outputs_by_id[eid] = outputs[idx]
                 scores_by_id[eid] = scores[idx]
@@ -177,3 +206,30 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                 side_infos,
             )
         return outputs_by_id, scores_by_id, objective_by_id, side_info_by_id, len(uncached_ids)
+
+
+def _validate_batch_cardinality(
+    example_ids: list[DataId],
+    outputs: list[RolloutOutput],
+    scores: list[float],
+    objective_scores_list: list[dict[str, float]] | None,
+    side_info_list: list[dict[str, Any]] | None,
+) -> None:
+    """Validate every positional evaluator output before cache/state mutation."""
+
+    expected = len(example_ids)
+    lengths = {
+        "outputs": len(outputs),
+        "scores": len(scores),
+    }
+    if objective_scores_list is not None:
+        lengths["objective_scores"] = len(objective_scores_list)
+    if side_info_list is not None:
+        lengths["side_info"] = len(side_info_list)
+    mismatched = {name: size for name, size in lengths.items() if size != expected}
+    if mismatched:
+        rendered = ", ".join(f"{name}={size}" for name, size in mismatched.items())
+        raise ValueError(
+            "Evaluator batch cardinality mismatch: "
+            f"expected {expected} result(s) for {expected} example id(s); {rendered}."
+        )

--- a/src/helix/eval_cache.py
+++ b/src/helix/eval_cache.py
@@ -1,8 +1,11 @@
-"""HELIX evaluation cache — GEPA parity.
+"""HELIX evaluation cache — GEPA parity with concurrent single-flight.
 
-Line-for-line port of the cache layer described in
-/tmp/gepa_eval_spec.md §3 (originally at gepa/core/state.py:27-130).
+The cache data model follows the layer described in /tmp/gepa_eval_spec.md §3
+(originally at gepa/core/state.py:27-130).  HELIX additionally coordinates
+concurrent cache misses per candidate-content/example key so parallel batches
+cannot evaluate the same missing example twice.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -39,9 +42,7 @@ def _candidate_hash(candidate: dict[str, str]) -> CandidateHash:
 
     GEPA §3.1: ``sha256(json.dumps(sorted(candidate.items())))``.
     """
-    return hashlib.sha256(
-        json.dumps(sorted(candidate.items())).encode()
-    ).hexdigest()
+    return hashlib.sha256(json.dumps(sorted(candidate.items())).encode()).hexdigest()
 
 
 @dataclass
@@ -57,11 +58,19 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
     _cache: dict[CacheKey, CachedEvaluation[RolloutOutput]] = field(
         default_factory=dict
     )
-    # Thread safety (audit-mutation §C4 / audit-budget-caching §C1): the
-    # parent-minibatch eval now runs inside a ThreadPoolExecutor (see
-    # evolution.py parent-eval parallel stage), so concurrent readers/writers
-    # can race on ``_cache``.  A single lock serialises every access.
-    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
+    # A bounded registry of keys currently being computed.  Entries exist only
+    # for cache misses owned by active calls and are removed on both success and
+    # failure.  Per-key events let overlapping batches share work without
+    # serialising evaluations for independent examples.
+    _in_flight: dict[CacheKey, threading.Event] = field(
+        default_factory=dict, repr=False, compare=False
+    )
+    # Thread safety (audit-mutation §C4 / audit-budget-caching §C1): protect
+    # both the persisted cache contents and the ephemeral single-flight
+    # registry.  Evaluator work and event waits always happen outside the lock.
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, compare=False
+    )
 
     def get(
         self, candidate: dict[str, str], example_id: DataId
@@ -157,55 +166,126 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         dict[DataId, dict[str, Any]] | None,
         int,
     ]:
-        cached, uncached_ids = self.get_batch(candidate, example_ids)
-        outputs_by_id: dict[DataId, RolloutOutput] = {
-            eid: c.output for eid, c in cached.items()
-        }
-        scores_by_id: dict[DataId, float] = {
-            eid: c.score for eid, c in cached.items()
-        }
+        candidate_hash = _candidate_hash(candidate)
+        outputs_by_id: dict[DataId, RolloutOutput] = {}
+        scores_by_id: dict[DataId, float] = {}
         objective_by_id: dict[DataId, dict[str, float]] | None = None
-        for eid, c in cached.items():
-            if c.objective_scores is not None:
-                if objective_by_id is None:
-                    objective_by_id = {}
-                objective_by_id[eid] = c.objective_scores
         side_info_by_id: dict[DataId, dict[str, Any]] | None = None
-        for eid, c in cached.items():
-            if c.side_info is not None:
-                if side_info_by_id is None:
-                    side_info_by_id = {}
-                side_info_by_id[eid] = c.side_info
-        if uncached_ids:
-            batch = fetcher(uncached_ids)
-            outputs, scores, obj_scores, side_infos = evaluator(batch, candidate)
-            _validate_batch_cardinality(
-                uncached_ids,
-                outputs,
-                scores,
-                obj_scores,
-                side_infos,
-            )
-            for idx, eid in enumerate(uncached_ids):
-                outputs_by_id[eid] = outputs[idx]
-                scores_by_id[eid] = scores[idx]
-                if obj_scores is not None:
+        num_actual_evaluations = 0
+        first_partition = True
+
+        # A call can own some missing keys while waiting for another call's
+        # overlapping keys.  Compute the owned subset first so independent
+        # examples keep running concurrently, then observe or retry any keys
+        # whose owner failed.
+        while True:
+            cached: dict[DataId, CachedEvaluation[RolloutOutput]] = {}
+            owned_ids: list[DataId] = []
+            owned: dict[CacheKey, threading.Event] = {}
+            waiting: dict[CacheKey, threading.Event] = {}
+
+            with self._lock:
+                for eid in example_ids:
+                    key: CacheKey = (candidate_hash, eid)
+                    entry = self._cache.get(key)
+                    if entry is not None:
+                        cached[eid] = entry
+                        continue
+
+                    # Preserve repeated slots within the owner's own batch.
+                    # The cache intentionally collapses results by example id,
+                    # but the evaluator and usage count retain multiplicity.
+                    if key in owned:
+                        owned_ids.append(eid)
+                        continue
+
+                    flight = self._in_flight.get(key)
+                    if flight is None:
+                        flight = threading.Event()
+                        self._in_flight[key] = flight
+                        owned[key] = flight
+                        owned_ids.append(eid)
+                    else:
+                        waiting[key] = flight
+
+            if first_partition:
+                TRACE.emit(
+                    EventType.CACHE_GET,
+                    candidate_id=candidate_hash,
+                    example_ids=list(example_ids),
+                    hit_ids=list(cached.keys()),
+                    miss_ids=[eid for eid in example_ids if eid not in cached],
+                )
+                first_partition = False
+
+            for eid, entry in cached.items():
+                outputs_by_id[eid] = entry.output
+                scores_by_id[eid] = entry.score
+                if entry.objective_scores is not None:
                     if objective_by_id is None:
                         objective_by_id = {}
-                    objective_by_id[eid] = obj_scores[idx]
-                if side_infos is not None:
+                    objective_by_id[eid] = entry.objective_scores
+                if entry.side_info is not None:
                     if side_info_by_id is None:
                         side_info_by_id = {}
-                    side_info_by_id[eid] = side_infos[idx]
-            self.put_batch(
-                candidate,
-                uncached_ids,
-                outputs,
-                scores,
-                obj_scores,
-                side_infos,
-            )
-        return outputs_by_id, scores_by_id, objective_by_id, side_info_by_id, len(uncached_ids)
+                    side_info_by_id[eid] = entry.side_info
+
+            if not owned_ids and not waiting:
+                break
+
+            if owned_ids:
+                try:
+                    batch = fetcher(owned_ids)
+                    outputs, scores, obj_scores, side_infos = evaluator(
+                        batch, candidate
+                    )
+                    _validate_batch_cardinality(
+                        owned_ids,
+                        outputs,
+                        scores,
+                        obj_scores,
+                        side_infos,
+                    )
+                    # Keep the established public write path (including its
+                    # cardinality guard and trace event), then wake waiters only
+                    # after every result is visible in the cache.
+                    self.put_batch(
+                        candidate,
+                        owned_ids,
+                        outputs,
+                        scores,
+                        obj_scores,
+                        side_infos,
+                    )
+                except BaseException:
+                    self._release_owned(owned)
+                    raise
+
+                self._release_owned(owned)
+                num_actual_evaluations += len(owned_ids)
+
+            # Owners publish cache entries before signalling.  If an owner
+            # failed, its event is still signalled after removing the claim;
+            # the next loop then claims and retries the still-missing key.
+            for flight in waiting.values():
+                flight.wait()
+
+        return (
+            outputs_by_id,
+            scores_by_id,
+            objective_by_id,
+            side_info_by_id,
+            num_actual_evaluations,
+        )
+
+    def _release_owned(self, owned: dict[CacheKey, threading.Event]) -> None:
+        """Drop completed claims and wake all waiters for those keys."""
+
+        with self._lock:
+            for key, flight in owned.items():
+                if self._in_flight.get(key) is flight:
+                    del self._in_flight[key]
+                flight.set()
 
 
 def _validate_batch_cardinality(

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import random as _random
-import shutil
 import shlex
 import subprocess
 import tempfile
@@ -110,7 +109,7 @@ from helix.worktree import (
     remove_worktree,
     snapshot_candidate,
 )
-from helix.evaluator_manifest import (  # noqa: E402  (after helix.worktree intentionally)
+from helix.evaluator_manifest import (  # noqa: E402, F401  (re-exported intentionally)
     # 14 moved symbols — re-exported for backward compatibility and internal use
     _collect_protected_evaluator_paths,
     _copy_protected_path,
@@ -136,6 +135,12 @@ logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 _R = TypeVar("_R")
+
+# Deterministic crash-injection seam for state durability tests.  Production
+# leaves this as ``None``.  Tests may install a hook that raises after a chosen
+# completed state+cache save; because it runs only after persistence, the next
+# process observes the exact crash barrier it is meant to reconcile.
+_DURABLE_BARRIER_HOOK: Callable[[str, EvolutionState], None] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -782,6 +787,53 @@ def _scheduler_checkpoint(
             if key in runtime_state:
                 checkpoint[key] = runtime_state[key]
     return checkpoint
+
+
+def _checkpoint_scheduler_and_batch_plan(
+    state: EvolutionState,
+    base_dir: Path,
+    *,
+    scheduler_state: Mapping[str, Any],
+    batch: ProposalBatchRecord,
+    max_evaluations: int,
+    max_in_flight_evaluations: int,
+    saver: Callable[[EvolutionState], None],
+) -> ProposalBatchRecord:
+    """Persist scheduler position and its complete P*N plan in one write.
+
+    Task sampling advances the shared RNG, minibatch sampler, proposal counter,
+    and reserved child-id counter together.  Persisting that advanced scheduler
+    before its plan creates an impossible resume image: the next process has
+    consumed randomness and IDs but has no durable record of what they selected.
+    Both state APIs therefore validate/mutate in memory with a deferred saver,
+    followed by exactly one cache-aware durable save containing both facts.
+    """
+
+    previous_scheduler_state = state.scheduler_state
+
+    def _defer_persistence(_state: EvolutionState) -> None:
+        return
+
+    checkpoint_scheduler_state(
+        state,
+        base_dir,
+        scheduler_state,
+        saver=_defer_persistence,
+    )
+    try:
+        persisted_batch = checkpoint_batch_before_dispatch(
+            state,
+            base_dir,
+            batch,
+            max_evaluations=max_evaluations,
+            max_in_flight_evaluations=max_in_flight_evaluations,
+            saver=_defer_persistence,
+        )
+    except BaseException:
+        state.scheduler_state = previous_scheduler_state
+        raise
+    saver(state)
+    return persisted_batch
 
 
 def _restore_scheduler_checkpoint(
@@ -1800,6 +1852,8 @@ def _run_evolution_impl(
         elif not _eval_cache_cleared[0]:
             clear_eval_cache(project_root)
             _eval_cache_cleared[0] = True
+        if _DURABLE_BARRIER_HOOK is not None:
+            _DURABLE_BARRIER_HOOK("state_and_eval_cache", s)
 
     def _sync_frontier_state() -> None:
         assert state is not None
@@ -1928,13 +1982,33 @@ def _run_evolution_impl(
                 "config while keeping the existing frontier and history."
             )
         recovered_acceptances = _recover_selected_evaluated_tasks()
-        reconcile_interrupted_batches(
+        reconciliations = reconcile_interrupted_batches(
             state,
             project_root,
             worktrees_dir=worktrees_dir,
             cleanup_worktree=_cleanup_interrupted_batch_worktree,
             saver=_save_state,
         )
+        cleanup_failures = [
+            candidate_id
+            for reconciliation in reconciliations
+            for candidate_id in reconciliation.cleanup_failed_child_ids
+        ]
+        if cleanup_failures:
+            # Do not reconstruct the frontier or dispatch a later generation
+            # while an interrupted candidate worktree remains live.  The
+            # reconciliation above is already durable and deliberately keeps
+            # cleanup="failed", so a repeated resume retries the same barrier.
+            raise HelixError(
+                "Cannot resume until interrupted proposal cleanup succeeds for: "
+                + ", ".join(cleanup_failures),
+                operation="resume",
+                phase="cleanup_interrupted_proposal_batch",
+                suggestion=(
+                    "Fix the reported worktree cleanup error, then run "
+                    "`helix resume` again; the retry is idempotent."
+                ),
+            )
         for interrupted_batch in state.proposal_batches:
             if interrupted_batch.phase == "complete":
                 continue
@@ -2603,16 +2677,6 @@ def _run_evolution_impl(
                 + (len(full_val_example_ids) if full_val_example_ids else 1)
                 for task in tasks
             )
-            checkpoint_scheduler_state(
-                state,
-                project_root,
-                _scheduler_checkpoint(
-                    rng,
-                    batch_sampler,
-                    state.scheduler_state,
-                ),
-                saver=_save_state,
-            )
             proposal_batch = ProposalBatchRecord(
                 batch_id=batch_id,
                 generation=gen,
@@ -2632,10 +2696,15 @@ def _run_evolution_impl(
                     for task in tasks
                 ],
             )
-            checkpoint_batch_before_dispatch(
+            _checkpoint_scheduler_and_batch_plan(
                 state,
                 project_root,
-                proposal_batch,
+                scheduler_state=_scheduler_checkpoint(
+                    rng,
+                    batch_sampler,
+                    state.scheduler_state,
+                ),
+                batch=proposal_batch,
                 max_evaluations=config.evolution.max_evaluations,
                 max_in_flight_evaluations=max_in_flight_evaluations,
                 saver=_save_state,
@@ -3153,6 +3222,20 @@ def _run_evolution_impl(
                 if pre_cleanup is not None:
                     cleaned_child_ids.add(child.id)
                     cleanup_results[child.id] = pre_cleanup
+                # ``mutate`` completed successfully enough to return a child,
+                # so its backend usage is real even when the child then fails
+                # the reserved-ID contract or the tamper detector raises.  The
+                # stable reserved slot owns this charge; validation must never
+                # erase already-consumed LLM work.
+                if child.usage:
+                    live.update(usage=child.usage)
+                    budget_api.charge_llm_usage(
+                        state,
+                        child.usage,
+                        candidate_id=task.reserved_child_id,
+                        source="mutation",
+                    )
+                    _add_usage_charge(task, child.usage)
                 if post_error is not None:
                     proposal_outcome = FailedProposal(
                         task=task,
@@ -3183,15 +3266,6 @@ def _run_evolution_impl(
                     continue
 
                 mutation_children.append(child)
-                if child.usage:
-                    live.update(usage=child.usage)
-                    budget_api.charge_llm_usage(
-                        state,
-                        child.usage,
-                        candidate_id=child.id,
-                        source="mutation",
-                    )
-                    _add_usage_charge(task, child.usage)
 
                 if tampered_paths:
                     proposal_outcome = TamperedProposal(

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -526,8 +526,12 @@ def _reconcile_incomplete_attempts_on_resume(
     if not incomplete_ids:
         return False
 
-    first_generation = min(_gen_from_id(candidate_id) for candidate_id in incomplete_ids)
-    first_counter = min(_proposal_counter_from_id(candidate_id) for candidate_id in incomplete_ids)
+    first_generation = min(
+        _gen_from_id(candidate_id) for candidate_id in incomplete_ids
+    )
+    first_counter = min(
+        _proposal_counter_from_id(candidate_id) for candidate_id in incomplete_ids
+    )
 
     for candidate_id in sorted(incomplete_ids):
         wt_path = worktrees_dir / candidate_id
@@ -580,9 +584,7 @@ def _safe_remove_worktree(candidate: Candidate, *, label: str) -> None:
     try:
         remove_worktree(candidate)
     except Exception as exc:
-        print_warning(
-            f"Could not remove worktree for {label} {candidate.id}: {exc}"
-        )
+        print_warning(f"Could not remove worktree for {label} {candidate.id}: {exc}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -689,9 +691,7 @@ def _plan_pxn_tasks(
     def _select_parent() -> Candidate:
         nonlocal selected_groups, advanced_for_current_task, selected_parent
         if selected_groups > 0:
-            budget_api.advance_proposal_counter(
-                state, source="parallel_proposal"
-            )
+            budget_api.advance_proposal_counter(state, source="parallel_proposal")
             advanced_for_current_task = True
         selected_parent = frontier.select_parent()
         selected_groups += 1
@@ -700,9 +700,7 @@ def _plan_pxn_tasks(
     def _sample_minibatch() -> Sequence[str] | None:
         nonlocal sampled_tasks, advanced_for_current_task
         if sampled_tasks > 0 and not advanced_for_current_task:
-            budget_api.advance_proposal_counter(
-                state, source="parallel_proposal"
-            )
+            budget_api.advance_proposal_counter(state, source="parallel_proposal")
         advanced_for_current_task = False
         sampled_tasks += 1
         if batch_sampler is None or train_loader is None:
@@ -862,14 +860,11 @@ def _restore_scheduler_checkpoint(
     if isinstance(raw_ids, list):
         batch_sampler.shuffled_ids = [str(value) for value in raw_ids]
     batch_sampler.epoch = int(raw_sampler.get("epoch", -1))
-    batch_sampler.last_trainset_size = int(
-        raw_sampler.get("last_trainset_size", 0)
-    )
+    batch_sampler.last_trainset_size = int(raw_sampler.get("last_trainset_size", 0))
 
     raw_frequencies = raw_sampler.get("id_frequencies", {})
-    if (
-        isinstance(batch_sampler, EpochShuffledBatchSampler)
-        and isinstance(raw_frequencies, Mapping)
+    if isinstance(batch_sampler, EpochShuffledBatchSampler) and isinstance(
+        raw_frequencies, Mapping
     ):
         batch_sampler.id_freqs = Counter(
             {str(key): int(value) for key, value in raw_frequencies.items()}
@@ -933,7 +928,9 @@ def _save_proposal_terminal_records(
 ) -> None:
     """Persist currently terminal proposal slots in planned task order."""
 
-    ordered = [records[task.batch_index] for task in tasks if task.batch_index in records]
+    ordered = [
+        records[task.batch_index] for task in tasks if task.batch_index in records
+    ]
     batch_dir = base_dir / "proposal_batches"
     _atomic_write_json(batch_dir / f"g{generation}.json", ordered)
 
@@ -1583,7 +1580,9 @@ def _build_helix_result(
                 ),
                 parents=candidate_parents,
                 operation=entry.operation if entry is not None else candidate.operation,
-                generation=entry.generation if entry is not None else candidate.generation,
+                generation=entry.generation
+                if entry is not None
+                else candidate.generation,
                 discovered_at_evaluation=state.num_metric_calls_by_discovery.get(cid),
                 is_non_dominated=cid in non_dominated,
             )
@@ -1631,10 +1630,7 @@ def run_evolution(
     # supported stopping conditions.  max_generations defaults to 10 and is
     # always a positive int; this guard fires only if a caller explicitly sets
     # it to <= 0 while leaving max_evaluations disabled.
-    if (
-        config.evolution.max_generations <= 0
-        and config.evolution.max_evaluations <= 0
-    ):
+    if config.evolution.max_generations <= 0 and config.evolution.max_evaluations <= 0:
         raise ValueError(
             "At least one stopping condition is required: set "
             "config.evolution.max_generations to a positive integer, or "
@@ -1877,8 +1873,7 @@ def _run_evolution_impl(
             remove_worktree(candidate)
         except Exception as exc:
             print_warning(
-                f"Could not remove interrupted batch worktree "
-                f"{candidate_id}: {exc}"
+                f"Could not remove interrupted batch worktree {candidate_id}: {exc}"
             )
             return False
         return not worktree_path.exists()
@@ -1904,13 +1899,8 @@ def _run_evolution_impl(
                     continue
                 if task_record.child_id not in state.frontier:
                     state.frontier.append(task_record.child_id)
-                    state.instance_scores[task_record.child_id] = (
-                        result.instance_scores
-                    )
-                if (
-                    task_record.child_id
-                    not in state.num_metric_calls_by_discovery
-                ):
+                    state.instance_scores[task_record.child_id] = result.instance_scores
+                if task_record.child_id not in state.num_metric_calls_by_discovery:
                     budget_api.record_discovery_budget(
                         state,
                         task_record.child_id,
@@ -1921,9 +1911,9 @@ def _run_evolution_impl(
                     and state.total_merge_invocations
                     < config.evolution.max_merge_invocations
                 ):
-                    state.scheduler_state["pending_merges_due"] = int(
-                        state.scheduler_state.get("pending_merges_due", 0)
-                    ) + 1
+                    state.scheduler_state["pending_merges_due"] = (
+                        int(state.scheduler_state.get("pending_merges_due", 0)) + 1
+                    )
                 state.scheduler_state["last_iter_found_new_program"] = True
                 checkpoint_batch_task(
                     state,
@@ -2434,7 +2424,9 @@ def _run_evolution_impl(
                                 f"Merge {merge_id} touched protected evaluator files "
                                 f"({', '.join(merge_tamper)}) -- rejecting."
                             )
-                            _safe_remove_worktree(merged, label="tamper-rejected merge candidate")
+                            _safe_remove_worktree(
+                                merged, label="tamper-rejected merge candidate"
+                            )
                         else:
                             candidates[merged.id] = merged
                             record_entry(
@@ -2471,7 +2463,9 @@ def _run_evolution_impl(
                                     f"Merge {merge_id} produced a previously-seen "
                                     f"output (desc {merged_sha[:8]}) -- skipping."
                                 )
-                                _safe_remove_worktree(merged, label="duplicate-desc merge candidate")
+                                _safe_remove_worktree(
+                                    merged, label="duplicate-desc merge candidate"
+                                )
                                 if merged.id in candidates:
                                     del candidates[merged.id]
                                 _save_state(state)
@@ -2607,9 +2601,7 @@ def _run_evolution_impl(
                                     break
 
                                 merges_due -= 1
-                                state.scheduler_state["pending_merges_due"] = (
-                                    merges_due
-                                )
+                                state.scheduler_state["pending_merges_due"] = merges_due
                                 budget_api.record_merge_invocation(state)
                                 frontier.add(merged, full_val_result)
                                 _sync_frontier_state()
@@ -2626,7 +2618,9 @@ def _run_evolution_impl(
                                     f"Merge {merge_id} score {merge_score:.4f} < "
                                     f"max parent {required_score:.4f} -- rejecting."
                                 )
-                                _safe_remove_worktree(merged, label="score-rejected merge candidate")
+                                _safe_remove_worktree(
+                                    merged, label="score-rejected merge candidate"
+                                )
                                 if merged.id in candidates:
                                     del candidates[merged.id]
 
@@ -2667,12 +2661,7 @@ def _run_evolution_impl(
             )
             batch_id = f"g{gen}-proposals"
             max_in_flight_evaluations = sum(
-                2
-                * (
-                    len(task.minibatch_ids)
-                    if task.minibatch_ids is not None
-                    else 1
-                )
+                2 * (len(task.minibatch_ids) if task.minibatch_ids is not None else 1)
                 + len(stage_val_example_ids)
                 + (len(full_val_example_ids) if full_val_example_ids else 1)
                 for task in tasks
@@ -2726,13 +2715,9 @@ def _run_evolution_impl(
             proposal_outcomes: dict[int, TerminalProposalOutcome] = {}
             cleaned_child_ids: set[str] = set()
             cleanup_results: dict[str, ProposalCleanupResult] = {}
-            task_budget_charges = {
-                task.batch_index: BudgetState() for task in tasks
-            }
+            task_budget_charges = {task.batch_index: BudgetState() for task in tasks}
             parent_ready: dict[int, tuple[EvalResult, int]] = {}
-            child_ready: dict[
-                int, tuple[ProposalTask, EvalResult, int, Candidate]
-            ] = {}
+            child_ready: dict[int, tuple[ProposalTask, EvalResult, int, Candidate]] = {}
             evaluated_proposals: list[EvaluatedProposal] = []
             selected_proposals: list[SelectedProposal] = []
             _gen_skip_records: list[dict[str, Any]] = []
@@ -2853,9 +2838,7 @@ def _run_evolution_impl(
                 charge.input_tokens += usage.input_tokens
                 charge.output_tokens += usage.output_tokens
                 charge.cached_input_tokens += usage.cached_input_tokens
-                charge.cache_creation_input_tokens += (
-                    usage.cache_creation_input_tokens
-                )
+                charge.cache_creation_input_tokens += usage.cache_creation_input_tokens
                 charge.cache_read_input_tokens += usage.cache_read_input_tokens
                 charge.reasoning_tokens += usage.reasoning_tokens
                 charge.cost_usd += usage.cost_usd
@@ -2937,8 +2920,7 @@ def _run_evolution_impl(
                         task=task,
                         stage="parent_evaluation",
                         message=(
-                            f"{type(parent_call.error).__name__}: "
-                            f"{parent_call.error}"
+                            f"{type(parent_call.error).__name__}: {parent_call.error}"
                         ),
                     )
                     proposal_outcomes[task.batch_index] = proposal_outcome
@@ -2985,12 +2967,9 @@ def _run_evolution_impl(
                     )
                 _add_evaluation_charge(task, charged)
 
-                if (
-                    config.evolution.perfect_score_threshold is not None
-                    and all(
-                        score >= config.evolution.perfect_score_threshold
-                        for score in parent_result.instance_scores.values()
-                    )
+                if config.evolution.perfect_score_threshold is not None and all(
+                    score >= config.evolution.perfect_score_threshold
+                    for score in parent_result.instance_scores.values()
                 ):
                     proposal_outcome = SkippedProposal(
                         task=task,
@@ -3155,9 +3134,7 @@ def _run_evolution_impl(
             )
             fatal_mutation_error: BaseException | None = None
             mutation_children: list[Candidate] = []
-            for mutation_item, mutation_call in zip(
-                mutation_inputs, mutation_calls
-            ):
+            for mutation_item, mutation_call in zip(mutation_inputs, mutation_calls):
                 task, (parent_result, parent_n_uncached) = mutation_item
                 if mutation_call.error is not None:
                     proposal_outcome = FailedProposal(
@@ -3200,9 +3177,7 @@ def _run_evolution_impl(
                     continue
 
                 assert mutation_call.value is not None
-                child, tampered_paths, post_error, pre_cleanup = (
-                    mutation_call.value
-                )
+                child, tampered_paths, post_error, pre_cleanup = mutation_call.value
                 if child is None:
                     proposal_outcome = FailedProposal(
                         task=task,
@@ -3439,8 +3414,7 @@ def _run_evolution_impl(
                         task=task,
                         stage="child_evaluation",
                         message=(
-                            f"{type(child_call.error).__name__}: "
-                            f"{child_call.error}"
+                            f"{type(child_call.error).__name__}: {child_call.error}"
                         ),
                         parent_eval_result=parent_result,
                         child_candidate=child,
@@ -3537,8 +3511,7 @@ def _run_evolution_impl(
                 cast(ProposalAcceptanceCriterion, acceptance),
             )
             selected_ids = {
-                selected.proposal.child_candidate.id
-                for selected in selected_proposals
+                selected.proposal.child_candidate.id for selected in selected_proposals
             }
 
             # Persist and clean every evaluated child not selected.  The
@@ -3843,9 +3816,7 @@ def _run_evolution_impl(
                     ),
                     split="val",
                     instance_ids=(
-                        tuple(full_val_example_ids)
-                        if full_val_example_ids
-                        else None
+                        tuple(full_val_example_ids) if full_val_example_ids else None
                     ),
                 )
                 for selected in validation_ready

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -3113,6 +3113,29 @@ def _run_evolution_impl(
                 if task.batch_index in parent_ready and not _budget_break
             ]
 
+            def _live_reserved_mutation_child(
+                task: ProposalTask,
+            ) -> Candidate | None:
+                """Recover a failed mutation's child from its durable slot.
+
+                ``mutate`` intentionally returns ``None`` for a handled
+                ``MutationError``.  Its worktree removal can still fail, so the
+                pre-dispatch child reservation is the authoritative identity
+                for deciding whether cleanup remains required.
+                """
+                worktree_path = worktrees_dir / task.reserved_child_id
+                if not worktree_path.exists():
+                    return None
+                return Candidate(
+                    id=task.reserved_child_id,
+                    worktree_path=str(worktree_path),
+                    branch_name=f"helix/{task.reserved_child_id}",
+                    generation=gen,
+                    parent_id=task.parent_candidate.id,
+                    parent_ids=[task.parent_candidate.id],
+                    operation="mutate",
+                )
+
             def _mutate_one(
                 item: tuple[ProposalTask, tuple[EvalResult, int]],
             ) -> tuple[
@@ -3208,6 +3231,7 @@ def _run_evolution_impl(
                             else "failed"
                         ),
                         reason="mutation",
+                        child=_live_reserved_mutation_child(task),
                     )
                     if _is_fatal_proposal_exception(mutation_call.error):
                         fatal_mutation_error = (
@@ -3243,6 +3267,7 @@ def _run_evolution_impl(
                         task,
                         status="failed",
                         reason="mutation_returned_none",
+                        child=_live_reserved_mutation_child(task),
                     )
                     continue
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -12,10 +12,12 @@ import shlex
 import subprocess
 import tempfile
 import threading
-import traceback
-from dataclasses import replace
+from collections.abc import Callable, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, Generic, TypeVar
 
 
 from helix.batch_sampler import (
@@ -52,7 +54,7 @@ from helix.exceptions import (
     ResumeIncompatibleError,
     print_helix_error,
 )
-from helix.executor import run_evaluator
+from helix.executor import EvalBatchItem, run_evaluator, run_evaluator_batch
 from helix.lineage import LineageEntry, find_merge_triplet, load_lineage, record_entry
 from helix.merger import merge, select_eval_subsample_for_merged_program
 from helix.mutator import mutate, build_seed_generation_prompt, generate_seed
@@ -62,6 +64,19 @@ from helix.population import (
     EvalResult,
     HelixResult,
     ParetoFrontier,
+)
+from helix.proposals import (
+    AllImprovements,
+    BestImprovement,
+    EvaluatedProposal,
+    FailedProposal,
+    ProposalTask,
+    PxNSampling,
+    SelectedProposal,
+    SkippedProposal,
+    TamperedProposal,
+    TerminalProposalOutcome,
+    TopKImprovements,
 )
 from helix.sandbox import start_evaluator_sidecar
 from helix.state import (
@@ -104,6 +119,9 @@ from helix.evaluator_manifest import (  # noqa: E402  (after helix.worktree inte
 )
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+_R = TypeVar("_R")
 
 
 # ---------------------------------------------------------------------------
@@ -546,6 +564,188 @@ def _safe_remove_worktree(candidate: Candidate, *, label: str) -> None:
         print_warning(
             f"Could not remove worktree for {label} {candidate.id}: {exc}"
         )
+
+
+@dataclass(frozen=True, slots=True)
+class _OrderedCallResult(Generic[_R]):
+    """One position in a drained bounded call batch.
+
+    Worker exceptions are values here, rather than control flow, so callers can
+    account and clean every completed slot in sampled order before deciding
+    whether a fatal exception must terminate the run.
+    """
+
+    value: _R | None = None
+    error: BaseException | None = None
+
+
+def _run_bounded_ordered(
+    items: Sequence[_T],
+    worker: Callable[[_T], _R],
+    *,
+    max_workers: int,
+) -> list[_OrderedCallResult[_R]]:
+    """Run ``items`` with a worker bound and restore exact input order.
+
+    The pool is always drained.  In particular, this helper never raises a
+    worker's exception; fatal-vs-slot classification belongs
+    to the phase that owns the corresponding resources and can therefore clean
+    siblings before re-raising.  Run-fatal ``BaseException`` subclasses are
+    retained only until the pool has drained, then immediately re-raised.
+    """
+
+    if not items:
+        return []
+
+    ordered: list[_OrderedCallResult[_R] | None] = [None] * len(items)
+
+    def _capture(item: _T) -> _OrderedCallResult[_R]:
+        try:
+            return _OrderedCallResult(value=worker(item))
+        except BaseException as exc:
+            return _OrderedCallResult(error=exc)
+
+    # Preserve the historical 1x1 path: it does not pay for a thread-pool hop.
+    if len(items) == 1:
+        return [_capture(items[0])]
+
+    worker_count = min(len(items), max_workers)
+    with ThreadPoolExecutor(max_workers=worker_count) as pool:
+        futures: dict[Future[_OrderedCallResult[_R]], int] = {
+            pool.submit(_capture, item): index for index, item in enumerate(items)
+        }
+        for future in as_completed(futures):
+            ordered[futures[future]] = future.result()
+
+    # Every submitted future completed before the executor context exited.
+    assert all(result is not None for result in ordered)
+    return [result for result in ordered if result is not None]
+
+
+def _is_fatal_proposal_exception(exc: BaseException) -> bool:
+    """Return whether a proposal-stage error invalidates the whole run.
+
+    Evaluator, mutation, rate-limit, container-runtime, and worktree-operation
+    failures are isolated to their slot.  Prompt-artifact collisions are a
+    security boundary, while ``ValueError``/``TypeError`` represent invalid
+    runtime configuration or a broken scheduler contract; those must not be
+    converted into a smaller proposal batch.
+    """
+
+    return not isinstance(exc, Exception) or isinstance(
+        exc,
+        (
+            PromptArtifactCollisionError,
+            ResumeIncompatibleError,
+            ValueError,
+            TypeError,
+        ),
+    )
+
+
+def _plan_pxn_tasks(
+    *,
+    p: int,
+    n: int,
+    frontier: ParetoFrontier,
+    batch_sampler: BatchSampler[str] | None,
+    train_loader: "HelixDataLoader | _RangeDataLoader | None",
+    state: EvolutionState,
+    generation: int,
+) -> list[ProposalTask]:
+    """Select P parents and reserve their N child slots in parent-major order.
+
+    ``state.i`` advances once per task.  At a parent-group boundary it advances
+    immediately before parent selection, which preserves the existing P=K,
+    N=1 RNG/event order; within a group it advances before each additional
+    sibling minibatch.  Parent selection remains with replacement.
+    """
+
+    selected_groups = 0
+    sampled_tasks = 0
+    advanced_for_current_task = False
+    selected_parent: Candidate | None = None
+
+    def _select_parent() -> Candidate:
+        nonlocal selected_groups, advanced_for_current_task, selected_parent
+        if selected_groups > 0:
+            budget_api.advance_proposal_counter(
+                state, source="parallel_proposal"
+            )
+            advanced_for_current_task = True
+        selected_parent = frontier.select_parent()
+        selected_groups += 1
+        return selected_parent
+
+    def _sample_minibatch() -> Sequence[str] | None:
+        nonlocal sampled_tasks, advanced_for_current_task
+        if sampled_tasks > 0 and not advanced_for_current_task:
+            budget_api.advance_proposal_counter(
+                state, source="parallel_proposal"
+            )
+        advanced_for_current_task = False
+        sampled_tasks += 1
+        if batch_sampler is None or train_loader is None:
+            return None
+        ids = batch_sampler.next_minibatch_ids(train_loader, state)
+        assert selected_parent is not None
+        TRACE.emit(
+            EventType.SAMPLE_MINIBATCH,
+            candidate_id=selected_parent.id,
+            example_ids=list(ids),
+            split="train",
+        )
+        return ids
+
+    def _reserve_child_id() -> str:
+        return budget_api.next_mutation_id(state, generation)
+
+    tasks = PxNSampling(p, n).sample_tasks(
+        select_parent=_select_parent,
+        sample_minibatch=_sample_minibatch,
+        reserve_child_id=_reserve_child_id,
+    )
+    assert selected_groups == p
+    assert sampled_tasks == p * n
+    assert len(tasks) == p * n
+    return tasks
+
+
+def _proposal_terminal_record(
+    task: ProposalTask,
+    *,
+    status: str,
+    reason: str,
+    child_id: str | None = None,
+) -> dict[str, Any]:
+    """Return the stable on-disk terminal record for one proposal slot."""
+
+    return {
+        "batch_index": task.batch_index,
+        "parent_group_index": task.parent_group_index,
+        "mutation_index": task.mutation_index,
+        "parent_id": task.parent_candidate.id,
+        "child_id": child_id or task.reserved_child_id,
+        "minibatch_ids": (
+            list(task.minibatch_ids) if task.minibatch_ids is not None else None
+        ),
+        "status": status,
+        "reason": reason,
+    }
+
+
+def _save_proposal_terminal_records(
+    base_dir: Path,
+    *,
+    generation: int,
+    tasks: Sequence[ProposalTask],
+    records: dict[int, dict[str, Any]],
+) -> None:
+    """Persist currently terminal proposal slots in planned task order."""
+
+    ordered = [records[task.batch_index] for task in tasks if task.batch_index in records]
+    batch_dir = base_dir / "proposal_batches"
+    _atomic_write_json(batch_dir / f"g{generation}.json", ordered)
 
 
 def _check_evaluator_script_exists(evaluator_command: str, project_root: Path) -> None:
@@ -2117,778 +2317,1095 @@ def _run_evolution_impl(
                 # GEPA engine.py:739-740 always clears before reflective mutation.
                 last_iter_found_new_program = False
             # =============================================================
-            # Phase 2: Mutation (only when merge did not fire above)
+            # Phase 2: Unified P*N mutation scheduler
             #
-            # GEPA parity (M6): when num_parallel_proposals > 1, run the
-            # GEPA 3-step parallel pipeline (engine.py:381-452):
-            #   1. Sample N parent contexts sequentially
-            #   2. Execute N mutations in ThreadPoolExecutor
-            #   3. Process acceptances SEQUENTIALLY
-            # When num_parallel_proposals == 1, behaviour is identical to
-            # the original single-mutation path.
+            # One iteration plans P parent groups with N sibling mutations per
+            # group.  Each dispatched phase is drained completely; budget
+            # exhaustion only prevents the next phase/batch.
             # =============================================================
 
-            # GEPA parity: ``num_parallel_proposals="auto"`` is resolved to an int
-            # in ``EvolutionConfig.model_post_init`` (mirrors GEPA
-            # optimize_anything._resolve_num_parallel_proposals).  The assert both
-            # documents that invariant and narrows the type for mypy --strict.
-            _np_raw = config.evolution.num_parallel_proposals
-            assert isinstance(_np_raw, int)
-            n_proposals = _np_raw
-
-            # -- Atomic-worker result types (sealed union via class hierarchy) --
-            # Using a proper class hierarchy instead of a single ``kind``-discriminated
-            # dataclass gives mypy --strict the isinstance narrowing it needs to verify
-            # field accesses in the acceptance loop without any asserts or TypeGuards.
-            from dataclasses import dataclass as _dc  # noqa: PLC0415
-
-            # Convenience alias for the pre-sample context tuple shared by all result types.
-            _ProposalCtx = tuple[Candidate, EvalResult | None, list[str] | None, str]
-
-            @_dc
-            class _SkippedResult:
-                """skip-perfect fired — LLM was not called."""
-                presample_ctx: _ProposalCtx
-                parent_eval_result: EvalResult
-                parent_n_uncached: int = 0
-
-            @_dc
-            class _LLMFailedResult:
-                """mutate() raised or returned None; parent_eval_result may be None."""
-                presample_ctx: _ProposalCtx
-                parent_eval_result: EvalResult | None
-                parent_n_uncached: int = 0
-
-            @_dc
-            class _TamperedResult:
-                """LLM produced a child that modified protected evaluator files."""
-                presample_ctx: _ProposalCtx
-                parent_eval_result: EvalResult
-                child: Candidate
-                tampered_paths: list[str]
-                parent_n_uncached: int = 0
-                child_usage: UsageStats | None = None
-
-            @_dc
-            class _SuccessResult:
-                """All steps completed; child_eval_result may be None (no-minibatch path)."""
-                presample_ctx: _ProposalCtx
-                parent_eval_result: EvalResult
-                child: Candidate
-                child_eval_result: EvalResult | None = None
-                parent_n_uncached: int = 0
-                child_n_uncached: int = 0
-                child_usage: UsageStats | None = None
-
-            _ProposalResult = (
-                _SkippedResult | _LLMFailedResult | _TamperedResult | _SuccessResult
+            raw_p = config.evolution.num_parallel_proposals
+            assert isinstance(raw_p, int)
+            p = raw_p
+            n = config.evolution.mutations_per_parent
+            tasks = _plan_pxn_tasks(
+                p=p,
+                n=n,
+                frontier=frontier,
+                batch_sampler=batch_sampler,
+                train_loader=train_loader,
+                state=state,
+                generation=gen,
             )
-
-
-            # ---- Step 1a: Build pre-sample contexts (SEQUENTIAL) ----
-            # GEPA core/engine.py:381-452 has three stages:
-            #   1. ``prepare_proposal`` — sequential (parent select + minibatch sample)
-            #   2. ``execute_proposal`` — PARALLEL (parent eval + reflect + child eval)
-            #   3. ``apply_proposal_output`` — sequential (budget + cache write)
-            # HELIX §1a mirrors GEPA's prepare_proposal: candidate selection,
-            # ``state.i`` bump, and minibatch sampling live here.  The parent
-            # minibatch EVAL is moved out to §1b (see below) to parallelise it,
-            # matching GEPA reflective_mutation.py:268 (``eval_curr = adapter.evaluate(...)``)
-            # running inside the thread pool submitted at engine.py:422-426.
-            #
-            # Entries are tuples ``(parent, parent_frontier_result, subsample_ids, new_id)``.
-            presample_contexts: list[
-                tuple[Candidate, EvalResult | None, list[str] | None, str]
-            ] = []
-            _budget_break = False
-
-            for _p_idx in range(n_proposals):
-                if budget_api.budget_exhausted(state, config):
-                    _budget_break = True
-                    break
-
-                # GEPA parity (engine.py:405-410): the FIRST proposal reuses
-                # the iteration slot already created at the top of the outer
-                # loop (state.i bumped at evolution.py loop head).  For each
-                # ADDITIONAL parallel proposal, GEPA bumps state.i again so
-                # the per-proposal counter advances independently of the
-                # outer loop.  The bump is unconditional (no minibatch gate).
-                if _p_idx > 0:
-                    budget_api.advance_proposal_counter(
-                        state, source="parallel_proposal"
-                    )
-
-                parent = frontier.select_parent()
-                parent_frontier_result = frontier._results.get(parent.id)
-
-                # --- Minibatch gate pre-sampling (GEPA §5.1) --------------
-                # Sample subsample ids.  ``state.i`` is now advanced at the
-                # top of the run loop (GEPA engine.py:649) — and again per
-                # extra parallel proposal above (engine.py:408) — so the
-                # sampler always sees the right counter.  The parent-on-
-                # minibatch eval is deferred to §1b so that N parent evals
-                # overlap under ``num_parallel_proposals > 1``
-                # (audit-mutation §C4 MODERATE E).
-                subsample_ids: list[str] | None = None
-                if (
-                    use_minibatch_gate
-                    and train_loader is not None
-                    and batch_sampler is not None
-                ):
-                    subsample_ids = batch_sampler.next_minibatch_ids(
-                        train_loader, state
-                    )
-                    TRACE.emit(
-                        EventType.SAMPLE_MINIBATCH,
-                        candidate_id=parent.id,
-                        example_ids=list(subsample_ids),
-                        split="train",
-                    )
-
-                # g (gen) and s (mutation_counter) advance together under n_proposals=1
-                # / merge_disabled defaults. They diverge when n_proposals > 1 (multiple
-                # s-slots per gen) or when merge fires (gen advances without incrementing s).
-                new_id = budget_api.next_mutation_id(state, gen)
-                presample_contexts.append(
-                    (parent, parent_frontier_result, subsample_ids, new_id)
-                )
-
-
-            # -- _run_proposal_worker closure (atomic per-proposal worker) --
-            # Replaces the old _eval_parent + _do_mutate split closures with a
-            # single atomic worker that runs the full GEPA execute_proposal shape:
-            #   parent_eval (reflective_mutation.py:268) →
-            #   skip-perfect (reflective_mutation.py:308) →
-            #   LLM mutate (reflective_mutation.py:369) →
-            #   tamper check → child_eval (reflective_mutation.py:420).
-            # Budget charging is deferred to the sequential acceptance loop
-            # (apply_proposal_output parity).
-            def _run_proposal_worker(
-                pre_ctx: _ProposalCtx,
-            ) -> "_SkippedResult | _LLMFailedResult | _TamperedResult | _SuccessResult":
-                """Atomic proposal worker — GEPA execute_proposal shape.
-
-                Runs inside a ThreadPoolExecutor. All parameters except pre_ctx
-                are captured from the enclosing scope (config, project_root,
-                frontier, minibatch_cache, eval_cache, worktrees_dir,
-                evaluator_manifest, use_minibatch_gate, gen).
-
-                Thread-safety:
-                - Reads frontier (read-only during worker phase) ✓
-                - Reads config, project_root (immutable) ✓
-                - Writes to per-candidate worktree only (no shared mutable state) ✓
-                - Budget mutations DEFERRED to sequential acceptance loop ✓
-                """
-                _parent, _pfr, _sub_ids, _new_id = pre_ctx
-
-                # ---- Step W1: Parent eval ----
-                # Minibatch path: run parent eval fresh (bypass cache, GEPA parity).
-                # No-minibatch path: run train eval (single-task mode, n=1 in practice).
-                _parent_eval: "EvalResult | None" = None
-                _parent_n_uncached: int = 0
-                if _sub_ids is not None:
-                    try:
-                        # Bypass minibatch_cache — mirrors GEPA reflective_mutation.py:268
-                        _mb, _n = _cached_evaluate_batch(
-                            _parent,
-                            list(_sub_ids),
-                            None,  # bypass minibatch_cache
-                            config,
-                            "train",
-                            project_root,
-                        )
-                        _mb.candidate_id = _parent.id
-                        _parent_eval = _mb
-                        _parent_n_uncached = _n
-                    except Exception as _pe_exc:
-                        print_warning(
-                            f"Parent eval for proposal {_new_id} "
-                            f"(parent: {_parent.id}, gen {gen}) failed: "
-                            f"{type(_pe_exc).__name__}: {_pe_exc} — proposal slot skipped."
-                        )
-                        return _LLMFailedResult(
-                            presample_ctx=pre_ctx,
-                            parent_eval_result=None,
-                            parent_n_uncached=0,
-                        )
-                else:
-                    # No-minibatch path: run train eval inside worker.
-                    # eval_cache is a shared dict; safe for n=1 (single-task mode).
-                    set_phase(HelixPhase.TRAIN_EVALUATION)
-                    _train_result, _train_cached = _cached_eval(
-                        _parent, config, "train", eval_cache
-                    )
-                    _train_result.candidate_id = _parent.id
-                    _parent_eval = _train_result
-                    # Encode was_cached as n_uncached (0 = was_cached, 1 = not cached)
-                    _parent_n_uncached = 0 if _train_cached else 1
-
-                # ---- Step W2: Build eval_for_mutate ----
-                assert _parent_eval is not None
-                _eval_for_mutate = _parent_eval
-
-                # ---- Step W3: Skip-perfect check ----
-                # GEPA parity (reflective_mutation.py:308-327): fires on both
-                # minibatch and no-minibatch paths.  _parent_eval is always set
-                # at this point (minibatch eval OR train eval above).
-                if (
-                    config.evolution.perfect_score_threshold is not None
-                    and _parent_eval is not None
-                    and all(
-                        s >= config.evolution.perfect_score_threshold
-                        for s in _parent_eval.instance_scores.values()
-                    )
-                ):
-                    return _SkippedResult(
-                        presample_ctx=pre_ctx,
-                        parent_eval_result=_parent_eval,
-                        parent_n_uncached=_parent_n_uncached,
-                    )
-
-                # ---- Step W4: LLM mutation ----
-                try:
-                    _child = mutate(
-                        parent=_parent,
-                        eval_result=_eval_for_mutate,
-                        new_id=_new_id,
-                        config=config,
-                        base_dir=worktrees_dir,
-                        background=config.agent.background,
-                        prepare_worktree=lambda cand: (
-                            _refresh_and_snapshot_protected_evaluator_files(
-                                cand, config, project_root
-                            )
-                        ),
-                    )
-                except Exception as _mu_exc:
-                    # Re-raise PromptArtifactCollisionError (fatal for the whole run)
-                    if isinstance(_mu_exc, PromptArtifactCollisionError):
-                        raise
-                    # For HelixError / RateLimitError and other errors, log and return llm_failed
-                    if isinstance(_mu_exc, HelixError):
-                        _mu_exc.operation = (
-                            _mu_exc.operation or f"parallel mutate {_new_id}"
-                        )
-                        print_helix_error(_mu_exc)
-                        if isinstance(_mu_exc, RateLimitError):
-                            logger.error(
-                                "Mutation %s (parent: %s, gen %d) failed after all retries: "
-                                "%s: %s — proposal slot skipped.",
-                                _new_id, _parent.id, gen,
-                                type(_mu_exc).__name__, _mu_exc,
-                            )
-                            print_error(
-                                f"Mutation [bold]{_new_id}[/bold] hit rate limit after all "
-                                f"retries — proposal slot skipped. "
-                                f"Run [cyan]helix resume[/cyan] when rate limits clear."
-                            )
-                    else:
-                        print_error(
-                            f"Parallel mutation {_new_id} (parent: {_parent.id}, gen {gen}) "
-                            f"failed with exception:\n{traceback.format_exc()}"
-                        )
-                    return _LLMFailedResult(
-                        presample_ctx=pre_ctx,
-                        parent_eval_result=_parent_eval,
-                        parent_n_uncached=_parent_n_uncached,
-                    )
-
-                if _child is None:
-                    return _LLMFailedResult(
-                        presample_ctx=pre_ctx,
-                        parent_eval_result=_parent_eval,
-                        parent_n_uncached=_parent_n_uncached,
-                    )
-
-                # ---- Step W5: Tamper check ----
-                _tampered = _detect_evaluator_tamper(
-                    _child, evaluator_manifest, config, project_root
-                )
-                if _tampered:
-                    return _TamperedResult(
-                        presample_ctx=pre_ctx,
-                        parent_eval_result=_parent_eval,
-                        child=_child,
-                        tampered_paths=_tampered,
-                        parent_n_uncached=_parent_n_uncached,
-                        child_usage=_child.usage if _child.usage else None,
-                    )
-
-                # ---- Step W6: Child minibatch eval ----
-                _child_eval: "EvalResult | None" = None
-                _child_n_uncached: int = 0
-                if _sub_ids is not None:
-                    _ce, _cn = _cached_evaluate_batch(
-                        _child,
-                        list(_sub_ids),
-                        minibatch_cache,  # use cache for child (unlike parent bypass)
-                        config,
-                        "train",
-                        project_root,
-                    )
-                    _ce.candidate_id = _child.id
-                    _child_eval = _ce
-                    _child_n_uncached = _cn
-
-                return _SuccessResult(
-                    presample_ctx=pre_ctx,
-                    parent_eval_result=_parent_eval,
-                    child=_child,
-                    child_eval_result=_child_eval,
-                    parent_n_uncached=_parent_n_uncached,
-                    child_n_uncached=_child_n_uncached,
-                    child_usage=_child.usage if _child.usage else None,
-                )
-
-            # ---- Step 2: Atomic workers (GEPA execute_proposal parity) ----
-            # One worker per proposal slot; all run in a single ThreadPoolExecutor.
-            # Each worker executes: parent_eval → skip-perfect → LLM → tamper → child_eval.
-            # Budget charging is deferred to the sequential acceptance loop (Step 3).
-            # GEPA parity: engine.py:422-443, reflective_mutation.py:268,308,369,420.
-
-            if _budget_break and not presample_contexts:
-                print_warning("Budget exhausted mid-generation -- stopping.")
-                _save_state(state)
-                break
-
-            set_phase(HelixPhase.MUTATION)
-
-            worker_results: "list[_ProposalResult | None]" = [None] * len(presample_contexts)
-
-            from concurrent.futures import (  # noqa: PLC0415
-                ThreadPoolExecutor as _TPE,
-                as_completed as _ac,
-            )
-
-            _w_max = min(len(presample_contexts), config.evolution.max_workers)
-            if len(presample_contexts) > 1:
-                with _TPE(max_workers=_w_max) as _wpool:
-                    _wfutures = {
-                        _wpool.submit(_run_proposal_worker, _pctx): _widx
-                        for _widx, _pctx in enumerate(presample_contexts)
-                    }
-                    for _wf in _ac(_wfutures):
-                        _widx = _wfutures[_wf]
-                        try:
-                            worker_results[_widx] = _wf.result()
-                        except PromptArtifactCollisionError:
-                            raise
-                        except Exception as _wexc:
-                            _wpctx = presample_contexts[_widx]
-                            _wid = _wpctx[3]
-                            _wparent = _wpctx[0]
-                            print_warning(
-                                f"Worker for proposal {_wid} "
-                                f"(parent: {_wparent.id}, gen {gen}) "
-                                f"raised an unexpected exception: "
-                                f"{type(_wexc).__name__}: {_wexc} — proposal slot dropped."
-                            )
-                            worker_results[_widx] = _LLMFailedResult(
-                                presample_ctx=_wpctx,
-                                parent_eval_result=None,
-                                parent_n_uncached=0,
-                            )
-            else:
-                # n=1 sequential path (or single surviving slot after budget break)
-                for _idx, _pctx in enumerate(presample_contexts):
-                    worker_results[_idx] = _run_proposal_worker(_pctx)
-
-            # ---- Step 3: Sequential acceptance (sampling order, GEPA engine.py:446-452) ----
-            # Read worker results in pre-sampling order.  Budget mutations, lineage
-            # writes, and frontier updates are all sequential here
-            # (GEPA apply_proposal_output parity, engine.py:449-452).
-
-            _last_eval_result: "EvalResult | None" = None
-            _gen_skip_records: "list[dict[str, Any]]" = []
+            parent_frontier_results = {
+                task.batch_index: frontier.get_result(task.parent_candidate.id)
+                for task in tasks
+            }
+            terminal_records: dict[int, dict[str, Any]] = {}
+            proposal_outcomes: dict[int, TerminalProposalOutcome] = {}
+            cleaned_child_ids: set[str] = set()
+            parent_ready: dict[int, tuple[EvalResult, int]] = {}
+            child_ready: dict[
+                int, tuple[ProposalTask, EvalResult, int, Candidate]
+            ] = {}
+            evaluated_proposals: list[EvaluatedProposal] = []
+            selected_proposals: list[SelectedProposal] = []
+            _gen_skip_records: list[dict[str, Any]] = []
             semantic_skip_count = 0
             retryable_semantic_skip_count = 0
+            _last_eval_result: EvalResult | None = None
+            _budget_break = False
 
-            for _p_idx, wr in enumerate(worker_results):
-                if wr is None:
-                    continue
+            def _record_terminal(
+                task: ProposalTask,
+                *,
+                status: str,
+                reason: str,
+                child: Candidate | None = None,
+            ) -> None:
+                terminal_records[task.batch_index] = _proposal_terminal_record(
+                    task,
+                    status=status,
+                    reason=reason,
+                    child_id=child.id if child is not None else None,
+                )
 
-                _parent, _parent_frontier_result, _subsample_ids, _new_id = wr.presample_ctx
+            def _discard_child(child: Candidate, *, label: str) -> None:
+                if child.id in cleaned_child_ids:
+                    return
+                cleaned_child_ids.add(child.id)
+                _safe_remove_worktree(child, label=label)
+                candidates.pop(child.id, None)
 
-                # --- Handle non-success kinds (isinstance narrows wr for mypy) ---
+            # ---- Parent scoring batch ------------------------------------
+            # The same parent can appear in more than one group, and siblings
+            # intentionally carry independently sampled minibatches.
+            parent_batch_items = [
+                EvalBatchItem(
+                    candidate=task.parent_candidate,
+                    content_key=_candidate_content_key(task.parent_candidate),
+                    split="train",
+                    instance_ids=task.minibatch_ids,
+                )
+                for task in tasks
+            ]
 
-                if isinstance(wr, _LLMFailedResult):
-                    # Charge parent eval budget if the parent eval ran successfully
-                    # before the LLM call failed.
-                    if _subsample_ids is not None and wr.parent_eval_result is not None:
-                        budget_api.charge_evaluation(
-                            state,
-                            num_actual_examples=wr.parent_n_uncached,
-                            candidate_id=_parent.id,
-                            split="train",
-                            source="parent_minibatch",
-                        )
-                    print_warning(f"Mutation {_new_id} failed -- skipping.")
-                    continue
+            def _evaluate_parent(item: EvalBatchItem) -> tuple[EvalResult, int]:
+                if item.instance_ids is not None:
+                    result, n_uncached = _cached_evaluate_batch(
+                        item.candidate,
+                        list(item.instance_ids),
+                        None,  # parent reflection evals are always fresh
+                        config,
+                        item.split,
+                        project_root,
+                    )
+                else:
+                    result, was_cached = _cached_eval(
+                        item.candidate,
+                        config,
+                        item.split,
+                        eval_cache,
+                    )
+                    n_uncached = 0 if was_cached else 1
+                result.candidate_id = item.candidate.id
+                return result, n_uncached
 
-                if isinstance(wr, _SkippedResult):
-                    # Charge parent eval budget (both paths)
-                    if _subsample_ids is not None:
-                        budget_api.charge_evaluation(
-                            state,
-                            num_actual_examples=wr.parent_n_uncached,
-                            candidate_id=_parent.id,
-                            split="train",
-                            source="parent_minibatch",
-                        )
+            set_phase(HelixPhase.TRAIN_EVALUATION)
+            try:
+                parent_calls = run_evaluator_batch(
+                    parent_batch_items,
+                    _evaluate_parent,
+                    max_workers=config.evolution.max_workers,
+                    config=config,
+                )
+            except BaseException:
+                for task in tasks:
+                    _record_terminal(
+                        task,
+                        status="fatal",
+                        reason="fatal_parent_eval_batch",
+                    )
+                _save_proposal_terminal_records(
+                    base_dir,
+                    generation=gen,
+                    tasks=tasks,
+                    records=terminal_records,
+                )
+                raise
+            fatal_parent_error: BaseException | None = None
+            for task, call in zip(tasks, parent_calls):
+                if call.error is not None:
+                    outcome = FailedProposal(
+                        task=task,
+                        stage="parent_evaluation",
+                        message=f"{type(call.error).__name__}: {call.error}",
+                    )
+                    proposal_outcomes[task.batch_index] = outcome
+                    _record_terminal(
+                        task,
+                        status=(
+                            "fatal"
+                            if _is_fatal_proposal_exception(call.error)
+                            else "failed"
+                        ),
+                        reason="parent_eval",
+                    )
+                    if _is_fatal_proposal_exception(call.error):
+                        fatal_parent_error = fatal_parent_error or call.error
                     else:
-                        # No-minibatch path: worker ran _cached_eval; n_uncached encodes was_cached
-                        budget_api.charge_evaluation(
-                            state,
-                            was_cached=(wr.parent_n_uncached == 0),
-                            candidate_id=_parent.id,
-                            split="train",
-                            source="parent_train_no_minibatch",
+                        print_warning(
+                            f"Parent eval for proposal {task.reserved_child_id} "
+                            f"(parent: {task.parent_candidate.id}, gen {gen}) "
+                            f"failed: {type(call.error).__name__}: {call.error} "
+                            "— proposal slot skipped."
                         )
-                    _gen_skip_records.append({
-                        "generation": gen,
-                        "parent_id": _parent.id,
-                        "reason": "perfect_subsample",
-                        "parent_eval": wr.parent_eval_result.to_dict(),
-                    })
-                    print_info(
-                        f"Iteration {gen}: all subsample scores perfect for parent "
-                        f"{_parent.id}; skipping proposal "
-                        f"(GEPA reflective_mutation.py:308-327)."
-                    )
-                    semantic_skip_count += 1
-                    if _subsample_ids is not None:
-                        retryable_semantic_skip_count += 1
                     continue
 
-                if isinstance(wr, _TamperedResult):
-                    # Charge parent eval budget
-                    if _subsample_ids is not None:
-                        budget_api.charge_evaluation(
-                            state,
-                            num_actual_examples=wr.parent_n_uncached,
-                            candidate_id=_parent.id,
-                            split="train",
-                            source="parent_minibatch",
-                        )
-                    # Charge LLM usage (mutation happened, even if rejected)
-                    if wr.child_usage:
-                        live.update(usage=wr.child_usage)
-                        budget_api.charge_llm_usage(
-                            state, wr.child_usage,
-                            candidate_id=wr.child.id, source="mutation",
-                        )
-                    print_warning(
-                        f"Mutation {wr.child.id} touched protected evaluator files "
-                        f"({', '.join(wr.tampered_paths)}) -- rejecting."
-                    )
-                    _safe_remove_worktree(wr.child, label="tamper-rejected mutation candidate")
-                    continue
-
-                # wr is _SuccessResult at this point (mypy narrows via isinstance exhaustion)
-                child = wr.child
-
-                # Charge parent eval budget
-                if _subsample_ids is not None and wr.parent_eval_result is not None:
-                    # Minibatch path
+                assert call.result is not None
+                parent_result = call.result
+                parent_result.candidate_id = task.parent_candidate.id
+                parent_n_uncached = call.num_actual_evaluations
+                if task.minibatch_ids is not None:
                     budget_api.charge_evaluation(
                         state,
-                        num_actual_examples=wr.parent_n_uncached,
-                        candidate_id=_parent.id,
+                        num_actual_examples=parent_n_uncached,
+                        candidate_id=task.parent_candidate.id,
                         split="train",
                         source="parent_minibatch",
                     )
                 else:
-                    # No-minibatch path: parent_n_uncached encodes was_cached
-                    # (0 = was cached, 1 = not cached)
                     budget_api.charge_evaluation(
                         state,
-                        was_cached=(wr.parent_n_uncached == 0),
-                        candidate_id=_parent.id,
+                        was_cached=(parent_n_uncached == 0),
+                        candidate_id=task.parent_candidate.id,
                         split="train",
                         source="parent_train_no_minibatch",
                     )
 
-                if budget_api.budget_exhausted(state, config):
-                    print_warning("Budget exhausted mid-generation -- stopping.")
-                    _save_state(state)
-                    _budget_break = True
-                    break
+                if (
+                    config.evolution.perfect_score_threshold is not None
+                    and all(
+                        score >= config.evolution.perfect_score_threshold
+                        for score in parent_result.instance_scores.values()
+                    )
+                ):
+                    outcome = SkippedProposal(
+                        task=task,
+                        parent_eval_result=parent_result,
+                        reason="perfect_subsample",
+                        parent_n_uncached=parent_n_uncached,
+                    )
+                    proposal_outcomes[task.batch_index] = outcome
+                    _record_terminal(
+                        task,
+                        status="skipped",
+                        reason="perfect_subsample",
+                    )
+                    _gen_skip_records.append(
+                        {
+                            "generation": gen,
+                            "parent_id": task.parent_candidate.id,
+                            "reason": "perfect_subsample",
+                            "parent_eval": parent_result.to_dict(),
+                            "batch_index": task.batch_index,
+                            "parent_group_index": task.parent_group_index,
+                            "mutation_index": task.mutation_index,
+                            "child_id": task.reserved_child_id,
+                        }
+                    )
+                    print_info(
+                        f"Iteration {gen}: all subsample scores perfect for parent "
+                        f"{task.parent_candidate.id}; skipping proposal "
+                        f"{task.reserved_child_id}."
+                    )
+                    semantic_skip_count += 1
+                    if task.minibatch_ids is not None:
+                        retryable_semantic_skip_count += 1
+                    continue
 
-                # Charge LLM usage
-                if wr.child_usage:
-                    live.update(usage=wr.child_usage)
-                    budget_api.charge_llm_usage(
-                        state, wr.child_usage, candidate_id=child.id, source="mutation",
+                parent_ready[task.batch_index] = (
+                    parent_result,
+                    parent_n_uncached,
+                )
+
+            _save_proposal_terminal_records(
+                base_dir,
+                generation=gen,
+                tasks=tasks,
+                records=terminal_records,
+            )
+            if fatal_parent_error is not None:
+                for task in tasks:
+                    if task.batch_index in parent_ready:
+                        _record_terminal(
+                            task,
+                            status="discarded",
+                            reason="fatal_sibling_parent_eval",
+                        )
+                _save_proposal_terminal_records(
+                    base_dir,
+                    generation=gen,
+                    tasks=tasks,
+                    records=terminal_records,
+                )
+                raise fatal_parent_error
+
+            # Parent work was fully drained and charged.  If it crossed the
+            # cap, do not start mutation workers; mark every otherwise-ready
+            # slot terminal and stop after persistence.
+            if budget_api.budget_exhausted(state, config):
+                _budget_break = True
+                for task in tasks:
+                    if task.batch_index not in parent_ready:
+                        continue
+                    outcome = FailedProposal(
+                        task=task,
+                        stage="mutation",
+                        message="evaluation budget exhausted before mutation dispatch",
+                        parent_eval_result=parent_ready[task.batch_index][0],
+                        parent_n_uncached=parent_ready[task.batch_index][1],
+                    )
+                    proposal_outcomes[task.batch_index] = outcome
+                    _record_terminal(
+                        task,
+                        status="not_dispatched",
+                        reason="budget_exhausted_before_mutation",
                     )
 
+            # ---- Isolated mutation batch ---------------------------------
+            mutation_inputs = [
+                (task, parent_ready[task.batch_index])
+                for task in tasks
+                if task.batch_index in parent_ready and not _budget_break
+            ]
+
+            def _mutate_one(
+                item: tuple[ProposalTask, tuple[EvalResult, int]],
+            ) -> tuple[Candidate | None, tuple[str, ...]]:
+                task, (parent_result, _) = item
+                child = mutate(
+                    parent=task.parent_candidate,
+                    eval_result=parent_result,
+                    new_id=task.reserved_child_id,
+                    config=config,
+                    base_dir=worktrees_dir,
+                    background=config.agent.background,
+                    prepare_worktree=lambda candidate: (
+                        _refresh_and_snapshot_protected_evaluator_files(
+                            candidate, config, project_root
+                        )
+                    ),
+                )
+                if child is None:
+                    return None, ()
+                if child.id != task.reserved_child_id:
+                    raise ValueError(
+                        "Mutation returned candidate id "
+                        f"{child.id!r}; reserved id was "
+                        f"{task.reserved_child_id!r}."
+                    )
+                tampered = tuple(
+                    _detect_evaluator_tamper(
+                        child,
+                        evaluator_manifest,
+                        config,
+                        project_root,
+                    )
+                )
+                return child, tampered
+
+            set_phase(HelixPhase.MUTATION)
+            mutation_calls = _run_bounded_ordered(
+                mutation_inputs,
+                _mutate_one,
+                max_workers=config.evolution.max_workers,
+            )
+            fatal_mutation_error: BaseException | None = None
+            mutation_children: list[Candidate] = []
+            for item, call in zip(mutation_inputs, mutation_calls):
+                task, (parent_result, parent_n_uncached) = item
+                if call.error is not None:
+                    outcome = FailedProposal(
+                        task=task,
+                        stage="mutation",
+                        message=f"{type(call.error).__name__}: {call.error}",
+                        parent_eval_result=parent_result,
+                        parent_n_uncached=parent_n_uncached,
+                    )
+                    proposal_outcomes[task.batch_index] = outcome
+                    _record_terminal(
+                        task,
+                        status=(
+                            "fatal"
+                            if _is_fatal_proposal_exception(call.error)
+                            else "failed"
+                        ),
+                        reason="mutation",
+                    )
+                    if _is_fatal_proposal_exception(call.error):
+                        fatal_mutation_error = fatal_mutation_error or call.error
+                    elif isinstance(call.error, HelixError):
+                        call.error.operation = (
+                            call.error.operation
+                            or f"parallel mutate {task.reserved_child_id}"
+                        )
+                        print_helix_error(call.error)
+                    else:
+                        print_error(
+                            f"Parallel mutation {task.reserved_child_id} "
+                            f"(parent: {task.parent_candidate.id}, gen {gen}) "
+                            f"failed: {type(call.error).__name__}: {call.error}"
+                        )
+                    continue
+
+                assert call.value is not None
+                child, tampered_paths = call.value
+                if child is None:
+                    outcome = FailedProposal(
+                        task=task,
+                        stage="mutation",
+                        message="mutation returned no candidate",
+                        parent_eval_result=parent_result,
+                        parent_n_uncached=parent_n_uncached,
+                    )
+                    proposal_outcomes[task.batch_index] = outcome
+                    _record_terminal(
+                        task,
+                        status="failed",
+                        reason="mutation_returned_none",
+                    )
+                    continue
+
+                mutation_children.append(child)
+                if child.usage:
+                    live.update(usage=child.usage)
+                    budget_api.charge_llm_usage(
+                        state,
+                        child.usage,
+                        candidate_id=child.id,
+                        source="mutation",
+                    )
+
+                if tampered_paths:
+                    outcome = TamperedProposal(
+                        task=task,
+                        parent_eval_result=parent_result,
+                        child_candidate=child,
+                        tampered_paths=tampered_paths,
+                        parent_n_uncached=parent_n_uncached,
+                    )
+                    proposal_outcomes[task.batch_index] = outcome
+                    _record_terminal(
+                        task,
+                        status="tampered",
+                        reason="protected_evaluator_files",
+                        child=child,
+                    )
+                    print_warning(
+                        f"Mutation {child.id} touched protected evaluator files "
+                        f"({', '.join(tampered_paths)}) — rejecting."
+                    )
+                    _discard_child(
+                        child,
+                        label="tamper-rejected mutation candidate",
+                    )
+                    continue
+
+                child_ready[task.batch_index] = (
+                    task,
+                    parent_result,
+                    parent_n_uncached,
+                    child,
+                )
+
+            # A fatal mutation/setup error ends the run only after every worker
+            # has completed and all sibling worktrees have been removed.
+            if fatal_mutation_error is not None:
+                for child in mutation_children:
+                    _discard_child(
+                        child,
+                        label="sibling of fatal mutation",
+                    )
+                for task, _, _, child in child_ready.values():
+                    _record_terminal(
+                        task,
+                        status="discarded",
+                        reason="fatal_sibling_mutation",
+                        child=child,
+                    )
+                _save_proposal_terminal_records(
+                    base_dir,
+                    generation=gen,
+                    tasks=tasks,
+                    records=terminal_records,
+                )
+                raise fatal_mutation_error
+
+            # Record and snapshot every viable mutation in planned order before
+            # cross-candidate scoring.  This makes content hashes stable for
+            # deduplication and keeps lineage independent of worker completion.
+            for task in tasks:
+                prepared = child_ready.get(task.batch_index)
+                if prepared is None:
+                    continue
+                _, _, _, child = prepared
                 mutations_attempted += 1
                 live.update(mutations_attempted=mutations_attempted)
-
                 candidates[child.id] = child
                 record_entry(
                     lineage_path,
                     LineageEntry(
                         id=child.id,
-                        parent=_parent.id,
-                        parents=[_parent.id],
+                        parent=task.parent_candidate.id,
+                        parents=[task.parent_candidate.id],
                         operation="mutate",
                         generation=gen,
                         files_changed=[],
                     ),
                 )
-                # Save state BEFORE snapshot so that if the commit crashes
-                # (e.g. empty-commit), state is already persisted and resume
-                # can skip re-doing this mutation.
                 _save_state(state)
-                snapshot_candidate(child, f"helix: mutate {child.id}")
+                try:
+                    snapshot_candidate(child, f"helix: mutate {child.id}")
+                except Exception as exc:
+                    outcome = FailedProposal(
+                        task=task,
+                        stage="mutation",
+                        message=f"{type(exc).__name__}: {exc}",
+                        parent_eval_result=prepared[1],
+                        child_candidate=child,
+                        parent_n_uncached=prepared[2],
+                    )
+                    proposal_outcomes[task.batch_index] = outcome
+                    _record_terminal(
+                        task,
+                        status="failed",
+                        reason="snapshot",
+                        child=child,
+                    )
+                    _discard_child(child, label="snapshot-failed candidate")
+                    del child_ready[task.batch_index]
 
-                # --- Gating evaluation ----------------------------------------
-                # Two paths — both gate on GEPA's strict-sum acceptance criterion:
-                # (a) Minibatch gate: child eval already done in worker → use directly.
-                # (b) Legacy no-minibatch: run child eval sequentially here (old behavior).
-                _eval_for_mutate = wr.parent_eval_result  # parent baseline
+            # ---- Child scoring batch -------------------------------------
+            child_inputs = [
+                child_ready[task.batch_index]
+                for task in tasks
+                if task.batch_index in child_ready and not _budget_break
+            ]
 
-                if (
-                    use_minibatch_gate
-                    and _subsample_ids is not None
-                    and wr.parent_eval_result is not None
-                    and wr.child_eval_result is not None
-                ):
-                    # (a) Minibatch path: child eval result already in worker result
-                    gating_result = wr.child_eval_result
-                    _last_eval_result = gating_result
+            child_batch_items = [
+                EvalBatchItem(
+                    candidate=child,
+                    content_key=_candidate_content_key(child),
+                    split="train",
+                    instance_ids=task.minibatch_ids,
+                )
+                for task, _, _, child in child_inputs
+            ]
+
+            def _evaluate_child(item: EvalBatchItem) -> tuple[EvalResult, int]:
+                if item.instance_ids is not None:
+                    result, n_uncached = _cached_evaluate_batch(
+                        item.candidate,
+                        list(item.instance_ids),
+                        minibatch_cache,
+                        config,
+                        item.split,
+                        project_root,
+                    )
+                else:
+                    result, was_cached = _cached_eval(
+                        item.candidate,
+                        config,
+                        item.split,
+                        eval_cache,
+                    )
+                    n_uncached = 0 if was_cached else 1
+                result.candidate_id = item.candidate.id
+                return result, n_uncached
+
+            set_phase(HelixPhase.MUTATION_GATING)
+            try:
+                child_calls = run_evaluator_batch(
+                    child_batch_items,
+                    _evaluate_child,
+                    max_workers=config.evolution.max_workers,
+                    config=config,
+                )
+            except BaseException:
+                for task, _, _, child in child_inputs:
+                    _record_terminal(
+                        task,
+                        status="discarded",
+                        reason="fatal_child_eval_batch",
+                        child=child,
+                    )
+                    _discard_child(
+                        child,
+                        label="fatal child-evaluation batch",
+                    )
+                _save_proposal_terminal_records(
+                    base_dir,
+                    generation=gen,
+                    tasks=tasks,
+                    records=terminal_records,
+                )
+                raise
+            fatal_child_error: BaseException | None = None
+            for item, call in zip(child_inputs, child_calls):
+                task, parent_result, parent_n_uncached, child = item
+                if call.error is not None:
+                    outcome = FailedProposal(
+                        task=task,
+                        stage="child_evaluation",
+                        message=f"{type(call.error).__name__}: {call.error}",
+                        parent_eval_result=parent_result,
+                        child_candidate=child,
+                        parent_n_uncached=parent_n_uncached,
+                    )
+                    proposal_outcomes[task.batch_index] = outcome
+                    _record_terminal(
+                        task,
+                        status=(
+                            "fatal"
+                            if _is_fatal_proposal_exception(call.error)
+                            else "failed"
+                        ),
+                        reason="child_eval",
+                        child=child,
+                    )
+                    if _is_fatal_proposal_exception(call.error):
+                        fatal_child_error = fatal_child_error or call.error
+                    else:
+                        _discard_child(
+                            child,
+                            label="child-evaluation-failed candidate",
+                        )
+                    continue
+
+                assert call.result is not None
+                child_result = call.result
+                child_result.candidate_id = child.id
+                child_n_uncached = call.num_actual_evaluations
+                _last_eval_result = child_result
+                if task.minibatch_ids is not None:
                     budget_api.charge_evaluation(
                         state,
-                        num_actual_examples=wr.child_n_uncached,
+                        num_actual_examples=child_n_uncached,
                         candidate_id=child.id,
                         split="train",
                         source="mutation_minibatch_gate",
                     )
-
-                    if budget_api.budget_exhausted(state, config):
-                        print_warning("Budget exhausted mid-generation -- stopping.")
-                        _save_state(state)
-                        _budget_break = True
-                        break
-
-                    # Apply the configured acceptance criterion on the
-                    # per-instance score vectors (GEPA §5.1).
-                    #
-                    # GEPA parity (adapter.py:154): a missing instance id in the
-                    # parent or child minibatch result is an evaluator bug, not a
-                    # benign zero.  Both vectors must cover every id in
-                    # ``_subsample_ids`` so the acceptance criterion compares like-for-like.
-                    from types import SimpleNamespace as _SN  # noqa: PLC0415
-
-                    assert set(_subsample_ids).issubset(
-                        wr.parent_eval_result.instance_scores
-                    ), (
-                        f"Parent minibatch eval missing ids: "
-                        f"{set(_subsample_ids) - set(wr.parent_eval_result.instance_scores)}"
-                    )
-                    _before = [
-                        float(wr.parent_eval_result.instance_scores[str(eid)])
-                        for eid in _subsample_ids
-                    ]
-                    assert set(_subsample_ids).issubset(
-                        gating_result.instance_scores
-                    ), (
-                        f"Child minibatch eval missing ids: "
-                        f"{set(_subsample_ids) - set(gating_result.instance_scores)}"
-                    )
-                    _after = [
-                        float(gating_result.instance_scores[str(eid)])
-                        for eid in _subsample_ids
-                    ]
-                    _proposal = _SN(
-                        subsample_scores_before=_before,
-                        subsample_scores_after=_after,
-                    )
-                    if not acceptance.should_accept(_proposal):
-                        _save_attempt_result(
-                            base_dir, gating_result,
-                            status="rejected", reason="minibatch_gate",
-                            parent_id=_parent.id, generation=gen,
-                            stage="train_minibatch", example_ids=list(_subsample_ids),
-                        )
-                        TRACE.emit(
-                            EventType.ACCEPT_DECISION, candidate_id=child.id,
-                            decision="reject", example_ids=list(_subsample_ids),
-                            score=float(sum(_after)),
-                        )
-                        print_warning(
-                            f"Minibatch gate: {child.id} rejected "
-                            f"(sum {sum(_after):.4f} vs parent {sum(_before):.4f}) -- removing."
-                        )
-                        _safe_remove_worktree(
-                            child, label="minibatch-gate-rejected candidate"
-                        )
-                        del candidates[child.id]
-                        continue
-                    else:
-                        TRACE.emit(
-                            EventType.ACCEPT_DECISION, candidate_id=child.id,
-                            decision="accept", example_ids=list(_subsample_ids),
-                            score=float(sum(_after)),
-                        )
-
                 else:
-                    # (b) Legacy no-minibatch path: run child eval sequentially
-                    # Single-task/no-example mode still gates on train eval.
-                    # The parent baseline comes from the train eval passed to the mutator.
-                    set_phase(HelixPhase.MUTATION_GATING)
-                    parent_acceptance_result = _eval_for_mutate
-                    gating_result, _gating_cached = _cached_eval(
-                        child, config, "train", eval_cache
-                    )
-                    gating_result.candidate_id = child.id
-                    _last_eval_result = gating_result
-                    # Single-task/no-example mode still charges on train eval.
-                    # GEPA parity (MODERATE D — audit-mutation.md C3):
-                    # same strict-sum acceptance criterion as minibatch path.
                     budget_api.charge_evaluation(
-                        state, was_cached=_gating_cached, candidate_id=child.id,
-                        split="train", source="mutation_train_gate",
+                        state,
+                        was_cached=(child_n_uncached == 0),
+                        candidate_id=child.id,
+                        split="train",
+                        source="mutation_train_gate",
                     )
-                    if budget_api.budget_exhausted(state, config):
-                        print_warning("Budget exhausted mid-generation -- stopping.")
-                        _save_state(state)
-                        _budget_break = True
-                        break
-
-                    from types import SimpleNamespace as _SN  # noqa: PLC0415
-
-                    _legacy_before = list(parent_acceptance_result.instance_scores.values())
-                    _legacy_after = list(gating_result.instance_scores.values())
-                    _legacy_proposal = _SN(
-                        subsample_scores_before=_legacy_before,
-                        subsample_scores_after=_legacy_after,
-                    )
-                    if not acceptance.should_accept(_legacy_proposal):
-                        parent_sum = sum(_legacy_before)
-                        child_sum = sum(_legacy_after)
-                        _save_attempt_result(
-                            base_dir, gating_result,
-                            status="rejected", reason="train_gate",
-                            parent_id=_parent.id, generation=gen,
-                            stage="train", example_ids=None,
-                        )
-                        print_warning(
-                            f"Acceptance: {child.id} does not improve "
-                            f"(child_sum={child_sum:.4f}, parent_sum={parent_sum:.4f}) -- removing."
-                        )
-                        _safe_remove_worktree(child, label="train-gate-rejected candidate")
-                        del candidates[child.id]
-                        continue
-
-                # --- Staged val gate ------------------------------------------
-                # UNCHANGED from previous architecture — runs sequentially after gating.
-                use_val_stage_gate = _has_example_scores(
-                    _parent_frontier_result, stage_val_example_ids
+                proposal = EvaluatedProposal(
+                    task=task,
+                    parent_eval_result=parent_result,
+                    child_candidate=child,
+                    child_eval_result=child_result,
+                    parent_n_uncached=parent_n_uncached,
+                    child_n_uncached=child_n_uncached,
                 )
-                if stage_val_example_ids and use_val_stage_gate:
-                    set_phase(HelixPhase.VAL_EVALUATION)
-                    stage_result, _n = _cached_evaluate_batch(
-                        child, list(stage_val_example_ids), minibatch_cache,
-                        config, "val", project_root,
-                    )
-                    stage_result.candidate_id = child.id
-                    _last_eval_result = stage_result
-                    budget_api.charge_evaluation(
-                        state, num_actual_examples=_n, candidate_id=child.id,
-                        split="val", source="mutation_val_stage",
-                    )
-                    if budget_api.budget_exhausted(state, config):
-                        print_warning("Budget exhausted mid-generation -- stopping.")
-                        _save_state(state)
-                        _budget_break = True
-                        break
+                proposal_outcomes[task.batch_index] = proposal
+                evaluated_proposals.append(proposal)
 
-                    from types import SimpleNamespace as _SN  # noqa: PLC0415
+            if fatal_child_error is not None:
+                for _, _, _, child in child_inputs:
+                    _discard_child(
+                        child,
+                        label="sibling of fatal child evaluation",
+                    )
+                for proposal in evaluated_proposals:
+                    _record_terminal(
+                        proposal.task,
+                        status="discarded",
+                        reason="fatal_sibling_child_eval",
+                        child=proposal.child_candidate,
+                    )
+                _save_proposal_terminal_records(
+                    base_dir,
+                    generation=gen,
+                    tasks=tasks,
+                    records=terminal_records,
+                )
+                raise fatal_child_error
 
-                    _stage_before = _scores_for_example_ids(
-                        _parent_frontier_result
-                        or EvalResult(
-                            candidate_id="", scores={}, asi={}, instance_scores={}
-                        ),
-                        stage_val_example_ids,
-                    )
-                    _stage_after = _scores_for_example_ids(stage_result, stage_val_example_ids)
-                    _proposal = _SN(
-                        subsample_scores_before=_stage_before,
-                        subsample_scores_after=_stage_after,
-                    )
-                    if not acceptance.should_accept(_proposal):
-                        _save_attempt_result(
-                            base_dir, stage_result,
-                            status="rejected", reason="val_stage",
-                            parent_id=_parent.id, generation=gen,
-                            stage="val_stage", example_ids=list(stage_val_example_ids),
-                        )
-                        TRACE.emit(
-                            EventType.ACCEPT_DECISION, candidate_id=child.id,
-                            decision="reject_stage", example_ids=list(stage_val_example_ids),
-                            score=float(sum(_stage_after)),
-                        )
-                        print_warning(
-                            f"Val stage: {child.id} rejected on first "
-                            f"{len(stage_val_example_ids)} val ids "
-                            f"(sum {sum(_stage_after):.4f} vs parent "
-                            f"{sum(_stage_before):.4f}) -- removing."
-                        )
-                        _safe_remove_worktree(child, label="val-stage-rejected candidate")
-                        del candidates[child.id]
-                        continue
+            # Run the configured selection exactly once over all successfully
+            # evaluated children.  Acceptance is owned by the selector, so a
+            # stateful criterion cannot be accidentally called twice.
+            if config.evolution.proposal_selection == "all_improvements":
+                selector = AllImprovements()
+            elif config.evolution.proposal_selection == "best_improvement":
+                selector = BestImprovement()
+            else:
+                assert config.evolution.proposal_top_k is not None
+                selector = TopKImprovements(config.evolution.proposal_top_k)
+            selected_proposals = selector.select(
+                evaluated_proposals,
+                acceptance,
+            )
+            selected_ids = {
+                selected.proposal.child_candidate.id
+                for selected in selected_proposals
+            }
 
-                    TRACE.emit(
-                        EventType.ACCEPT_DECISION, candidate_id=child.id,
-                        decision="accept_stage", example_ids=list(stage_val_example_ids),
-                        score=float(sum(_stage_after)),
-                    )
-                    print_info(
-                        f"Val stage: {child.id} passed on first {len(stage_val_example_ids)} "
-                        f"val ids (sum {sum(_stage_after):.4f} vs parent "
-                        f"{sum(_stage_before):.4f}); promoting to full val."
-                    )
-
-                # --- Val evaluation -------------------------------------------
-                # UNCHANGED: run full val eval sequentially after gating.
-                set_phase(HelixPhase.VAL_EVALUATION)
-                val_result = _run_full_val_eval(
+            # Persist and clean every evaluated child not selected.  The
+            # default all-improvements mode retains historical gate reasons.
+            for proposal in evaluated_proposals:
+                child = proposal.child_candidate
+                if child.id in selected_ids:
+                    continue
+                reason = (
+                    "minibatch_gate"
+                    if proposal.task.minibatch_ids is not None
+                    else "train_gate"
+                )
+                if config.evolution.proposal_selection != "all_improvements":
+                    reason = "proposal_selection"
+                _save_attempt_result(
+                    base_dir,
+                    proposal.child_eval_result,
+                    status="rejected",
+                    reason=reason,
+                    parent_id=proposal.task.parent_candidate.id,
+                    generation=gen,
+                    stage=(
+                        "train_minibatch"
+                        if proposal.task.minibatch_ids is not None
+                        else "train"
+                    ),
+                    example_ids=(
+                        list(proposal.task.minibatch_ids)
+                        if proposal.task.minibatch_ids is not None
+                        else None
+                    ),
+                )
+                _record_terminal(
+                    proposal.task,
+                    status="not_selected",
+                    reason=reason,
+                    child=child,
+                )
+                TRACE.emit(
+                    EventType.ACCEPT_DECISION,
+                    candidate_id=child.id,
+                    decision="reject",
+                    example_ids=(
+                        list(proposal.task.minibatch_ids)
+                        if proposal.task.minibatch_ids is not None
+                        else None
+                    ),
+                    score=proposal.child_eval_result.sum_score(),
+                )
+                _discard_child(
                     child,
-                    state,
-                    full_val_example_ids=full_val_example_ids,
-                    minibatch_cache=minibatch_cache,
-                    eval_cache=eval_cache,
-                    config=config,
-                    project_root=project_root,
-                    source_batch="mutation_full_val_batch",
-                    source_single="mutation_full_val",
+                    label="proposal-selection-rejected candidate",
                 )
+
+            # A dispatched child batch is always fully accounted before this
+            # check.  Crossing the cap withholds staged/full validation and
+            # cleans selected-but-unapplied children.
+            if budget_api.budget_exhausted(state, config):
+                _budget_break = True
+                for selected in selected_proposals:
+                    proposal = selected.proposal
+                    _save_attempt_result(
+                        base_dir,
+                        proposal.child_eval_result,
+                        status="rejected",
+                        reason="budget_exhausted_after_child_batch",
+                        parent_id=proposal.task.parent_candidate.id,
+                        generation=gen,
+                        stage="train",
+                        example_ids=(
+                            list(proposal.task.minibatch_ids)
+                            if proposal.task.minibatch_ids is not None
+                            else None
+                        ),
+                    )
+                    _record_terminal(
+                        proposal.task,
+                        status="not_applied",
+                        reason="budget_exhausted_after_child_batch",
+                        child=proposal.child_candidate,
+                    )
+                    _discard_child(
+                        proposal.child_candidate,
+                        label="budget-withheld selected candidate",
+                    )
+                selected_proposals = []
+
+            # ---- Optional staged validation batch ------------------------
+            stage_inputs = [
+                selected
+                for selected in selected_proposals
+                if stage_val_example_ids
+                and _has_example_scores(
+                    parent_frontier_results[selected.proposal.task.batch_index],
+                    stage_val_example_ids,
+                )
+            ]
+            stage_input_ids = {
+                selected.proposal.child_candidate.id for selected in stage_inputs
+            }
+            stage_pass_ids: set[str] = set()
+
+            stage_batch_items = [
+                EvalBatchItem(
+                    candidate=selected.proposal.child_candidate,
+                    content_key=_candidate_content_key(
+                        selected.proposal.child_candidate
+                    ),
+                    split="val",
+                    instance_ids=tuple(stage_val_example_ids),
+                )
+                for selected in stage_inputs
+            ]
+
+            def _evaluate_stage(item: EvalBatchItem) -> tuple[EvalResult, int]:
+                assert item.instance_ids is not None
+                result, n_uncached = _cached_evaluate_batch(
+                    item.candidate,
+                    list(item.instance_ids),
+                    minibatch_cache,
+                    config,
+                    item.split,
+                    project_root,
+                )
+                result.candidate_id = item.candidate.id
+                return result, n_uncached
+
+            set_phase(HelixPhase.VAL_EVALUATION)
+            try:
+                stage_calls = run_evaluator_batch(
+                    stage_batch_items,
+                    _evaluate_stage,
+                    max_workers=config.evolution.max_workers,
+                    config=config,
+                )
+            except BaseException:
+                for selected in selected_proposals:
+                    proposal = selected.proposal
+                    _record_terminal(
+                        proposal.task,
+                        status="discarded",
+                        reason="fatal_val_stage_batch",
+                        child=proposal.child_candidate,
+                    )
+                    _discard_child(
+                        proposal.child_candidate,
+                        label="fatal staged-validation batch",
+                    )
+                _save_proposal_terminal_records(
+                    base_dir,
+                    generation=gen,
+                    tasks=tasks,
+                    records=terminal_records,
+                )
+                raise
+            fatal_stage_error: BaseException | None = None
+            for selected, call in zip(stage_inputs, stage_calls):
+                proposal = selected.proposal
+                task = proposal.task
+                child = proposal.child_candidate
+                if call.error is not None:
+                    _record_terminal(
+                        task,
+                        status=(
+                            "fatal"
+                            if _is_fatal_proposal_exception(call.error)
+                            else "failed"
+                        ),
+                        reason="val_stage",
+                        child=child,
+                    )
+                    if _is_fatal_proposal_exception(call.error):
+                        fatal_stage_error = fatal_stage_error or call.error
+                    else:
+                        _discard_child(
+                            child,
+                            label="val-stage-evaluation-failed candidate",
+                        )
+                    continue
+
+                assert call.result is not None
+                stage_result = call.result
+                stage_result.candidate_id = child.id
+                stage_n_uncached = call.num_actual_evaluations
+                _last_eval_result = stage_result
+                budget_api.charge_evaluation(
+                    state,
+                    num_actual_examples=stage_n_uncached,
+                    candidate_id=child.id,
+                    split="val",
+                    source="mutation_val_stage",
+                )
+                parent_frontier_result = parent_frontier_results[task.batch_index]
+                assert parent_frontier_result is not None
+                before = _scores_for_example_ids(
+                    parent_frontier_result,
+                    stage_val_example_ids,
+                )
+                after = _scores_for_example_ids(
+                    stage_result,
+                    stage_val_example_ids,
+                )
+                stage_proposal = SimpleNamespace(
+                    subsample_scores_before=before,
+                    subsample_scores_after=after,
+                )
+                if not acceptance.should_accept(stage_proposal):
+                    _save_attempt_result(
+                        base_dir,
+                        stage_result,
+                        status="rejected",
+                        reason="val_stage",
+                        parent_id=task.parent_candidate.id,
+                        generation=gen,
+                        stage="val_stage",
+                        example_ids=list(stage_val_example_ids),
+                    )
+                    _record_terminal(
+                        task,
+                        status="rejected",
+                        reason="val_stage",
+                        child=child,
+                    )
+                    TRACE.emit(
+                        EventType.ACCEPT_DECISION,
+                        candidate_id=child.id,
+                        decision="reject_stage",
+                        example_ids=list(stage_val_example_ids),
+                        score=float(sum(after)),
+                    )
+                    _discard_child(
+                        child,
+                        label="val-stage-rejected candidate",
+                    )
+                    continue
+                stage_pass_ids.add(child.id)
+                TRACE.emit(
+                    EventType.ACCEPT_DECISION,
+                    candidate_id=child.id,
+                    decision="accept_stage",
+                    example_ids=list(stage_val_example_ids),
+                    score=float(sum(after)),
+                )
+
+            if fatal_stage_error is not None:
+                for selected in selected_proposals:
+                    proposal = selected.proposal
+                    _discard_child(
+                        proposal.child_candidate,
+                        label="sibling of fatal staged validation",
+                    )
+                    if proposal.task.batch_index not in terminal_records:
+                        _record_terminal(
+                            proposal.task,
+                            status="discarded",
+                            reason="fatal_sibling_val_stage",
+                            child=proposal.child_candidate,
+                        )
+                _save_proposal_terminal_records(
+                    base_dir,
+                    generation=gen,
+                    tasks=tasks,
+                    records=terminal_records,
+                )
+                raise fatal_stage_error
+
+            # Preserve selector order even when only a subset required the
+            # staged gate and those evaluations completed out of order.
+            validation_ready = [
+                selected
+                for selected in selected_proposals
+                if (
+                    selected.proposal.child_candidate.id not in stage_input_ids
+                    or selected.proposal.child_candidate.id in stage_pass_ids
+                )
+            ]
+
+            if budget_api.budget_exhausted(state, config) and validation_ready:
+                _budget_break = True
+                for selected in validation_ready:
+                    proposal = selected.proposal
+                    _record_terminal(
+                        proposal.task,
+                        status="not_applied",
+                        reason="budget_exhausted_after_val_stage",
+                        child=proposal.child_candidate,
+                    )
+                    _discard_child(
+                        proposal.child_candidate,
+                        label="budget-withheld validation candidate",
+                    )
+                validation_ready = []
+
+            # ---- Full-validation batch -----------------------------------
+            full_batch_items = [
+                EvalBatchItem(
+                    candidate=selected.proposal.child_candidate,
+                    content_key=_candidate_content_key(
+                        selected.proposal.child_candidate
+                    ),
+                    split="val",
+                    instance_ids=(
+                        tuple(full_val_example_ids)
+                        if full_val_example_ids
+                        else None
+                    ),
+                )
+                for selected in validation_ready
+            ]
+
+            def _evaluate_full(item: EvalBatchItem) -> tuple[EvalResult, int]:
+                if item.instance_ids is not None:
+                    result, n_uncached = _cached_evaluate_batch(
+                        item.candidate,
+                        list(item.instance_ids),
+                        minibatch_cache,
+                        config,
+                        item.split,
+                        project_root,
+                    )
+                else:
+                    result, was_cached = _cached_eval(
+                        item.candidate,
+                        config,
+                        item.split,
+                        eval_cache,
+                    )
+                    n_uncached = 0 if was_cached else 1
+                result.candidate_id = item.candidate.id
+                return result, n_uncached
+
+            try:
+                full_calls = run_evaluator_batch(
+                    full_batch_items,
+                    _evaluate_full,
+                    max_workers=config.evolution.max_workers,
+                    config=config,
+                )
+            except BaseException:
+                for selected in validation_ready:
+                    proposal = selected.proposal
+                    _record_terminal(
+                        proposal.task,
+                        status="discarded",
+                        reason="fatal_full_validation_batch",
+                        child=proposal.child_candidate,
+                    )
+                    _discard_child(
+                        proposal.child_candidate,
+                        label="fatal full-validation batch",
+                    )
+                _save_proposal_terminal_records(
+                    base_dir,
+                    generation=gen,
+                    tasks=tasks,
+                    records=terminal_records,
+                )
+                raise
+            fatal_full_error: BaseException | None = None
+            full_results: list[tuple[SelectedProposal, EvalResult]] = []
+            for selected, call in zip(validation_ready, full_calls):
+                proposal = selected.proposal
+                task = proposal.task
+                child = proposal.child_candidate
+                if call.error is not None:
+                    _record_terminal(
+                        task,
+                        status=(
+                            "fatal"
+                            if _is_fatal_proposal_exception(call.error)
+                            else "failed"
+                        ),
+                        reason="full_validation",
+                        child=child,
+                    )
+                    if _is_fatal_proposal_exception(call.error):
+                        fatal_full_error = fatal_full_error or call.error
+                    else:
+                        _discard_child(
+                            child,
+                            label="full-validation-failed candidate",
+                        )
+                    continue
+
+                assert call.result is not None
+                val_result = call.result
+                val_result.candidate_id = child.id
+                val_n_uncached = call.num_actual_evaluations
                 _last_eval_result = val_result
+                if full_val_example_ids:
+                    budget_api.charge_evaluation(
+                        state,
+                        num_actual_examples=val_n_uncached,
+                        candidate_id=child.id,
+                        split="val",
+                        source="mutation_full_val_batch",
+                    )
+                else:
+                    budget_api.charge_evaluation(
+                        state,
+                        was_cached=(val_n_uncached == 0),
+                        candidate_id=child.id,
+                        split="val",
+                        source="mutation_full_val",
+                    )
+                full_results.append((selected, val_result))
 
-                if budget_api.budget_exhausted(state, config):
-                    print_warning("Budget exhausted mid-generation -- stopping.")
-                    _save_state(state)
-                    _budget_break = True
-                    break
+            if fatal_full_error is not None:
+                for selected in validation_ready:
+                    proposal = selected.proposal
+                    _discard_child(
+                        proposal.child_candidate,
+                        label="sibling of fatal full validation",
+                    )
+                    if proposal.task.batch_index not in terminal_records:
+                        _record_terminal(
+                            proposal.task,
+                            status="discarded",
+                            reason="fatal_sibling_full_validation",
+                            child=proposal.child_candidate,
+                        )
+                _save_proposal_terminal_records(
+                    base_dir,
+                    generation=gen,
+                    tasks=tasks,
+                    records=terminal_records,
+                )
+                raise fatal_full_error
 
-                # --- Update frontier ------------------------------------------
-                set_phase(HelixPhase.PARETO_UPDATE)
+            # Apply successful full validations in selector order.  No budget
+            # check may break this loop: every dispatched result was already
+            # completed and charged above.
+            set_phase(HelixPhase.PARETO_UPDATE)
+            for selected, val_result in full_results:
+                proposal = selected.proposal
+                child = proposal.child_candidate
                 _save_evaluation(base_dir, val_result)
                 frontier.add(child, val_result)
                 _sync_frontier_state()
                 state.instance_scores[child.id] = val_result.instance_scores
-                # GEPA parity (audit-rng-state-persist C/§3): record per-program
-                # discovery budget at the moment the child enters the frontier.
-                # GEPA core/state.py:537.
                 budget_api.record_discovery_budget(state, child.id)
                 TRACE.emit(
                     EventType.FRONTIER_UPDATE,
                     candidate_id=child.id,
                     score=val_result.aggregate_score(),
                 )
-                # GEPA parity (Fix 7): accepting a new program increments merges_due.
+                _record_terminal(
+                    proposal.task,
+                    status="accepted",
+                    reason="selected",
+                    child=child,
+                )
                 if (
                     config.evolution.merge_enabled
                     and state.total_merge_invocations
@@ -2896,34 +3413,59 @@ def _run_evolution_impl(
                 ):
                     merges_due += 1
                 last_iter_found_new_program = True
-
                 mutations_accepted += 1
                 live.update(
                     mutations_attempted=mutations_attempted,
                     mutations_accepted=mutations_accepted,
                 )
 
-            # Write skip records for this generation (GEPA parity — single JSON list)
-            if _gen_skip_records:
-                _save_skip_record(base_dir, generation=gen, records=_gen_skip_records)
+            if budget_api.budget_exhausted(state, config):
+                _budget_break = True
 
-            # Check semantic skip: all proposals were perfect on the minibatch.
-            # GEPA parity (engine.py:649, reflective_mutation.py:308-327): gen was
-            # already incremented unconditionally at the top of the loop, so on
-            # resume the next iteration will be gen+1 — no rollback, no infinite loop.
+            # Every planned task now has a terminal status.  Parent/mutation
+            # failures, skipped tasks, unselected children, and accepted
+            # children are serialized in parent-major task order.
+            for task in tasks:
+                if task.batch_index in terminal_records:
+                    continue
+                _record_terminal(
+                    task,
+                    status="failed",
+                    reason="no_terminal_outcome",
+                )
+            _save_proposal_terminal_records(
+                base_dir,
+                generation=gen,
+                tasks=tasks,
+                records=terminal_records,
+            )
+            if _gen_skip_records:
+                _save_skip_record(
+                    base_dir,
+                    generation=gen,
+                    records=_gen_skip_records,
+                )
+
             if (
                 not any(
-                    wr and isinstance(wr, (_SuccessResult, _TamperedResult))
-                    for wr in worker_results
+                    isinstance(
+                        outcome,
+                        (EvaluatedProposal, TamperedProposal),
+                    )
+                    for outcome in proposal_outcomes.values()
                 )
                 and semantic_skip_count
                 and retryable_semantic_skip_count == semantic_skip_count
+                and not _budget_break
             ):
                 _save_state(state)
                 TRACE.emit(EventType.ITER_END, decision=f"{gen}:skip")
                 continue
-            # If budget was exhausted during sequential acceptance, break outer loop.
+
+            # A cap crossed by any drained phase stops the next batch/iteration,
+            # never the accounting or cleanup of work already dispatched.
             if _budget_break:
+                _save_state(state)
                 break
 
             # Render at end of generation using the last result seen.

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1220,6 +1220,8 @@ def _cached_evaluate_batch(
                 split=split,
                 instance_ids=example_ids,
             )
+        missing = set(example_ids) - set(result.instance_scores)
+        assert not missing, f"Evaluator result missing ids: {sorted(missing)}"
         return result, len(example_ids)
 
     # Cached branch — delegate to the GEPA-parity helper on the cache
@@ -1819,6 +1821,50 @@ def _run_evolution_impl(
             return False
         return not worktree_path.exists()
 
+    def _recover_selected_evaluated_tasks() -> None:
+        """Finish the crash window between selected-eval and frontier apply."""
+
+        assert state is not None
+        for batch in state.proposal_batches:
+            for task_record in batch.tasks:
+                if not (
+                    task_record.status == "evaluated"
+                    and task_record.selection == "selected"
+                    and not task_record.applied
+                ):
+                    continue
+                result = _load_evaluation(base_dir, task_record.child_id)
+                worktree_path = worktrees_dir / task_record.child_id
+                if result is None or not worktree_path.exists():
+                    # Generic interrupted-batch reconciliation will
+                    # terminalize and clean an unrecoverable slot.
+                    continue
+                if task_record.child_id not in state.frontier:
+                    state.frontier.append(task_record.child_id)
+                    state.instance_scores[task_record.child_id] = (
+                        result.instance_scores
+                    )
+                if (
+                    task_record.child_id
+                    not in state.num_metric_calls_by_discovery
+                ):
+                    budget_api.record_discovery_budget(
+                        state,
+                        task_record.child_id,
+                    )
+                checkpoint_batch_task(
+                    state,
+                    project_root,
+                    batch_id=batch.batch_id,
+                    task_index=task_record.task_index,
+                    status="applied",
+                    selection="selected",
+                    cleanup="not_required",
+                    applied=True,
+                    detail="resume recovered selected evaluated task",
+                    saver=_save_state,
+                )
+
     if state is None:
         state = EvolutionState(
             generation=0,
@@ -1860,6 +1906,7 @@ def _run_evolution_impl(
                 "Config hash differs from the saved state; resuming with the current "
                 "config while keeping the existing frontier and history."
             )
+        _recover_selected_evaluated_tasks()
         reconcile_interrupted_batches(
             state,
             project_root,
@@ -2654,17 +2701,7 @@ def _run_evolution_impl(
                     if isinstance(outcome, EvaluatedProposal)
                     else None
                 )
-                charge = task_budget_charges[task.batch_index]
-                persisted_charge = BudgetState(
-                    evaluations=charge.evaluations,
-                    input_tokens=charge.input_tokens,
-                    output_tokens=charge.output_tokens,
-                    cached_input_tokens=charge.cached_input_tokens,
-                    cache_creation_input_tokens=charge.cache_creation_input_tokens,
-                    cache_read_input_tokens=charge.cache_read_input_tokens,
-                    reasoning_tokens=charge.reasoning_tokens,
-                    cost_usd=charge.cost_usd,
-                )
+                persisted_charge = _task_budget_snapshot(task)
                 checkpoint_batch_task(
                     state,
                     project_root,
@@ -2704,6 +2741,19 @@ def _run_evolution_impl(
                 charge.cache_read_input_tokens += usage.cache_read_input_tokens
                 charge.reasoning_tokens += usage.reasoning_tokens
                 charge.cost_usd += usage.cost_usd
+
+            def _task_budget_snapshot(task: ProposalTask) -> BudgetState:
+                charge = task_budget_charges[task.batch_index]
+                return BudgetState(
+                    evaluations=charge.evaluations,
+                    input_tokens=charge.input_tokens,
+                    output_tokens=charge.output_tokens,
+                    cached_input_tokens=charge.cached_input_tokens,
+                    cache_creation_input_tokens=charge.cache_creation_input_tokens,
+                    cache_read_input_tokens=charge.cache_read_input_tokens,
+                    reasoning_tokens=charge.reasoning_tokens,
+                    cost_usd=charge.cost_usd,
+                )
 
             # ---- Parent scoring batch ------------------------------------
             # The same parent can appear in more than one group, and siblings
@@ -3734,14 +3784,36 @@ def _run_evolution_impl(
                 )
                 raise fatal_full_error
 
-            # Apply successful full validations in selector order.  No budget
-            # check may break this loop: every dispatched result was already
-            # completed and charged above.
+            # Journal every successful full validation in selector order
+            # before inserting any selected child into the frontier.  This
+            # closes the sibling crash window: once application starts, every
+            # selected child has a durable evaluation artifact, full budget
+            # charge, and resume-recoverable selected/evaluated task record.
             set_phase(HelixPhase.PARETO_UPDATE)
             for selected, val_result in full_results:
                 proposal = selected.proposal
-                child = proposal.child_candidate
                 _save_evaluation(base_dir, val_result)
+                checkpoint_batch_task(
+                    state,
+                    project_root,
+                    batch_id=batch_id,
+                    task_index=proposal.task.batch_index,
+                    status="evaluated",
+                    score_delta=selected.improvement,
+                    selection="selected",
+                    cleanup="not_required",
+                    budget_charge=_task_budget_snapshot(proposal.task),
+                    budget_accounted=True,
+                    applied=False,
+                    saver=_save_state,
+                )
+
+            # Apply the already-journaled children deterministically.  No
+            # budget check may break this loop: every dispatched result was
+            # completed, charged, and made recoverable above.
+            for selected, val_result in full_results:
+                proposal = selected.proposal
+                child = proposal.child_candidate
                 frontier.add(child, val_result)
                 _sync_frontier_state()
                 state.instance_scores[child.id] = val_result.instance_scores
@@ -3790,12 +3862,13 @@ def _run_evolution_impl(
                 tasks=tasks,
                 records=terminal_records,
             )
-            checkpoint_batch_after_apply(
+            completed_batch = checkpoint_batch_after_apply(
                 state,
                 project_root,
                 batch_id=batch_id,
                 saver=_save_state,
             )
+            TRACE.emit_proposal_batch_terminal(completed_batch)
             if _gen_skip_records:
                 _save_skip_record(
                     base_dir,

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -730,6 +730,7 @@ def _plan_pxn_tasks(
 def _scheduler_checkpoint(
     rng: _random.Random,
     batch_sampler: BatchSampler[str] | None,
+    runtime_state: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Snapshot the shared frontier/sampler RNG and sampler schedule."""
 
@@ -765,7 +766,7 @@ def _scheduler_checkpoint(
                 },
             }
 
-    return build_scheduler_checkpoint(
+    checkpoint = build_scheduler_checkpoint(
         frontier_rng_state=rng.getstate(),
         sampler_rng_state=sampler_rng_state,
         sampler_epoch=sampler_epoch,
@@ -774,6 +775,14 @@ def _scheduler_checkpoint(
         sampler_id_frequencies=id_frequencies,
         sampler_fallback=fallback,
     )
+    if runtime_state is not None:
+        for key in (
+            "pending_merges_due",
+            "last_iter_found_new_program",
+        ):
+            if key in runtime_state:
+                checkpoint[key] = runtime_state[key]
+    return checkpoint
 
 
 def _restore_scheduler_checkpoint(
@@ -1821,10 +1830,11 @@ def _run_evolution_impl(
             return False
         return not worktree_path.exists()
 
-    def _recover_selected_evaluated_tasks() -> None:
+    def _recover_selected_evaluated_tasks() -> int:
         """Finish the crash window between selected-eval and frontier apply."""
 
         assert state is not None
+        recovered_acceptances = 0
         for batch in state.proposal_batches:
             for task_record in batch.tasks:
                 if not (
@@ -1852,6 +1862,16 @@ def _run_evolution_impl(
                         state,
                         task_record.child_id,
                     )
+                recovered_acceptances += 1
+                if (
+                    config.evolution.merge_enabled
+                    and state.total_merge_invocations
+                    < config.evolution.max_merge_invocations
+                ):
+                    state.scheduler_state["pending_merges_due"] = int(
+                        state.scheduler_state.get("pending_merges_due", 0)
+                    ) + 1
+                state.scheduler_state["last_iter_found_new_program"] = True
                 checkpoint_batch_task(
                     state,
                     project_root,
@@ -1864,7 +1884,9 @@ def _run_evolution_impl(
                     detail="resume recovered selected evaluated task",
                     saver=_save_state,
                 )
+        return recovered_acceptances
 
+    recovered_acceptances = 0
     if state is None:
         state = EvolutionState(
             generation=0,
@@ -1906,7 +1928,7 @@ def _run_evolution_impl(
                 "Config hash differs from the saved state; resuming with the current "
                 "config while keeping the existing frontier and history."
             )
-        _recover_selected_evaluated_tasks()
+        recovered_acceptances = _recover_selected_evaluated_tasks()
         reconcile_interrupted_batches(
             state,
             project_root,
@@ -2099,14 +2121,16 @@ def _run_evolution_impl(
         start_gen = state.generation + 1
         # GEPA parity: discovery-based merge trigger.  merges_due increments
         # when a new candidate is accepted to the frontier.
-        merges_due = 0
+        merges_due = int(state.scheduler_state.get("pending_merges_due", 0))
         # GEPA parity (M1): merge only fires when the *previous* iteration
         # found (accepted) a new program.  This prevents consecutive merge-only
         # generations after a rejected merge.  Mirrors GEPA engine.py:666.
-        last_iter_found_new_program = False
+        last_iter_found_new_program = bool(
+            state.scheduler_state.get("last_iter_found_new_program", False)
+        )
         # Mutation counters for display
         mutations_attempted = 0
-        mutations_accepted = 0
+        mutations_accepted = recovered_acceptances
 
         gen = start_gen - 1
         while gen < config.evolution.max_generations:
@@ -2175,6 +2199,7 @@ def _run_evolution_impl(
                 # GEPA parity (M1): clear the flag so consecutive merge-only
                 # generations cannot fire (mirrors engine.py:668,740).
                 last_iter_found_new_program = False
+                state.scheduler_state["last_iter_found_new_program"] = False
 
                 lineage = load_lineage(lineage_path)
                 score_map: dict[str, float] = {}
@@ -2509,6 +2534,9 @@ def _run_evolution_impl(
                                     break
 
                                 merges_due -= 1
+                                state.scheduler_state["pending_merges_due"] = (
+                                    merges_due
+                                )
                                 budget_api.record_merge_invocation(state)
                                 frontier.add(merged, full_val_result)
                                 _sync_frontier_state()
@@ -2542,6 +2570,7 @@ def _run_evolution_impl(
                 # but gate conditions not met (merges_due==0 or last_iter_found=False).
                 # GEPA engine.py:739-740 always clears before reflective mutation.
                 last_iter_found_new_program = False
+                state.scheduler_state["last_iter_found_new_program"] = False
             # =============================================================
             # Phase 2: Unified P*N mutation scheduler
             #
@@ -2578,7 +2607,11 @@ def _run_evolution_impl(
             checkpoint_scheduler_state(
                 state,
                 project_root,
-                _scheduler_checkpoint(rng, batch_sampler),
+                _scheduler_checkpoint(
+                    rng,
+                    batch_sampler,
+                    state.scheduler_state,
+                ),
                 saver=_save_state,
             )
             proposal_batch = ProposalBatchRecord(
@@ -2983,7 +3016,12 @@ def _run_evolution_impl(
 
             def _mutate_one(
                 item: tuple[ProposalTask, tuple[EvalResult, int]],
-            ) -> tuple[Candidate | None, tuple[str, ...]]:
+            ) -> tuple[
+                Candidate | None,
+                tuple[str, ...],
+                BaseException | None,
+                ProposalCleanupResult | None,
+            ]:
                 task, (parent_result, _) = item
                 child = mutate(
                     parent=task.parent_candidate,
@@ -2999,22 +3037,47 @@ def _run_evolution_impl(
                     ),
                 )
                 if child is None:
-                    return None, ()
-                if child.id != task.reserved_child_id:
-                    raise ValueError(
-                        "Mutation returned candidate id "
-                        f"{child.id!r}; reserved id was "
-                        f"{task.reserved_child_id!r}."
+                    return None, (), None, None
+                try:
+                    if child.id != task.reserved_child_id:
+                        raise ValueError(
+                            "Mutation returned candidate id "
+                            f"{child.id!r}; reserved id was "
+                            f"{task.reserved_child_id!r}."
+                        )
+                    tampered = tuple(
+                        _detect_evaluator_tamper(
+                            child,
+                            evaluator_manifest,
+                            config,
+                            project_root,
+                        )
                     )
-                tampered = tuple(
-                    _detect_evaluator_tamper(
-                        child,
-                        evaluator_manifest,
-                        config,
-                        project_root,
-                    )
-                )
-                return child, tampered
+                except BaseException as exc:
+                    # mutate() has already created a live worktree/branch.  A
+                    # reserved-ID contract failure or tamper-detector error
+                    # must retain the child long enough to clean and journal
+                    # it instead of being reduced to an exception-only pool
+                    # result.
+                    worktree_path = Path(child.worktree_path)
+                    existed = worktree_path.exists()
+                    try:
+                        remove_worktree(child)
+                    except Exception as cleanup_exc:
+                        print_warning(
+                            "Could not remove post-mutation-validation "
+                            f"candidate {child.id}: {cleanup_exc}"
+                        )
+                        cleanup: ProposalCleanupResult = "failed"
+                    else:
+                        if existed and worktree_path.exists():
+                            cleanup = "failed"
+                        elif existed:
+                            cleanup = "removed"
+                        else:
+                            cleanup = "missing"
+                    return child, (), exc, cleanup
+                return child, tampered, None, None
 
             set_phase(HelixPhase.MUTATION)
             mutation_calls = _run_bounded_ordered(
@@ -3069,7 +3132,9 @@ def _run_evolution_impl(
                     continue
 
                 assert mutation_call.value is not None
-                child, tampered_paths = mutation_call.value
+                child, tampered_paths, post_error, pre_cleanup = (
+                    mutation_call.value
+                )
                 if child is None:
                     proposal_outcome = FailedProposal(
                         task=task,
@@ -3084,6 +3149,38 @@ def _run_evolution_impl(
                         status="failed",
                         reason="mutation_returned_none",
                     )
+                    continue
+
+                if pre_cleanup is not None:
+                    cleaned_child_ids.add(child.id)
+                    cleanup_results[child.id] = pre_cleanup
+                if post_error is not None:
+                    proposal_outcome = FailedProposal(
+                        task=task,
+                        stage="mutation",
+                        message=f"{type(post_error).__name__}: {post_error}",
+                        parent_eval_result=parent_result,
+                        child_candidate=child,
+                        parent_n_uncached=parent_n_uncached,
+                    )
+                    proposal_outcomes[task.batch_index] = proposal_outcome
+                    _record_terminal(
+                        task,
+                        status=(
+                            "fatal"
+                            if _is_fatal_proposal_exception(post_error)
+                            else "failed"
+                        ),
+                        reason="post_mutation_validation",
+                        child=child,
+                    )
+                    if _is_fatal_proposal_exception(post_error):
+                        fatal_mutation_error = fatal_mutation_error or post_error
+                    else:
+                        print_warning(
+                            f"Post-mutation validation for {child.id} failed: "
+                            f"{type(post_error).__name__}: {post_error}"
+                        )
                     continue
 
                 mutation_children.append(child)
@@ -3807,9 +3904,18 @@ def _run_evolution_impl(
             # selected child has a durable evaluation artifact, full budget
             # charge, and resume-recoverable selected/evaluated task record.
             set_phase(HelixPhase.PARETO_UPDATE)
-            for selected, val_result in full_results:
-                proposal = selected.proposal
+            for _, val_result in full_results:
                 _save_evaluation(base_dir, val_result)
+
+            def _defer_selected_barrier_save(_state: EvolutionState) -> None:
+                # checkpoint_batch_task still validates and updates each
+                # record in memory, but no partial sibling ledger may become
+                # durable.  The single _save_state below is the atomic
+                # all-selected barrier.
+                return
+
+            for selected, _ in full_results:
+                proposal = selected.proposal
                 checkpoint_batch_task(
                     state,
                     project_root,
@@ -3822,8 +3928,10 @@ def _run_evolution_impl(
                     budget_charge=_task_budget_snapshot(proposal.task),
                     budget_accounted=True,
                     applied=False,
-                    saver=_save_state,
+                    saver=_defer_selected_barrier_save,
                 )
+            if full_results:
+                _save_state(state)
 
             # Apply the already-journaled children deterministically.  No
             # budget check may break this loop: every dispatched result was
@@ -3840,19 +3948,21 @@ def _run_evolution_impl(
                     candidate_id=child.id,
                     score=val_result.aggregate_score(),
                 )
-                _record_terminal(
-                    proposal.task,
-                    status="accepted",
-                    reason="selected",
-                    child=child,
-                )
                 if (
                     config.evolution.merge_enabled
                     and state.total_merge_invocations
                     < config.evolution.max_merge_invocations
                 ):
                     merges_due += 1
+                    state.scheduler_state["pending_merges_due"] = merges_due
                 last_iter_found_new_program = True
+                state.scheduler_state["last_iter_found_new_program"] = True
+                _record_terminal(
+                    proposal.task,
+                    status="accepted",
+                    reason="selected",
+                    child=child,
+                )
                 mutations_accepted += 1
                 live.update(
                     mutations_attempted=mutations_attempted,

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1914,6 +1914,22 @@ def _run_evolution_impl(
             cleanup_worktree=_cleanup_interrupted_batch_worktree,
             saver=_save_state,
         )
+        for interrupted_batch in state.proposal_batches:
+            if interrupted_batch.phase == "complete":
+                continue
+            if any(
+                not task_record.is_terminal()
+                or task_record.cleanup == "failed"
+                for task_record in interrupted_batch.tasks
+            ):
+                continue
+            completed_batch = checkpoint_batch_after_apply(
+                state,
+                project_root,
+                batch_id=interrupted_batch.batch_id,
+                saver=_save_state,
+            )
+            TRACE.emit_proposal_batch_terminal(completed_batch)
         if _reconcile_incomplete_attempts_on_resume(
             state=state,
             base_dir=base_dir,

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -53,7 +53,12 @@ from helix.exceptions import (
     ResumeIncompatibleError,
     print_helix_error,
 )
-from helix.executor import EvalBatchItem, run_evaluator, run_evaluator_batch
+from helix.executor import (
+    EvalBatchItem,
+    EvalBatchResult,
+    run_evaluator,
+    run_evaluator_batch,
+)
 from helix.lineage import LineageEntry, find_merge_triplet, load_lineage, record_entry
 from helix.merger import merge, select_eval_subsample_for_merged_program
 from helix.mutator import mutate, build_seed_generation_prompt, generate_seed
@@ -2715,7 +2720,13 @@ def _run_evolution_impl(
             proposal_outcomes: dict[int, TerminalProposalOutcome] = {}
             cleaned_child_ids: set[str] = set()
             cleanup_results: dict[str, ProposalCleanupResult] = {}
-            task_budget_charges = {task.batch_index: BudgetState() for task in tasks}
+            # Keep the live accumulator attached to the durable task row.  A task's
+            # charge may lead ``budget_accounted`` while a drained batch is being
+            # processed; the terminal checkpoint closes that journal entry.
+            task_budget_charges = {
+                task.batch_index: proposal_batch.tasks[task.batch_index].budget_charge
+                for task in tasks
+            }
             parent_ready: dict[int, tuple[EvalResult, int]] = {}
             child_ready: dict[int, tuple[ProposalTask, EvalResult, int, Candidate]] = {}
             evaluated_proposals: list[EvaluatedProposal] = []
@@ -2856,6 +2867,44 @@ def _run_evolution_impl(
                     cost_usd=charge.cost_usd,
                 )
 
+            def _precharge_drained_evaluation(
+                task: ProposalTask,
+                call: EvalBatchResult,
+                *,
+                candidate_id: str,
+                split: str,
+                source: str,
+                counts_examples: bool,
+            ) -> None:
+                """Journal one successful drained result before any phase save.
+
+                Evaluator workers populate the shared cache before the ordered main
+                thread consumes their results.  Every successful positional result in
+                a drained batch must therefore be charged before the first sibling can
+                checkpoint state plus that cache.  ``num_actual_evaluations`` is the
+                runtime distinction: cache hits and deduplicated followers report zero,
+                while executed leaders report their actual metric-call count.
+                """
+                if call.error is not None:
+                    return
+                if counts_examples:
+                    charged = budget_api.charge_evaluation(
+                        state,
+                        num_actual_examples=call.num_actual_evaluations,
+                        candidate_id=candidate_id,
+                        split=split,
+                        source=source,
+                    )
+                else:
+                    charged = budget_api.charge_evaluation(
+                        state,
+                        was_cached=(call.num_actual_evaluations == 0),
+                        candidate_id=candidate_id,
+                        split=split,
+                        source=source,
+                    )
+                _add_evaluation_charge(task, charged)
+
             # ---- Parent scoring batch ------------------------------------
             # The same parent can appear in more than one group, and siblings
             # intentionally carry independently sampled minibatches.
@@ -2912,6 +2961,19 @@ def _run_evolution_impl(
                     records=terminal_records,
                 )
                 raise
+            for task, parent_call in zip(tasks, parent_calls):
+                _precharge_drained_evaluation(
+                    task,
+                    parent_call,
+                    candidate_id=task.parent_candidate.id,
+                    split="train",
+                    source=(
+                        "parent_minibatch"
+                        if task.minibatch_ids is not None
+                        else "parent_train_no_minibatch"
+                    ),
+                    counts_examples=task.minibatch_ids is not None,
+                )
             fatal_parent_error: BaseException | None = None
             proposal_outcome: TerminalProposalOutcome
             for task, parent_call in zip(tasks, parent_calls):
@@ -2949,23 +3011,6 @@ def _run_evolution_impl(
                 parent_result = parent_call.result
                 parent_result.candidate_id = task.parent_candidate.id
                 parent_n_uncached = parent_call.num_actual_evaluations
-                if task.minibatch_ids is not None:
-                    charged = budget_api.charge_evaluation(
-                        state,
-                        num_actual_examples=parent_n_uncached,
-                        candidate_id=task.parent_candidate.id,
-                        split="train",
-                        source="parent_minibatch",
-                    )
-                else:
-                    charged = budget_api.charge_evaluation(
-                        state,
-                        was_cached=(parent_n_uncached == 0),
-                        candidate_id=task.parent_candidate.id,
-                        split="train",
-                        source="parent_train_no_minibatch",
-                    )
-                _add_evaluation_charge(task, charged)
 
                 if config.evolution.perfect_score_threshold is not None and all(
                     score >= config.evolution.perfect_score_threshold
@@ -3406,6 +3451,20 @@ def _run_evolution_impl(
                     records=terminal_records,
                 )
                 raise
+            for child_item, child_call in zip(child_inputs, child_calls):
+                task, _, _, child = child_item
+                _precharge_drained_evaluation(
+                    task,
+                    child_call,
+                    candidate_id=child.id,
+                    split="train",
+                    source=(
+                        "mutation_minibatch_gate"
+                        if task.minibatch_ids is not None
+                        else "mutation_train_gate"
+                    ),
+                    counts_examples=task.minibatch_ids is not None,
+                )
             fatal_child_error: BaseException | None = None
             for child_item, child_call in zip(child_inputs, child_calls):
                 task, parent_result, parent_n_uncached, child = child_item
@@ -3445,23 +3504,6 @@ def _run_evolution_impl(
                 child_result.candidate_id = child.id
                 child_n_uncached = child_call.num_actual_evaluations
                 _last_eval_result = child_result
-                if task.minibatch_ids is not None:
-                    charged = budget_api.charge_evaluation(
-                        state,
-                        num_actual_examples=child_n_uncached,
-                        candidate_id=child.id,
-                        split="train",
-                        source="mutation_minibatch_gate",
-                    )
-                else:
-                    charged = budget_api.charge_evaluation(
-                        state,
-                        was_cached=(child_n_uncached == 0),
-                        candidate_id=child.id,
-                        split="train",
-                        source="mutation_train_gate",
-                    )
-                _add_evaluation_charge(task, charged)
                 proposal_outcome = EvaluatedProposal(
                     task=task,
                     parent_eval_result=parent_result,
@@ -3668,6 +3710,16 @@ def _run_evolution_impl(
                     records=terminal_records,
                 )
                 raise
+            for selected, stage_call in zip(stage_inputs, stage_calls):
+                proposal = selected.proposal
+                _precharge_drained_evaluation(
+                    proposal.task,
+                    stage_call,
+                    candidate_id=proposal.child_candidate.id,
+                    split="val",
+                    source="mutation_val_stage",
+                    counts_examples=True,
+                )
             fatal_stage_error: BaseException | None = None
             for selected, stage_call in zip(stage_inputs, stage_calls):
                 proposal = selected.proposal
@@ -3696,16 +3748,7 @@ def _run_evolution_impl(
                 assert stage_call.result is not None
                 stage_result = stage_call.result
                 stage_result.candidate_id = child.id
-                stage_n_uncached = stage_call.num_actual_evaluations
                 _last_eval_result = stage_result
-                charged = budget_api.charge_evaluation(
-                    state,
-                    num_actual_examples=stage_n_uncached,
-                    candidate_id=child.id,
-                    split="val",
-                    source="mutation_val_stage",
-                )
-                _add_evaluation_charge(task, charged)
                 parent_frontier_result = parent_frontier_results[task.batch_index]
                 assert parent_frontier_result is not None
                 before = _scores_for_example_ids(
@@ -3870,6 +3913,20 @@ def _run_evolution_impl(
                     records=terminal_records,
                 )
                 raise
+            for selected, full_call in zip(validation_ready, full_calls):
+                proposal = selected.proposal
+                _precharge_drained_evaluation(
+                    proposal.task,
+                    full_call,
+                    candidate_id=proposal.child_candidate.id,
+                    split="val",
+                    source=(
+                        "mutation_full_val_batch"
+                        if full_val_example_ids
+                        else "mutation_full_val"
+                    ),
+                    counts_examples=bool(full_val_example_ids),
+                )
             fatal_full_error: BaseException | None = None
             full_results: list[tuple[SelectedProposal, EvalResult]] = []
             for selected, full_call in zip(validation_ready, full_calls):
@@ -3899,25 +3956,7 @@ def _run_evolution_impl(
                 assert full_call.result is not None
                 val_result = full_call.result
                 val_result.candidate_id = child.id
-                val_n_uncached = full_call.num_actual_evaluations
                 _last_eval_result = val_result
-                if full_val_example_ids:
-                    charged = budget_api.charge_evaluation(
-                        state,
-                        num_actual_examples=val_n_uncached,
-                        candidate_id=child.id,
-                        split="val",
-                        source="mutation_full_val_batch",
-                    )
-                else:
-                    charged = budget_api.charge_evaluation(
-                        state,
-                        was_cached=(val_n_uncached == 0),
-                        candidate_id=child.id,
-                        split="val",
-                        source="mutation_full_val",
-                    )
-                _add_evaluation_charge(task, charged)
                 full_results.append((selected, val_result))
 
             if fatal_full_error is not None:

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1920,6 +1920,7 @@ def _run_evolution_impl(
             if any(
                 not task_record.is_terminal()
                 or task_record.cleanup == "failed"
+                or not task_record.budget_accounted
                 for task_record in interrupted_batch.tasks
             ):
                 continue

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -56,6 +56,7 @@ from helix.exceptions import (
 from helix.executor import (
     EvalBatchItem,
     EvalBatchResult,
+    record_evaluator_units,
     run_evaluator,
     run_evaluator_batch,
 )
@@ -1231,11 +1232,13 @@ def _cached_eval(
     than HELIX's lineage id so equivalent candidates can reuse results.
     """
     if cache is None:
+        record_evaluator_units(1)
         return run_evaluator(candidate, config, split=split), False
     candidate_key = _candidate_content_key(candidate)
     cached = cache.get(candidate_key, split)
     if cached is not None:
         return EvalResult.from_dict(cached), True
+    record_evaluator_units(1)
     result = run_evaluator(candidate, config, split=split)
     cache.put(candidate_key, split, result.to_dict())
     return result, False
@@ -1276,6 +1279,7 @@ def _cached_evaluate_batch(
         with _worktree_lock(candidate.worktree_path):
             _refresh_protected_evaluator_files(candidate, config, project_root)
             _write_helix_batch(candidate.worktree_path, example_ids)
+            record_evaluator_units(len(example_ids))
             result = run_evaluator(
                 candidate,
                 config,
@@ -1324,6 +1328,11 @@ def _cached_evaluate_batch(
         with _worktree_lock(candidate.worktree_path):
             _refresh_protected_evaluator_files(candidate, config, project_root)
             _write_helix_batch(candidate.worktree_path, batch)
+            # The cache invokes this adapter only for keys this call owns.
+            # Report immediately before dispatch so a failed single-flight
+            # owner retains its actual units while waiters remain uncharged
+            # until they claim and retry a still-missing key themselves.
+            record_evaluator_units(len(batch))
             fresh = run_evaluator(
                 candidate,
                 config,
@@ -2876,17 +2885,15 @@ def _run_evolution_impl(
                 source: str,
                 counts_examples: bool,
             ) -> None:
-                """Journal one successful drained result before any phase save.
+                """Journal one drained outcome before any phase save.
 
                 Evaluator workers populate the shared cache before the ordered main
-                thread consumes their results.  Every successful positional result in
-                a drained batch must therefore be charged before the first sibling can
-                checkpoint state plus that cache.  ``num_actual_evaluations`` is the
-                runtime distinction: cache hits and deduplicated followers report zero,
-                while executed leaders report their actual metric-call count.
+                thread consumes their results.  Every positional outcome in a drained
+                batch must therefore be charged before the first sibling can checkpoint
+                state plus that cache.  ``num_actual_evaluations`` is the runtime
+                distinction: cache hits and deduplicated followers report zero, while
+                executed leaders retain their actual metric-call count even on error.
                 """
-                if call.error is not None:
-                    return
                 if counts_examples:
                     charged = budget_api.charge_evaluation(
                         state,

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -51,7 +51,6 @@ from helix.display import (
 from helix.exceptions import (
     HelixError,
     PromptArtifactCollisionError,
-    RateLimitError,
     ResumeIncompatibleError,
     print_helix_error,
 )

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -12,7 +12,8 @@ import shlex
 import subprocess
 import tempfile
 import threading
-from collections.abc import Callable, Sequence
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -83,11 +84,23 @@ from helix.proposals import (
 from helix.sandbox import start_evaluator_sidecar
 from helix.state import (
     BudgetState,
+    ProposalBatchRecord,
+    ProposalCleanupResult,
+    ProposalSelectionResult,
+    ProposalTaskRecord,
+    ProposalTaskStatus,
+    build_scheduler_checkpoint,
+    checkpoint_batch_after_apply,
+    checkpoint_batch_before_dispatch,
+    checkpoint_batch_task,
+    checkpoint_scheduler_state,
     clear_eval_cache,
+    decode_rng_state,
     EvaluationCache,
     EvolutionState,
     load_eval_cache,
     load_state,
+    reconcile_interrupted_batches,
     save_eval_cache,
     save_state,
 )
@@ -639,6 +652,7 @@ def _is_fatal_proposal_exception(exc: BaseException) -> bool:
         (
             PromptArtifactCollisionError,
             ResumeIncompatibleError,
+            AssertionError,
             ValueError,
             TypeError,
         ),
@@ -711,6 +725,120 @@ def _plan_pxn_tasks(
     assert sampled_tasks == p * n
     assert len(tasks) == p * n
     return tasks
+
+
+def _scheduler_checkpoint(
+    rng: _random.Random,
+    batch_sampler: BatchSampler[str] | None,
+) -> dict[str, Any]:
+    """Snapshot the shared frontier/sampler RNG and sampler schedule."""
+
+    sampler_rng_state = rng.getstate()
+    sampler_epoch = -1
+    shuffled_ids: Sequence[str] = ()
+    last_trainset_size = 0
+    id_frequencies: Mapping[str, int] | None = None
+    fallback: dict[str, Any] | None = None
+
+    if isinstance(batch_sampler, EpochShuffledBatchSampler):
+        sampler_rng_state = batch_sampler.rng.getstate()
+        sampler_epoch = batch_sampler.epoch
+        shuffled_ids = batch_sampler.shuffled_ids
+        last_trainset_size = batch_sampler.last_trainset_size
+        id_frequencies = {
+            str(key): int(value) for key, value in batch_sampler.id_freqs.items()
+        }
+    elif isinstance(batch_sampler, StratifiedBatchSampler):
+        sampler_rng_state = batch_sampler.rng.getstate()
+        sampler_epoch = batch_sampler.epoch
+        shuffled_ids = batch_sampler.shuffled_ids
+        last_trainset_size = batch_sampler.last_trainset_size
+        inner = batch_sampler._fallback
+        if inner is not None:
+            fallback = {
+                "rng_state": list(inner.rng.getstate()),
+                "epoch": inner.epoch,
+                "shuffled_ids": list(inner.shuffled_ids),
+                "last_trainset_size": inner.last_trainset_size,
+                "id_frequencies": {
+                    str(key): int(value) for key, value in inner.id_freqs.items()
+                },
+            }
+
+    return build_scheduler_checkpoint(
+        frontier_rng_state=rng.getstate(),
+        sampler_rng_state=sampler_rng_state,
+        sampler_epoch=sampler_epoch,
+        sampler_shuffled_ids=shuffled_ids,
+        sampler_last_trainset_size=last_trainset_size,
+        sampler_id_frequencies=id_frequencies,
+        sampler_fallback=fallback,
+    )
+
+
+def _restore_scheduler_checkpoint(
+    checkpoint: Mapping[str, Any],
+    rng: _random.Random,
+    batch_sampler: BatchSampler[str] | None,
+) -> None:
+    """Restore the exact shared RNG/minibatch position from persisted state."""
+
+    raw_frontier_state = checkpoint.get("frontier_rng_state")
+    if isinstance(raw_frontier_state, list):
+        rng.setstate(decode_rng_state(raw_frontier_state))
+
+    raw_sampler = checkpoint.get("sampler")
+    if not isinstance(raw_sampler, Mapping) or batch_sampler is None:
+        return
+    if not isinstance(
+        batch_sampler,
+        (EpochShuffledBatchSampler, StratifiedBatchSampler),
+    ):
+        return
+    raw_sampler_rng = raw_sampler.get("rng_state")
+    if isinstance(raw_sampler_rng, list):
+        batch_sampler.rng.setstate(decode_rng_state(raw_sampler_rng))
+    raw_ids = raw_sampler.get("shuffled_ids", [])
+    if isinstance(raw_ids, list):
+        batch_sampler.shuffled_ids = [str(value) for value in raw_ids]
+    batch_sampler.epoch = int(raw_sampler.get("epoch", -1))
+    batch_sampler.last_trainset_size = int(
+        raw_sampler.get("last_trainset_size", 0)
+    )
+
+    raw_frequencies = raw_sampler.get("id_frequencies", {})
+    if (
+        isinstance(batch_sampler, EpochShuffledBatchSampler)
+        and isinstance(raw_frequencies, Mapping)
+    ):
+        batch_sampler.id_freqs = Counter(
+            {str(key): int(value) for key, value in raw_frequencies.items()}
+        )
+
+    if not isinstance(batch_sampler, StratifiedBatchSampler):
+        return
+    raw_fallback = raw_sampler.get("fallback")
+    if not isinstance(raw_fallback, Mapping) or not raw_fallback:
+        batch_sampler._fallback = None
+        return
+    inner = EpochShuffledBatchSampler[str](
+        minibatch_size=batch_sampler.effective_minibatch_size,
+        rng=batch_sampler.rng,
+    )
+    inner.epoch = int(raw_fallback.get("epoch", -1))
+    inner.last_trainset_size = int(raw_fallback.get("last_trainset_size", 0))
+    raw_inner_ids = raw_fallback.get("shuffled_ids", [])
+    if isinstance(raw_inner_ids, list):
+        inner.shuffled_ids = [str(value) for value in raw_inner_ids]
+    raw_inner_freqs = raw_fallback.get("id_frequencies", {})
+    if isinstance(raw_inner_freqs, Mapping):
+        inner.id_freqs = Counter(
+            {str(key): int(value) for key, value in raw_inner_freqs.items()}
+        )
+    raw_inner_rng = raw_fallback.get("rng_state")
+    if isinstance(raw_inner_rng, list):
+        inner.rng.setstate(decode_rng_state(raw_inner_rng))
+    batch_sampler._fallback = inner
 
 
 def _proposal_terminal_record(
@@ -1668,6 +1796,29 @@ def _run_evolution_impl(
         state.frontier = frontier.candidate_ids()
         state.active_frontier = frontier.active_frontier_snapshot()
 
+    def _cleanup_interrupted_batch_worktree(
+        candidate_id: str,
+        worktree_path: Path,
+    ) -> bool:
+        candidate = Candidate(
+            id=candidate_id,
+            worktree_path=str(worktree_path),
+            branch_name=f"helix/{candidate_id}",
+            generation=_gen_from_id(candidate_id),
+            parent_id=None,
+            parent_ids=[],
+            operation="interrupted",
+        )
+        try:
+            remove_worktree(candidate)
+        except Exception as exc:
+            print_warning(
+                f"Could not remove interrupted batch worktree "
+                f"{candidate_id}: {exc}"
+            )
+            return False
+        return not worktree_path.exists()
+
     if state is None:
         state = EvolutionState(
             generation=0,
@@ -1686,6 +1837,8 @@ def _run_evolution_impl(
     else:
         needs_seed = False
         _validate_resume_semantics(state, config)
+        if state.scheduler_state:
+            _restore_scheduler_checkpoint(state.scheduler_state, rng, batch_sampler)
         if not state.resume_semantics:
             # Legacy state predating the resume_semantics guard: validation
             # short-circuits, so surface that the guard is dormant for THIS
@@ -1707,6 +1860,13 @@ def _run_evolution_impl(
                 "Config hash differs from the saved state; resuming with the current "
                 "config while keeping the existing frontier and history."
             )
+        reconcile_interrupted_batches(
+            state,
+            project_root,
+            worktrees_dir=worktrees_dir,
+            cleanup_worktree=_cleanup_interrupted_batch_worktree,
+            saver=_save_state,
+        )
         if _reconcile_incomplete_attempts_on_resume(
             state=state,
             base_dir=base_dir,
@@ -2339,6 +2499,60 @@ def _run_evolution_impl(
                 state=state,
                 generation=gen,
             )
+            batch_id = f"g{gen}-proposals"
+            max_in_flight_evaluations = sum(
+                2
+                * (
+                    len(task.minibatch_ids)
+                    if task.minibatch_ids is not None
+                    else 1
+                )
+                + len(stage_val_example_ids)
+                + (len(full_val_example_ids) if full_val_example_ids else 1)
+                for task in tasks
+            )
+            checkpoint_scheduler_state(
+                state,
+                project_root,
+                _scheduler_checkpoint(rng, batch_sampler),
+                saver=_save_state,
+            )
+            proposal_batch = ProposalBatchRecord(
+                batch_id=batch_id,
+                generation=gen,
+                p=p,
+                n=n,
+                tasks=[
+                    ProposalTaskRecord(
+                        batch_id=batch_id,
+                        p=p,
+                        n=n,
+                        task_index=task.batch_index,
+                        parent_group=task.parent_group_index,
+                        mutation_index=task.mutation_index,
+                        parent_id=task.parent_candidate.id,
+                        child_id=task.reserved_child_id,
+                    )
+                    for task in tasks
+                ],
+            )
+            checkpoint_batch_before_dispatch(
+                state,
+                project_root,
+                proposal_batch,
+                max_evaluations=config.evolution.max_evaluations,
+                max_in_flight_evaluations=max_in_flight_evaluations,
+                saver=_save_state,
+            )
+            for task in tasks:
+                checkpoint_batch_task(
+                    state,
+                    project_root,
+                    batch_id=batch_id,
+                    task_index=task.batch_index,
+                    status="running",
+                    saver=_save_state,
+                )
             parent_frontier_results = {
                 task.batch_index: frontier.get_result(task.parent_candidate.id)
                 for task in tasks
@@ -2346,6 +2560,10 @@ def _run_evolution_impl(
             terminal_records: dict[int, dict[str, Any]] = {}
             proposal_outcomes: dict[int, TerminalProposalOutcome] = {}
             cleaned_child_ids: set[str] = set()
+            cleanup_results: dict[str, ProposalCleanupResult] = {}
+            task_budget_charges = {
+                task.batch_index: BudgetState() for task in tasks
+            }
             parent_ready: dict[int, tuple[EvalResult, int]] = {}
             child_ready: dict[
                 int, tuple[ProposalTask, EvalResult, int, Candidate]
@@ -2358,6 +2576,34 @@ def _run_evolution_impl(
             _last_eval_result: EvalResult | None = None
             _budget_break = False
 
+            def _discard_child(
+                child: Candidate,
+                *,
+                label: str,
+            ) -> ProposalCleanupResult:
+                if child.id in cleaned_child_ids:
+                    return cleanup_results[child.id]
+                cleaned_child_ids.add(child.id)
+                candidates.pop(child.id, None)
+                worktree_path = Path(child.worktree_path)
+                existed = worktree_path.exists()
+                try:
+                    remove_worktree(child)
+                except Exception as exc:
+                    print_warning(
+                        f"Could not remove worktree for {label} {child.id}: {exc}"
+                    )
+                    cleanup: ProposalCleanupResult = "failed"
+                else:
+                    if existed and worktree_path.exists():
+                        cleanup = "failed"
+                    elif existed:
+                        cleanup = "removed"
+                    else:
+                        cleanup = "missing"
+                cleanup_results[child.id] = cleanup
+                return cleanup
+
             def _record_terminal(
                 task: ProposalTask,
                 *,
@@ -2365,19 +2611,99 @@ def _run_evolution_impl(
                 reason: str,
                 child: Candidate | None = None,
             ) -> None:
+                if task.batch_index in terminal_records:
+                    return
+                if status == "accepted":
+                    persisted_status: ProposalTaskStatus = "applied"
+                elif status == "skipped":
+                    persisted_status = "skipped"
+                elif status == "tampered":
+                    persisted_status = "tampered"
+                elif status in {"not_selected", "rejected", "not_applied"}:
+                    persisted_status = "rejected"
+                else:
+                    # Internal labels such as fatal, discarded, and
+                    # not_dispatched are detail strings, not persisted enum
+                    # values.  They terminalize as failed.
+                    persisted_status = "failed"
+
+                if persisted_status == "applied":
+                    selection: ProposalSelectionResult = "selected"
+                elif status == "not_selected":
+                    selection = "not_selected"
+                elif status in {"rejected", "not_applied"} or reason in {
+                    "val_stage",
+                    "full_validation",
+                }:
+                    selection = "selected"
+                else:
+                    selection = "not_applicable"
+
+                cleanup: ProposalCleanupResult
+                if child is not None and persisted_status != "applied":
+                    cleanup = _discard_child(
+                        child,
+                        label=f"{reason} proposal candidate",
+                    )
+                else:
+                    cleanup = "not_required"
+
+                outcome = proposal_outcomes.get(task.batch_index)
+                score_delta = (
+                    outcome.improvement
+                    if isinstance(outcome, EvaluatedProposal)
+                    else None
+                )
+                charge = task_budget_charges[task.batch_index]
+                persisted_charge = BudgetState(
+                    evaluations=charge.evaluations,
+                    input_tokens=charge.input_tokens,
+                    output_tokens=charge.output_tokens,
+                    cached_input_tokens=charge.cached_input_tokens,
+                    cache_creation_input_tokens=charge.cache_creation_input_tokens,
+                    cache_read_input_tokens=charge.cache_read_input_tokens,
+                    reasoning_tokens=charge.reasoning_tokens,
+                    cost_usd=charge.cost_usd,
+                )
+                checkpoint_batch_task(
+                    state,
+                    project_root,
+                    batch_id=batch_id,
+                    task_index=task.batch_index,
+                    status=persisted_status,
+                    score_delta=score_delta,
+                    selection=selection,
+                    cleanup=cleanup,
+                    budget_charge=persisted_charge,
+                    budget_accounted=True,
+                    applied=(persisted_status == "applied"),
+                    detail=f"{status}: {reason}",
+                    saver=_save_state,
+                )
                 terminal_records[task.batch_index] = _proposal_terminal_record(
                     task,
-                    status=status,
+                    status=persisted_status,
                     reason=reason,
                     child_id=child.id if child is not None else None,
                 )
 
-            def _discard_child(child: Candidate, *, label: str) -> None:
-                if child.id in cleaned_child_ids:
-                    return
-                cleaned_child_ids.add(child.id)
-                _safe_remove_worktree(child, label=label)
-                candidates.pop(child.id, None)
+            def _add_evaluation_charge(task: ProposalTask, units: int) -> None:
+                task_budget_charges[task.batch_index].evaluations += units
+
+            def _add_usage_charge(
+                task: ProposalTask,
+                usage: UsageStats,
+            ) -> None:
+                charge = task_budget_charges[task.batch_index]
+                charge.input_tokens += usage.input_tokens
+                charge.output_tokens += usage.output_tokens
+                charge.cached_input_tokens += usage.cached_input_tokens
+                charge.cache_creation_input_tokens += (
+                    usage.cache_creation_input_tokens
+                )
+                charge.cache_read_input_tokens += usage.cache_read_input_tokens
+                charge.reasoning_tokens += usage.reasoning_tokens
+                charge.cost_usd += usage.cost_usd
 
             # ---- Parent scoring batch ------------------------------------
             # The same parent can appear in more than one group, and siblings
@@ -2474,7 +2800,7 @@ def _run_evolution_impl(
                 parent_result.candidate_id = task.parent_candidate.id
                 parent_n_uncached = parent_call.num_actual_evaluations
                 if task.minibatch_ids is not None:
-                    budget_api.charge_evaluation(
+                    charged = budget_api.charge_evaluation(
                         state,
                         num_actual_examples=parent_n_uncached,
                         candidate_id=task.parent_candidate.id,
@@ -2482,13 +2808,14 @@ def _run_evolution_impl(
                         source="parent_minibatch",
                     )
                 else:
-                    budget_api.charge_evaluation(
+                    charged = budget_api.charge_evaluation(
                         state,
                         was_cached=(parent_n_uncached == 0),
                         candidate_id=task.parent_candidate.id,
                         split="train",
                         source="parent_train_no_minibatch",
                     )
+                _add_evaluation_charge(task, charged)
 
                 if (
                     config.evolution.perfect_score_threshold is not None
@@ -2701,6 +3028,7 @@ def _run_evolution_impl(
                         candidate_id=child.id,
                         source="mutation",
                     )
+                    _add_usage_charge(task, child.usage)
 
                 if tampered_paths:
                     proposal_outcome = TamperedProposal(
@@ -2907,7 +3235,7 @@ def _run_evolution_impl(
                 child_n_uncached = child_call.num_actual_evaluations
                 _last_eval_result = child_result
                 if task.minibatch_ids is not None:
-                    budget_api.charge_evaluation(
+                    charged = budget_api.charge_evaluation(
                         state,
                         num_actual_examples=child_n_uncached,
                         candidate_id=child.id,
@@ -2915,13 +3243,14 @@ def _run_evolution_impl(
                         source="mutation_minibatch_gate",
                     )
                 else:
-                    budget_api.charge_evaluation(
+                    charged = budget_api.charge_evaluation(
                         state,
                         was_cached=(child_n_uncached == 0),
                         candidate_id=child.id,
                         split="train",
                         source="mutation_train_gate",
                     )
+                _add_evaluation_charge(task, charged)
                 proposal_outcome = EvaluatedProposal(
                     task=task,
                     parent_eval_result=parent_result,
@@ -3159,13 +3488,14 @@ def _run_evolution_impl(
                 stage_result.candidate_id = child.id
                 stage_n_uncached = stage_call.num_actual_evaluations
                 _last_eval_result = stage_result
-                budget_api.charge_evaluation(
+                charged = budget_api.charge_evaluation(
                     state,
                     num_actual_examples=stage_n_uncached,
                     candidate_id=child.id,
                     split="val",
                     source="mutation_val_stage",
                 )
+                _add_evaluation_charge(task, charged)
                 parent_frontier_result = parent_frontier_results[task.batch_index]
                 assert parent_frontier_result is not None
                 before = _scores_for_example_ids(
@@ -3364,7 +3694,7 @@ def _run_evolution_impl(
                 val_n_uncached = full_call.num_actual_evaluations
                 _last_eval_result = val_result
                 if full_val_example_ids:
-                    budget_api.charge_evaluation(
+                    charged = budget_api.charge_evaluation(
                         state,
                         num_actual_examples=val_n_uncached,
                         candidate_id=child.id,
@@ -3372,13 +3702,14 @@ def _run_evolution_impl(
                         source="mutation_full_val_batch",
                     )
                 else:
-                    budget_api.charge_evaluation(
+                    charged = budget_api.charge_evaluation(
                         state,
                         was_cached=(val_n_uncached == 0),
                         candidate_id=child.id,
                         split="val",
                         source="mutation_full_val",
                     )
+                _add_evaluation_charge(task, charged)
                 full_results.append((selected, val_result))
 
             if fatal_full_error is not None:
@@ -3458,6 +3789,12 @@ def _run_evolution_impl(
                 generation=gen,
                 tasks=tasks,
                 records=terminal_records,
+            )
+            checkpoint_batch_after_apply(
+                state,
+                project_root,
+                batch_id=batch_id,
+                saver=_save_state,
             )
             if _gen_skip_records:
                 _save_skip_record(

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -17,7 +17,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
 
 from helix.batch_sampler import (
@@ -71,6 +71,8 @@ from helix.proposals import (
     EvaluatedProposal,
     FailedProposal,
     ProposalTask,
+    ProposalAcceptanceCriterion,
+    ProposalSelectionStrategy,
     PxNSampling,
     SelectedProposal,
     SkippedProposal,
@@ -2434,38 +2436,43 @@ def _run_evolution_impl(
                 )
                 raise
             fatal_parent_error: BaseException | None = None
-            for task, call in zip(tasks, parent_calls):
-                if call.error is not None:
-                    outcome = FailedProposal(
+            proposal_outcome: TerminalProposalOutcome
+            for task, parent_call in zip(tasks, parent_calls):
+                if parent_call.error is not None:
+                    proposal_outcome = FailedProposal(
                         task=task,
                         stage="parent_evaluation",
-                        message=f"{type(call.error).__name__}: {call.error}",
+                        message=(
+                            f"{type(parent_call.error).__name__}: "
+                            f"{parent_call.error}"
+                        ),
                     )
-                    proposal_outcomes[task.batch_index] = outcome
+                    proposal_outcomes[task.batch_index] = proposal_outcome
                     _record_terminal(
                         task,
                         status=(
                             "fatal"
-                            if _is_fatal_proposal_exception(call.error)
+                            if _is_fatal_proposal_exception(parent_call.error)
                             else "failed"
                         ),
                         reason="parent_eval",
                     )
-                    if _is_fatal_proposal_exception(call.error):
-                        fatal_parent_error = fatal_parent_error or call.error
+                    if _is_fatal_proposal_exception(parent_call.error):
+                        fatal_parent_error = fatal_parent_error or parent_call.error
                     else:
                         print_warning(
                             f"Parent eval for proposal {task.reserved_child_id} "
                             f"(parent: {task.parent_candidate.id}, gen {gen}) "
-                            f"failed: {type(call.error).__name__}: {call.error} "
+                            f"failed: {type(parent_call.error).__name__}: "
+                            f"{parent_call.error} "
                             "— proposal slot skipped."
                         )
                     continue
 
-                assert call.result is not None
-                parent_result = call.result
+                assert parent_call.result is not None
+                parent_result = parent_call.result
                 parent_result.candidate_id = task.parent_candidate.id
-                parent_n_uncached = call.num_actual_evaluations
+                parent_n_uncached = parent_call.num_actual_evaluations
                 if task.minibatch_ids is not None:
                     budget_api.charge_evaluation(
                         state,
@@ -2490,13 +2497,13 @@ def _run_evolution_impl(
                         for score in parent_result.instance_scores.values()
                     )
                 ):
-                    outcome = SkippedProposal(
+                    proposal_outcome = SkippedProposal(
                         task=task,
                         parent_eval_result=parent_result,
                         reason="perfect_subsample",
                         parent_n_uncached=parent_n_uncached,
                     )
-                    proposal_outcomes[task.batch_index] = outcome
+                    proposal_outcomes[task.batch_index] = proposal_outcome
                     _record_terminal(
                         task,
                         status="skipped",
@@ -2559,14 +2566,14 @@ def _run_evolution_impl(
                 for task in tasks:
                     if task.batch_index not in parent_ready:
                         continue
-                    outcome = FailedProposal(
+                    proposal_outcome = FailedProposal(
                         task=task,
                         stage="mutation",
                         message="evaluation budget exhausted before mutation dispatch",
                         parent_eval_result=parent_ready[task.batch_index][0],
                         parent_n_uncached=parent_ready[task.batch_index][1],
                     )
-                    proposal_outcomes[task.batch_index] = outcome
+                    proposal_outcomes[task.batch_index] = proposal_outcome
                     _record_terminal(
                         task,
                         status="not_dispatched",
@@ -2623,53 +2630,61 @@ def _run_evolution_impl(
             )
             fatal_mutation_error: BaseException | None = None
             mutation_children: list[Candidate] = []
-            for item, call in zip(mutation_inputs, mutation_calls):
-                task, (parent_result, parent_n_uncached) = item
-                if call.error is not None:
-                    outcome = FailedProposal(
+            for mutation_item, mutation_call in zip(
+                mutation_inputs, mutation_calls
+            ):
+                task, (parent_result, parent_n_uncached) = mutation_item
+                if mutation_call.error is not None:
+                    proposal_outcome = FailedProposal(
                         task=task,
                         stage="mutation",
-                        message=f"{type(call.error).__name__}: {call.error}",
+                        message=(
+                            f"{type(mutation_call.error).__name__}: "
+                            f"{mutation_call.error}"
+                        ),
                         parent_eval_result=parent_result,
                         parent_n_uncached=parent_n_uncached,
                     )
-                    proposal_outcomes[task.batch_index] = outcome
+                    proposal_outcomes[task.batch_index] = proposal_outcome
                     _record_terminal(
                         task,
                         status=(
                             "fatal"
-                            if _is_fatal_proposal_exception(call.error)
+                            if _is_fatal_proposal_exception(mutation_call.error)
                             else "failed"
                         ),
                         reason="mutation",
                     )
-                    if _is_fatal_proposal_exception(call.error):
-                        fatal_mutation_error = fatal_mutation_error or call.error
-                    elif isinstance(call.error, HelixError):
-                        call.error.operation = (
-                            call.error.operation
+                    if _is_fatal_proposal_exception(mutation_call.error):
+                        fatal_mutation_error = (
+                            fatal_mutation_error or mutation_call.error
+                        )
+                    elif isinstance(mutation_call.error, HelixError):
+                        mutation_call.error.operation = (
+                            mutation_call.error.operation
                             or f"parallel mutate {task.reserved_child_id}"
                         )
-                        print_helix_error(call.error)
+                        print_helix_error(mutation_call.error)
                     else:
                         print_error(
                             f"Parallel mutation {task.reserved_child_id} "
                             f"(parent: {task.parent_candidate.id}, gen {gen}) "
-                            f"failed: {type(call.error).__name__}: {call.error}"
+                            f"failed: {type(mutation_call.error).__name__}: "
+                            f"{mutation_call.error}"
                         )
                     continue
 
-                assert call.value is not None
-                child, tampered_paths = call.value
+                assert mutation_call.value is not None
+                child, tampered_paths = mutation_call.value
                 if child is None:
-                    outcome = FailedProposal(
+                    proposal_outcome = FailedProposal(
                         task=task,
                         stage="mutation",
                         message="mutation returned no candidate",
                         parent_eval_result=parent_result,
                         parent_n_uncached=parent_n_uncached,
                     )
-                    proposal_outcomes[task.batch_index] = outcome
+                    proposal_outcomes[task.batch_index] = proposal_outcome
                     _record_terminal(
                         task,
                         status="failed",
@@ -2688,14 +2703,14 @@ def _run_evolution_impl(
                     )
 
                 if tampered_paths:
-                    outcome = TamperedProposal(
+                    proposal_outcome = TamperedProposal(
                         task=task,
                         parent_eval_result=parent_result,
                         child_candidate=child,
                         tampered_paths=tampered_paths,
                         parent_n_uncached=parent_n_uncached,
                     )
-                    proposal_outcomes[task.batch_index] = outcome
+                    proposal_outcomes[task.batch_index] = proposal_outcome
                     _record_terminal(
                         task,
                         status="tampered",
@@ -2768,7 +2783,7 @@ def _run_evolution_impl(
                 try:
                     snapshot_candidate(child, f"helix: mutate {child.id}")
                 except Exception as exc:
-                    outcome = FailedProposal(
+                    proposal_outcome = FailedProposal(
                         task=task,
                         stage="mutation",
                         message=f"{type(exc).__name__}: {exc}",
@@ -2776,7 +2791,7 @@ def _run_evolution_impl(
                         child_candidate=child,
                         parent_n_uncached=prepared[2],
                     )
-                    proposal_outcomes[task.batch_index] = outcome
+                    proposal_outcomes[task.batch_index] = proposal_outcome
                     _record_terminal(
                         task,
                         status="failed",
@@ -2852,30 +2867,33 @@ def _run_evolution_impl(
                 )
                 raise
             fatal_child_error: BaseException | None = None
-            for item, call in zip(child_inputs, child_calls):
-                task, parent_result, parent_n_uncached, child = item
-                if call.error is not None:
-                    outcome = FailedProposal(
+            for child_item, child_call in zip(child_inputs, child_calls):
+                task, parent_result, parent_n_uncached, child = child_item
+                if child_call.error is not None:
+                    proposal_outcome = FailedProposal(
                         task=task,
                         stage="child_evaluation",
-                        message=f"{type(call.error).__name__}: {call.error}",
+                        message=(
+                            f"{type(child_call.error).__name__}: "
+                            f"{child_call.error}"
+                        ),
                         parent_eval_result=parent_result,
                         child_candidate=child,
                         parent_n_uncached=parent_n_uncached,
                     )
-                    proposal_outcomes[task.batch_index] = outcome
+                    proposal_outcomes[task.batch_index] = proposal_outcome
                     _record_terminal(
                         task,
                         status=(
                             "fatal"
-                            if _is_fatal_proposal_exception(call.error)
+                            if _is_fatal_proposal_exception(child_call.error)
                             else "failed"
                         ),
                         reason="child_eval",
                         child=child,
                     )
-                    if _is_fatal_proposal_exception(call.error):
-                        fatal_child_error = fatal_child_error or call.error
+                    if _is_fatal_proposal_exception(child_call.error):
+                        fatal_child_error = fatal_child_error or child_call.error
                     else:
                         _discard_child(
                             child,
@@ -2883,10 +2901,10 @@ def _run_evolution_impl(
                         )
                     continue
 
-                assert call.result is not None
-                child_result = call.result
+                assert child_call.result is not None
+                child_result = child_call.result
                 child_result.candidate_id = child.id
-                child_n_uncached = call.num_actual_evaluations
+                child_n_uncached = child_call.num_actual_evaluations
                 _last_eval_result = child_result
                 if task.minibatch_ids is not None:
                     budget_api.charge_evaluation(
@@ -2904,7 +2922,7 @@ def _run_evolution_impl(
                         split="train",
                         source="mutation_train_gate",
                     )
-                proposal = EvaluatedProposal(
+                proposal_outcome = EvaluatedProposal(
                     task=task,
                     parent_eval_result=parent_result,
                     child_candidate=child,
@@ -2912,8 +2930,9 @@ def _run_evolution_impl(
                     parent_n_uncached=parent_n_uncached,
                     child_n_uncached=child_n_uncached,
                 )
-                proposal_outcomes[task.batch_index] = proposal
-                evaluated_proposals.append(proposal)
+                proposal_outcomes[task.batch_index] = proposal_outcome
+                assert isinstance(proposal_outcome, EvaluatedProposal)
+                evaluated_proposals.append(proposal_outcome)
 
             if fatal_child_error is not None:
                 for _, _, _, child in child_inputs:
@@ -2939,6 +2958,7 @@ def _run_evolution_impl(
             # Run the configured selection exactly once over all successfully
             # evaluated children.  Acceptance is owned by the selector, so a
             # stateful criterion cannot be accidentally called twice.
+            selector: ProposalSelectionStrategy
             if config.evolution.proposal_selection == "all_improvements":
                 selector = AllImprovements()
             elif config.evolution.proposal_selection == "best_improvement":
@@ -2948,7 +2968,7 @@ def _run_evolution_impl(
                 selector = TopKImprovements(config.evolution.proposal_top_k)
             selected_proposals = selector.select(
                 evaluated_proposals,
-                acceptance,
+                cast(ProposalAcceptanceCriterion, acceptance),
             )
             selected_ids = {
                 selected.proposal.child_candidate.id
@@ -3110,23 +3130,23 @@ def _run_evolution_impl(
                 )
                 raise
             fatal_stage_error: BaseException | None = None
-            for selected, call in zip(stage_inputs, stage_calls):
+            for selected, stage_call in zip(stage_inputs, stage_calls):
                 proposal = selected.proposal
                 task = proposal.task
                 child = proposal.child_candidate
-                if call.error is not None:
+                if stage_call.error is not None:
                     _record_terminal(
                         task,
                         status=(
                             "fatal"
-                            if _is_fatal_proposal_exception(call.error)
+                            if _is_fatal_proposal_exception(stage_call.error)
                             else "failed"
                         ),
                         reason="val_stage",
                         child=child,
                     )
-                    if _is_fatal_proposal_exception(call.error):
-                        fatal_stage_error = fatal_stage_error or call.error
+                    if _is_fatal_proposal_exception(stage_call.error):
+                        fatal_stage_error = fatal_stage_error or stage_call.error
                     else:
                         _discard_child(
                             child,
@@ -3134,10 +3154,10 @@ def _run_evolution_impl(
                         )
                     continue
 
-                assert call.result is not None
-                stage_result = call.result
+                assert stage_call.result is not None
+                stage_result = stage_call.result
                 stage_result.candidate_id = child.id
-                stage_n_uncached = call.num_actual_evaluations
+                stage_n_uncached = stage_call.num_actual_evaluations
                 _last_eval_result = stage_result
                 budget_api.charge_evaluation(
                     state,
@@ -3314,23 +3334,23 @@ def _run_evolution_impl(
                 raise
             fatal_full_error: BaseException | None = None
             full_results: list[tuple[SelectedProposal, EvalResult]] = []
-            for selected, call in zip(validation_ready, full_calls):
+            for selected, full_call in zip(validation_ready, full_calls):
                 proposal = selected.proposal
                 task = proposal.task
                 child = proposal.child_candidate
-                if call.error is not None:
+                if full_call.error is not None:
                     _record_terminal(
                         task,
                         status=(
                             "fatal"
-                            if _is_fatal_proposal_exception(call.error)
+                            if _is_fatal_proposal_exception(full_call.error)
                             else "failed"
                         ),
                         reason="full_validation",
                         child=child,
                     )
-                    if _is_fatal_proposal_exception(call.error):
-                        fatal_full_error = fatal_full_error or call.error
+                    if _is_fatal_proposal_exception(full_call.error):
+                        fatal_full_error = fatal_full_error or full_call.error
                     else:
                         _discard_child(
                             child,
@@ -3338,10 +3358,10 @@ def _run_evolution_impl(
                         )
                     continue
 
-                assert call.result is not None
-                val_result = call.result
+                assert full_call.result is not None
+                val_result = full_call.result
                 val_result.candidate_id = child.id
-                val_n_uncached = call.num_actual_evaluations
+                val_n_uncached = full_call.num_actual_evaluations
                 _last_eval_result = val_result
                 if full_val_example_ids:
                     budget_api.charge_evaluation(

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -707,9 +707,7 @@ def run_evaluator_batch(
 
     pool_workers = min(max_workers, len(leader_indices))
     with ThreadPoolExecutor(max_workers=pool_workers) as pool:
-        futures = {
-            pool.submit(_run_leader, idx): idx for idx in leader_indices
-        }
+        futures = {pool.submit(_run_leader, idx): idx for idx in leader_indices}
         # ``future.result()`` re-raises whatever the worker raised.  Capture all
         # post-dispatch failures as positional outcomes; returning partial
         # successes is what lets the caller conserve accounting before it
@@ -763,9 +761,7 @@ def run_evaluator_batch(
             leader_result, _count = leader_outcome[leader]
             results[i] = EvalBatchResult(
                 item=item,
-                result=_clone_result_for_follower(
-                    leader_result, item.candidate.id
-                ),
+                result=_clone_result_for_follower(leader_result, item.candidate.id),
                 error=None,
                 num_actual_evaluations=0,
                 deduplicated_from=leader,

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import shlex
 import subprocess
+import threading
 import uuid
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias
 
 from helix.asi import (
     HELIX_ASI_LOG_ENV,
@@ -16,9 +21,15 @@ from helix.asi import (
     read as read_asi_log,
     read_text as read_asi_log_text,
 )
+from helix.eval_cache import EvaluationBatchKey
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig
-from helix.exceptions import EvaluatorError, format_error_context
+from helix.exceptions import (
+    EvaluatorError,
+    PromptArtifactCollisionError,
+    ResumeIncompatibleError,
+    format_error_context,
+)
 from helix.parsers import get_parser
 from helix.sandbox import (
     current_evaluator_sidecar_runtime,
@@ -485,3 +496,294 @@ def run_evaluator(
         score=_result.aggregate_score(),
     )
     return _result
+
+
+# ---------------------------------------------------------------------------
+# Step 3: ordered cross-candidate evaluator batching
+# ---------------------------------------------------------------------------
+#
+# ``run_evaluator_batch`` runs a list of evaluator requests concurrently under
+# a bounded worker pool, returns one result per input in the SAME order, and
+# collapses cross-candidate duplicates so identical evaluator work runs once.
+#
+# Two requests are duplicates iff their :class:`EvaluationBatchKey` matches —
+# ``(content_key, split, instance_ids)``.  Candidate *lineage* ids are absent
+# from the key on purpose: two distinct candidates whose committed content,
+# split, and exact ordered minibatch are identical evaluate to the same scores,
+# so only the first (the "leader") is dispatched.  Every later request sharing
+# that key (a "follower") reuses the leader's result and is charged
+# ``num_actual_evaluations == 0`` so evaluation-budget accounting never
+# double-counts shared work.  ``instance_ids`` is carried and hashed as an
+# ordered tuple because evaluator side information is positional to
+# ``helix_batch.json`` — reordering the minibatch is a *different* request.
+
+
+@dataclass(frozen=True)
+class EvalBatchItem:
+    """One evaluator request submitted to :func:`run_evaluator_batch`.
+
+    ``content_key`` is the caller-computed cache identity of the candidate's
+    committed content (see ``evolution._candidate_content_key``); it — not
+    ``candidate.id`` — participates in cross-candidate deduplication.
+    ``instance_ids`` is an ordered tuple (``None`` → evaluate the whole split);
+    its order is significant and preserved through hashing and dispatch.
+    """
+
+    candidate: Candidate
+    content_key: str
+    split: str
+    instance_ids: tuple[str, ...] | None
+
+    @property
+    def dedup_key(self) -> EvaluationBatchKey:
+        """Cross-candidate dedup identity: ``(content_key, split, instance_ids)``."""
+        return EvaluationBatchKey(
+            content_key=self.content_key,
+            split=self.split,
+            instance_ids=self.instance_ids,
+        )
+
+
+@dataclass(frozen=True)
+class EvalBatchResult:
+    """One result slot from :func:`run_evaluator_batch`, positional to input.
+
+    Exactly one of ``result``/``error`` is populated:
+
+    * ``result`` set, ``error`` None  → the evaluator succeeded.
+    * ``result`` None, ``error`` set  → an ordinary per-item failure; the rest
+      of the batch is unaffected.
+
+    ``num_actual_evaluations`` is the evaluation-budget charge for this slot:
+    the leader carries the runner's reported count, and every deduplicated
+    follower is charged ``0``.  ``deduplicated_from`` is ``None`` for a leader
+    (the request that actually ran) or the input index of the leader this
+    follower reused.
+    """
+
+    item: EvalBatchItem
+    result: EvalResult | None
+    error: Exception | None
+    num_actual_evaluations: int
+    deduplicated_from: int | None
+
+
+# The runner seam: ``runner(item) -> (EvalResult, num_actual_evaluations)``.
+# Production wires this to a closure over the per-example cache (see
+# ``evolution._cached_evaluate_batch``) so ``num_actual_evaluations`` reflects
+# cache hits; tests inject fakes to exercise ordering/dedup/failure/fatal paths
+# without a subprocess.
+BatchEvaluatorRunner: TypeAlias = Callable[[EvalBatchItem], tuple[EvalResult, int]]
+
+# Fatal exceptions abort the whole batch instead of being captured as an
+# ordinary per-item failure: a prompt-artifact collision or resume-semantics
+# mismatch invalidates the entire run, and Ctrl-C / interpreter exit must not
+# be swallowed by a worker thread.
+_FATAL_BATCH_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    PromptArtifactCollisionError,
+    ResumeIncompatibleError,
+    KeyboardInterrupt,
+    SystemExit,
+)
+
+# Per-worktree serialization: two leaders that share a worktree path must not
+# run concurrently, because the evaluator handoff writes ``helix_batch.json``
+# into that worktree and parallel runs would clobber each other's batch file.
+# Distinct worktrees evaluate concurrently.  Mirrors ``evolution._worktree_lock``
+# but is owned here so the batch runner is self-contained.
+_BATCH_WORKTREE_LOCKS: dict[str, threading.Lock] = {}
+_BATCH_WORKTREE_LOCKS_MUTEX = threading.Lock()
+
+
+def _batch_worktree_lock(worktree_path: str) -> threading.Lock:
+    key = str(worktree_path)
+    with _BATCH_WORKTREE_LOCKS_MUTEX:
+        lock = _BATCH_WORKTREE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _BATCH_WORKTREE_LOCKS[key] = lock
+        return lock
+
+
+def _clone_result_for_follower(result: EvalResult, candidate_id: str) -> EvalResult:
+    """Return an independent ``EvalResult`` for a deduplicated follower.
+
+    The leader's :class:`~helix.population.EvalResult` is deep-copied so a
+    follower slot never aliases the leader's mutable ``scores`` /
+    ``instance_scores`` / ``asi`` / side-info containers — HELIX relabels
+    ``candidate_id`` and mutates these dicts per candidate downstream (see the
+    many ``result.candidate_id = ...`` sites in ``evolution.py``), so a shared
+    object would silently corrupt every peer slot.  ``candidate_id`` is set to
+    the follower's own candidate to preserve positional candidate identity.
+    """
+    cloned = copy.deepcopy(result)
+    cloned.candidate_id = candidate_id
+    return cloned
+
+
+def make_default_batch_runner(config: HelixConfig) -> BatchEvaluatorRunner:
+    """Default runner seam: evaluate each item via :func:`run_evaluator`.
+
+    ``num_actual_evaluations`` is the number of examples actually sent to the
+    evaluator: ``len(instance_ids)`` for a minibatch, else the number of
+    instance scores the whole-split run produced.  Production overrides this
+    with a cache-aware runner so hits are charged ``0``.
+    """
+
+    def _run(item: EvalBatchItem) -> tuple[EvalResult, int]:
+        instance_ids = (
+            list(item.instance_ids) if item.instance_ids is not None else None
+        )
+        result = run_evaluator(
+            item.candidate,
+            config,
+            split=item.split,
+            instance_ids=instance_ids,
+        )
+        count = (
+            len(item.instance_ids)
+            if item.instance_ids is not None
+            else len(result.instance_scores)
+        )
+        return result, count
+
+    return _run
+
+
+def run_evaluator_batch(
+    items: Sequence[EvalBatchItem],
+    runner: BatchEvaluatorRunner,
+    *,
+    max_workers: int,
+    config: HelixConfig | None = None,
+) -> list[EvalBatchResult]:
+    """Run evaluator requests concurrently, deduplicated, in input order.
+
+    Args:
+        items: Evaluator requests.  The returned list is positional to this
+            sequence — ``result[i]`` corresponds to ``items[i]``.
+        runner: The runner seam, ``runner(item) -> (EvalResult, count)``.  Only
+            *leaders* (the first item bearing a given
+            :attr:`EvalBatchItem.dedup_key`) are handed to the runner; followers
+            reuse the leader's outcome.
+        max_workers: Upper bound on concurrent runner invocations.  The pool is
+            additionally capped at the number of leaders.  Must be ``>= 1``.
+        config: When provided, the evaluator command is validated ONCE before
+            any dispatch; a malformed command raises :class:`EvaluatorError`
+            here rather than as N identical per-item failures.
+
+    Returns:
+        One :class:`EvalBatchResult` per input item, in order.
+
+    Raises:
+        The pre-dispatch config error (e.g. :class:`EvaluatorError` from command
+        validation, or ``ValueError`` for ``max_workers < 1``) before any work
+        starts; and any fatal runner exception
+        (:class:`PromptArtifactCollisionError`, :class:`ResumeIncompatibleError`,
+        ``KeyboardInterrupt``, ``SystemExit``) that aborts the whole batch.
+        Ordinary runner exceptions are captured per-item in
+        :attr:`EvalBatchResult.error` and do not propagate.
+    """
+    # --- Pre-dispatch config validation (propagates; never per-item) --------
+    if max_workers < 1:
+        raise ValueError(f"max_workers must be >= 1, got {max_workers}")
+    if config is not None:
+        # Fail the whole batch once on a malformed command rather than letting
+        # every leader raise the identical EvaluatorError inside a worker.
+        _validate_and_split_command(config.evaluator.command)
+
+    results: list[EvalBatchResult | None] = [None] * len(items)
+    if not items:
+        return []
+
+    # --- Deduplicate: first occurrence of a key is the leader --------------
+    leader_index_by_key: dict[EvaluationBatchKey, int] = {}
+    leader_of: list[int] = []  # leader_of[i] = input index of i's leader
+    leader_indices: list[int] = []
+    for i, item in enumerate(items):
+        key = item.dedup_key
+        leader = leader_index_by_key.get(key)
+        if leader is None:
+            leader_index_by_key[key] = i
+            leader_of.append(i)
+            leader_indices.append(i)
+        else:
+            leader_of.append(leader)
+
+    # --- Dispatch leaders concurrently, serialized per worktree ------------
+    # leader input index -> (result, count) on success, or a captured error.
+    leader_outcome: dict[int, tuple[EvalResult, int]] = {}
+    leader_error: dict[int, Exception] = {}
+
+    def _run_leader(index: int) -> None:
+        item = items[index]
+        with _batch_worktree_lock(item.candidate.worktree_path):
+            leader_outcome[index] = runner(item)
+
+    pool_workers = min(max_workers, len(leader_indices))
+    with ThreadPoolExecutor(max_workers=pool_workers) as pool:
+        futures = {
+            pool.submit(_run_leader, idx): idx for idx in leader_indices
+        }
+        # ``future.result()`` re-raises whatever the worker raised.  Fatal
+        # exceptions propagate out of this loop (and the ``with`` block waits
+        # for in-flight leaders to drain); ordinary failures are captured.
+        for future, idx in futures.items():
+            try:
+                future.result()
+            except _FATAL_BATCH_EXCEPTIONS:
+                raise
+            except Exception as exc:  # ordinary per-item failure
+                leader_error[idx] = exc
+
+    # --- Validate runner-reported counts before assembly -------------------
+    # A negative evaluation charge is a runner-contract violation; reject the
+    # whole batch rather than emit a nonsensical budget number.
+    for idx, (_res, count) in leader_outcome.items():
+        if count < 0:
+            raise ValueError(
+                "runner reported negative num_actual_evaluations "
+                f"({count}) for item index {idx}"
+            )
+
+    # --- Assemble results in input order ------------------------------------
+    for i, item in enumerate(items):
+        leader = leader_of[i]
+        is_leader = leader == i
+        if leader in leader_error:
+            # Failed leader → failed slot; followers reuse the same error and
+            # are still charged zero.
+            results[i] = EvalBatchResult(
+                item=item,
+                result=None,
+                error=leader_error[leader],
+                num_actual_evaluations=0,
+                deduplicated_from=None if is_leader else leader,
+            )
+        elif is_leader:
+            leader_result, count = leader_outcome[leader]
+            results[i] = EvalBatchResult(
+                item=item,
+                result=leader_result,
+                error=None,
+                num_actual_evaluations=count,
+                deduplicated_from=None,
+            )
+        else:
+            # Deduplicated follower: hand back an INDEPENDENT clone relabeled to
+            # this slot's candidate, charged zero.  Never share the leader's
+            # mutable EvalResult (see ``_clone_result_for_follower``).
+            leader_result, _count = leader_outcome[leader]
+            results[i] = EvalBatchResult(
+                item=item,
+                result=_clone_result_for_follower(
+                    leader_result, item.candidate.id
+                ),
+                error=None,
+                num_actual_evaluations=0,
+                deduplicated_from=leader,
+            )
+
+    # Cardinality guard: exactly one result per input, all populated.
+    assert all(r is not None for r in results) and len(results) == len(items)
+    return [r for r in results if r is not None]

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -11,6 +11,7 @@ import threading
 import uuid
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeAlias
@@ -506,11 +507,12 @@ def run_evaluator(
 # from the key on purpose: two distinct candidates whose committed content,
 # split, and exact ordered minibatch are identical evaluate to the same scores,
 # so only the first (the "leader") is dispatched.  Every later request sharing
-# that key (a "follower") reuses the leader's result and is charged
+# that key (a "follower") reuses the leader's outcome and is charged
 # ``num_actual_evaluations == 0`` so evaluation-budget accounting never
-# double-counts shared work.  ``instance_ids`` is carried and hashed as an
-# ordered tuple because evaluator side information is positional to
-# ``helix_batch.json`` — reordering the minibatch is a *different* request.
+# double-counts shared work, including when the shared outcome is a failure.
+# ``instance_ids`` is carried and hashed as an ordered tuple because evaluator
+# side information is positional to ``helix_batch.json`` — reordering the
+# minibatch is a *different* request.
 
 
 @dataclass(frozen=True)
@@ -550,11 +552,13 @@ class EvalBatchResult:
       integrity error; the rest of the drained batch remains positional so its
       successful work can be accounted before the owner re-raises.
 
-    ``num_actual_evaluations`` is the evaluation-budget charge for this slot:
-    the leader carries the runner's reported count, and every deduplicated
-    follower is charged ``0``.  ``deduplicated_from`` is ``None`` for a leader
-    (the request that actually ran) or the input index of the leader this
-    follower reused.
+    ``num_actual_evaluations`` is the evaluation-budget charge for this slot.
+    A successful leader carries the runner's returned count; a failed leader
+    carries the progress reported with :func:`record_evaluator_units` before
+    the exception; and every deduplicated follower is charged ``0``.  Thus a
+    failure never erases work that already ran and shared work is never charged
+    twice.  ``deduplicated_from`` is ``None`` for a leader (the request that
+    actually ran) or the input index of the leader this follower reused.
     """
 
     item: EvalBatchItem
@@ -570,6 +574,33 @@ class EvalBatchResult:
 # cache hits; tests inject fakes to exercise ordering/dedup/failure/fatal paths
 # without a subprocess.
 BatchEvaluatorRunner: TypeAlias = Callable[[EvalBatchItem], tuple[EvalResult, int]]
+
+# A runner reports actual work at the dispatch boundary, before an evaluator
+# attempt can raise and erase its normal ``(result, count)`` return value.  The
+# context is installed independently in each leader worker, so concurrent
+# leaders cannot leak units into one another.  Outside ``run_evaluator_batch``
+# the helper is intentionally a no-op: the ordinary sequential call sites use
+# their existing direct budget charge.
+_EVALUATION_UNIT_REPORTER: ContextVar[Callable[[int], None] | None] = ContextVar(
+    "helix_evaluation_unit_reporter",
+    default=None,
+)
+
+
+def record_evaluator_units(units: int) -> None:
+    """Record newly dispatched evaluator units for the current batch leader.
+
+    Runner implementations that can fail after dispatch must call this once at
+    the point each group of uncached units becomes actual.  Calls accumulate;
+    cache hits report nothing.  The successful runner return remains the
+    authoritative count for compatibility with existing one-argument runners.
+    """
+    if units < 0:
+        raise ValueError(f"evaluator units must be >= 0, got {units}")
+    reporter = _EVALUATION_UNIT_REPORTER.get()
+    if reporter is not None and units:
+        reporter(units)
+
 
 # Per-worktree serialization: two leaders that share a worktree path must not
 # run concurrently, because the evaluator handoff writes ``helix_batch.json``
@@ -619,6 +650,12 @@ def make_default_batch_runner(config: HelixConfig) -> BatchEvaluatorRunner:
         instance_ids = (
             list(item.instance_ids) if item.instance_ids is not None else None
         )
+        # The default runner has no cache.  Record before invoking the
+        # evaluator so an exception after dispatch retains the attempted work.
+        # Whole-split calls consume one HELIX evaluation-budget unit.
+        record_evaluator_units(
+            len(item.instance_ids) if item.instance_ids is not None else 1
+        )
         result = run_evaluator(
             item.candidate,
             config,
@@ -650,7 +687,9 @@ def run_evaluator_batch(
         runner: The runner seam, ``runner(item) -> (EvalResult, count)``.  Only
             *leaders* (the first item bearing a given
             :attr:`EvalBatchItem.dedup_key`) are handed to the runner; followers
-            reuse the leader's outcome.
+            reuse the leader's outcome.  A runner must call
+            :func:`record_evaluator_units` when uncached work is dispatched if
+            later operations can fail before it returns its count.
         max_workers: Upper bound on concurrent runner invocations.  The pool is
             additionally capped at the number of leaders.  Must be ``>= 1``.
         config: When provided, the evaluator command is validated ONCE before
@@ -666,8 +705,9 @@ def run_evaluator_batch(
         starts.  Once dispatch begins, every runner exception -- including
         ``BaseException`` subclasses and run-fatal integrity failures -- is
         returned in its positional :attr:`EvalBatchResult.error` slot after the
-        executor drains.  The owning evolution phase can then account successful
-        siblings and clean resources before re-raising the fatal error.
+        executor drains.  The owning evolution phase can then account every
+        reported attempt, account successful siblings, and clean resources
+        before re-raising the fatal error.
     """
     # --- Pre-dispatch config validation (propagates; never per-item) --------
     if max_workers < 1:
@@ -699,11 +739,23 @@ def run_evaluator_batch(
     # leader input index -> (result, count) on success, or a captured error.
     leader_outcome: dict[int, tuple[EvalResult, int]] = {}
     leader_error: dict[int, BaseException] = {}
+    leader_reported_units: dict[int, int] = {}
 
     def _run_leader(index: int) -> None:
         item = items[index]
-        with _batch_worktree_lock(item.candidate.worktree_path):
-            leader_outcome[index] = runner(item)
+        reported_units = 0
+
+        def _record(units: int) -> None:
+            nonlocal reported_units
+            reported_units += units
+
+        token = _EVALUATION_UNIT_REPORTER.set(_record)
+        try:
+            with _batch_worktree_lock(item.candidate.worktree_path):
+                leader_outcome[index] = runner(item)
+        finally:
+            _EVALUATION_UNIT_REPORTER.reset(token)
+            leader_reported_units[index] = reported_units
 
     pool_workers = min(max_workers, len(leader_indices))
     with ThreadPoolExecutor(max_workers=pool_workers) as pool:
@@ -736,13 +788,16 @@ def run_evaluator_batch(
         leader = leader_of[i]
         is_leader = leader == i
         if leader in leader_error:
-            # Failed leader → failed slot; followers reuse the same error and
-            # are still charged zero.
+            # A failed leader retains units reported before the exception.
+            # Followers reuse the same error but remain zero-charge: the
+            # leader alone owns the shared evaluator attempt.
             results[i] = EvalBatchResult(
                 item=item,
                 result=None,
                 error=leader_error[leader],
-                num_actual_evaluations=0,
+                num_actual_evaluations=(
+                    leader_reported_units.get(leader, 0) if is_leader else 0
+                ),
                 deduplicated_from=None if is_leader else leader,
             )
         elif is_leader:

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -24,12 +24,7 @@ from helix.asi import (
 from helix.eval_cache import EvaluationBatchKey
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig
-from helix.exceptions import (
-    EvaluatorError,
-    PromptArtifactCollisionError,
-    ResumeIncompatibleError,
-    format_error_context,
-)
+from helix.exceptions import EvaluatorError, format_error_context
 from helix.parsers import get_parser
 from helix.sandbox import (
     current_evaluator_sidecar_runtime,
@@ -551,8 +546,9 @@ class EvalBatchResult:
     Exactly one of ``result``/``error`` is populated:
 
     * ``result`` set, ``error`` None  → the evaluator succeeded.
-    * ``result`` None, ``error`` set  → an ordinary per-item failure; the rest
-      of the batch is unaffected.
+    * ``result`` None, ``error`` set  → a per-item failure or fatal contract /
+      integrity error; the rest of the drained batch remains positional so its
+      successful work can be accounted before the owner re-raises.
 
     ``num_actual_evaluations`` is the evaluation-budget charge for this slot:
     the leader carries the runner's reported count, and every deduplicated
@@ -563,7 +559,7 @@ class EvalBatchResult:
 
     item: EvalBatchItem
     result: EvalResult | None
-    error: Exception | None
+    error: BaseException | None
     num_actual_evaluations: int
     deduplicated_from: int | None
 
@@ -574,17 +570,6 @@ class EvalBatchResult:
 # cache hits; tests inject fakes to exercise ordering/dedup/failure/fatal paths
 # without a subprocess.
 BatchEvaluatorRunner: TypeAlias = Callable[[EvalBatchItem], tuple[EvalResult, int]]
-
-# Fatal exceptions abort the whole batch instead of being captured as an
-# ordinary per-item failure: a prompt-artifact collision or resume-semantics
-# mismatch invalidates the entire run, and Ctrl-C / interpreter exit must not
-# be swallowed by a worker thread.
-_FATAL_BATCH_EXCEPTIONS: tuple[type[BaseException], ...] = (
-    PromptArtifactCollisionError,
-    ResumeIncompatibleError,
-    KeyboardInterrupt,
-    SystemExit,
-)
 
 # Per-worktree serialization: two leaders that share a worktree path must not
 # run concurrently, because the evaluator handoff writes ``helix_batch.json``
@@ -678,11 +663,11 @@ def run_evaluator_batch(
     Raises:
         The pre-dispatch config error (e.g. :class:`EvaluatorError` from command
         validation, or ``ValueError`` for ``max_workers < 1``) before any work
-        starts; and any fatal runner exception
-        (:class:`PromptArtifactCollisionError`, :class:`ResumeIncompatibleError`,
-        ``KeyboardInterrupt``, ``SystemExit``) that aborts the whole batch.
-        Ordinary runner exceptions are captured per-item in
-        :attr:`EvalBatchResult.error` and do not propagate.
+        starts.  Once dispatch begins, every runner exception -- including
+        ``BaseException`` subclasses and run-fatal integrity failures -- is
+        returned in its positional :attr:`EvalBatchResult.error` slot after the
+        executor drains.  The owning evolution phase can then account successful
+        siblings and clean resources before re-raising the fatal error.
     """
     # --- Pre-dispatch config validation (propagates; never per-item) --------
     if max_workers < 1:
@@ -713,7 +698,7 @@ def run_evaluator_batch(
     # --- Dispatch leaders concurrently, serialized per worktree ------------
     # leader input index -> (result, count) on success, or a captured error.
     leader_outcome: dict[int, tuple[EvalResult, int]] = {}
-    leader_error: dict[int, Exception] = {}
+    leader_error: dict[int, BaseException] = {}
 
     def _run_leader(index: int) -> None:
         item = items[index]
@@ -725,26 +710,28 @@ def run_evaluator_batch(
         futures = {
             pool.submit(_run_leader, idx): idx for idx in leader_indices
         }
-        # ``future.result()`` re-raises whatever the worker raised.  Fatal
-        # exceptions propagate out of this loop (and the ``with`` block waits
-        # for in-flight leaders to drain); ordinary failures are captured.
+        # ``future.result()`` re-raises whatever the worker raised.  Capture all
+        # post-dispatch failures as positional outcomes; returning partial
+        # successes is what lets the caller conserve accounting before it
+        # decides whether a fatal slot must terminate the run.
         for future, idx in futures.items():
             try:
                 future.result()
-            except _FATAL_BATCH_EXCEPTIONS:
-                raise
-            except Exception as exc:  # ordinary per-item failure
+            except BaseException as exc:
                 leader_error[idx] = exc
 
     # --- Validate runner-reported counts before assembly -------------------
-    # A negative evaluation charge is a runner-contract violation; reject the
-    # whole batch rather than emit a nonsensical budget number.
-    for idx, (_res, count) in leader_outcome.items():
+    # A negative evaluation charge is a fatal runner-contract violation, but it
+    # is still a *positional* post-dispatch outcome.  Convert only that leader
+    # to an error so successful siblings survive assembly and the owning phase
+    # can account them before re-raising the ValueError.
+    for idx, (_res, count) in list(leader_outcome.items()):
         if count < 0:
-            raise ValueError(
+            leader_error[idx] = ValueError(
                 "runner reported negative num_actual_evaluations "
                 f"({count}) for item index {idx}"
             )
+            del leader_outcome[idx]
 
     # --- Assemble results in input order ------------------------------------
     for i, item in enumerate(items):

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from helix.backends import BACKEND_AUTH_ENV, backend_display_name
-from helix.display import UsageStats
+from helix.display import UsageStats, print_warning
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, SandboxConfig
 from helix.exceptions import (
@@ -1801,16 +1801,25 @@ def mutate(
         print_helix_error(exc)
         try:
             remove_worktree(child)
-        except Exception:
-            pass
+        except Exception as cleanup_exc:
+            # The proposal scheduler owns a durable reservation for ``new_id``
+            # and will retry this cleanup from that identity.  Keep the local
+            # failure visible: returning ``None`` must not make a failed remove
+            # look like a worktree was never created.
+            print_warning(
+                f"Could not remove failed mutation worktree {new_id}: {cleanup_exc}"
+            )
         return None
-    except Exception:
+    except Exception as exc:
         # Rate limits and fatal setup/security failures must propagate to the
         # batch coordinator unchanged, but never leave this worktree orphaned.
         try:
             remove_worktree(child)
-        except Exception:
-            pass
+        except Exception as cleanup_exc:
+            print_warning(
+                f"Could not remove failed mutation worktree {new_id} after "
+                f"{type(exc).__name__}: {cleanup_exc}"
+            )
         raise
 
     # NOTE: snapshot_candidate() is intentionally NOT called here.

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -769,9 +769,7 @@ def _build_backend_args(
             # is valid TOML basic-string syntax for all printable ASCII — safe
             # for any realistic effort value.  See ``codex exec --help`` for
             # the full ``-c`` interface.
-            args.extend(
-                ["-c", f"model_reasoning_effort={json.dumps(config.effort)}"]
-            )
+            args.extend(["-c", f"model_reasoning_effort={json.dumps(config.effort)}"])
         args.append(_prompt_file_instruction(prompt_artifact_name))
         return args
 

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1573,7 +1573,7 @@ def invoke_claude_code(
     _add_backend_auth_env(backend_env, backend)
     if backend == "gemini":
         backend_env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"
-    if backend == "opencode" and (sandbox is None or not sandbox.enabled):
+    if backend == "opencode":
         # Per-candidate SQLite isolation for concurrent opencode subprocesses.
         #
         # OpenCode stores its session database at:
@@ -1587,16 +1587,18 @@ def invoke_claude_code(
         #   "Failed to run the query 'PRAGMA journal_mode = WAL'"
         # (observed in PR #34 E2E re-verify: g1-s1 lost to this error while g1-s2 succeeded).
         #
-        # Fix: set XDG_DATA_HOME to a per-candidate directory.  OpenCode respects
-        # XDG_DATA_HOME and will create an isolated database at:
-        #   <worktree>/.helix_opencode_state/opencode/opencode.db
-        # Each parallel worker gets its own fresh database; no contention.
-        #
-        # The sandbox branch is excluded: container isolation already provides
-        # per-candidate filesystem separation, so XDG_DATA_HOME would be redundant.
-        opencode_state_dir = Path(worktree_path) / ".helix_opencode_state"
-        opencode_state_dir.mkdir(parents=True, exist_ok=True)
-        backend_env["XDG_DATA_HOME"] = str(opencode_state_dir)
+        # Fix: set XDG_DATA_HOME to storage owned by this proposal. OpenCode
+        # respects XDG_DATA_HOME and creates its database below ``opencode/``.
+        # Sandboxed agents share ``/home/node`` through the backend auth volume,
+        # so their default ~/.local/share directory is *not* isolated. Put the
+        # database in the candidate-specific /workspace mount instead. Direct
+        # subprocesses use the equivalent directory in their real worktree.
+        if sandbox is not None and sandbox.enabled:
+            backend_env["XDG_DATA_HOME"] = "/workspace/.helix_opencode_state"
+        else:
+            opencode_state_dir = Path(worktree_path) / ".helix_opencode_state"
+            opencode_state_dir.mkdir(parents=True, exist_ok=True)
+            backend_env["XDG_DATA_HOME"] = str(opencode_state_dir)
     if sandbox is not None and sandbox.enabled:
         sandbox_image = resolve_sandbox_image(sandbox, backend)
         result = run_sandboxed_command(
@@ -1763,27 +1765,29 @@ def mutate(
         The new candidate on success, or ``None`` if mutation failed.
     """
     child = clone_candidate(parent, new_id, base_dir)
-    child.operation = "mutate"
-    if prepare_worktree is not None:
-        prepare_worktree(child)
-
-    prompt = build_mutation_prompt(
-        config.objective,
-        eval_result,
-        background,
-        config.agent.max_turns,
-    )
-
-    # Persist the rendered prompt to the worktree for post-hoc inspection:
-    # what did the mutator actually see on this generation?  Sits next to
-    # ``helix_batch.json`` in the worktree root.  The leading dot and the
-    # per-worktree ``.gitignore`` entry (see ``_ignore_helix_artifacts``)
-    # keep it out of the candidate git tree — otherwise it'd leak into
-    # every subsequent mutation's diff and the mutator would see its own
-    # prior prompt file as part of the codebase.
-    prompt_artifact_name = _write_mutation_prompt_artifact(child.worktree_path, prompt)
-
     try:
+        child.operation = "mutate"
+        if prepare_worktree is not None:
+            prepare_worktree(child)
+
+        prompt = build_mutation_prompt(
+            config.objective,
+            eval_result,
+            background,
+            config.agent.max_turns,
+        )
+
+        # Persist the rendered prompt to the worktree for post-hoc inspection:
+        # what did the mutator actually see on this generation?  Sits next to
+        # ``helix_batch.json`` in the worktree root.  The leading dot and the
+        # per-worktree ``.gitignore`` entry (see ``_ignore_helix_artifacts``)
+        # keep it out of the candidate git tree — otherwise it'd leak into
+        # every subsequent mutation's diff and the mutator would see its own
+        # prior prompt file as part of the codebase.
+        prompt_artifact_name = _write_mutation_prompt_artifact(
+            child.worktree_path, prompt
+        )
+
         _, usage = invoke_claude_code(
             child.worktree_path,
             prompt,
@@ -1802,10 +1806,9 @@ def mutate(
         except Exception:
             pass
         return None
-    except RateLimitError:
-        # Rate limit — clean up orphaned worktree, then re-raise so the parallel
-        # futures handler in evolution.py can log it and continue with a smaller
-        # proposal set.
+    except Exception:
+        # Rate limits and fatal setup/security failures must propagate to the
+        # batch coordinator unchanged, but never leave this worktree orphaned.
         try:
             remove_worktree(child)
         except Exception:

--- a/src/helix/proposals.py
+++ b/src/helix/proposals.py
@@ -99,23 +99,36 @@ class EvaluatedProposal:
     parent_n_uncached: int = 0
     child_n_uncached: int = 0
 
+    def _scores_for_task(self, result: EvalResult) -> list[float]:
+        """Return scores in task order, retaining padded ID multiplicity.
+
+        ``EvalResult.instance_scores`` is a mapping and therefore has one
+        entry per unique example ID.  The epoch sampler may pad a minibatch by
+        repeating an ID, so the task's immutable ID tuple is the authoritative
+        positional view for acceptance and ranking.
+        """
+
+        if self.task.minibatch_ids is None:
+            return list(result.instance_scores.values())
+        return [result.instance_scores[eid] for eid in self.task.minibatch_ids]
+
     @property
     def subsample_scores_before(self) -> list[float]:
         """GEPA-compatible view used by HELIX acceptance criteria."""
 
-        return list(self.parent_eval_result.instance_scores.values())
+        return self._scores_for_task(self.parent_eval_result)
 
     @property
     def subsample_scores_after(self) -> list[float]:
         """GEPA-compatible view used by HELIX acceptance criteria."""
 
-        return list(self.child_eval_result.instance_scores.values())
+        return self._scores_for_task(self.child_eval_result)
 
     @property
     def improvement(self) -> float:
         """Return the child's minibatch score gain over its parent."""
 
-        return self.child_eval_result.sum_score() - self.parent_eval_result.sum_score()
+        return sum(self.subsample_scores_after) - sum(self.subsample_scores_before)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/helix/proposals.py
+++ b/src/helix/proposals.py
@@ -1,0 +1,367 @@
+"""Typed proposal sampling, outcomes, and selection strategies.
+
+Proposal planning is intentionally sequential.  A sampling strategy records
+all parent choices, minibatches, and child IDs before evolution starts any
+concurrent work.  The explicit ``batch_index`` on each task then provides the
+canonical order for evaluation alignment, selection ties, and state updates.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Literal, Protocol, TypeAlias
+
+from helix.population import Candidate, EvalResult
+
+
+MinibatchIds: TypeAlias = tuple[str, ...] | None
+ProposalFailureStage: TypeAlias = Literal[
+    "parent_evaluation",
+    "mutation",
+    "child_evaluation",
+    "full_validation",
+]
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class ProposalTask:
+    """One immutable, pre-reserved child proposal in a P-by-N batch.
+
+    ``batch_index`` is the task's parent-major position.  The parent candidate
+    is excluded from generated comparisons because ``Candidate`` is mutable
+    and not orderable; all scheduling metadata remains part of the ordering.
+    Minibatch IDs are stored as a tuple so neither completion order nor caller
+    mutation can change the planned evaluation.
+    """
+
+    batch_index: int
+    parent_group_index: int
+    mutation_index: int
+    parent_candidate: Candidate = field(compare=False)
+    minibatch_ids: MinibatchIds = field(compare=False)
+    reserved_child_id: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("batch_index", self.batch_index),
+            ("parent_group_index", self.parent_group_index),
+            ("mutation_index", self.mutation_index),
+        ):
+            if value < 0:
+                raise ValueError(f"{name} must be >= 0 (got {value})")
+        if not self.reserved_child_id:
+            raise ValueError("reserved_child_id must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class SkippedProposal:
+    """A proposal skipped before a child candidate was produced."""
+
+    task: ProposalTask
+    parent_eval_result: EvalResult
+    reason: str
+    parent_n_uncached: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class FailedProposal:
+    """A proposal whose isolated work failed without invalidating siblings."""
+
+    task: ProposalTask
+    stage: ProposalFailureStage
+    message: str
+    parent_eval_result: EvalResult | None = None
+    child_candidate: Candidate | None = None
+    parent_n_uncached: int = 0
+    child_n_uncached: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class TamperedProposal:
+    """A child rejected for modifying protected evaluator files."""
+
+    task: ProposalTask
+    parent_eval_result: EvalResult
+    child_candidate: Candidate
+    tampered_paths: tuple[str, ...]
+    parent_n_uncached: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluatedProposal:
+    """A child and its parent evaluated on the task's minibatch."""
+
+    task: ProposalTask
+    parent_eval_result: EvalResult
+    child_candidate: Candidate
+    child_eval_result: EvalResult
+    parent_n_uncached: int = 0
+    child_n_uncached: int = 0
+
+    @property
+    def subsample_scores_before(self) -> list[float]:
+        """GEPA-compatible view used by HELIX acceptance criteria."""
+
+        return list(self.parent_eval_result.instance_scores.values())
+
+    @property
+    def subsample_scores_after(self) -> list[float]:
+        """GEPA-compatible view used by HELIX acceptance criteria."""
+
+        return list(self.child_eval_result.instance_scores.values())
+
+    @property
+    def improvement(self) -> float:
+        """Return the child's minibatch score gain over its parent."""
+
+        return self.child_eval_result.sum_score() - self.parent_eval_result.sum_score()
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedProposal:
+    """An evaluated proposal selected for the full-validation phase."""
+
+    proposal: EvaluatedProposal
+    improvement: float
+
+
+TerminalProposalOutcome: TypeAlias = (
+    SkippedProposal | FailedProposal | TamperedProposal | EvaluatedProposal
+)
+ProposalOutcome: TypeAlias = TerminalProposalOutcome | SelectedProposal
+
+
+ParentSelector: TypeAlias = Callable[[], Candidate]
+MinibatchSampler: TypeAlias = Callable[[], Sequence[str] | None]
+ChildIdReservation: TypeAlias = Callable[[], str]
+
+
+class ProposalSamplingStrategy(Protocol):
+    """Plan a deterministic sequence of proposal tasks."""
+
+    def sample_tasks(
+        self,
+        *,
+        select_parent: ParentSelector,
+        sample_minibatch: MinibatchSampler,
+        reserve_child_id: ChildIdReservation,
+    ) -> list[ProposalTask]: ...
+
+
+def _require_positive(name: str, value: int) -> None:
+    if value < 1:
+        raise ValueError(f"{name} must be >= 1 (got {value})")
+
+
+def _sample_pxn(
+    p: int,
+    n: int,
+    *,
+    select_parent: ParentSelector,
+    sample_minibatch: MinibatchSampler,
+    reserve_child_id: ChildIdReservation,
+) -> list[ProposalTask]:
+    """Sample P parent groups with N tasks each in parent-major order."""
+
+    tasks: list[ProposalTask] = []
+    for parent_group_index in range(p):
+        # Selection is deliberately inside the group loop: repeated Candidate
+        # objects are valid and represent frontier sampling with replacement.
+        parent = select_parent()
+        for mutation_index in range(n):
+            minibatch = sample_minibatch()
+            reserved_child_id = reserve_child_id()
+            tasks.append(
+                ProposalTask(
+                    batch_index=len(tasks),
+                    parent_group_index=parent_group_index,
+                    mutation_index=mutation_index,
+                    parent_candidate=parent,
+                    minibatch_ids=None if minibatch is None else tuple(minibatch),
+                    reserved_child_id=reserved_child_id,
+                )
+            )
+    return tasks
+
+
+class SingleMutationSampling:
+    """Plan one mutation from one selected parent (the default shape)."""
+
+    def sample_tasks(
+        self,
+        *,
+        select_parent: ParentSelector,
+        sample_minibatch: MinibatchSampler,
+        reserve_child_id: ChildIdReservation,
+    ) -> list[ProposalTask]:
+        return _sample_pxn(
+            1,
+            1,
+            select_parent=select_parent,
+            sample_minibatch=sample_minibatch,
+            reserve_child_id=reserve_child_id,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SameParentSampling:
+    """Plan N mutations from one selected parent."""
+
+    n: int
+
+    def __post_init__(self) -> None:
+        _require_positive("n", self.n)
+
+    def sample_tasks(
+        self,
+        *,
+        select_parent: ParentSelector,
+        sample_minibatch: MinibatchSampler,
+        reserve_child_id: ChildIdReservation,
+    ) -> list[ProposalTask]:
+        return _sample_pxn(
+            1,
+            self.n,
+            select_parent=select_parent,
+            sample_minibatch=sample_minibatch,
+            reserve_child_id=reserve_child_id,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class IndependentSampling:
+    """Plan one mutation for each of N independently selected parents."""
+
+    n: int
+
+    def __post_init__(self) -> None:
+        _require_positive("n", self.n)
+
+    def sample_tasks(
+        self,
+        *,
+        select_parent: ParentSelector,
+        sample_minibatch: MinibatchSampler,
+        reserve_child_id: ChildIdReservation,
+    ) -> list[ProposalTask]:
+        return _sample_pxn(
+            self.n,
+            1,
+            select_parent=select_parent,
+            sample_minibatch=sample_minibatch,
+            reserve_child_id=reserve_child_id,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PxNSampling:
+    """Plan P parent selections by N mutations in parent-major order."""
+
+    p: int
+    n: int
+
+    def __post_init__(self) -> None:
+        _require_positive("p", self.p)
+        _require_positive("n", self.n)
+
+    def sample_tasks(
+        self,
+        *,
+        select_parent: ParentSelector,
+        sample_minibatch: MinibatchSampler,
+        reserve_child_id: ChildIdReservation,
+    ) -> list[ProposalTask]:
+        return _sample_pxn(
+            self.p,
+            self.n,
+            select_parent=select_parent,
+            sample_minibatch=sample_minibatch,
+            reserve_child_id=reserve_child_id,
+        )
+
+
+class ProposalAcceptanceCriterion(Protocol):
+    """Acceptance gate applied before ranking evaluated proposals."""
+
+    def should_accept(self, proposal: EvaluatedProposal) -> bool: ...
+
+
+class ProposalSelectionStrategy(Protocol):
+    """Filter and rank evaluated proposals for full validation."""
+
+    def select(
+        self,
+        proposals: Sequence[EvaluatedProposal],
+        acceptance_criterion: ProposalAcceptanceCriterion,
+    ) -> list[SelectedProposal]: ...
+
+
+def _selected(proposal: EvaluatedProposal) -> SelectedProposal:
+    return SelectedProposal(proposal=proposal, improvement=proposal.improvement)
+
+
+class AllImprovements:
+    """Select every accepted proposal, preserving input order."""
+
+    def select(
+        self,
+        proposals: Sequence[EvaluatedProposal],
+        acceptance_criterion: ProposalAcceptanceCriterion,
+    ) -> list[SelectedProposal]:
+        return [
+            _selected(proposal)
+            for proposal in proposals
+            if acceptance_criterion.should_accept(proposal)
+        ]
+
+
+class BestImprovement:
+    """Select the accepted proposal with the greatest score gain."""
+
+    def select(
+        self,
+        proposals: Sequence[EvaluatedProposal],
+        acceptance_criterion: ProposalAcceptanceCriterion,
+    ) -> list[SelectedProposal]:
+        best: EvaluatedProposal | None = None
+        best_improvement = float("-inf")
+        for proposal in proposals:
+            if not acceptance_criterion.should_accept(proposal):
+                continue
+            improvement = proposal.improvement
+            # Strict comparison is intentional: an exact tie retains the
+            # first proposal in sampled order.
+            if improvement > best_improvement:
+                best = proposal
+                best_improvement = improvement
+        return [_selected(best)] if best is not None else []
+
+
+@dataclass(frozen=True, slots=True)
+class TopKImprovements:
+    """Select up to K accepted proposals by descending score gain."""
+
+    k: int
+
+    def __post_init__(self) -> None:
+        _require_positive("k", self.k)
+
+    def select(
+        self,
+        proposals: Sequence[EvaluatedProposal],
+        acceptance_criterion: ProposalAcceptanceCriterion,
+    ) -> list[SelectedProposal]:
+        passing = [
+            proposal
+            for proposal in proposals
+            if acceptance_criterion.should_accept(proposal)
+        ]
+        # Python's sort is stable, so equally improving proposals retain their
+        # sampled order and completion timing cannot affect the tie-break.
+        passing.sort(key=lambda proposal: proposal.improvement, reverse=True)
+        return [_selected(proposal) for proposal in passing[: self.k]]
+
+
+DEFAULT_SAMPLING_STRATEGY: ProposalSamplingStrategy = SingleMutationSampling()
+DEFAULT_SELECTION_STRATEGY: ProposalSelectionStrategy = AllImprovements()

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 import json
@@ -17,13 +17,32 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from helix.backends import BACKEND_AUTH_COMMANDS, DEFAULT_BACKEND_IMAGES
 from helix.config import EvaluatorSidecarConfig, SandboxConfig
 
 
 logger = logging.getLogger(__name__)
+
+
+_REDACTED_DOCKER_ENV_VALUE = "<redacted>"
+_SENSITIVE_ENV_KEY_PARTS = frozenset(
+    {
+        "AUTH",
+        "COOKIE",
+        "CREDENTIAL",
+        "CREDENTIALS",
+        "KEY",
+        "PASS",
+        "PASSWD",
+        "PASSWORD",
+        "PRIVATE",
+        "SECRET",
+        "SESSION",
+        "TOKEN",
+    }
+)
 
 
 HELIX_ARTIFACT_NAMES = {
@@ -509,13 +528,7 @@ def _run_workspace_helper(
     ]
     if extra_args:
         args.extend(extra_args)
-    result = subprocess.run(
-        args,
-        check=False,
-        capture_output=True,
-        text=True,
-        env=_docker_host_env(),
-    )
+    result = _run_docker_process(args, check=False)
     if result.returncode != 0:
         logger.warning(
             "docker workspace helper %s failed for %s: rc=%s stderr=%s",
@@ -570,7 +583,7 @@ def _host_owner() -> str | None:
     if not hasattr(os, "getuid") or not hasattr(os, "getgid"):
         return None
     try:
-        info = subprocess.run(
+        info = _run_docker_process(
             [
                 "docker",
                 "info",
@@ -578,9 +591,6 @@ def _host_owner() -> str | None:
                 "{{.OperatingSystem}}|{{.SecurityOptions}}|{{.Name}}",
             ],
             check=False,
-            capture_output=True,
-            text=True,
-            env=_docker_host_env(),
             timeout=10,
         )
     except (OSError, subprocess.SubprocessError):
@@ -623,18 +633,147 @@ def _docker_host_env() -> dict[str, str]:
     return env
 
 
+def _docker_env_assignments(args: Sequence[str]) -> list[tuple[str, str]]:
+    """Return literal ``KEY=VALUE`` assignments passed to ``docker run``.
+
+    Docker accepts environment values as ``-e KEY=VALUE``, ``--env KEY=VALUE``,
+    ``-eKEY=VALUE``, and ``--env=KEY=VALUE``.  Keeping this parser next to the
+    subprocess boundary ensures every diagnostic path applies the same policy.
+    """
+    assignments: list[tuple[str, str]] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        assignment: str | None = None
+        if arg in {"-e", "--env"} and index + 1 < len(args):
+            assignment = args[index + 1]
+            index += 1
+        elif arg.startswith("--env="):
+            assignment = arg.removeprefix("--env=")
+        elif arg.startswith("-e") and arg != "-e":
+            assignment = arg[2:]
+        if assignment is not None and "=" in assignment:
+            key, value = assignment.split("=", 1)
+            assignments.append((key, value))
+        index += 1
+    return assignments
+
+
+def _is_sensitive_env_key(key: str) -> bool:
+    parts = {part for part in key.upper().replace("-", "_").split("_") if part}
+    return bool(parts & _SENSITIVE_ENV_KEY_PARTS)
+
+
+def _sensitive_docker_env_values(args: Sequence[str]) -> tuple[str, ...]:
+    """Return non-empty secret values, longest first, for output scrubbing."""
+    values = {
+        value
+        for key, value in _docker_env_assignments(args)
+        if value and _is_sensitive_env_key(key)
+    }
+    return tuple(sorted(values, key=len, reverse=True))
+
+
+def _redact_diagnostic_output(value: Any, secrets: Sequence[str]) -> Any:
+    """Replace known Docker env secrets in text/bytes diagnostic output."""
+    if isinstance(value, str):
+        for secret in secrets:
+            value = value.replace(secret, _REDACTED_DOCKER_ENV_VALUE)
+    elif isinstance(value, bytes):
+        replacement = _REDACTED_DOCKER_ENV_VALUE.encode()
+        for secret in secrets:
+            value = value.replace(secret.encode(), replacement)
+    return value
+
+
+def _redact_docker_argv(args: Sequence[str]) -> list[str]:
+    """Render Docker argv safely while preserving environment key context.
+
+    Every literal Docker environment value is replaced, including values whose
+    key does not look secret.  This avoids heuristic gaps in command/exception
+    rendering while retaining the key names needed to diagnose configuration.
+    """
+    redacted = list(args)
+    index = 0
+    while index < len(redacted):
+        arg = redacted[index]
+        if arg in {"-e", "--env"} and index + 1 < len(redacted):
+            assignment = redacted[index + 1]
+            if "=" in assignment:
+                key, _value = assignment.split("=", 1)
+                redacted[index + 1] = f"{key}={_REDACTED_DOCKER_ENV_VALUE}"
+            index += 1
+        elif arg.startswith("--env="):
+            assignment = arg.removeprefix("--env=")
+            if "=" in assignment:
+                key, _value = assignment.split("=", 1)
+                redacted[index] = (
+                    f"--env={key}={_REDACTED_DOCKER_ENV_VALUE}"
+                )
+        elif arg.startswith("-e") and arg != "-e":
+            assignment = arg[2:]
+            if "=" in assignment:
+                key, _value = assignment.split("=", 1)
+                redacted[index] = f"-e{key}={_REDACTED_DOCKER_ENV_VALUE}"
+        index += 1
+    return redacted
+
+
+def _redact_subprocess_exception(
+    exc: subprocess.CalledProcessError | subprocess.TimeoutExpired,
+    args: Sequence[str],
+) -> None:
+    """Sanitize a subprocess exception in place, including indirect rendering."""
+    safe_args = _redact_docker_argv(args)
+    secrets = _sensitive_docker_env_values(args)
+    exc.cmd = safe_args
+    if isinstance(exc, subprocess.CalledProcessError):
+        exc.args = (exc.returncode, safe_args)
+        exc.output = _redact_diagnostic_output(exc.output, secrets)
+        exc.stderr = _redact_diagnostic_output(exc.stderr, secrets)
+    else:
+        exc.args = (safe_args, exc.timeout)
+        exc.output = _redact_diagnostic_output(exc.output, secrets)
+        exc.stderr = _redact_diagnostic_output(exc.stderr, secrets)
+
+
+def _run_docker_process(
+    args: list[str],
+    *,
+    check: bool = False,
+    capture_output: bool = True,
+    cwd: str | None = None,
+    input_text: str | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run Docker and sanitize every returned or raised diagnostic object."""
+    secrets = _sensitive_docker_env_values(args)
+    try:
+        result = subprocess.run(
+            args,
+            check=check,
+            capture_output=capture_output,
+            text=True,
+            cwd=cwd,
+            input=input_text,
+            env=_docker_host_env(),
+            timeout=timeout,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        _redact_subprocess_exception(exc, args)
+        raise
+    result.args = _redact_docker_argv(args)
+    result.stdout = _redact_diagnostic_output(result.stdout, secrets)
+    result.stderr = _redact_diagnostic_output(result.stderr, secrets)
+    return result
+
+
 def _run_docker(
     args: list[str],
     *,
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        args,
-        check=check,
-        capture_output=True,
-        text=True,
-        env=_docker_host_env(),
-    )
+    return _run_docker_process(args, check=check)
 
 
 def _build_add_host_args(
@@ -961,13 +1100,10 @@ def run_sandboxed_commands(
                 )
                 try:
                     results.append(
-                        subprocess.run(
+                        _run_docker_process(
                             docker_cmd,
                             cwd=str(source),
-                            capture_output=True,
-                            text=True,
-                            input=input_text,
-                            env=_docker_host_env(),
+                            input_text=input_text,
                             timeout=sandbox.timeout_seconds,
                         )
                     )
@@ -1095,8 +1231,8 @@ def run_sandbox_auth_command(
         interactive=interactive,
     )
     if interactive:
-        return subprocess.run(args, text=True)
-    return subprocess.run(args, capture_output=True, text=True)
+        return _run_docker_process(args, capture_output=False)
+    return _run_docker_process(args)
 
 
 def run_command(

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 _REDACTED_DOCKER_ENV_VALUE = "<redacted>"
+_SHORT_REDACTION_VALUE_MAX_LENGTH = 3
 
 
 HELIX_ARTIFACT_NAMES = {
@@ -670,10 +672,10 @@ def _docker_diagnostic_redaction_values(
 def _endpoint_component_redaction_values(endpoint: str) -> set[str]:
     """Return sensitive structured pieces of an evaluator endpoint URL.
 
-    A failed URL client may print only userinfo, a query value, or a fragment,
-    so scrubbing the complete environment value is insufficient.  Limit the
-    derived values to those URL components rather than hiding harmless scheme,
-    host, or path text that remains useful in diagnostics.
+    A failed URL client may print only userinfo or an isolated raw/decoded
+    query or fragment field.  Scrub complete structured fields, ``&``
+    segments, and both sides of key/value pairs without hiding the harmless
+    scheme, host, or path text that remains useful in diagnostics.
     """
     try:
         parsed = urlsplit(endpoint)
@@ -682,19 +684,26 @@ def _endpoint_component_redaction_values(endpoint: str) -> set[str]:
             for value in (
                 parsed.username,
                 parsed.password,
+                parsed.query,
                 parsed.fragment,
             )
             if value
         }
-        for pair in parsed.query.split("&"):
-            _key, separator, raw_value = pair.partition("=")
-            if separator and raw_value:
-                values.add(raw_value)
         for field in (parsed.query, parsed.fragment):
+            for segment in field.split("&"):
+                if not segment:
+                    continue
+                values.add(segment)
+                raw_key, separator, raw_value = segment.partition("=")
+                if raw_key:
+                    values.add(raw_key)
+                if separator and raw_value:
+                    values.add(raw_value)
             values.update(
-                value
-                for _key, value in parse_qsl(field, keep_blank_values=True)
-                if value
+                component
+                for key, value in parse_qsl(field, keep_blank_values=True)
+                for component in (key, value)
+                if component
             )
         values.update(unquote(value) for value in tuple(values))
     except (UnicodeError, ValueError):
@@ -703,14 +712,34 @@ def _endpoint_component_redaction_values(endpoint: str) -> set[str]:
 
 
 def _redact_diagnostic_output(value: Any, secrets: Sequence[str]) -> Any:
-    """Replace known Docker env secrets in text/bytes diagnostic output."""
+    """Replace known Docker env secrets in text/bytes diagnostic output.
+
+    Very short alphanumeric URL keys are matched only at word boundaries. This
+    still removes a duplicated ``--flag=x`` value without replacing every
+    occurrence of ``x`` inside harmless diagnostic words or URL context.
+    """
     if isinstance(value, str):
         for secret in secrets:
-            value = value.replace(secret, _REDACTED_DOCKER_ENV_VALUE)
+            if len(secret) <= _SHORT_REDACTION_VALUE_MAX_LENGTH and secret.isalnum():
+                value = re.sub(
+                    rf"(?<!\w){re.escape(secret)}(?!\w)",
+                    _REDACTED_DOCKER_ENV_VALUE,
+                    value,
+                )
+            else:
+                value = value.replace(secret, _REDACTED_DOCKER_ENV_VALUE)
     elif isinstance(value, bytes):
         replacement = _REDACTED_DOCKER_ENV_VALUE.encode()
         for secret in secrets:
-            value = value.replace(secret.encode(), replacement)
+            encoded_secret = secret.encode()
+            if len(secret) <= _SHORT_REDACTION_VALUE_MAX_LENGTH and secret.isalnum():
+                value = re.sub(
+                    rb"(?<!\w)" + re.escape(encoded_secret) + rb"(?!\w)",
+                    replacement,
+                    value,
+                )
+            else:
+                value = value.replace(encoded_secret, replacement)
     return value
 
 
@@ -722,7 +751,8 @@ def _redact_docker_argv(
     Every literal Docker environment value is replaced, including values whose
     key does not look secret.  This avoids heuristic gaps in command/exception
     rendering while retaining the key names needed to diagnose configuration.
-    Known values are also scrubbed wherever they recur in another argv token.
+    Known values are also scrubbed wherever safely identifiable in another
+    argv token.
     """
     values = _docker_diagnostic_redaction_values(args, redaction_values)
     redacted = list(args)

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -714,13 +714,17 @@ def _redact_diagnostic_output(value: Any, secrets: Sequence[str]) -> Any:
     return value
 
 
-def _redact_docker_argv(args: Sequence[str]) -> list[str]:
+def _redact_docker_argv(
+    args: Sequence[str], *, redaction_values: Sequence[str] = ()
+) -> list[str]:
     """Render Docker argv safely while preserving environment key context.
 
     Every literal Docker environment value is replaced, including values whose
     key does not look secret.  This avoids heuristic gaps in command/exception
     rendering while retaining the key names needed to diagnose configuration.
+    Known values are also scrubbed wherever they recur in another argv token.
     """
+    values = _docker_diagnostic_redaction_values(args, redaction_values)
     redacted = list(args)
     index = 0
     while index < len(redacted):
@@ -742,6 +746,8 @@ def _redact_docker_argv(args: Sequence[str]) -> list[str]:
                 key, _value = assignment.split("=", 1)
                 redacted[index] = f"-e{key}={_REDACTED_DOCKER_ENV_VALUE}"
         index += 1
+    for index, arg in enumerate(redacted):
+        redacted[index] = _redact_diagnostic_output(arg, values)
     return redacted
 
 
@@ -752,7 +758,7 @@ def _redact_subprocess_exception(
     redaction_values: Sequence[str] = (),
 ) -> None:
     """Sanitize a subprocess exception in place, including indirect rendering."""
-    safe_args = _redact_docker_argv(args)
+    safe_args = _redact_docker_argv(args, redaction_values=redaction_values)
     values = _docker_diagnostic_redaction_values(args, redaction_values)
     exc.cmd = safe_args
     if isinstance(exc, subprocess.CalledProcessError):
@@ -798,7 +804,7 @@ def _run_docker_process(
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
         _redact_subprocess_exception(exc, args, redaction_values=redaction_values)
         raise
-    result.args = _redact_docker_argv(args)
+    result.args = _redact_docker_argv(args, redaction_values=redaction_values)
     if result.returncode != 0 or diagnostic_output:
         result.stdout = _redact_diagnostic_output(result.stdout, values)
         result.stderr = _redact_diagnostic_output(result.stderr, values)

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -27,22 +27,6 @@ logger = logging.getLogger(__name__)
 
 
 _REDACTED_DOCKER_ENV_VALUE = "<redacted>"
-_SENSITIVE_ENV_KEY_PARTS = frozenset(
-    {
-        "AUTH",
-        "COOKIE",
-        "CREDENTIAL",
-        "CREDENTIALS",
-        "KEY",
-        "PASS",
-        "PASSWD",
-        "PASSWORD",
-        "PRIVATE",
-        "SECRET",
-        "SESSION",
-        "TOKEN",
-    }
-)
 
 
 HELIX_ARTIFACT_NAMES = {
@@ -663,18 +647,18 @@ def _docker_env_assignments(args: Sequence[str]) -> list[tuple[str, str]]:
     return assignments
 
 
-def _is_sensitive_env_key(key: str) -> bool:
-    parts = {part for part in key.upper().replace("-", "_").split("_") if part}
-    return bool(parts & _SENSITIVE_ENV_KEY_PARTS)
+def _docker_diagnostic_redaction_values(
+    args: Sequence[str], explicit_values: Sequence[str] = ()
+) -> tuple[str, ...]:
+    """Return literal Docker env values to scrub from failure diagnostics.
 
-
-def _sensitive_docker_env_values(args: Sequence[str]) -> tuple[str, ...]:
-    """Return non-empty secret values, longest first, for output scrubbing."""
-    values = {
-        value
-        for key, value in _docker_env_assignments(args)
-        if value and _is_sensitive_env_key(key)
-    }
+    Any explicit ``KEY=VALUE`` passed to Docker can carry sensitive data,
+    regardless of how the key is named.  Callers may also supply values from
+    an earlier Docker invocation when later output (such as ``docker logs``)
+    is rendered as part of the same failure.
+    """
+    values = {value for _key, value in _docker_env_assignments(args) if value}
+    values.update(value for value in explicit_values if value)
     return tuple(sorted(values, key=len, reverse=True))
 
 
@@ -724,19 +708,21 @@ def _redact_docker_argv(args: Sequence[str]) -> list[str]:
 def _redact_subprocess_exception(
     exc: subprocess.CalledProcessError | subprocess.TimeoutExpired,
     args: Sequence[str],
+    *,
+    redaction_values: Sequence[str] = (),
 ) -> None:
     """Sanitize a subprocess exception in place, including indirect rendering."""
     safe_args = _redact_docker_argv(args)
-    secrets = _sensitive_docker_env_values(args)
+    values = _docker_diagnostic_redaction_values(args, redaction_values)
     exc.cmd = safe_args
     if isinstance(exc, subprocess.CalledProcessError):
         exc.args = (exc.returncode, safe_args)
-        exc.output = _redact_diagnostic_output(exc.output, secrets)
-        exc.stderr = _redact_diagnostic_output(exc.stderr, secrets)
+        exc.output = _redact_diagnostic_output(exc.output, values)
+        exc.stderr = _redact_diagnostic_output(exc.stderr, values)
     else:
         exc.args = (safe_args, exc.timeout)
-        exc.output = _redact_diagnostic_output(exc.output, secrets)
-        exc.stderr = _redact_diagnostic_output(exc.stderr, secrets)
+        exc.output = _redact_diagnostic_output(exc.output, values)
+        exc.stderr = _redact_diagnostic_output(exc.stderr, values)
 
 
 def _run_docker_process(
@@ -747,9 +733,17 @@ def _run_docker_process(
     cwd: str | None = None,
     input_text: str | None = None,
     timeout: float | None = None,
+    redaction_values: Sequence[str] = (),
+    diagnostic_output: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    """Run Docker and sanitize every returned or raised diagnostic object."""
-    secrets = _sensitive_docker_env_values(args)
+    """Run Docker, sanitizing argv and any output used as a diagnostic.
+
+    Successful functional stdout/stderr is preserved by default.  Failure
+    output is always scrubbed, and callers that intentionally consume a
+    successful command's output as diagnostics can opt in with
+    ``diagnostic_output=True``.
+    """
+    values = _docker_diagnostic_redaction_values(args, redaction_values)
     try:
         result = subprocess.run(
             args,
@@ -762,11 +756,12 @@ def _run_docker_process(
             timeout=timeout,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        _redact_subprocess_exception(exc, args)
+        _redact_subprocess_exception(exc, args, redaction_values=redaction_values)
         raise
     result.args = _redact_docker_argv(args)
-    result.stdout = _redact_diagnostic_output(result.stdout, secrets)
-    result.stderr = _redact_diagnostic_output(result.stderr, secrets)
+    if result.returncode != 0 or diagnostic_output:
+        result.stdout = _redact_diagnostic_output(result.stdout, values)
+        result.stderr = _redact_diagnostic_output(result.stderr, values)
     return result
 
 
@@ -774,8 +769,15 @@ def _run_docker(
     args: list[str],
     *,
     check: bool = True,
+    redaction_values: Sequence[str] = (),
+    diagnostic_output: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    return _run_docker_process(args, check=check)
+    return _run_docker_process(
+        args,
+        check=check,
+        redaction_values=redaction_values,
+        diagnostic_output=diagnostic_output,
+    )
 
 
 def _build_add_host_args(
@@ -791,7 +793,12 @@ def _build_add_host_args(
     return args
 
 
-def _wait_for_container_running(container_name: str, timeout_seconds: int) -> None:
+def _wait_for_container_running(
+    container_name: str,
+    timeout_seconds: int,
+    *,
+    redaction_values: Sequence[str] = (),
+) -> None:
     deadline = time.monotonic() + timeout_seconds
     last_stderr = ""
     while time.monotonic() < deadline:
@@ -804,13 +811,19 @@ def _wait_for_container_running(container_name: str, timeout_seconds: int) -> No
                 container_name,
             ],
             check=False,
+            redaction_values=redaction_values,
         )
         if result.returncode == 0:
             status = result.stdout.strip().split()
             if status[:1] == ["true"]:
                 return
             if len(status) > 1 and status[1] in {"exited", "dead"}:
-                logs = _run_docker(["docker", "logs", container_name], check=False)
+                logs = _run_docker(
+                    ["docker", "logs", container_name],
+                    check=False,
+                    redaction_values=redaction_values,
+                    diagnostic_output=True,
+                )
                 raise RuntimeError(
                     "Evaluator sidecar exited before it became ready.\n"
                     f"stdout:\n{logs.stdout}\nstderr:\n{logs.stderr}"
@@ -874,6 +887,7 @@ def _wait_for_sidecar_service(
     network: str,
     container_name: str,
     extra_hosts: dict[str, str] | None = None,
+    redaction_values: Sequence[str] = (),
 ) -> None:
     deadline = time.monotonic() + sidecar.startup_timeout_seconds
     last_output = ""
@@ -887,11 +901,17 @@ def _wait_for_sidecar_service(
                 container_name,
             ],
             check=False,
+            redaction_values=redaction_values,
         )
         if status.returncode == 0:
             parts = status.stdout.strip().split()
             if len(parts) > 1 and parts[1] in {"exited", "dead"}:
-                logs = _run_docker(["docker", "logs", container_name], check=False)
+                logs = _run_docker(
+                    ["docker", "logs", container_name],
+                    check=False,
+                    redaction_values=redaction_values,
+                    diagnostic_output=True,
+                )
                 raise RuntimeError(
                     "Evaluator sidecar exited before its endpoint became ready.\n"
                     f"stdout:\n{logs.stdout}\nstderr:\n{logs.stderr}"
@@ -903,6 +923,7 @@ def _wait_for_sidecar_service(
                 extra_hosts=extra_hosts,
             ),
             check=False,
+            redaction_values=redaction_values,
         )
         if result.returncode == 0:
             return
@@ -954,13 +975,19 @@ def start_evaluator_sidecar(
             args.extend(["-e", f"{key}={value}"])
         args.append(sidecar.image)
         args.extend(shlex.split(sidecar.command))
+        redaction_values = _docker_diagnostic_redaction_values(args)
         _run_docker(args)
-        _wait_for_container_running(container_name, sidecar.startup_timeout_seconds)
+        _wait_for_container_running(
+            container_name,
+            sidecar.startup_timeout_seconds,
+            redaction_values=redaction_values,
+        )
         _wait_for_sidecar_service(
             sidecar,
             network=network,
             container_name=container_name,
             extra_hosts=extra_hosts,
+            redaction_values=redaction_values,
         )
         runtime = EvaluatorSidecarRuntime(
             network=network,

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -931,7 +931,8 @@ def _wait_for_sidecar_service(
         time.sleep(0.5)
     raise TimeoutError(
         "Evaluator sidecar endpoint did not become reachable within "
-        f"{sidecar.startup_timeout_seconds}s: {sidecar.endpoint}\n{last_output}"
+        f"{sidecar.startup_timeout_seconds}s: "
+        f"HELIX_EVALUATOR_ENDPOINT={_REDACTED_DOCKER_ENV_VALUE}\n{last_output}"
     )
 
 

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -428,14 +428,18 @@ def _sync_back_backend_transcripts(src: Path, dst: Path) -> None:
         if not source.exists():
             return
     except OSError as exc:
-        logger.warning("skipping inaccessible backend transcript artifacts %s: %s", source, exc)
+        logger.warning(
+            "skipping inaccessible backend transcript artifacts %s: %s", source, exc
+        )
         return
     target = dst / ".helix_artifacts" / "backend_transcripts"
     target.mkdir(parents=True, exist_ok=True)
     try:
         shutil.copytree(source, target, dirs_exist_ok=True)
     except OSError as exc:
-        logger.warning("skipping backend transcript artifact copy from %s: %s", source, exc)
+        logger.warning(
+            "skipping backend transcript artifact copy from %s: %s", source, exc
+        )
 
 
 def _init_synthetic_git_repo(workspace: Path) -> None:
@@ -707,9 +711,7 @@ def _redact_docker_argv(args: Sequence[str]) -> list[str]:
             assignment = arg.removeprefix("--env=")
             if "=" in assignment:
                 key, _value = assignment.split("=", 1)
-                redacted[index] = (
-                    f"--env={key}={_REDACTED_DOCKER_ENV_VALUE}"
-                )
+                redacted[index] = f"--env={key}={_REDACTED_DOCKER_ENV_VALUE}"
         elif arg.startswith("-e") and arg != "-e":
             assignment = arg[2:]
             if "=" in assignment:

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -32,6 +32,14 @@ _REDACTED_DOCKER_ENV_VALUE = "<redacted>"
 _SHORT_REDACTION_VALUE_MAX_LENGTH = 3
 
 
+@dataclass(frozen=True)
+class _DiagnosticRedactionPolicy:
+    """Secrets grouped by the matching policy their provenance permits."""
+
+    substring_secrets: tuple[str, ...] = ()
+    boundary_secrets: tuple[str, ...] = ()
+
+
 HELIX_ARTIFACT_NAMES = {
     ".helix_backend_result.json",
     ".helix_backend_stdout.txt",
@@ -650,23 +658,46 @@ def _docker_env_assignments(args: Sequence[str]) -> list[tuple[str, str]]:
     return assignments
 
 
-def _docker_diagnostic_redaction_values(
-    args: Sequence[str], explicit_values: Sequence[str] = ()
-) -> tuple[str, ...]:
-    """Return literal Docker env values to scrub from failure diagnostics.
+def _docker_diagnostic_redaction_policy(
+    args: Sequence[str],
+    explicit_values: Sequence[str] = (),
+    inherited_policy: _DiagnosticRedactionPolicy | None = None,
+) -> _DiagnosticRedactionPolicy:
+    """Classify Docker secrets by their required diagnostic matching policy.
 
     Any explicit ``KEY=VALUE`` passed to Docker can carry sensitive data,
     regardless of how the key is named.  Callers may also supply values from
     an earlier Docker invocation when later output (such as ``docker logs``)
-    is rendered as part of the same failure.
+    is rendered as part of the same failure. Literal env and explicit values
+    are always substring-matched. Only short alphanumeric endpoint-derived
+    components use boundaries, unless literal provenance overrides that rule.
     """
     assignments = _docker_env_assignments(args)
-    values = {value for _key, value in assignments if value}
+    substring_secrets = {value for _key, value in assignments if value}
+    substring_secrets.update(value for value in explicit_values if value)
+    derived_secrets: set[str] = set()
     for key, value in assignments:
         if key == "HELIX_EVALUATOR_ENDPOINT":
-            values.update(_endpoint_component_redaction_values(value))
-    values.update(value for value in explicit_values if value)
-    return tuple(sorted(values, key=len, reverse=True))
+            derived_secrets.update(_endpoint_component_redaction_values(value))
+    if inherited_policy is not None:
+        substring_secrets.update(inherited_policy.substring_secrets)
+        derived_secrets.update(inherited_policy.boundary_secrets)
+
+    derived_secrets.difference_update(substring_secrets)
+    boundary_secrets = {
+        secret
+        for secret in derived_secrets
+        if len(secret) <= _SHORT_REDACTION_VALUE_MAX_LENGTH and secret.isalnum()
+    }
+    substring_secrets.update(derived_secrets - boundary_secrets)
+    return _DiagnosticRedactionPolicy(
+        substring_secrets=tuple(
+            sorted(substring_secrets, key=lambda secret: (-len(secret), secret))
+        ),
+        boundary_secrets=tuple(
+            sorted(boundary_secrets, key=lambda secret: (-len(secret), secret))
+        ),
+    )
 
 
 def _endpoint_component_redaction_values(endpoint: str) -> set[str]:
@@ -711,15 +742,23 @@ def _endpoint_component_redaction_values(endpoint: str) -> set[str]:
     return {value for value in values if value}
 
 
-def _redact_diagnostic_output(value: Any, secrets: Sequence[str]) -> Any:
+def _redact_diagnostic_output(
+    value: Any,
+    secrets: Sequence[str],
+    *,
+    boundary_secrets: Sequence[str] = (),
+) -> Any:
     """Replace known Docker env secrets in text/bytes diagnostic output.
 
-    Very short alphanumeric URL keys are matched only at word boundaries. This
-    still removes a duplicated ``--flag=x`` value without replacing every
-    occurrence of ``x`` inside harmless diagnostic words or URL context.
+    ``secrets`` are literal env or explicit values and are always replaced as
+    substrings. ``boundary_secrets`` are endpoint-derived values; only short
+    alphanumeric members use word boundaries so a query key such as ``q`` does
+    not corrupt harmless diagnostic words, hostnames, or paths.
     """
     if isinstance(value, str):
         for secret in secrets:
+            value = value.replace(secret, _REDACTED_DOCKER_ENV_VALUE)
+        for secret in boundary_secrets:
             if len(secret) <= _SHORT_REDACTION_VALUE_MAX_LENGTH and secret.isalnum():
                 value = re.sub(
                     rf"(?<!\w){re.escape(secret)}(?!\w)",
@@ -731,6 +770,8 @@ def _redact_diagnostic_output(value: Any, secrets: Sequence[str]) -> Any:
     elif isinstance(value, bytes):
         replacement = _REDACTED_DOCKER_ENV_VALUE.encode()
         for secret in secrets:
+            value = value.replace(secret.encode(), replacement)
+        for secret in boundary_secrets:
             encoded_secret = secret.encode()
             if len(secret) <= _SHORT_REDACTION_VALUE_MAX_LENGTH and secret.isalnum():
                 value = re.sub(
@@ -744,7 +785,10 @@ def _redact_diagnostic_output(value: Any, secrets: Sequence[str]) -> Any:
 
 
 def _redact_docker_argv(
-    args: Sequence[str], *, redaction_values: Sequence[str] = ()
+    args: Sequence[str],
+    *,
+    redaction_values: Sequence[str] = (),
+    redaction_policy: _DiagnosticRedactionPolicy | None = None,
 ) -> list[str]:
     """Render Docker argv safely while preserving environment key context.
 
@@ -754,7 +798,9 @@ def _redact_docker_argv(
     Known values are also scrubbed wherever safely identifiable in another
     argv token.
     """
-    values = _docker_diagnostic_redaction_values(args, redaction_values)
+    policy = _docker_diagnostic_redaction_policy(
+        args, redaction_values, redaction_policy
+    )
     redacted = list(args)
     index = 0
     while index < len(redacted):
@@ -777,7 +823,11 @@ def _redact_docker_argv(
                 redacted[index] = f"-e{key}={_REDACTED_DOCKER_ENV_VALUE}"
         index += 1
     for index, arg in enumerate(redacted):
-        redacted[index] = _redact_diagnostic_output(arg, values)
+        redacted[index] = _redact_diagnostic_output(
+            arg,
+            policy.substring_secrets,
+            boundary_secrets=policy.boundary_secrets,
+        )
     return redacted
 
 
@@ -786,19 +836,28 @@ def _redact_subprocess_exception(
     args: Sequence[str],
     *,
     redaction_values: Sequence[str] = (),
+    redaction_policy: _DiagnosticRedactionPolicy | None = None,
 ) -> None:
     """Sanitize a subprocess exception in place, including indirect rendering."""
-    safe_args = _redact_docker_argv(args, redaction_values=redaction_values)
-    values = _docker_diagnostic_redaction_values(args, redaction_values)
+    policy = _docker_diagnostic_redaction_policy(
+        args, redaction_values, redaction_policy
+    )
+    safe_args = _redact_docker_argv(args, redaction_policy=policy)
     exc.cmd = safe_args
     if isinstance(exc, subprocess.CalledProcessError):
         exc.args = (exc.returncode, safe_args)
-        exc.output = _redact_diagnostic_output(exc.output, values)
-        exc.stderr = _redact_diagnostic_output(exc.stderr, values)
     else:
         exc.args = (safe_args, exc.timeout)
-        exc.output = _redact_diagnostic_output(exc.output, values)
-        exc.stderr = _redact_diagnostic_output(exc.stderr, values)
+    exc.output = _redact_diagnostic_output(
+        exc.output,
+        policy.substring_secrets,
+        boundary_secrets=policy.boundary_secrets,
+    )
+    exc.stderr = _redact_diagnostic_output(
+        exc.stderr,
+        policy.substring_secrets,
+        boundary_secrets=policy.boundary_secrets,
+    )
 
 
 def _run_docker_process(
@@ -810,6 +869,7 @@ def _run_docker_process(
     input_text: str | None = None,
     timeout: float | None = None,
     redaction_values: Sequence[str] = (),
+    redaction_policy: _DiagnosticRedactionPolicy | None = None,
     diagnostic_output: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Run Docker, sanitizing argv and any output used as a diagnostic.
@@ -819,7 +879,9 @@ def _run_docker_process(
     successful command's output as diagnostics can opt in with
     ``diagnostic_output=True``.
     """
-    values = _docker_diagnostic_redaction_values(args, redaction_values)
+    policy = _docker_diagnostic_redaction_policy(
+        args, redaction_values, redaction_policy
+    )
     try:
         result = subprocess.run(
             args,
@@ -832,12 +894,20 @@ def _run_docker_process(
             timeout=timeout,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        _redact_subprocess_exception(exc, args, redaction_values=redaction_values)
+        _redact_subprocess_exception(exc, args, redaction_policy=policy)
         raise
-    result.args = _redact_docker_argv(args, redaction_values=redaction_values)
+    result.args = _redact_docker_argv(args, redaction_policy=policy)
     if result.returncode != 0 or diagnostic_output:
-        result.stdout = _redact_diagnostic_output(result.stdout, values)
-        result.stderr = _redact_diagnostic_output(result.stderr, values)
+        result.stdout = _redact_diagnostic_output(
+            result.stdout,
+            policy.substring_secrets,
+            boundary_secrets=policy.boundary_secrets,
+        )
+        result.stderr = _redact_diagnostic_output(
+            result.stderr,
+            policy.substring_secrets,
+            boundary_secrets=policy.boundary_secrets,
+        )
     return result
 
 
@@ -846,12 +916,14 @@ def _run_docker(
     *,
     check: bool = True,
     redaction_values: Sequence[str] = (),
+    redaction_policy: _DiagnosticRedactionPolicy | None = None,
     diagnostic_output: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     return _run_docker_process(
         args,
         check=check,
         redaction_values=redaction_values,
+        redaction_policy=redaction_policy,
         diagnostic_output=diagnostic_output,
     )
 
@@ -873,7 +945,7 @@ def _wait_for_container_running(
     container_name: str,
     timeout_seconds: int,
     *,
-    redaction_values: Sequence[str] = (),
+    redaction_policy: _DiagnosticRedactionPolicy | None = None,
 ) -> None:
     deadline = time.monotonic() + timeout_seconds
     last_stderr = ""
@@ -887,7 +959,7 @@ def _wait_for_container_running(
                 container_name,
             ],
             check=False,
-            redaction_values=redaction_values,
+            redaction_policy=redaction_policy,
         )
         if result.returncode == 0:
             status = result.stdout.strip().split()
@@ -897,7 +969,7 @@ def _wait_for_container_running(
                 logs = _run_docker(
                     ["docker", "logs", container_name],
                     check=False,
-                    redaction_values=redaction_values,
+                    redaction_policy=redaction_policy,
                     diagnostic_output=True,
                 )
                 raise RuntimeError(
@@ -963,7 +1035,7 @@ def _wait_for_sidecar_service(
     network: str,
     container_name: str,
     extra_hosts: dict[str, str] | None = None,
-    redaction_values: Sequence[str] = (),
+    redaction_policy: _DiagnosticRedactionPolicy | None = None,
 ) -> None:
     deadline = time.monotonic() + sidecar.startup_timeout_seconds
     last_output = ""
@@ -977,7 +1049,7 @@ def _wait_for_sidecar_service(
                 container_name,
             ],
             check=False,
-            redaction_values=redaction_values,
+            redaction_policy=redaction_policy,
         )
         if status.returncode == 0:
             parts = status.stdout.strip().split()
@@ -985,7 +1057,7 @@ def _wait_for_sidecar_service(
                 logs = _run_docker(
                     ["docker", "logs", container_name],
                     check=False,
-                    redaction_values=redaction_values,
+                    redaction_policy=redaction_policy,
                     diagnostic_output=True,
                 )
                 raise RuntimeError(
@@ -999,7 +1071,7 @@ def _wait_for_sidecar_service(
                 extra_hosts=extra_hosts,
             ),
             check=False,
-            redaction_values=redaction_values,
+            redaction_policy=redaction_policy,
         )
         if result.returncode == 0:
             return
@@ -1052,26 +1124,26 @@ def start_evaluator_sidecar(
             args.extend(["-e", f"{key}={value}"])
         args.append(sidecar.image)
         args.extend(shlex.split(sidecar.command))
-        redaction_values = _docker_diagnostic_redaction_values(
+        redaction_policy = _docker_diagnostic_redaction_policy(
             _healthcheck_docker_args(
                 sidecar,
                 network=network,
                 extra_hosts=extra_hosts,
             ),
-            _docker_diagnostic_redaction_values(args),
+            inherited_policy=_docker_diagnostic_redaction_policy(args),
         )
         _run_docker(args)
         _wait_for_container_running(
             container_name,
             sidecar.startup_timeout_seconds,
-            redaction_values=redaction_values,
+            redaction_policy=redaction_policy,
         )
         _wait_for_sidecar_service(
             sidecar,
             network=network,
             container_name=container_name,
             extra_hosts=extra_hosts,
-            redaction_values=redaction_values,
+            redaction_policy=redaction_policy,
         )
         runtime = EvaluatorSidecarRuntime(
             network=network,

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -18,6 +18,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import parse_qsl, unquote, urlsplit
 
 from helix.backends import BACKEND_AUTH_COMMANDS, DEFAULT_BACKEND_IMAGES
 from helix.config import EvaluatorSidecarConfig, SandboxConfig
@@ -657,9 +658,48 @@ def _docker_diagnostic_redaction_values(
     an earlier Docker invocation when later output (such as ``docker logs``)
     is rendered as part of the same failure.
     """
-    values = {value for _key, value in _docker_env_assignments(args) if value}
+    assignments = _docker_env_assignments(args)
+    values = {value for _key, value in assignments if value}
+    for key, value in assignments:
+        if key == "HELIX_EVALUATOR_ENDPOINT":
+            values.update(_endpoint_component_redaction_values(value))
     values.update(value for value in explicit_values if value)
     return tuple(sorted(values, key=len, reverse=True))
+
+
+def _endpoint_component_redaction_values(endpoint: str) -> set[str]:
+    """Return sensitive structured pieces of an evaluator endpoint URL.
+
+    A failed URL client may print only userinfo, a query value, or a fragment,
+    so scrubbing the complete environment value is insufficient.  Limit the
+    derived values to those URL components rather than hiding harmless scheme,
+    host, or path text that remains useful in diagnostics.
+    """
+    try:
+        parsed = urlsplit(endpoint)
+        values = {
+            value
+            for value in (
+                parsed.username,
+                parsed.password,
+                parsed.fragment,
+            )
+            if value
+        }
+        for pair in parsed.query.split("&"):
+            _key, separator, raw_value = pair.partition("=")
+            if separator and raw_value:
+                values.add(raw_value)
+        for field in (parsed.query, parsed.fragment):
+            values.update(
+                value
+                for _key, value in parse_qsl(field, keep_blank_values=True)
+                if value
+            )
+        values.update(unquote(value) for value in tuple(values))
+    except (UnicodeError, ValueError):
+        return set()
+    return {value for value in values if value}
 
 
 def _redact_diagnostic_output(value: Any, secrets: Sequence[str]) -> Any:
@@ -976,7 +1016,14 @@ def start_evaluator_sidecar(
             args.extend(["-e", f"{key}={value}"])
         args.append(sidecar.image)
         args.extend(shlex.split(sidecar.command))
-        redaction_values = _docker_diagnostic_redaction_values(args)
+        redaction_values = _docker_diagnostic_redaction_values(
+            _healthcheck_docker_args(
+                sidecar,
+                network=network,
+                extra_hosts=extra_hosts,
+            ),
+            _docker_diagnostic_redaction_values(args),
+        )
         _run_docker(args)
         _wait_for_container_running(
             container_name,

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 import warnings
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -22,7 +22,7 @@ from helix.population import FrontierType
 # had no schema version on ``state.json``; subsequent bumps mark explicit
 # JSON-native schema additions (the unversioned predecessor is treated as
 # v0; ``load_state`` migrates by default-filling missing fields).
-SCHEMA_VERSION: int = 3
+SCHEMA_VERSION: int = 4
 
 
 @dataclass
@@ -206,6 +206,12 @@ class ProposalBatchRecord:
     tasks: list[ProposalTaskRecord]
     phase: ProposalBatchPhase = "planned"
     budget_before_dispatch: int = 0
+    # Full resource snapshot paired with ``budget_before_dispatch``.  The
+    # integer field remains for schema/backward compatibility and the explicit
+    # overshoot contract; this snapshot lets resume conserve token/cost usage
+    # when a process stopped after a worker returned but before its task row was
+    # terminalized.
+    budget_state_before_dispatch: BudgetState | None = None
     max_evaluations: int = 0
     max_in_flight_evaluations: int = 0
     maximum_overshoot: int = 0
@@ -260,6 +266,11 @@ class ProposalBatchRecord:
             "n": self.n,
             "phase": self.phase,
             "budget_before_dispatch": self.budget_before_dispatch,
+            "budget_state_before_dispatch": (
+                asdict(self.budget_state_before_dispatch)
+                if self.budget_state_before_dispatch is not None
+                else None
+            ),
             "max_evaluations": self.max_evaluations,
             "max_in_flight_evaluations": self.max_in_flight_evaluations,
             "maximum_overshoot": self.maximum_overshoot,
@@ -281,6 +292,10 @@ class ProposalBatchRecord:
                 raise ValueError("Proposal batch task must be an object")
             tasks.append(ProposalTaskRecord.from_dict(raw_task))
         raw_after = data.get("budget_after_apply")
+        raw_budget_before = data.get("budget_state_before_dispatch")
+        budget_before_mapping = (
+            raw_budget_before if isinstance(raw_budget_before, Mapping) else None
+        )
         batch = cls(
             batch_id=str(data["batch_id"]),
             generation=int(data["generation"]),
@@ -289,6 +304,11 @@ class ProposalBatchRecord:
             tasks=tasks,
             phase=cast(ProposalBatchPhase, raw_phase),
             budget_before_dispatch=int(data.get("budget_before_dispatch", 0)),
+            budget_state_before_dispatch=(
+                _budget_state_from_mapping(budget_before_mapping)
+                if budget_before_mapping is not None
+                else None
+            ),
             max_evaluations=int(data.get("max_evaluations", 0)),
             max_in_flight_evaluations=int(
                 data.get("max_in_flight_evaluations", 0)
@@ -665,6 +685,7 @@ def checkpoint_batch_before_dispatch(
 
     batch.phase = "dispatched"
     batch.budget_before_dispatch = decision.evaluations_before
+    batch.budget_state_before_dispatch = replace(state.budget)
     batch.max_evaluations = decision.max_evaluations
     batch.max_in_flight_evaluations = decision.max_in_flight_evaluations
     batch.maximum_overshoot = decision.maximum_overshoot
@@ -833,7 +854,22 @@ def checkpoint_batch_after_apply(
             f"Cannot complete proposal batch {batch_id!r}; unaccounted slots: "
             + ", ".join(str(index) for index in unaccounted)
         )
-    actual_in_flight = state.budget.evaluations - batch.budget_before_dispatch
+    batch_index = next(
+        index
+        for index, candidate_batch in enumerate(state.proposal_batches)
+        if candidate_batch is batch
+    )
+    next_batch = (
+        state.proposal_batches[batch_index + 1]
+        if batch_index + 1 < len(state.proposal_batches)
+        else None
+    )
+    evaluations_at_end = (
+        next_batch.budget_before_dispatch
+        if next_batch is not None
+        else state.budget.evaluations
+    )
+    actual_in_flight = evaluations_at_end - batch.budget_before_dispatch
     if actual_in_flight < 0:
         raise ValueError(
             f"Proposal batch {batch_id!r} ended below its pre-dispatch budget"
@@ -858,15 +894,15 @@ def checkpoint_batch_after_apply(
     actual_overshoot = (
         0
         if batch.max_evaluations <= 0
-        else max(0, state.budget.evaluations - batch.max_evaluations)
+        else max(0, evaluations_at_end - batch.max_evaluations)
     )
     if actual_overshoot > batch.maximum_overshoot:
         raise ValueError(
             f"Proposal batch {batch_id!r} overshot by {actual_overshoot}; "
             f"checkpoint bound is {batch.maximum_overshoot}"
-        )
+    )
     batch.phase = "complete"
-    batch.budget_after_apply = state.budget.evaluations
+    batch.budget_after_apply = evaluations_at_end
     _persist_checkpoint(state, base_dir, saver)
     return batch
 
@@ -883,13 +919,24 @@ def reconcile_interrupted_batches(
 
     Applied/frontier children are preserved and marked applied, preventing a
     second frontier insertion.  Every other planned worktree is passed to the
-    caller's Git-aware cleanup callback.  Budget facts are never changed:
-    already-accounted completed work remains charged, while unaccounted work
-    is not guessed at.  All child IDs remain reserved through the ledger.
+    caller's Git-aware cleanup callback.  The authoritative global budget is
+    never changed; once cleanup succeeds, any durable delta not yet present in
+    a task row is attributed deterministically so the batch ledger conserves
+    that total.  All child IDs remain reserved through the ledger.
     """
     reconciled: list[BatchReconciliation] = []
     changed = False
-    for batch in state.proposal_batches:
+    for batch_index, batch in enumerate(state.proposal_batches):
+        next_batch = (
+            state.proposal_batches[batch_index + 1]
+            if batch_index + 1 < len(state.proposal_batches)
+            else None
+        )
+        evaluations_at_end = (
+            next_batch.budget_before_dispatch
+            if next_batch is not None
+            else state.budget.evaluations
+        )
         retry_failed_cleanup = any(
             task.cleanup == "failed" and not task.applied for task in batch.tasks
         )
@@ -905,8 +952,6 @@ def reconcile_interrupted_batches(
         failed_ids: list[str] = []
         for task in batch.tasks:
             reserved_ids.append(task.child_id)
-            if task.budget_accounted:
-                accounted_ids.append(task.child_id)
 
             if task.applied or task.status == "applied" or task.child_id in state.frontier:
                 task.status = "applied"
@@ -943,8 +988,89 @@ def reconcile_interrupted_batches(
                 task.selection = "not_applicable"
             task.applied = False
 
+        # Cleanup is a resume barrier: only after every non-applied worktree is
+        # gone may an interrupted batch be declared fully accounted.  A worker
+        # can finish and update the global durable budget immediately before a
+        # crash prevents its task row from being terminalized.  Preserve that
+        # authoritative global total by assigning the unjournaled residual to
+        # the first unaccounted slot in stable task order, then close every
+        # remaining zero-residual slot.  This never charges the global budget a
+        # second time and is idempotent on later resumes.
+        if not failed_ids:
+            unaccounted = [task for task in batch.tasks if not task.budget_accounted]
+            if unaccounted:
+                before = batch.budget_state_before_dispatch
+                has_full_budget_baseline = before is not None
+                if before is None:
+                    # Legacy ledgers only persisted the evaluation baseline.
+                    # Conserve that field exactly without guessing historical
+                    # token/cost baselines that were never recorded.
+                    before = BudgetState(evaluations=batch.budget_before_dispatch)
+
+                durable_end = (
+                    next_batch.budget_state_before_dispatch
+                    if next_batch is not None
+                    else state.budget
+                )
+                has_full_budget_end = durable_end is not None
+                if durable_end is None:
+                    # A legacy next batch still gives us an exact evaluation
+                    # boundary, but never persisted token/cost counters.
+                    assert next_batch is not None
+                    durable_end = BudgetState(
+                        evaluations=next_batch.budget_before_dispatch
+                    )
+
+                fields = (
+                    (
+                        "evaluations",
+                        "input_tokens",
+                        "output_tokens",
+                        "cached_input_tokens",
+                        "cache_creation_input_tokens",
+                        "cache_read_input_tokens",
+                        "reasoning_tokens",
+                        "cost_usd",
+                    )
+                    if has_full_budget_baseline and has_full_budget_end
+                    else ("evaluations",)
+                )
+                residuals: dict[str, int | float] = {}
+                for field_name in fields:
+                    durable_total = getattr(durable_end, field_name)
+                    baseline = getattr(before, field_name)
+                    recorded = sum(
+                        getattr(task.budget_charge, field_name)
+                        for task in batch.tasks
+                    )
+                    residual = durable_total - baseline - recorded
+                    tolerance = 1e-12 if field_name == "cost_usd" else 0
+                    if residual < -tolerance:
+                        raise ValueError(
+                            f"Interrupted proposal batch {batch.batch_id!r} "
+                            f"over-recorded {field_name}: baseline={baseline}, "
+                            f"recorded={recorded}, durable_total={durable_total}"
+                        )
+                    residuals[field_name] = 0 if abs(residual) <= tolerance else residual
+
+                residual_task = unaccounted[0]
+                for field_name, residual in residuals.items():
+                    setattr(
+                        residual_task.budget_charge,
+                        field_name,
+                        getattr(residual_task.budget_charge, field_name) + residual,
+                    )
+                for task in unaccounted:
+                    task.budget_accounted = True
+                    suffix = "resume cleanup and accounting reconciled"
+                    task.detail = f"{task.detail}; {suffix}" if task.detail else suffix
+
+        accounted_ids.extend(
+            task.child_id for task in batch.tasks if task.budget_accounted
+        )
+
         batch.phase = "interrupted"
-        batch.budget_after_apply = state.budget.evaluations
+        batch.budget_after_apply = evaluations_at_end
         reconciled.append(
             BatchReconciliation(
                 batch_id=batch.batch_id,

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -8,9 +8,10 @@ import pickle
 import tempfile
 import time
 import warnings
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 from helix.population import FrontierType
 
@@ -21,7 +22,7 @@ from helix.population import FrontierType
 # had no schema version on ``state.json``; subsequent bumps mark explicit
 # JSON-native schema additions (the unversioned predecessor is treated as
 # v0; ``load_state`` migrates by default-filling missing fields).
-SCHEMA_VERSION: int = 2
+SCHEMA_VERSION: int = 3
 
 
 @dataclass
@@ -40,6 +41,287 @@ class BudgetState:
     cache_read_input_tokens: int = 0
     reasoning_tokens: int = 0
     cost_usd: float = 0.0
+
+
+ProposalTaskStatus = Literal[
+    "planned",
+    "running",
+    "evaluated",
+    "skipped",
+    "failed",
+    "tampered",
+    "rejected",
+    "applied",
+    "interrupted",
+]
+ProposalSelectionResult = Literal[
+    "pending", "not_applicable", "not_selected", "selected"
+]
+ProposalCleanupResult = Literal[
+    "pending", "not_required", "removed", "missing", "failed"
+]
+ProposalBatchPhase = Literal["planned", "dispatched", "applying", "complete", "interrupted"]
+
+TERMINAL_PROPOSAL_STATUSES: frozenset[ProposalTaskStatus] = frozenset(
+    {"skipped", "failed", "tampered", "rejected", "applied", "interrupted"}
+)
+TERMINAL_CLEANUP_RESULTS: frozenset[ProposalCleanupResult] = frozenset(
+    {"not_required", "removed", "missing", "failed"}
+)
+
+_PROPOSAL_TASK_STATUSES = frozenset(
+    {
+        "planned",
+        "running",
+        "evaluated",
+        "skipped",
+        "failed",
+        "tampered",
+        "rejected",
+        "applied",
+        "interrupted",
+    }
+)
+_PROPOSAL_SELECTION_RESULTS = frozenset(
+    {"pending", "not_applicable", "not_selected", "selected"}
+)
+_PROPOSAL_CLEANUP_RESULTS = frozenset(
+    {"pending", "not_required", "removed", "missing", "failed"}
+)
+_PROPOSAL_BATCH_PHASES = frozenset(
+    {"planned", "dispatched", "applying", "complete", "interrupted"}
+)
+
+
+def _budget_state_from_mapping(data: Mapping[str, Any]) -> BudgetState:
+    return BudgetState(
+        evaluations=int(data.get("evaluations", 0)),
+        input_tokens=int(data.get("input_tokens", 0)),
+        output_tokens=int(data.get("output_tokens", 0)),
+        cached_input_tokens=int(data.get("cached_input_tokens", 0)),
+        cache_creation_input_tokens=int(data.get("cache_creation_input_tokens", 0)),
+        cache_read_input_tokens=int(data.get("cache_read_input_tokens", 0)),
+        reasoning_tokens=int(data.get("reasoning_tokens", 0)),
+        cost_usd=float(data.get("cost_usd", 0.0)),
+    )
+
+
+@dataclass
+class ProposalTaskRecord:
+    """Durable state for one parent-major P-by-N proposal slot.
+
+    ``budget_accounted`` and ``applied`` are explicit crash barriers.  A
+    resumed run can therefore distinguish completed evaluator work from work
+    that still needs charging, and a selected result from one already inserted
+    into the frontier.  Candidate IDs remain reserved even when the task is
+    interrupted or cleaned up.
+    """
+
+    batch_id: str
+    p: int
+    n: int
+    task_index: int
+    parent_group: int
+    mutation_index: int
+    parent_id: str
+    child_id: str
+    status: ProposalTaskStatus = "planned"
+    score_delta: float | None = None
+    selection: ProposalSelectionResult = "pending"
+    cleanup: ProposalCleanupResult = "pending"
+    budget_charge: BudgetState = field(default_factory=BudgetState)
+    budget_accounted: bool = False
+    applied: bool = False
+    detail: str | None = None
+
+    def is_terminal(self) -> bool:
+        """Return whether both execution and cleanup reached a terminal state."""
+        return (
+            self.status in TERMINAL_PROPOSAL_STATUSES
+            and self.cleanup in TERMINAL_CLEANUP_RESULTS
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "batch_id": self.batch_id,
+            "p": self.p,
+            "n": self.n,
+            "task_index": self.task_index,
+            "parent_group": self.parent_group,
+            "mutation_index": self.mutation_index,
+            "parent_id": self.parent_id,
+            "child_id": self.child_id,
+            "status": self.status,
+            "score_delta": self.score_delta,
+            "selection": self.selection,
+            "cleanup": self.cleanup,
+            "budget_charge": asdict(self.budget_charge),
+            "budget_accounted": self.budget_accounted,
+            "applied": self.applied,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ProposalTaskRecord:
+        raw_status = str(data.get("status", "planned"))
+        raw_selection = str(data.get("selection", "pending"))
+        raw_cleanup = str(data.get("cleanup", "pending"))
+        if raw_status not in _PROPOSAL_TASK_STATUSES:
+            raise ValueError(f"Invalid proposal task status: {raw_status!r}")
+        if raw_selection not in _PROPOSAL_SELECTION_RESULTS:
+            raise ValueError(f"Invalid proposal selection result: {raw_selection!r}")
+        if raw_cleanup not in _PROPOSAL_CLEANUP_RESULTS:
+            raise ValueError(f"Invalid proposal cleanup result: {raw_cleanup!r}")
+        raw_budget = data.get("budget_charge", {})
+        budget_mapping = raw_budget if isinstance(raw_budget, Mapping) else {}
+        raw_delta = data.get("score_delta")
+        return cls(
+            batch_id=str(data["batch_id"]),
+            p=int(data["p"]),
+            n=int(data["n"]),
+            task_index=int(data["task_index"]),
+            parent_group=int(data["parent_group"]),
+            mutation_index=int(data["mutation_index"]),
+            parent_id=str(data["parent_id"]),
+            child_id=str(data["child_id"]),
+            status=cast(ProposalTaskStatus, raw_status),
+            score_delta=None if raw_delta is None else float(raw_delta),
+            selection=cast(ProposalSelectionResult, raw_selection),
+            cleanup=cast(ProposalCleanupResult, raw_cleanup),
+            budget_charge=_budget_state_from_mapping(budget_mapping),
+            budget_accounted=bool(data.get("budget_accounted", False)),
+            applied=bool(data.get("applied", False)),
+            detail=None if data.get("detail") is None else str(data["detail"]),
+        )
+
+
+@dataclass
+class ProposalBatchRecord:
+    """Durable pre-dispatch plan and deterministic post-apply checkpoint."""
+
+    batch_id: str
+    generation: int
+    p: int
+    n: int
+    tasks: list[ProposalTaskRecord]
+    phase: ProposalBatchPhase = "planned"
+    budget_before_dispatch: int = 0
+    max_evaluations: int = 0
+    max_in_flight_evaluations: int = 0
+    maximum_overshoot: int = 0
+    budget_after_apply: int | None = None
+
+    def validate_plan(self) -> None:
+        """Validate the exact parent-major P-by-N shape and unique IDs."""
+        if not self.batch_id:
+            raise ValueError("Proposal batch_id cannot be empty")
+        if self.p < 1 or self.n < 1:
+            raise ValueError("Proposal batch P and N must both be at least one")
+        expected_count = self.p * self.n
+        if len(self.tasks) != expected_count:
+            raise ValueError(
+                f"Proposal batch {self.batch_id!r} has {len(self.tasks)} tasks; "
+                f"expected exactly P*N={expected_count}"
+            )
+        child_ids: set[str] = set()
+        group_parents: dict[int, str] = {}
+        for index, task in enumerate(self.tasks):
+            expected_group, expected_mutation = divmod(index, self.n)
+            if task.batch_id != self.batch_id or task.p != self.p or task.n != self.n:
+                raise ValueError(f"Task {index} does not match its proposal batch")
+            if (
+                task.task_index != index
+                or task.parent_group != expected_group
+                or task.mutation_index != expected_mutation
+            ):
+                raise ValueError(
+                    f"Task {index} is not in parent-major P-by-N order "
+                    f"(expected group={expected_group}, mutation={expected_mutation})"
+                )
+            if not task.child_id:
+                raise ValueError(f"Task {index} has an empty child_id")
+            if task.child_id in child_ids:
+                raise ValueError(f"Duplicate planned child_id: {task.child_id}")
+            child_ids.add(task.child_id)
+            previous_parent = group_parents.setdefault(task.parent_group, task.parent_id)
+            if previous_parent != task.parent_id:
+                raise ValueError(
+                    f"Parent group {task.parent_group} contains different parents"
+                )
+
+    def all_tasks_terminal(self) -> bool:
+        return all(task.is_terminal() for task in self.tasks)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "batch_id": self.batch_id,
+            "generation": self.generation,
+            "p": self.p,
+            "n": self.n,
+            "phase": self.phase,
+            "budget_before_dispatch": self.budget_before_dispatch,
+            "max_evaluations": self.max_evaluations,
+            "max_in_flight_evaluations": self.max_in_flight_evaluations,
+            "maximum_overshoot": self.maximum_overshoot,
+            "budget_after_apply": self.budget_after_apply,
+            "tasks": [task.to_dict() for task in self.tasks],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ProposalBatchRecord:
+        raw_phase = str(data.get("phase", "planned"))
+        if raw_phase not in _PROPOSAL_BATCH_PHASES:
+            raise ValueError(f"Invalid proposal batch phase: {raw_phase!r}")
+        raw_tasks = data.get("tasks", [])
+        if not isinstance(raw_tasks, list):
+            raise ValueError("Proposal batch tasks must be a list")
+        tasks: list[ProposalTaskRecord] = []
+        for raw_task in raw_tasks:
+            if not isinstance(raw_task, Mapping):
+                raise ValueError("Proposal batch task must be an object")
+            tasks.append(ProposalTaskRecord.from_dict(raw_task))
+        raw_after = data.get("budget_after_apply")
+        batch = cls(
+            batch_id=str(data["batch_id"]),
+            generation=int(data["generation"]),
+            p=int(data["p"]),
+            n=int(data["n"]),
+            tasks=tasks,
+            phase=cast(ProposalBatchPhase, raw_phase),
+            budget_before_dispatch=int(data.get("budget_before_dispatch", 0)),
+            max_evaluations=int(data.get("max_evaluations", 0)),
+            max_in_flight_evaluations=int(
+                data.get("max_in_flight_evaluations", 0)
+            ),
+            maximum_overshoot=int(data.get("maximum_overshoot", 0)),
+            budget_after_apply=None if raw_after is None else int(raw_after),
+        )
+        batch.validate_plan()
+        return batch
+
+
+@dataclass(frozen=True)
+class BatchDispatchDecision:
+    """Pre-dispatch budget decision and the batch's explicit overshoot bound."""
+
+    allowed: bool
+    evaluations_before: int
+    max_evaluations: int
+    max_in_flight_evaluations: int
+    maximum_overshoot: int
+
+
+@dataclass(frozen=True)
+class BatchReconciliation:
+    """Audit summary produced while terminalizing an interrupted batch."""
+
+    batch_id: str
+    reserved_child_ids: tuple[str, ...]
+    applied_child_ids: tuple[str, ...]
+    accounted_child_ids: tuple[str, ...]
+    cleaned_child_ids: tuple[str, ...]
+    missing_child_ids: tuple[str, ...]
+    cleanup_failed_child_ids: tuple[str, ...]
 
 
 class EvaluationCache:
@@ -126,11 +408,23 @@ class EvolutionState:
     # a GEPA-style single pickled artifact: HELIX still persists worktrees,
     # evaluations, lineage, and state as separate artifacts.
     resume_semantics: dict[str, Any] = field(default_factory=dict)
+    # Step 7 parallel-proposal ledger.  Every planned P*N child id remains
+    # here permanently, including skipped and interrupted slots, so resume
+    # never rewinds into an already-issued id or infers completion from only
+    # the first worker/artifact in a batch.
+    proposal_batches: list[ProposalBatchRecord] = field(default_factory=list)
+    # JSON-safe runtime scheduler checkpoint.  Kept separate from
+    # ``resume_semantics`` because it is evolving execution position, not a
+    # compatibility knob.  Legacy states default to an empty mapping.
+    scheduler_state: dict[str, Any] = field(default_factory=dict)
     # GEPA parity (audit-rng-state-persist D1): persisted schema version.
     # Mirrors GEPA core/state.py:182 / class-var :153.  Bumped when the
     # serialized schema changes; ``load_state`` migrates older payloads by
     # supplying defaults for any missing fields.
     schema_version: int = SCHEMA_VERSION
+
+
+CheckpointSaver = Callable[[EvolutionState], None]
 
 
 _STATE_FILENAME = "state.json"
@@ -150,6 +444,505 @@ def _state_path(base_dir: Path) -> Path:
 
 def _eval_cache_path(base_dir: Path) -> Path:
     return base_dir / _STATE_DIR / _EVAL_CACHE_FILENAME
+
+
+def _persist_checkpoint(
+    state: EvolutionState,
+    base_dir: Path,
+    saver: CheckpointSaver | None,
+) -> None:
+    """Persist through evolution's cache-aware wrapper when one is supplied."""
+    if saver is None:
+        save_state(state, base_dir)
+    else:
+        saver(state)
+
+
+def _to_json_safe(value: Any) -> Any:
+    """Normalize tuples/mappings into JSON-native scheduler state."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (tuple, list)):
+        return [_to_json_safe(item) for item in value]
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("Scheduler state mapping keys must be strings")
+            normalized[key] = _to_json_safe(item)
+        return normalized
+    raise TypeError(f"Scheduler state value is not JSON-safe: {type(value).__name__}")
+
+
+def encode_rng_state(rng_state: object) -> list[Any]:
+    """Encode ``random.Random.getstate()`` output for ``state.json``."""
+    normalized = _to_json_safe(rng_state)
+    if not isinstance(normalized, list):
+        raise TypeError("RNG state must be tuple/list shaped")
+    return normalized
+
+
+def _lists_to_tuples(value: Any) -> Any:
+    if isinstance(value, list):
+        return tuple(_lists_to_tuples(item) for item in value)
+    if isinstance(value, dict):
+        return {key: _lists_to_tuples(item) for key, item in value.items()}
+    return value
+
+
+def decode_rng_state(encoded: Sequence[Any]) -> tuple[Any, ...]:
+    """Reconstruct the tuple shape required by ``random.Random.setstate``."""
+    restored = _lists_to_tuples(list(encoded))
+    if not isinstance(restored, tuple):
+        raise TypeError("Encoded RNG state must restore to a tuple")
+    return restored
+
+
+def build_scheduler_checkpoint(
+    *,
+    frontier_rng_state: object,
+    sampler_rng_state: object,
+    sampler_epoch: int,
+    sampler_shuffled_ids: Sequence[Any],
+    sampler_last_trainset_size: int,
+    sampler_id_frequencies: Mapping[str, int] | None = None,
+    sampler_fallback: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the JSON-native frontier/sampler checkpoint runtime restores.
+
+    ``sampler_fallback`` can contain the inner epoch sampler's equivalent
+    fields when stratified sampling delegated to its fallback path.
+    """
+    if sampler_epoch < -1:
+        raise ValueError("sampler_epoch cannot be less than -1")
+    if sampler_last_trainset_size < 0:
+        raise ValueError("sampler_last_trainset_size cannot be negative")
+    checkpoint = {
+        "frontier_rng_state": encode_rng_state(frontier_rng_state),
+        "sampler": {
+            "rng_state": encode_rng_state(sampler_rng_state),
+            "epoch": sampler_epoch,
+            "shuffled_ids": list(sampler_shuffled_ids),
+            "last_trainset_size": sampler_last_trainset_size,
+            "id_frequencies": dict(sampler_id_frequencies or {}),
+            "fallback": dict(sampler_fallback or {}),
+        },
+    }
+    normalized = _to_json_safe(checkpoint)
+    assert isinstance(normalized, dict)
+    return normalized
+
+
+def checkpoint_scheduler_state(
+    state: EvolutionState,
+    base_dir: Path,
+    scheduler_state: Mapping[str, Any],
+    *,
+    saver: CheckpointSaver | None = None,
+) -> None:
+    """Persist current RNG/sampler position through the cache-aware saver."""
+    normalized = _to_json_safe(scheduler_state)
+    if not isinstance(normalized, dict):
+        raise TypeError("scheduler_state must be an object")
+    state.scheduler_state = normalized
+    _persist_checkpoint(state, base_dir, saver)
+
+
+def check_batch_dispatch_budget(
+    state: EvolutionState,
+    *,
+    max_evaluations: int,
+    max_in_flight_evaluations: int,
+) -> BatchDispatchDecision:
+    """Check the budget once before dispatch and state the overshoot bound.
+
+    A batch may start only while the current evaluation count is below a
+    positive cap.  Once started, every completed in-flight call is accounted,
+    even if that crosses the cap.  Consequently the permitted overshoot is
+    bounded by ``max(0, before + max_in_flight_evaluations - cap)``.  A
+    non-positive cap is unlimited and reports no finite overshoot.
+    """
+    if max_in_flight_evaluations < 0:
+        raise ValueError("max_in_flight_evaluations cannot be negative")
+    before = state.budget.evaluations
+    allowed = max_evaluations <= 0 or before < max_evaluations
+    overshoot = (
+        0
+        if max_evaluations <= 0
+        else max(0, before + max_in_flight_evaluations - max_evaluations)
+    )
+    return BatchDispatchDecision(
+        allowed=allowed,
+        evaluations_before=before,
+        max_evaluations=max_evaluations,
+        max_in_flight_evaluations=max_in_flight_evaluations,
+        maximum_overshoot=overshoot,
+    )
+
+
+def get_proposal_batch(
+    state: EvolutionState, batch_id: str
+) -> ProposalBatchRecord | None:
+    """Return one persisted batch by id, or ``None`` when it is new."""
+    return next(
+        (batch for batch in state.proposal_batches if batch.batch_id == batch_id),
+        None,
+    )
+
+
+def reserved_candidate_ids(state: EvolutionState) -> set[str]:
+    """Return frontier and planned child IDs that may never be issued again."""
+    reserved = set(state.frontier)
+    reserved.update(
+        task.child_id
+        for batch in state.proposal_batches
+        for task in batch.tasks
+    )
+    return reserved
+
+
+def _batch_plan_signature(batch: ProposalBatchRecord) -> tuple[Any, ...]:
+    return (
+        batch.batch_id,
+        batch.generation,
+        batch.p,
+        batch.n,
+        tuple(
+            (
+                task.task_index,
+                task.parent_group,
+                task.mutation_index,
+                task.parent_id,
+                task.child_id,
+            )
+            for task in batch.tasks
+        ),
+    )
+
+
+def checkpoint_batch_before_dispatch(
+    state: EvolutionState,
+    base_dir: Path,
+    batch: ProposalBatchRecord,
+    *,
+    max_evaluations: int = 0,
+    max_in_flight_evaluations: int = 0,
+    saver: CheckpointSaver | None = None,
+) -> ProposalBatchRecord:
+    """Persist a complete P*N plan before any worker is submitted.
+
+    Repeating the call with the same batch plan is idempotent.  Reusing a
+    batch id for a different plan, or any child id reserved by another batch,
+    is rejected before state is changed.
+    """
+    batch.validate_plan()
+    existing = get_proposal_batch(state, batch.batch_id)
+    if existing is not None:
+        if _batch_plan_signature(existing) != _batch_plan_signature(batch):
+            raise ValueError(f"Proposal batch id collision: {batch.batch_id}")
+        return existing
+
+    decision = check_batch_dispatch_budget(
+        state,
+        max_evaluations=max_evaluations,
+        max_in_flight_evaluations=max_in_flight_evaluations,
+    )
+    if not decision.allowed:
+        raise ValueError(
+            f"Cannot dispatch proposal batch {batch.batch_id!r}: evaluation "
+            f"budget {decision.evaluations_before}/{decision.max_evaluations} "
+            "is exhausted"
+        )
+
+    already_reserved = reserved_candidate_ids(state)
+    collisions = sorted(
+        task.child_id for task in batch.tasks if task.child_id in already_reserved
+    )
+    if collisions:
+        raise ValueError(
+            "Planned proposal child IDs are already reserved: " + ", ".join(collisions)
+        )
+
+    batch.phase = "dispatched"
+    batch.budget_before_dispatch = decision.evaluations_before
+    batch.max_evaluations = decision.max_evaluations
+    batch.max_in_flight_evaluations = decision.max_in_flight_evaluations
+    batch.maximum_overshoot = decision.maximum_overshoot
+    state.proposal_batches.append(batch)
+    _persist_checkpoint(state, base_dir, saver)
+    return batch
+
+
+_ALLOWED_TASK_TRANSITIONS: dict[ProposalTaskStatus, frozenset[ProposalTaskStatus]] = {
+    "planned": frozenset(
+        {
+            "planned",
+            "running",
+            "evaluated",
+            "skipped",
+            "failed",
+            "tampered",
+            "rejected",
+            "interrupted",
+        }
+    ),
+    "running": frozenset(
+        {
+            "running",
+            "evaluated",
+            "skipped",
+            "failed",
+            "tampered",
+            "rejected",
+            "interrupted",
+        }
+    ),
+    "evaluated": frozenset(
+        {"evaluated", "rejected", "applied", "interrupted"}
+    ),
+    "skipped": frozenset({"skipped"}),
+    "failed": frozenset({"failed"}),
+    "tampered": frozenset({"tampered"}),
+    "rejected": frozenset({"rejected"}),
+    "applied": frozenset({"applied"}),
+    "interrupted": frozenset({"interrupted"}),
+}
+
+
+def _task_by_index(batch: ProposalBatchRecord, task_index: int) -> ProposalTaskRecord:
+    if task_index < 0 or task_index >= len(batch.tasks):
+        raise IndexError(
+            f"Proposal task index {task_index} is outside batch {batch.batch_id!r}"
+        )
+    return batch.tasks[task_index]
+
+
+def checkpoint_batch_task(
+    state: EvolutionState,
+    base_dir: Path,
+    *,
+    batch_id: str,
+    task_index: int,
+    status: ProposalTaskStatus | None = None,
+    score_delta: float | None = None,
+    selection: ProposalSelectionResult | None = None,
+    cleanup: ProposalCleanupResult | None = None,
+    budget_charge: BudgetState | None = None,
+    budget_accounted: bool | None = None,
+    applied: bool | None = None,
+    detail: str | None = None,
+    expected_status: ProposalTaskStatus | None = None,
+    saver: CheckpointSaver | None = None,
+) -> ProposalTaskRecord:
+    """Atomically checkpoint one ordered result/apply transition.
+
+    Evolution remains the authoritative charger: it first calls the relevant
+    source-tagged ``budget_api.charge_*`` helper, then passes the already-
+    computed delta here with ``budget_accounted=True``.  This function never
+    mutates the global budget.  Retrying an identical accounted marker is a
+    no-op; retrying with a different charge is rejected.
+    """
+    batch = get_proposal_batch(state, batch_id)
+    if batch is None:
+        raise KeyError(f"Unknown proposal batch: {batch_id}")
+    task = _task_by_index(batch, task_index)
+    if expected_status is not None and task.status != expected_status:
+        raise ValueError(
+            f"Proposal task {batch_id}/{task_index} is {task.status!r}; "
+            f"expected {expected_status!r}"
+        )
+    next_status = task.status if status is None else status
+    if next_status not in _ALLOWED_TASK_TRANSITIONS[task.status]:
+        raise ValueError(
+            f"Invalid proposal task transition: {task.status!r} -> {next_status!r}"
+        )
+    if applied is True and next_status != "applied":
+        raise ValueError("A task can be marked applied only with status='applied'")
+    if next_status == "applied" and selection not in (None, "selected"):
+        raise ValueError("An applied proposal task must have selection='selected'")
+
+    if budget_charge is not None:
+        if task.budget_accounted and task.budget_charge != budget_charge:
+            raise ValueError(
+                f"Proposal task {batch_id}/{task_index} was already charged "
+                "with a different budget delta"
+            )
+        task.budget_charge = budget_charge
+    if budget_accounted is False and task.budget_accounted:
+        raise ValueError(
+            f"Proposal task {batch_id}/{task_index} is already budget-accounted"
+        )
+    if budget_accounted is True:
+        task.budget_accounted = True
+
+    task.status = next_status
+    if score_delta is not None:
+        task.score_delta = score_delta
+    if selection is not None:
+        task.selection = selection
+    if cleanup is not None:
+        task.cleanup = cleanup
+    if applied is not None:
+        task.applied = applied
+    if next_status == "applied":
+        task.selection = "selected"
+        task.cleanup = "not_required" if cleanup is None else cleanup
+        task.applied = True
+    elif next_status in {"skipped", "failed", "tampered"} and selection is None:
+        task.selection = "not_applicable"
+    elif next_status == "rejected" and selection is None:
+        task.selection = "not_selected"
+    if detail is not None:
+        task.detail = detail
+    if batch.phase == "dispatched" and next_status not in {"planned", "running"}:
+        batch.phase = "applying"
+    _persist_checkpoint(state, base_dir, saver)
+    return task
+
+
+def checkpoint_batch_after_apply(
+    state: EvolutionState,
+    base_dir: Path,
+    *,
+    batch_id: str,
+    saver: CheckpointSaver | None = None,
+) -> ProposalBatchRecord:
+    """Persist the post-apply barrier after every planned slot is terminal."""
+    batch = get_proposal_batch(state, batch_id)
+    if batch is None:
+        raise KeyError(f"Unknown proposal batch: {batch_id}")
+    nonterminal = [task.task_index for task in batch.tasks if not task.is_terminal()]
+    if nonterminal:
+        raise ValueError(
+            f"Cannot complete proposal batch {batch_id!r}; nonterminal slots: "
+            + ", ".join(str(index) for index in nonterminal)
+        )
+    cleanup_failed = [
+        task.task_index for task in batch.tasks if task.cleanup == "failed"
+    ]
+    if cleanup_failed:
+        raise ValueError(
+            f"Cannot complete proposal batch {batch_id!r}; cleanup failed for slots: "
+            + ", ".join(str(index) for index in cleanup_failed)
+        )
+    actual_in_flight = state.budget.evaluations - batch.budget_before_dispatch
+    if actual_in_flight < 0:
+        raise ValueError(
+            f"Proposal batch {batch_id!r} ended below its pre-dispatch budget"
+        )
+    if (
+        batch.max_in_flight_evaluations > 0
+        and actual_in_flight > batch.max_in_flight_evaluations
+    ):
+        raise ValueError(
+            f"Proposal batch {batch_id!r} accounted {actual_in_flight} evaluations; "
+            f"declared in-flight bound is {batch.max_in_flight_evaluations}"
+        )
+    actual_overshoot = (
+        0
+        if batch.max_evaluations <= 0
+        else max(0, state.budget.evaluations - batch.max_evaluations)
+    )
+    if actual_overshoot > batch.maximum_overshoot:
+        raise ValueError(
+            f"Proposal batch {batch_id!r} overshot by {actual_overshoot}; "
+            f"checkpoint bound is {batch.maximum_overshoot}"
+        )
+    batch.phase = "complete"
+    batch.budget_after_apply = state.budget.evaluations
+    _persist_checkpoint(state, base_dir, saver)
+    return batch
+
+
+def reconcile_interrupted_batches(
+    state: EvolutionState,
+    base_dir: Path,
+    *,
+    worktrees_dir: Path,
+    cleanup_worktree: Callable[[str, Path], bool],
+    saver: CheckpointSaver | None = None,
+) -> list[BatchReconciliation]:
+    """Terminalize every slot in every interrupted persisted batch.
+
+    Applied/frontier children are preserved and marked applied, preventing a
+    second frontier insertion.  Every other planned worktree is passed to the
+    caller's Git-aware cleanup callback.  Budget facts are never changed:
+    already-accounted completed work remains charged, while unaccounted work
+    is not guessed at.  All child IDs remain reserved through the ledger.
+    """
+    reconciled: list[BatchReconciliation] = []
+    changed = False
+    for batch in state.proposal_batches:
+        retry_failed_cleanup = any(
+            task.cleanup == "failed" and not task.applied for task in batch.tasks
+        )
+        if batch.phase == "complete" or (
+            batch.phase == "interrupted" and not retry_failed_cleanup
+        ):
+            continue
+        reserved_ids: list[str] = []
+        applied_ids: list[str] = []
+        accounted_ids: list[str] = []
+        cleaned_ids: list[str] = []
+        missing_ids: list[str] = []
+        failed_ids: list[str] = []
+        for task in batch.tasks:
+            reserved_ids.append(task.child_id)
+            if task.budget_accounted:
+                accounted_ids.append(task.child_id)
+
+            if task.applied or task.status == "applied" or task.child_id in state.frontier:
+                task.status = "applied"
+                task.selection = "selected"
+                task.cleanup = "not_required"
+                task.applied = True
+                applied_ids.append(task.child_id)
+                continue
+
+            worktree_path = worktrees_dir / task.child_id
+            if not worktree_path.exists() and task.cleanup in {"removed", "missing"}:
+                if task.cleanup == "removed":
+                    cleaned_ids.append(task.child_id)
+                else:
+                    missing_ids.append(task.child_id)
+                continue
+            if worktree_path.exists():
+                try:
+                    removed = cleanup_worktree(task.child_id, worktree_path)
+                except Exception as exc:
+                    removed = False
+                    task.detail = f"Interrupted-batch cleanup failed: {exc}"
+                if removed and not worktree_path.exists():
+                    task.cleanup = "removed"
+                    cleaned_ids.append(task.child_id)
+                else:
+                    task.cleanup = "failed"
+                    failed_ids.append(task.child_id)
+            else:
+                task.cleanup = "missing"
+                missing_ids.append(task.child_id)
+            task.status = "interrupted"
+            if task.selection == "pending":
+                task.selection = "not_applicable"
+            task.applied = False
+
+        batch.phase = "interrupted"
+        batch.budget_after_apply = state.budget.evaluations
+        reconciled.append(
+            BatchReconciliation(
+                batch_id=batch.batch_id,
+                reserved_child_ids=tuple(reserved_ids),
+                applied_child_ids=tuple(applied_ids),
+                accounted_child_ids=tuple(accounted_ids),
+                cleaned_child_ids=tuple(cleaned_ids),
+                missing_child_ids=tuple(missing_ids),
+                cleanup_failed_child_ids=tuple(failed_ids),
+            )
+        )
+        changed = True
+    if changed:
+        _persist_checkpoint(state, base_dir, saver)
+    return reconciled
 
 
 def save_state(state: EvolutionState, base_dir: Path) -> None:
@@ -177,6 +970,8 @@ def save_state(state: EvolutionState, base_dir: Path) -> None:
         "active_frontier": state.active_frontier,
         "frontier_type": state.frontier_type,
         "resume_semantics": state.resume_semantics,
+        "proposal_batches": [batch.to_dict() for batch in state.proposal_batches],
+        "scheduler_state": _to_json_safe(state.scheduler_state),
     }
 
     # Atomic write: write to tmp file in same directory, then rename
@@ -214,17 +1009,23 @@ def load_state(base_dir: Path) -> EvolutionState | None:
             f"version {SCHEMA_VERSION}; upgrade HELIX or use a different run dir."
         )
 
-    budget_data = data.get("budget", {})
-    budget = BudgetState(
-        evaluations=budget_data.get("evaluations", 0),
-        input_tokens=budget_data.get("input_tokens", 0),
-        output_tokens=budget_data.get("output_tokens", 0),
-        cached_input_tokens=budget_data.get("cached_input_tokens", 0),
-        cache_creation_input_tokens=budget_data.get("cache_creation_input_tokens", 0),
-        cache_read_input_tokens=budget_data.get("cache_read_input_tokens", 0),
-        reasoning_tokens=budget_data.get("reasoning_tokens", 0),
-        cost_usd=budget_data.get("cost_usd", 0.0),
-    )
+    raw_budget = data.get("budget", {})
+    budget_data = raw_budget if isinstance(raw_budget, Mapping) else {}
+    budget = _budget_state_from_mapping(budget_data)
+
+    raw_batches = data.get("proposal_batches", [])
+    if not isinstance(raw_batches, list):
+        raise ValueError("state.json proposal_batches must be a list")
+    proposal_batches: list[ProposalBatchRecord] = []
+    for raw_batch in raw_batches:
+        if not isinstance(raw_batch, Mapping):
+            raise ValueError("state.json proposal batch must be an object")
+        proposal_batches.append(ProposalBatchRecord.from_dict(raw_batch))
+    raw_scheduler_state = data.get("scheduler_state", {})
+    if not isinstance(raw_scheduler_state, Mapping):
+        raise ValueError("state.json scheduler_state must be an object")
+    normalized_scheduler_state = _to_json_safe(raw_scheduler_state)
+    assert isinstance(normalized_scheduler_state, dict)
 
     # Migrate legacy frontier_type: default to "instance" (HELIX's
     # historical single-axis behaviour) for states written before the
@@ -253,6 +1054,8 @@ def load_state(base_dir: Path) -> EvolutionState | None:
         active_frontier=data.get("active_frontier", {}),
         frontier_type=frontier_type,
         resume_semantics=data.get("resume_semantics", {}),
+        proposal_batches=proposal_batches,
+        scheduler_state=normalized_scheduler_state,
         schema_version=SCHEMA_VERSION,
     )
 

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -113,11 +113,12 @@ def _budget_state_from_mapping(data: Mapping[str, Any]) -> BudgetState:
 class ProposalTaskRecord:
     """Durable state for one parent-major P-by-N proposal slot.
 
-    ``budget_accounted`` and ``applied`` are explicit crash barriers.  A
-    resumed run can therefore distinguish completed evaluator work from work
-    that still needs charging, and a selected result from one already inserted
-    into the frontier.  Candidate IDs remain reserved even when the task is
-    interrupted or cleaned up.
+    ``budget_charge`` is a monotonic runtime journal and may advance while the
+    task is still running; ``budget_accounted`` closes that journal as an
+    explicit crash barrier.  A resumed run can therefore conserve completed
+    evaluator work before terminal accounting, and ``applied`` distinguishes a
+    selected result from one already inserted into the frontier.  Candidate IDs
+    remain reserved even when the task is interrupted or cleaned up.
     """
 
     batch_id: str
@@ -759,9 +760,10 @@ def checkpoint_batch_task(
 ) -> ProposalTaskRecord:
     """Atomically checkpoint one ordered result/apply transition.
 
-    Evolution remains the authoritative charger: it first calls the relevant
-    source-tagged ``budget_api.charge_*`` helper, then passes the already-
-    computed delta here with ``budget_accounted=True``.  This function never
+    Evolution remains the authoritative charger: it journals drained runtime
+    results into ``budget_charge`` before a sibling checkpoint can expose their
+    cache entries, then passes the computed delta here with
+    ``budget_accounted=True`` at the terminal barrier.  This function never
     mutates the global budget.  Retrying an identical accounted marker is a
     no-op; retrying with a different charge is rejected.
     """

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -33,6 +33,7 @@ class BudgetState:
     examples evaluated; single-task/no-example paths add 0/1
     (cached=0, uncached evaluator call=1 because no per-example ids exist).
     """
+
     evaluations: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
@@ -60,7 +61,9 @@ ProposalSelectionResult = Literal[
 ProposalCleanupResult = Literal[
     "pending", "not_required", "removed", "missing", "failed"
 ]
-ProposalBatchPhase = Literal["planned", "dispatched", "applying", "complete", "interrupted"]
+ProposalBatchPhase = Literal[
+    "planned", "dispatched", "applying", "complete", "interrupted"
+]
 
 TERMINAL_PROPOSAL_STATUSES: frozenset[ProposalTaskStatus] = frozenset(
     {"skipped", "failed", "tampered", "rejected", "applied", "interrupted"}
@@ -249,7 +252,9 @@ class ProposalBatchRecord:
             if task.child_id in child_ids:
                 raise ValueError(f"Duplicate planned child_id: {task.child_id}")
             child_ids.add(task.child_id)
-            previous_parent = group_parents.setdefault(task.parent_group, task.parent_id)
+            previous_parent = group_parents.setdefault(
+                task.parent_group, task.parent_id
+            )
             if previous_parent != task.parent_id:
                 raise ValueError(
                     f"Parent group {task.parent_group} contains different parents"
@@ -310,9 +315,7 @@ class ProposalBatchRecord:
                 else None
             ),
             max_evaluations=int(data.get("max_evaluations", 0)),
-            max_in_flight_evaluations=int(
-                data.get("max_in_flight_evaluations", 0)
-            ),
+            max_in_flight_evaluations=int(data.get("max_in_flight_evaluations", 0)),
             maximum_overshoot=int(data.get("maximum_overshoot", 0)),
             budget_after_apply=None if raw_after is None else int(raw_after),
         )
@@ -374,9 +377,12 @@ class EvolutionState:
     Tracks current generation, Pareto frontier, scores, budgets, and
     operation counters. Serialized to .helix/state.json for resumption.
     """
+
     generation: int
     frontier: list[str]
-    instance_scores: dict[str, Any]  # dict[str, dict[str, float]] — candidate_id -> instance -> score
+    instance_scores: dict[
+        str, Any
+    ]  # dict[str, dict[str, float]] — candidate_id -> instance -> score
     budget: BudgetState
     config_hash: str
     mutation_counter: int = 0
@@ -614,9 +620,7 @@ def reserved_candidate_ids(state: EvolutionState) -> set[str]:
     """Return frontier and planned child IDs that may never be issued again."""
     reserved = set(state.frontier)
     reserved.update(
-        task.child_id
-        for batch in state.proposal_batches
-        for task in batch.tasks
+        task.child_id for batch in state.proposal_batches for task in batch.tasks
     )
     return reserved
 
@@ -718,9 +722,7 @@ _ALLOWED_TASK_TRANSITIONS: dict[ProposalTaskStatus, frozenset[ProposalTaskStatus
             "interrupted",
         }
     ),
-    "evaluated": frozenset(
-        {"evaluated", "rejected", "applied", "interrupted"}
-    ),
+    "evaluated": frozenset({"evaluated", "rejected", "applied", "interrupted"}),
     "skipped": frozenset({"skipped"}),
     "failed": frozenset({"failed"}),
     "tampered": frozenset({"tampered"}),
@@ -846,9 +848,7 @@ def checkpoint_batch_after_apply(
             f"Cannot complete proposal batch {batch_id!r}; cleanup failed for slots: "
             + ", ".join(str(index) for index in cleanup_failed)
         )
-    unaccounted = [
-        task.task_index for task in batch.tasks if not task.budget_accounted
-    ]
+    unaccounted = [task.task_index for task in batch.tasks if not task.budget_accounted]
     if unaccounted:
         raise ValueError(
             f"Cannot complete proposal batch {batch_id!r}; unaccounted slots: "
@@ -874,9 +874,7 @@ def checkpoint_batch_after_apply(
         raise ValueError(
             f"Proposal batch {batch_id!r} ended below its pre-dispatch budget"
         )
-    recorded_in_flight = sum(
-        task.budget_charge.evaluations for task in batch.tasks
-    )
+    recorded_in_flight = sum(task.budget_charge.evaluations for task in batch.tasks)
     if recorded_in_flight != actual_in_flight:
         raise ValueError(
             f"Proposal batch {batch_id!r} recorded {recorded_in_flight} "
@@ -900,7 +898,7 @@ def checkpoint_batch_after_apply(
         raise ValueError(
             f"Proposal batch {batch_id!r} overshot by {actual_overshoot}; "
             f"checkpoint bound is {batch.maximum_overshoot}"
-    )
+        )
     batch.phase = "complete"
     batch.budget_after_apply = evaluations_at_end
     _persist_checkpoint(state, base_dir, saver)
@@ -953,7 +951,11 @@ def reconcile_interrupted_batches(
         for task in batch.tasks:
             reserved_ids.append(task.child_id)
 
-            if task.applied or task.status == "applied" or task.child_id in state.frontier:
+            if (
+                task.applied
+                or task.status == "applied"
+                or task.child_id in state.frontier
+            ):
                 task.status = "applied"
                 task.selection = "selected"
                 task.cleanup = "not_required"
@@ -1040,8 +1042,7 @@ def reconcile_interrupted_batches(
                     durable_total = getattr(durable_end, field_name)
                     baseline = getattr(before, field_name)
                     recorded = sum(
-                        getattr(task.budget_charge, field_name)
-                        for task in batch.tasks
+                        getattr(task.budget_charge, field_name) for task in batch.tasks
                     )
                     residual = durable_total - baseline - recorded
                     tolerance = 1e-12 if field_name == "cost_usd" else 0
@@ -1051,7 +1052,9 @@ def reconcile_interrupted_batches(
                             f"over-recorded {field_name}: baseline={baseline}, "
                             f"recorded={recorded}, durable_total={durable_total}"
                         )
-                    residuals[field_name] = 0 if abs(residual) <= tolerance else residual
+                    residuals[field_name] = (
+                        0 if abs(residual) <= tolerance else residual
+                    )
 
                 residual_task = unaccounted[0]
                 for field_name, residual in residuals.items():

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -114,9 +114,10 @@ class ProposalTaskRecord:
     """Durable state for one parent-major P-by-N proposal slot.
 
     ``budget_charge`` is a monotonic runtime journal and may advance while the
-    task is still running; ``budget_accounted`` closes that journal as an
-    explicit crash barrier.  A resumed run can therefore conserve completed
-    evaluator work before terminal accounting, and ``applied`` distinguishes a
+    task is still running, including evaluator work whose outcome is a failure;
+    ``budget_accounted`` closes that journal as an explicit crash barrier.  A
+    resumed run can therefore conserve attempted evaluator work before terminal
+    accounting without charging it again, and ``applied`` distinguishes a
     selected result from one already inserted into the frontier.  Candidate IDs
     remain reserved even when the task is interrupted or cleaned up.
     """

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -825,10 +825,27 @@ def checkpoint_batch_after_apply(
             f"Cannot complete proposal batch {batch_id!r}; cleanup failed for slots: "
             + ", ".join(str(index) for index in cleanup_failed)
         )
+    unaccounted = [
+        task.task_index for task in batch.tasks if not task.budget_accounted
+    ]
+    if unaccounted:
+        raise ValueError(
+            f"Cannot complete proposal batch {batch_id!r}; unaccounted slots: "
+            + ", ".join(str(index) for index in unaccounted)
+        )
     actual_in_flight = state.budget.evaluations - batch.budget_before_dispatch
     if actual_in_flight < 0:
         raise ValueError(
             f"Proposal batch {batch_id!r} ended below its pre-dispatch budget"
+        )
+    recorded_in_flight = sum(
+        task.budget_charge.evaluations for task in batch.tasks
+    )
+    if recorded_in_flight != actual_in_flight:
+        raise ValueError(
+            f"Proposal batch {batch_id!r} recorded {recorded_in_flight} "
+            f"evaluation(s) across its tasks, but the global budget advanced "
+            f"by {actual_in_flight}"
         )
     if (
         batch.max_in_flight_evaluations > 0

--- a/src/helix/trace.py
+++ b/src/helix/trace.py
@@ -17,7 +17,10 @@ import inspect
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
+
+if TYPE_CHECKING:
+    from helix.state import ProposalBatchRecord
 
 
 class EventType(str, Enum):
@@ -33,6 +36,9 @@ class EventType(str, Enum):
     ITER_END = "ITER_END"
     OPT_END = "OPT_END"
     BUDGET_UPDATE = "BUDGET_UPDATE"
+    PROPOSAL_BATCH_START = "PROPOSAL_BATCH_START"
+    PROPOSAL_TASK_TERMINAL = "PROPOSAL_TASK_TERMINAL"
+    PROPOSAL_BATCH_END = "PROPOSAL_BATCH_END"
 
 
 @dataclass
@@ -62,6 +68,18 @@ class Event:
     cost_usd: float | None = None
     generation: int | None = None
     proposal_index: int | None = None
+    batch_id: str | None = None
+    p: int | None = None
+    n: int | None = None
+    task_index: int | None = None
+    parent_group: int | None = None
+    mutation_index: int | None = None
+    parent_id: str | None = None
+    child_id: str | None = None
+    status: str | None = None
+    score_delta: float | None = None
+    selection: str | None = None
+    cleanup: str | None = None
     mutation_counter: int | None = None
     merge_counter: int | None = None
     merge_invocations: int | None = None
@@ -83,6 +101,58 @@ class TraceBus:
         frame = inspect.stack()[1]
         source = f"{frame.filename}:{frame.lineno}"
         self.events.append(Event(type=type, source=source, **fields))
+
+    def emit_proposal_batch_terminal(self, batch: ProposalBatchRecord) -> None:
+        """Emit one ordered terminal event for every planned P*N slot.
+
+        A partial batch is rejected instead of producing a misleading trace.
+        Consumers can rely on the interval between ``PROPOSAL_BATCH_START``
+        and ``PROPOSAL_BATCH_END`` containing exactly ``P*N`` terminal task
+        events in parent-major order.
+        """
+        if not self.enabled:
+            return
+        batch.validate_plan()
+        nonterminal = [task.task_index for task in batch.tasks if not task.is_terminal()]
+        if nonterminal:
+            raise ValueError(
+                f"Cannot trace proposal batch {batch.batch_id!r}; nonterminal slots: "
+                + ", ".join(str(index) for index in nonterminal)
+            )
+        self.emit(
+            EventType.PROPOSAL_BATCH_START,
+            batch_id=batch.batch_id,
+            p=batch.p,
+            n=batch.n,
+            generation=batch.generation,
+        )
+        for task in batch.tasks:
+            self.emit(
+                EventType.PROPOSAL_TASK_TERMINAL,
+                batch_id=task.batch_id,
+                p=task.p,
+                n=task.n,
+                task_index=task.task_index,
+                proposal_index=task.task_index,
+                parent_group=task.parent_group,
+                mutation_index=task.mutation_index,
+                parent_id=task.parent_id,
+                candidate_id=task.child_id,
+                child_id=task.child_id,
+                status=task.status,
+                score_delta=task.score_delta,
+                selection=task.selection,
+                cleanup=task.cleanup,
+                generation=batch.generation,
+            )
+        self.emit(
+            EventType.PROPOSAL_BATCH_END,
+            batch_id=batch.batch_id,
+            p=batch.p,
+            n=batch.n,
+            generation=batch.generation,
+            decision=batch.phase,
+        )
 
     @contextmanager
     def record(self) -> Iterator[list[Event]]:

--- a/src/helix/trace.py
+++ b/src/helix/trace.py
@@ -11,6 +11,7 @@ Event points are sprinkled throughout ``evolution.py``, ``eval_cache.py``,
 differential harness consumes these events to assert runtime parity against
 the GEPA reference engine.
 """
+
 from __future__ import annotations
 
 import inspect
@@ -113,7 +114,9 @@ class TraceBus:
         if not self.enabled:
             return
         batch.validate_plan()
-        nonterminal = [task.task_index for task in batch.tasks if not task.is_terminal()]
+        nonterminal = [
+            task.task_index for task in batch.tasks if not task.is_terminal()
+        ]
         if nonterminal:
             raise ValueError(
                 f"Cannot trace proposal batch {batch.batch_id!r}; nonterminal slots: "

--- a/src/helix/worktree.py
+++ b/src/helix/worktree.py
@@ -249,6 +249,7 @@ def _warn_uncommitted_changes(repo_root: Path) -> None:
     if result.returncode == 0 and result.stdout.strip():
         # Local import avoids any circular-import risk at module load time.
         from helix.display import console  # noqa: PLC0415
+
         console.print(
             f"[yellow]⚠️  You have uncommitted changes in {repo_root}. "
             f"HELIX will snapshot the current working tree into the seed "
@@ -305,7 +306,9 @@ def _snapshot_dirty_working_tree(repo_root: Path, worktree_path: Path) -> bool:
         check=True,
         capture_output=True,
     )
-    for raw_path in untracked_proc.stdout.decode("utf-8", errors="surrogateescape").split("\x00"):
+    for raw_path in untracked_proc.stdout.decode(
+        "utf-8", errors="surrogateescape"
+    ).split("\x00"):
         if not raw_path:
             continue
         rel_path = Path(raw_path)
@@ -394,7 +397,13 @@ def create_empty_seed_worktree(repo_root: Path, base_dir: Path) -> Candidate:
         )
         # Create an empty initial commit so HEAD is valid.
         _run(
-            ["git", "commit", "--allow-empty", "-m", "helix: empty seed (seedless mode)"],
+            [
+                "git",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "helix: empty seed (seedless mode)",
+            ],
             cwd=repo_root,
             operation="git commit --allow-empty (seedless)",
             env={**os.environ, **helix_git_env()},

--- a/src/helix/worktree.py
+++ b/src/helix/worktree.py
@@ -9,10 +9,17 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 
 from helix.exceptions import GitError, HelixError, print_helix_error
 from helix.population import Candidate
+
+
+# ``git worktree`` mutates common-repository metadata even when each candidate
+# has a distinct path and branch. Proposal workers share this process, so keep
+# prune/add/remove/branch-delete transactions from interleaving.
+_worktree_metadata_lock = threading.RLock()
 
 
 # ---------------------------------------------------------------------------
@@ -393,26 +400,26 @@ def create_empty_seed_worktree(repo_root: Path, base_dir: Path) -> Candidate:
             env={**os.environ, **helix_git_env()},
         )
 
-    # Prune stale worktree registrations before creating new ones.
-    subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
-
     seed_id = "g0-s0"
     worktree_path = base_dir / seed_id
     base_dir.mkdir(parents=True, exist_ok=True)
 
-    try:
-        _run(
-            ["git", "worktree", "add", str(worktree_path), "--detach", "HEAD"],
-            cwd=repo_root,
-            operation=f"create empty seed worktree at {worktree_path}",
-        )
-    except GitError as exc:
-        exc.suggestion = (
-            f"Could not create empty seed worktree at {worktree_path}. "
-            f"Try: git worktree prune && rm -rf {worktree_path}, then retry."
-        )
-        print_helix_error(exc)
-        raise
+    with _worktree_metadata_lock:
+        # Prune and add are one common-metadata transaction.
+        subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
+        try:
+            _run(
+                ["git", "worktree", "add", str(worktree_path), "--detach", "HEAD"],
+                cwd=repo_root,
+                operation=f"create empty seed worktree at {worktree_path}",
+            )
+        except GitError as exc:
+            exc.suggestion = (
+                f"Could not create empty seed worktree at {worktree_path}. "
+                f"Try: git worktree prune && rm -rf {worktree_path}, then retry."
+            )
+            print_helix_error(exc)
+            raise
 
     return Candidate(
         id=seed_id,
@@ -452,28 +459,28 @@ def create_seed_worktree(repo_root: Path, base_dir: Path) -> Candidate:
     # Fix 6: Abort early if stale helix/* branches exist from a previous run.
     _check_no_stale_helix_branches(repo_root)
 
-    # Prune stale worktree registrations before creating new ones
-    subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
-
     seed_id = "g0-s0"
     worktree_path = base_dir / seed_id
     base_dir.mkdir(parents=True, exist_ok=True)
 
-    try:
-        _run(
-            ["git", "worktree", "add", str(worktree_path), "--detach", "HEAD"],
-            cwd=repo_root,
-            operation=f"create seed worktree at {worktree_path}",
-        )
-    except GitError as exc:
-        exc.suggestion = (
-            f"Could not create seed worktree at {worktree_path}. "
-            f"Try: git worktree prune && rm -rf {worktree_path}, then retry. "
-            f"If the path already exists as a worktree, also try: "
-            f"git worktree remove --force {worktree_path}"
-        )
-        print_helix_error(exc)
-        raise
+    with _worktree_metadata_lock:
+        # Prune and add are one common-metadata transaction.
+        subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
+        try:
+            _run(
+                ["git", "worktree", "add", str(worktree_path), "--detach", "HEAD"],
+                cwd=repo_root,
+                operation=f"create seed worktree at {worktree_path}",
+            )
+        except GitError as exc:
+            exc.suggestion = (
+                f"Could not create seed worktree at {worktree_path}. "
+                f"Try: git worktree prune && rm -rf {worktree_path}, then retry. "
+                f"If the path already exists as a worktree, also try: "
+                f"git worktree remove --force {worktree_path}"
+            )
+            print_helix_error(exc)
+            raise
 
     candidate = Candidate(
         id=seed_id,
@@ -537,32 +544,35 @@ def clone_candidate(parent: Candidate, new_id: str, base_dir: Path) -> Candidate
     )
     commit_sha = head_result.stdout.strip()
 
-    # Prune stale worktree registrations (safe — only removes metadata for missing paths)
-    subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
-
-    try:
-        _run(
-            [
-                "git", "worktree", "add",
-                str(new_worktree_path),
-                "-b", new_branch,
-                commit_sha,
-            ],
-            cwd=repo_root,
-            operation=f"clone candidate {parent.id} -> {new_id}",
-        )
-    except GitError as exc:
-        exc.suggestion = (
-            f"Could not create worktree for {new_id} (branch {new_branch}). "
-            f"If a stale branch exists, try: git branch -D {new_branch} && "
-            f"git worktree prune. "
-            f"If the worktree path already exists, try: "
-            f"git worktree remove --force {new_worktree_path} && "
-            f"git worktree prune. "
-            f"Then retry the evolution."
-        )
-        print_helix_error(exc)
-        raise
+    with _worktree_metadata_lock:
+        # Prune and add are one common-metadata transaction.
+        subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
+        try:
+            _run(
+                [
+                    "git",
+                    "worktree",
+                    "add",
+                    str(new_worktree_path),
+                    "-b",
+                    new_branch,
+                    commit_sha,
+                ],
+                cwd=repo_root,
+                operation=f"clone candidate {parent.id} -> {new_id}",
+            )
+        except GitError as exc:
+            exc.suggestion = (
+                f"Could not create worktree for {new_id} (branch {new_branch}). "
+                f"If a stale branch exists, try: git branch -D {new_branch} && "
+                f"git worktree prune. "
+                f"If the worktree path already exists, try: "
+                f"git worktree remove --force {new_worktree_path} && "
+                f"git worktree prune. "
+                f"Then retry the evolution."
+            )
+            print_helix_error(exc)
+            raise
 
     # Parse generation from new_id (format: g<gen>-s<slot>)
     try:
@@ -659,20 +669,21 @@ def remove_worktree(candidate: Candidate) -> None:
     else:
         repo_root = wt
 
-    _run(
-        ["git", "worktree", "remove", "--force", str(wt)],
-        cwd=repo_root,
-        operation=f"remove worktree {candidate.id}",
-    )
+    with _worktree_metadata_lock:
+        _run(
+            ["git", "worktree", "remove", "--force", str(wt)],
+            cwd=repo_root,
+            operation=f"remove worktree {candidate.id}",
+        )
 
-    # Delete the tracking branch; ignore errors (branch may not exist)
-    branch = f"helix/{candidate.id}"
-    _run(
-        ["git", "branch", "-D", branch],
-        cwd=repo_root,
-        check=False,
-        operation=f"delete branch {branch}",
-    )
+        # Delete the tracking branch; ignore errors (branch may not exist).
+        branch = f"helix/{candidate.id}"
+        _run(
+            ["git", "branch", "-D", branch],
+            cwd=repo_root,
+            check=False,
+            operation=f"delete branch {branch}",
+        )
 
 
 def get_diff(candidate_a: Candidate, candidate_b: Candidate) -> str:

--- a/tests/integration/parallel-sandbox.Dockerfile
+++ b/tests/integration/parallel-sandbox.Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.22
+
+RUN addgroup -g 1000 node && adduser -D -u 1000 -G node node
+
+USER node
+WORKDIR /workspace

--- a/tests/integration/test_parallel_sandbox.py
+++ b/tests/integration/test_parallel_sandbox.py
@@ -1,0 +1,167 @@
+"""Daemon-backed proof of parallel proposal sandbox isolation."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import queue
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import helix.sandbox as sandbox_module
+from helix.config import SandboxConfig
+from helix.sandbox import run_sandboxed_command
+
+
+pytestmark = pytest.mark.docker_integration
+
+_FIXTURE_IMAGE = "helix-runner-base:latest"
+
+
+def _docker(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", *args],
+        check=check,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def _require_local_docker_fixture() -> None:
+    try:
+        daemon = _docker("info")
+        image = _docker("image", "inspect", _FIXTURE_IMAGE)
+    except (OSError, subprocess.SubprocessError) as exc:
+        pytest.skip(f"Docker daemon unavailable: {exc}")
+    if daemon.returncode != 0:
+        pytest.skip(f"Docker daemon unavailable: {daemon.stderr.strip()}")
+    if image.returncode != 0:
+        pytest.skip(f"local fixture image {_FIXTURE_IMAGE!r} is not installed")
+
+
+def _wait_until_running(container_names: list[str]) -> None:
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        status = _docker(
+            "inspect",
+            "--format",
+            "{{.State.Running}}",
+            *container_names,
+        )
+        if status.returncode == 0 and status.stdout.splitlines() == ["true", "true"]:
+            return
+    raise AssertionError(
+        "parallel sandbox containers did not become simultaneously active: "
+        + ", ".join(container_names)
+    )
+
+
+def test_parallel_sandboxes_overlap_isolate_state_and_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _require_local_docker_fixture()
+    candidates = [tmp_path / "candidate-a", tmp_path / "candidate-b"]
+    for candidate in candidates:
+        candidate.mkdir()
+
+    starts = threading.Barrier(3)
+    observed: queue.Queue[tuple[str, Path, list[str]]] = queue.Queue()
+    original_docker_args = sandbox_module._docker_args
+
+    def record_docker_args(*args: Any, **kwargs: Any) -> list[str]:
+        docker_args = original_docker_args(*args, **kwargs)
+        name = docker_args[docker_args.index("--name") + 1]
+        mount = docker_args[docker_args.index("-v") + 1]
+        workspace = Path(mount.removesuffix(":/workspace:rw"))
+        observed.put((name, workspace, docker_args))
+        return docker_args
+
+    monkeypatch.setattr(sandbox_module, "_docker_args", record_docker_args)
+    command = [
+        "sh",
+        "-c",
+        (
+            'mkdir -p "$XDG_DATA_HOME/opencode"; '
+            'printf "%s\\n" "$PROPOSAL_ID" > "$XDG_DATA_HOME/opencode/owner"; '
+            'printf "%s\\n" "$PROPOSAL_ID" > /workspace/result.txt; '
+            "while [ ! -e /workspace/release ]; do sleep 0.05; done"
+        ),
+    ]
+
+    def run_proposal(index: int) -> subprocess.CompletedProcess[str]:
+        starts.wait(timeout=10)
+        return run_sandboxed_command(
+            command,
+            cwd=candidates[index],
+            env={
+                "PROPOSAL_ID": f"candidate-{index}",
+                "XDG_DATA_HOME": "/workspace/.helix_opencode_state",
+            },
+            sandbox=SandboxConfig(
+                enabled=True,
+                image=_FIXTURE_IMAGE,
+                network="none",
+                timeout_seconds=30,
+            ),
+            scope="agent",
+            sync_back=True,
+            image=_FIXTURE_IMAGE,
+            agent_backend="opencode",
+        )
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+    futures = [pool.submit(run_proposal, index) for index in range(2)]
+    container_names: list[str] = []
+    workspaces: list[Path] = []
+    docker_runs: list[list[str]] = []
+    try:
+        starts.wait(timeout=10)
+        for _ in range(2):
+            name, workspace, docker_args = observed.get(timeout=15)
+            container_names.append(name)
+            workspaces.append(workspace)
+            docker_runs.append(docker_args)
+
+        assert len(set(container_names)) == 2
+        assert len(set(workspaces)) == 2
+        assert all("--rm" in args for args in docker_runs)
+        assert all(
+            "XDG_DATA_HOME=/workspace/.helix_opencode_state" in args
+            for args in docker_runs
+        )
+        assert all(
+            any(item.endswith(":/workspace:rw") for item in args)
+            for args in docker_runs
+        )
+
+        _wait_until_running(container_names)
+        owners = [
+            _docker(
+                "exec",
+                name,
+                "sh",
+                "-c",
+                'cat "$XDG_DATA_HOME/opencode/owner"',
+                check=True,
+            ).stdout.strip()
+            for name in container_names
+        ]
+        assert set(owners) == {"candidate-0", "candidate-1"}
+    finally:
+        for name in container_names:
+            _docker("exec", name, "touch", "/workspace/release")
+        for future in futures:
+            future.result(timeout=20)
+        pool.shutdown(wait=True)
+        for name in container_names:
+            _docker("rm", "-f", name)
+
+    assert (candidates[0] / "result.txt").read_text() == "candidate-0\n"
+    assert (candidates[1] / "result.txt").read_text() == "candidate-1\n"
+    assert all(not workspace.parent.exists() for workspace in workspaces)
+    assert all(_docker("inspect", name).returncode != 0 for name in container_names)

--- a/tests/integration/test_parallel_sandbox.py
+++ b/tests/integration/test_parallel_sandbox.py
@@ -169,3 +169,71 @@ def test_parallel_sandboxes_overlap_isolate_state_and_cleanup(
     assert (candidates[1] / "result.txt").read_text() == "candidate-1\n"
     assert all(not workspace.parent.exists() for workspace in workspaces)
     assert all(_docker("inspect", name).returncode != 0 for name in container_names)
+
+
+@pytest.mark.parametrize(
+    ("command", "timeout_seconds", "expected_returncode"),
+    [
+        (["sh", "-c", "exit 7"], 10, 7),
+        (["sh", "-c", "sleep 5"], 1, None),
+    ],
+    ids=["nonzero-exit", "timeout"],
+)
+def test_sandbox_failure_paths_remove_container_and_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: list[str],
+    timeout_seconds: int,
+    expected_returncode: int | None,
+) -> None:
+    """Daemon-backed failures leave neither containers nor temp workspaces."""
+    _require_local_docker_fixture()
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+
+    observed: list[tuple[str, Path]] = []
+    original_docker_args = sandbox_module._docker_args
+
+    def record_docker_args(*args: Any, **kwargs: Any) -> list[str]:
+        docker_args = original_docker_args(*args, **kwargs)
+        name = docker_args[docker_args.index("--name") + 1]
+        mount = docker_args[docker_args.index("-v") + 1]
+        workspace = Path(mount.removesuffix(":/workspace:rw"))
+        observed.append((name, workspace))
+        return docker_args
+
+    monkeypatch.setattr(sandbox_module, "_docker_args", record_docker_args)
+    sandbox = SandboxConfig(
+        enabled=True,
+        image=_FIXTURE_IMAGE,
+        network="none",
+        timeout_seconds=timeout_seconds,
+    )
+
+    if expected_returncode is None:
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_sandboxed_command(
+                command,
+                cwd=candidate,
+                env={},
+                sandbox=sandbox,
+                scope="evaluator",
+                sync_back=True,
+                image=_FIXTURE_IMAGE,
+            )
+    else:
+        result = run_sandboxed_command(
+            command,
+            cwd=candidate,
+            env={},
+            sandbox=sandbox,
+            scope="evaluator",
+            sync_back=True,
+            image=_FIXTURE_IMAGE,
+        )
+        assert result.returncode == expected_returncode
+
+    assert len(observed) == 1
+    container_name, workspace = observed[0]
+    assert not workspace.parent.exists()
+    assert _docker("inspect", container_name).returncode != 0

--- a/tests/integration/test_parallel_sandbox.py
+++ b/tests/integration/test_parallel_sandbox.py
@@ -20,9 +20,7 @@ from helix.sandbox import run_sandboxed_command
 
 pytestmark = pytest.mark.docker_integration
 
-_FIXTURE_IMAGE = os.environ.get(
-    "HELIX_DOCKER_TEST_IMAGE", "helix-runner-base:latest"
-)
+_FIXTURE_IMAGE = os.environ.get("HELIX_DOCKER_TEST_IMAGE", "helix-runner-base:latest")
 
 
 def _docker(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:

--- a/tests/integration/test_parallel_sandbox.py
+++ b/tests/integration/test_parallel_sandbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import os
 import queue
 import subprocess
 import threading
@@ -19,7 +20,9 @@ from helix.sandbox import run_sandboxed_command
 
 pytestmark = pytest.mark.docker_integration
 
-_FIXTURE_IMAGE = "helix-runner-base:latest"
+_FIXTURE_IMAGE = os.environ.get(
+    "HELIX_DOCKER_TEST_IMAGE", "helix-runner-base:latest"
+)
 
 
 def _docker(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
@@ -55,6 +58,7 @@ def _wait_until_running(container_names: list[str]) -> None:
         )
         if status.returncode == 0 and status.stdout.splitlines() == ["true", "true"]:
             return
+        time.sleep(0.05)
     raise AssertionError(
         "parallel sandbox containers did not become simultaneously active: "
         + ", ".join(container_names)

--- a/tests/unit/test_align_iteration.py
+++ b/tests/unit/test_align_iteration.py
@@ -19,6 +19,7 @@ Covers three audit findings:
 All tests run with ``val_stage_size=None`` (default) to exercise the
 GEPA-parity configuration specified in the task directive.
 """
+
 from __future__ import annotations
 
 from helix.evolution import run_evolution
@@ -46,7 +47,10 @@ class TestPerfectScoreContinues:
     """
 
     def test_perfect_score_does_not_terminate_run(
-        self, mocker, tmp_path, all_mocks  # noqa: F811
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,  # noqa: F811
     ):
         seed = make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
@@ -82,7 +86,10 @@ class TestPerfectScoreContinues:
         all_mocks["mutate"].assert_not_called()
 
     def test_perfect_score_uses_per_example_all_not_mean(
-        self, mocker, tmp_path, all_mocks  # noqa: F811
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,  # noqa: F811
     ):
         """GEPA parity (M1) — audit-init-engine.md B2.
 
@@ -101,14 +108,10 @@ class TestPerfectScoreContinues:
             if candidate.id == "g1-s1":
                 # Child is irrelevant to the M1 criterion; we just need it
                 # to pass gating so the run completes cleanly.
-                return make_eval_result(
-                    "g1-s1", {"i1": 0.6, "i2": 1.0, "i3": 1.0}
-                )
+                return make_eval_result("g1-s1", {"i1": 0.6, "i2": 1.0, "i3": 1.0})
             # Parent seed: mean = 0.833 >= 0.8 (old check fires) but
             # min = 0.5 < 0.8 (GEPA all() check does NOT fire).
-            return make_eval_result(
-                candidate.id, {"i1": 0.5, "i2": 1.0, "i3": 1.0}
-            )
+            return make_eval_result(candidate.id, {"i1": 0.5, "i2": 1.0, "i3": 1.0})
 
         all_mocks["run_evaluator"].side_effect = run_eval
 
@@ -141,7 +144,10 @@ class TestMergeFallthroughToMutation:
     """
 
     def test_merge_op_failure_falls_through_to_mutation(
-        self, mocker, tmp_path, all_mocks  # noqa: F811
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,  # noqa: F811
     ):
         """``merge()`` returns None (Claude Code / subprocess failure) →
         no merged candidate instantiated → no eval → GEPA falls through
@@ -162,7 +168,9 @@ class TestMergeFallthroughToMutation:
         # to calling ``merge(...)``.  But merge(...) returns None, so
         # no merged candidate is created and no eval runs.
         all_mocks["find_merge_triplet"].return_value = (
-            "g0-s0", "g1-s1", "g0-s0",
+            "g0-s0",
+            "g1-s1",
+            "g0-s0",
         )
         all_mocks["merge"].return_value = None
 
@@ -202,7 +210,10 @@ class TestMergeFallthroughToMutation:
         all_mocks["merge"].assert_called_once()
 
     def test_merge_actually_attempted_still_consumes_iteration(
-        self, mocker, tmp_path, all_mocks  # noqa: F811
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,  # noqa: F811
     ):
         """Guard rail: when a merge IS attempted (eval runs), the iteration
         is still consumed (GEPA engine.py:719 on accept, 737 on reject).
@@ -215,12 +226,12 @@ class TestMergeFallthroughToMutation:
         merged = make_candidate("g2-m1", generation=2)
         children = iter([child])
         all_mocks["create_seed_worktree"].return_value = seed
-        all_mocks["mutate"].side_effect = lambda *a, **kw: next(
-            children, None
-        )
+        all_mocks["mutate"].side_effect = lambda *a, **kw: next(children, None)
         all_mocks["merge"].return_value = merged
         all_mocks["find_merge_triplet"].return_value = (
-            "g0-s0", "g1-s1", "g0-s0",
+            "g0-s0",
+            "g1-s1",
+            "g0-s0",
         )
 
         def run_eval(candidate, config, split=None, instance_ids=None, **kwargs):
@@ -274,7 +285,11 @@ class TestLegacyGatingUsesSumOnly:
     """
 
     def test_degrades_is_not_called_in_legacy_path(
-        self, mocker, tmp_path, all_mocks, monkeypatch  # noqa: F811
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,
+        monkeypatch,  # noqa: F811
     ):
         from helix import evolution as _evo
 
@@ -314,7 +329,10 @@ class TestLegacyGatingUsesSumOnly:
         )
 
     def test_legacy_accepts_strict_improvement(
-        self, mocker, tmp_path, all_mocks  # noqa: F811
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,  # noqa: F811
     ):
         """GEPA sum-score acceptance requires strict improvement only.
         A child with parent_sum=0.5 child_sum=0.55 must be accepted.

--- a/tests/unit/test_align_iteration.py
+++ b/tests/unit/test_align_iteration.py
@@ -288,8 +288,8 @@ class TestLegacyGatingUsesSumOnly:
         self,
         mocker,
         tmp_path,
-        all_mocks,
-        monkeypatch,  # noqa: F811
+        all_mocks,  # noqa: F811
+        monkeypatch,
     ):
         from helix import evolution as _evo
 

--- a/tests/unit/test_align_iteration.py
+++ b/tests/unit/test_align_iteration.py
@@ -152,12 +152,10 @@ class TestMergeFallthroughToMutation:
         ``if triplet is not None`` nesting), consuming the iteration.
         """
         seed = make_candidate("g0-s0")
-        child1 = make_candidate("g1-s1", generation=1)
-        child2 = make_candidate("g2-s1", generation=2)
         all_mocks["create_seed_worktree"].return_value = seed
-        children = iter([child1, child2])
-        all_mocks["mutate"].side_effect = lambda *a, **kw: next(
-            children, None
+        all_mocks["mutate"].side_effect = lambda *a, **kw: make_candidate(
+            kw["new_id"],
+            generation=int(kw["new_id"].split("-", 1)[0][1:]),
         )
 
         # A valid triplet is returned, so the merge attempt proceeds

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -200,6 +200,263 @@ class TestEvolutionConfigNewFields:
 
 
 # ---------------------------------------------------------------------------
+# Unified P*N proposal scheduler: mutations_per_parent (N), proposal_selection,
+# proposal_top_k, and the effective P*N validation (Step 1 of the parallel
+# proposals plan).
+# ---------------------------------------------------------------------------
+
+
+class TestProposalSchedulerFields:
+    def test_defaults_are_k_by_1(self):
+        """Omitting the new fields is exactly the K-by-1 case: P defaults to 1,
+        N defaults to 1, and selection defaults to all_improvements."""
+        cfg = EvolutionConfig()
+        assert cfg.num_parallel_proposals == 1  # P
+        assert cfg.mutations_per_parent == 1  # N
+        assert cfg.proposal_selection == "all_improvements"
+        assert cfg.proposal_top_k is None
+
+    def test_omitted_n_matches_explicit_n_one(self):
+        """An existing K-slot run (N omitted) is identical to an explicit
+        N=1 K-by-1 configuration for every existing K value."""
+        for k in (1, 2, 4, 8):
+            omitted = EvolutionConfig(num_parallel_proposals=k)
+            explicit = EvolutionConfig(
+                num_parallel_proposals=k, mutations_per_parent=1
+            )
+            assert omitted.num_parallel_proposals == k
+            assert omitted.mutations_per_parent == 1
+            assert (
+                omitted.model_dump() == explicit.model_dump()
+            ), f"omitted vs explicit N=1 diverged for K={k}"
+
+    def test_override_pn_fields(self):
+        cfg = EvolutionConfig(
+            num_parallel_proposals=2,
+            mutations_per_parent=3,
+            proposal_selection="top_k",
+            proposal_top_k=4,
+        )
+        assert cfg.num_parallel_proposals == 2
+        assert cfg.mutations_per_parent == 3
+        assert cfg.proposal_selection == "top_k"
+        assert cfg.proposal_top_k == 4
+
+    # -- mutations_per_parent (N) bounds ----------------------------------
+
+    def test_mutations_per_parent_default_is_one(self):
+        assert EvolutionConfig().mutations_per_parent == 1
+
+    @pytest.mark.parametrize("n", [0, -1, -5])
+    def test_mutations_per_parent_rejects_non_positive(self, n):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(mutations_per_parent=n)
+
+    def test_mutations_per_parent_accepts_large(self):
+        assert EvolutionConfig(mutations_per_parent=16).mutations_per_parent == 16
+
+    # -- num_parallel_proposals (P) bounds --------------------------------
+
+    @pytest.mark.parametrize("p", [0, -1, -3])
+    def test_num_parallel_proposals_rejects_non_positive(self, p):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(num_parallel_proposals=p)
+
+    def test_num_parallel_proposals_accepts_one(self):
+        assert EvolutionConfig(num_parallel_proposals=1).num_parallel_proposals == 1
+
+    # -- max_workers bounds ------------------------------------------------
+
+    @pytest.mark.parametrize("w", [0, -1, -32])
+    def test_max_workers_rejects_non_positive(self, w):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(max_workers=w)
+
+    def test_max_workers_accepts_one(self):
+        assert EvolutionConfig(max_workers=1).max_workers == 1
+
+    # -- proposal_selection ------------------------------------------------
+
+    def test_proposal_selection_default(self):
+        assert EvolutionConfig().proposal_selection == "all_improvements"
+
+    @pytest.mark.parametrize(
+        "strategy", ["all_improvements", "best_improvement", "top_k"]
+    )
+    def test_proposal_selection_accepts_supported(self, strategy):
+        kwargs = {"proposal_selection": strategy}
+        if strategy == "top_k":
+            kwargs["proposal_top_k"] = 1
+        cfg = EvolutionConfig(**kwargs)
+        assert cfg.proposal_selection == strategy
+
+    def test_proposal_selection_rejects_unknown(self):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(proposal_selection="pareto")  # type: ignore[arg-type]
+
+    # -- proposal_top_k: required only / valid only for top_k -------------
+
+    def test_top_k_required_for_top_k_selection(self):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(proposal_selection="top_k")
+
+    def test_top_k_rejected_for_all_improvements(self):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(
+                proposal_selection="all_improvements", proposal_top_k=1
+            )
+
+    def test_top_k_rejected_for_best_improvement(self):
+        with pytest.raises(ValidationError):
+            EvolutionConfig(
+                proposal_selection="best_improvement", proposal_top_k=1
+            )
+
+    def test_top_k_none_ok_for_non_top_k_modes(self):
+        assert (
+            EvolutionConfig(proposal_selection="best_improvement").proposal_top_k
+            is None
+        )
+
+    # -- proposal_top_k: within 1..P*N ------------------------------------
+
+    def test_top_k_within_effective_pn(self):
+        # P=2, N=3 => P*N = 6; top_k in 1..6 accepted.
+        for k in range(1, 7):
+            cfg = EvolutionConfig(
+                num_parallel_proposals=2,
+                mutations_per_parent=3,
+                proposal_selection="top_k",
+                proposal_top_k=k,
+            )
+            assert cfg.proposal_top_k == k
+
+    def test_top_k_rejects_zero_and_negative(self):
+        for k in (0, -1):
+            with pytest.raises(ValidationError):
+                EvolutionConfig(
+                    num_parallel_proposals=2,
+                    mutations_per_parent=3,
+                    proposal_selection="top_k",
+                    proposal_top_k=k,
+                )
+
+    def test_top_k_rejects_above_pn(self):
+        # P=2, N=3 => P*N = 6; top_k=7 exceeds the effective width.
+        with pytest.raises(ValidationError):
+            EvolutionConfig(
+                num_parallel_proposals=2,
+                mutations_per_parent=3,
+                proposal_selection="top_k",
+                proposal_top_k=7,
+            )
+
+    def test_top_k_equals_pn_upper_bound_ok(self):
+        cfg = EvolutionConfig(
+            num_parallel_proposals=4,
+            mutations_per_parent=1,
+            proposal_selection="top_k",
+            proposal_top_k=4,
+        )
+        assert cfg.proposal_top_k == 4
+
+    def test_top_k_uses_resolved_auto_p_for_bound(self):
+        # "auto" with max_workers=9, minibatch_size=3 => P=3; N=2 => P*N=6.
+        cfg = EvolutionConfig(
+            num_parallel_proposals="auto",
+            max_workers=9,
+            minibatch_size=3,
+            mutations_per_parent=2,
+            proposal_selection="top_k",
+            proposal_top_k=6,
+        )
+        assert cfg.num_parallel_proposals == 3
+        assert cfg.proposal_top_k == 6
+        # 7 would exceed the resolved P*N of 6.
+        with pytest.raises(ValidationError):
+            EvolutionConfig(
+                num_parallel_proposals="auto",
+                max_workers=9,
+                minibatch_size=3,
+                mutations_per_parent=2,
+                proposal_selection="top_k",
+                proposal_top_k=7,
+            )
+
+    # -- TOML round trips --------------------------------------------------
+
+    def test_toml_loads_pn_fields(self, tmp_path):
+        toml = tmp_path / "helix.toml"
+        toml.write_text(
+            textwrap.dedent("""
+            objective = "P by N"
+
+            [evaluator]
+            command = "pytest"
+
+            [evolution]
+            num_parallel_proposals = 2
+            mutations_per_parent = 2
+            proposal_selection = "top_k"
+            proposal_top_k = 3
+        """)
+        )
+        cfg = load_config(toml)
+        assert cfg.evolution.num_parallel_proposals == 2
+        assert cfg.evolution.mutations_per_parent == 2
+        assert cfg.evolution.proposal_selection == "top_k"
+        assert cfg.evolution.proposal_top_k == 3
+
+    def test_toml_defaults_when_omitted(self, tmp_path):
+        toml = tmp_path / "helix.toml"
+        toml.write_text(
+            textwrap.dedent("""
+            objective = "Defaults"
+
+            [evaluator]
+            command = "pytest"
+        """)
+        )
+        cfg = load_config(toml)
+        assert cfg.evolution.num_parallel_proposals == 1
+        assert cfg.evolution.mutations_per_parent == 1
+        assert cfg.evolution.proposal_selection == "all_improvements"
+        assert cfg.evolution.proposal_top_k is None
+
+    def test_toml_invalid_top_k_combo_rejected_at_load(self, tmp_path):
+        toml = tmp_path / "helix.toml"
+        toml.write_text(
+            textwrap.dedent("""
+            objective = "Bad top_k"
+
+            [evaluator]
+            command = "pytest"
+
+            [evolution]
+            num_parallel_proposals = 1
+            mutations_per_parent = 1
+            proposal_selection = "top_k"
+            proposal_top_k = 5
+        """)
+        )
+        with pytest.raises(SystemExit):
+            load_config(toml)
+
+    def test_model_dump_roundtrip_pn_fields(self):
+        cfg = EvolutionConfig(
+            num_parallel_proposals=2,
+            mutations_per_parent=3,
+            proposal_selection="top_k",
+            proposal_top_k=5,
+        )
+        restored = EvolutionConfig.model_validate(cfg.model_dump())
+        assert restored.num_parallel_proposals == 2
+        assert restored.mutations_per_parent == 3
+        assert restored.proposal_selection == "top_k"
+        assert restored.proposal_top_k == 5
+
+
+# ---------------------------------------------------------------------------
 # evolution.frontier_type — GEPA multi-axis Pareto dimensionality
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -221,14 +221,12 @@ class TestProposalSchedulerFields:
         N=1 K-by-1 configuration for every existing K value."""
         for k in (1, 2, 4, 8):
             omitted = EvolutionConfig(num_parallel_proposals=k)
-            explicit = EvolutionConfig(
-                num_parallel_proposals=k, mutations_per_parent=1
-            )
+            explicit = EvolutionConfig(num_parallel_proposals=k, mutations_per_parent=1)
             assert omitted.num_parallel_proposals == k
             assert omitted.mutations_per_parent == 1
-            assert (
-                omitted.model_dump() == explicit.model_dump()
-            ), f"omitted vs explicit N=1 diverged for K={k}"
+            assert omitted.model_dump() == explicit.model_dump(), (
+                f"omitted vs explicit N=1 diverged for K={k}"
+            )
 
     def test_override_pn_fields(self):
         cfg = EvolutionConfig(
@@ -302,15 +300,11 @@ class TestProposalSchedulerFields:
 
     def test_top_k_rejected_for_all_improvements(self):
         with pytest.raises(ValidationError):
-            EvolutionConfig(
-                proposal_selection="all_improvements", proposal_top_k=1
-            )
+            EvolutionConfig(proposal_selection="all_improvements", proposal_top_k=1)
 
     def test_top_k_rejected_for_best_improvement(self):
         with pytest.raises(ValidationError):
-            EvolutionConfig(
-                proposal_selection="best_improvement", proposal_top_k=1
-            )
+            EvolutionConfig(proposal_selection="best_improvement", proposal_top_k=1)
 
     def test_top_k_none_ok_for_non_top_k_modes(self):
         assert (

--- a/tests/unit/test_display.py
+++ b/tests/unit/test_display.py
@@ -161,7 +161,9 @@ class TestUsageStatsSerialization:
         assert restored.input_tokens == original.input_tokens
         assert restored.output_tokens == original.output_tokens
         assert restored.cached_input_tokens == original.cached_input_tokens
-        assert restored.cache_creation_input_tokens == original.cache_creation_input_tokens
+        assert (
+            restored.cache_creation_input_tokens == original.cache_creation_input_tokens
+        )
         assert restored.cache_read_input_tokens == original.cache_read_input_tokens
         assert restored.reasoning_tokens == original.reasoning_tokens
         assert restored.num_turns == original.num_turns
@@ -213,9 +215,9 @@ class TestUsageStatsSerialization:
         """from_dict must coerce int/float defensively."""
         stats = UsageStats.from_dict(
             {
-                "input_tokens": "11",   # str → int
-                "cost_usd": "0.31",     # str → float
-                "output_tokens": 7.9,   # float → int (truncates)
+                "input_tokens": "11",  # str → int
+                "cost_usd": "0.31",  # str → float
+                "output_tokens": 7.9,  # float → int (truncates)
             }
         )
         assert stats.input_tokens == 11
@@ -340,9 +342,7 @@ def test_trace_emits_exactly_one_terminal_event_per_batch_slot() -> None:
         TRACE.emit_proposal_batch_terminal(batch)
 
     terminal_events = [
-        event
-        for event in events
-        if event.type is EventType.PROPOSAL_TASK_TERMINAL
+        event for event in events if event.type is EventType.PROPOSAL_TASK_TERMINAL
     ]
     assert len(terminal_events) == batch.p * batch.n
     assert [event.task_index for event in terminal_events] == [0, 1, 2, 3]

--- a/tests/unit/test_display.py
+++ b/tests/unit/test_display.py
@@ -5,9 +5,51 @@ from __future__ import annotations
 import json
 
 import pytest
+from rich.console import Console
 
-from helix.display import UsageStats
+from helix.display import UsageStats, render_proposal_batch_table
 from helix.population import Candidate, CandidateSummary, EvalResult
+from helix.state import ProposalBatchRecord, ProposalTaskRecord
+from helix.trace import TRACE, EventType
+
+
+def _terminal_batch() -> ProposalBatchRecord:
+    batch_id = "g2-b0"
+    tasks = [
+        ProposalTaskRecord(
+            batch_id=batch_id,
+            p=2,
+            n=2,
+            task_index=index,
+            parent_group=index // 2,
+            mutation_index=index % 2,
+            parent_id="parent-a" if index < 2 else "parent-b",
+            child_id=f"child-{index}",
+        )
+        for index in range(4)
+    ]
+    terminal = [
+        ("applied", "selected", "not_required", 0.25, True),
+        ("rejected", "not_selected", "removed", -0.1, False),
+        ("failed", "not_applicable", "missing", None, False),
+        ("interrupted", "not_applicable", "failed", None, False),
+    ]
+    for task, (status, selection, cleanup, delta, applied) in zip(
+        tasks, terminal, strict=True
+    ):
+        task.status = status  # type: ignore[assignment]
+        task.selection = selection  # type: ignore[assignment]
+        task.cleanup = cleanup  # type: ignore[assignment]
+        task.score_delta = delta
+        task.applied = applied
+    return ProposalBatchRecord(
+        batch_id=batch_id,
+        generation=2,
+        p=2,
+        n=2,
+        tasks=tasks,
+        phase="interrupted",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -261,3 +303,64 @@ class TestCandidateSummaryJsonSerialization:
             "CandidateSummary.to_dict() must call .to_dict() on usage; "
             f"got {type(d['usage'])!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# P-by-N proposal observability
+# ---------------------------------------------------------------------------
+
+
+def test_batch_table_renders_every_terminal_slot_in_parent_major_order() -> None:
+    batch = _terminal_batch()
+    table = render_proposal_batch_table(batch)
+    render_console = Console(record=True, width=140)
+    render_console.print(table)
+    rendered = render_console.export_text()
+
+    assert "2×2, 4 slots" in rendered
+    positions = [rendered.index(f"child-{index}") for index in range(4)]
+    assert positions == sorted(positions)
+    for status in ("applied", "rejected", "failed", "interrupted"):
+        assert status in rendered
+    for cleanup in ("not_required", "removed", "missing"):
+        assert cleanup in rendered
+
+
+def test_completed_batch_table_rejects_nonterminal_slot() -> None:
+    batch = _terminal_batch()
+    batch.tasks[2].status = "running"
+    batch.tasks[2].cleanup = "pending"
+    with pytest.raises(ValueError, match="nonterminal slots: 2"):
+        render_proposal_batch_table(batch)
+
+
+def test_trace_emits_exactly_one_terminal_event_per_batch_slot() -> None:
+    batch = _terminal_batch()
+    with TRACE.record() as events:
+        TRACE.emit_proposal_batch_terminal(batch)
+
+    terminal_events = [
+        event
+        for event in events
+        if event.type is EventType.PROPOSAL_TASK_TERMINAL
+    ]
+    assert len(terminal_events) == batch.p * batch.n
+    assert [event.task_index for event in terminal_events] == [0, 1, 2, 3]
+    assert [event.child_id for event in terminal_events] == [
+        "child-0",
+        "child-1",
+        "child-2",
+        "child-3",
+    ]
+    assert all(event.status is not None for event in terminal_events)
+    assert events[0].type is EventType.PROPOSAL_BATCH_START
+    assert events[-1].type is EventType.PROPOSAL_BATCH_END
+
+
+def test_trace_rejects_partial_batch_instead_of_omitting_slot() -> None:
+    batch = _terminal_batch()
+    batch.tasks[3].status = "evaluated"
+    batch.tasks[3].cleanup = "pending"
+    with TRACE.record():
+        with pytest.raises(ValueError, match="nonterminal slots: 3"):
+            TRACE.emit_proposal_batch_terminal(batch)

--- a/tests/unit/test_eval_cache.py
+++ b/tests/unit/test_eval_cache.py
@@ -1,8 +1,11 @@
 """Unit tests for helix.eval_cache."""
 from __future__ import annotations
 
+import dataclasses
 
-from helix.eval_cache import EvaluationCache, _candidate_hash
+import pytest
+
+from helix.eval_cache import EvaluationBatchKey, EvaluationCache, _candidate_hash
 
 
 def test_get_put_round_trip() -> None:
@@ -179,3 +182,88 @@ def test_cache_isolation_by_candidate() -> None:
     cached, uncached = cache.get_batch(b, [1])
     assert cached == {}
     assert uncached == [1]
+
+
+# ---------------------------------------------------------------------------
+# Cardinality validation — must reject before any cache mutation
+# ---------------------------------------------------------------------------
+
+
+def test_put_batch_rejects_short_outputs_before_mutation() -> None:
+    cache: EvaluationCache[str, int] = EvaluationCache()
+    cand = {"k": "v"}
+    with pytest.raises(ValueError, match="cardinality mismatch"):
+        cache.put_batch(cand, [1, 2, 3], ["a", "b"], [0.1, 0.2, 0.3])
+    # No partial writes: the whole put was rejected up front.
+    assert cache.get(cand, 1) is None
+    assert cache.get(cand, 2) is None
+    assert cache.get(cand, 3) is None
+
+
+def test_put_batch_rejects_objective_and_side_info_mismatch() -> None:
+    cache: EvaluationCache[str, int] = EvaluationCache()
+    cand = {"k": "v"}
+    with pytest.raises(ValueError, match="objective_scores"):
+        cache.put_batch(cand, [1, 2], ["a", "b"], [0.1, 0.2], [{"m": 1.0}])
+    with pytest.raises(ValueError, match="side_info"):
+        cache.put_batch(cand, [1, 2], ["a", "b"], [0.1, 0.2], None, [{"log": "x"}])
+    assert cache.get(cand, 1) is None
+    assert cache.get(cand, 2) is None
+
+
+def test_evaluate_with_cache_full_rejects_bad_cardinality_before_mutation() -> None:
+    cache: EvaluationCache[str, int] = EvaluationCache()
+    cand = {"k": "v"}
+
+    def fetcher(ids: list[int]) -> list[int]:
+        return list(ids)
+
+    def evaluator(
+        batch: list[int], _c: dict[str, str]
+    ) -> tuple[
+        list[str],
+        list[float],
+        list[dict[str, float]] | None,
+        list[dict[str, str]] | None,
+    ]:
+        # Two outputs but only one score for a two-id request → mismatch.
+        return ["o1", "o2"], [0.1], None, None
+
+    with pytest.raises(ValueError, match="cardinality mismatch"):
+        cache.evaluate_with_cache_full(cand, [1, 2], fetcher, evaluator)
+
+    # The evaluator ran but its bad payload never reached the cache.
+    assert cache.get(cand, 1) is None
+    assert cache.get(cand, 2) is None
+
+
+# ---------------------------------------------------------------------------
+# EvaluationBatchKey — cross-candidate dedup identity
+# ---------------------------------------------------------------------------
+
+
+def test_evaluation_batch_key_equality_and_hash() -> None:
+    a = EvaluationBatchKey("K", "val", ("1", "2"))
+    b = EvaluationBatchKey("K", "val", ("1", "2"))
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a in {b}
+
+
+def test_evaluation_batch_key_instance_id_order_is_significant() -> None:
+    a = EvaluationBatchKey("K", "val", ("1", "2"))
+    b = EvaluationBatchKey("K", "val", ("2", "1"))
+    assert a != b
+
+
+def test_evaluation_batch_key_content_split_and_none_distinguish() -> None:
+    base = EvaluationBatchKey("K", "val", ("1",))
+    assert base != EvaluationBatchKey("J", "val", ("1",))  # content_key
+    assert base != EvaluationBatchKey("K", "train", ("1",))  # split
+    assert base != EvaluationBatchKey("K", "val", None)  # whole-split vs minibatch
+
+
+def test_evaluation_batch_key_is_frozen() -> None:
+    key = EvaluationBatchKey("K", "val", None)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        key.split = "train"  # type: ignore[misc]

--- a/tests/unit/test_eval_cache.py
+++ b/tests/unit/test_eval_cache.py
@@ -1,7 +1,11 @@
 """Unit tests for helix.eval_cache."""
+
 from __future__ import annotations
 
 import dataclasses
+import threading
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -100,8 +104,8 @@ def test_evaluate_with_cache_full_calls_evaluator_only_for_uncached() -> None:
         side_info = [{"feedback": f"log{eid}"} for eid in batch]
         return outs, scores, obj, side_info
 
-    outputs, scores, obj_by_id, side_info_by_id, n_uncached = cache.evaluate_with_cache_full(
-        cand, [1, 2, 3], fetcher, evaluator
+    outputs, scores, obj_by_id, side_info_by_id, n_uncached = (
+        cache.evaluate_with_cache_full(cand, [1, 2, 3], fetcher, evaluator)
     )
 
     assert calls == [[2, 3]]
@@ -156,6 +160,136 @@ def test_evaluate_with_cache_full_second_call_fully_cached() -> None:
         2: {"feedback": "log2"},
         3: {"feedback": "log3"},
     }
+
+
+def test_overlapping_concurrent_batches_compute_each_cache_key_once() -> None:
+    """Overlapping keys single-flight while independent misses stay parallel."""
+
+    cache: EvaluationCache[str, int] = EvaluationCache()
+    candidate = {"content_key": "same-tree", "split": "train"}
+    start = threading.Barrier(2)
+    evaluators_running = threading.Barrier(2)
+    calls_lock = threading.Lock()
+    calls: list[list[int]] = []
+
+    def fetcher(ids: list[int]) -> list[int]:
+        return list(ids)
+
+    def evaluator(
+        batch: list[int], _candidate: dict[str, str]
+    ) -> tuple[list[str], list[float], None, None]:
+        with calls_lock:
+            calls.append(list(batch))
+        # Both batches retain an independent miss, so keyed coordination must
+        # let both evaluators enter concurrently.  A global compute lock would
+        # time out here instead of satisfying the barrier.
+        evaluators_running.wait(timeout=5)
+        return [f"out-{eid}" for eid in batch], [eid / 10 for eid in batch], None, None
+
+    def evaluate(ids: list[int]) -> tuple[dict[int, str], dict[int, float], int]:
+        start.wait(timeout=5)
+        outputs, scores, _, _, n_uncached = cache.evaluate_with_cache_full(
+            candidate,
+            ids,
+            fetcher,
+            evaluator,
+        )
+        return outputs, scores, n_uncached
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(evaluate, [1, 2])
+        second = pool.submit(evaluate, [2, 3])
+        results = [first.result(timeout=10), second.result(timeout=10)]
+
+    assert results[0][:2] == (
+        {1: "out-1", 2: "out-2"},
+        {1: 0.1, 2: 0.2},
+    )
+    assert results[1][:2] == (
+        {2: "out-2", 3: "out-3"},
+        {2: 0.2, 3: 0.3},
+    )
+    assert sorted(result[2] for result in results) == [1, 2]
+    assert sum(result[2] for result in results) == 3
+    assert Counter(eid for batch in calls for eid in batch) == Counter(
+        {1: 1, 2: 1, 3: 1}
+    )
+    assert cache._in_flight == {}
+
+
+def test_failed_singleflight_owner_wakes_waiter_for_retry() -> None:
+    """An owner failure releases its key; a blocked waiter retries it."""
+
+    cache: EvaluationCache[str, int] = EvaluationCache()
+    candidate = {"content_key": "same-tree", "split": "train"}
+    owner_started = threading.Event()
+    release_owner = threading.Event()
+    waiter_is_waiting = threading.Event()
+    attempts_lock = threading.Lock()
+    attempts = 0
+
+    def fetcher(ids: list[int]) -> list[int]:
+        return list(ids)
+
+    def evaluator(
+        batch: list[int], _candidate: dict[str, str]
+    ) -> tuple[list[str], list[float], None, None]:
+        nonlocal attempts
+        with attempts_lock:
+            attempts += 1
+            attempt = attempts
+        if attempt == 1:
+            owner_started.set()
+            assert release_owner.wait(timeout=5)
+            raise RuntimeError("transient evaluator failure")
+        return [f"out-{eid}" for eid in batch], [eid / 10 for eid in batch], None, None
+
+    def evaluate() -> tuple[dict[int, str], dict[int, float], int]:
+        outputs, scores, _, _, n_uncached = cache.evaluate_with_cache_full(
+            candidate,
+            [7],
+            fetcher,
+            evaluator,
+        )
+        return outputs, scores, n_uncached
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        owner = pool.submit(evaluate)
+        assert owner_started.wait(timeout=5)
+
+        # Instrument the concrete per-key event so the test deterministically
+        # observes the second call blocked as a waiter before failing the owner.
+        with cache._lock:
+            (flight,) = cache._in_flight.values()
+        original_wait = flight.wait
+
+        def observed_wait(timeout: float | None = None) -> bool:
+            waiter_is_waiting.set()
+            return original_wait(timeout)
+
+        setattr(flight, "wait", observed_wait)
+        waiter = pool.submit(evaluate)
+        assert waiter_is_waiting.wait(timeout=5)
+        release_owner.set()
+
+        with pytest.raises(RuntimeError, match="transient evaluator failure"):
+            owner.result(timeout=5)
+        outputs, scores, n_uncached = waiter.result(timeout=5)
+
+    assert (outputs, scores, n_uncached) == ({7: "out-7"}, {7: 0.7}, 1)
+    assert attempts == 2
+    assert cache._in_flight == {}
+
+    # The successful retry populated the normal cache; no poison marker or
+    # stale coordination entry can force another evaluation.
+    outputs, scores, _, _, n_uncached = cache.evaluate_with_cache_full(
+        candidate,
+        [7],
+        fetcher,
+        evaluator,
+    )
+    assert (outputs, scores, n_uncached) == ({7: "out-7"}, {7: 0.7}, 0)
+    assert attempts == 2
 
 
 def test_candidate_hash_order_independent() -> None:

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -647,10 +647,10 @@ class TestGatingInEvolutionLoop:
         seed (which loses on every axis) is dominated.
         """
         seed = make_candidate("g0-s0")
-        child_a = make_candidate("g1-s1", generation=1)
-        child_b = make_candidate("g2-s1", generation=2)
         all_mocks["create_seed_worktree"].return_value = seed
-        all_mocks["mutate"].side_effect = [child_a, child_b]
+        all_mocks["mutate"].side_effect = lambda **kwargs: make_candidate(
+            kwargs["new_id"], generation=int(kwargs["new_id"].split("-")[0][1:])
+        )
 
         def run_eval(candidate, config, split=None, instances=None, **kwargs):
             # Each child wins on a different instance key; child_b's sum
@@ -659,7 +659,7 @@ class TestGatingInEvolutionLoop:
             scores = {
                 "g0-s0": {"i1": 0.1, "i2": 0.1},
                 "g1-s1": {"i1": 0.9, "i2": 0.1},
-                "g2-s1": {"i1": 0.2, "i2": 0.95},
+                "g2-s2": {"i1": 0.2, "i2": 0.95},
             }[candidate.id]
             return make_eval_result(candidate.id, scores)
 
@@ -668,11 +668,11 @@ class TestGatingInEvolutionLoop:
         config = make_config(max_generations=2, max_evaluations=10000)
         result = run_evolution(config, tmp_path, tmp_path / ".helix")
 
-        assert set(result.non_dominated_ids) == {"g1-s1", "g2-s1"}
+        assert set(result.non_dominated_ids) == {"g1-s1", "g2-s2"}
         # ``non_dominated_ids`` is sorted for stability.
         assert result.non_dominated_ids == sorted(result.non_dominated_ids)
         flagged = {s.id for s in result.candidate_summaries if s.is_non_dominated}
-        assert flagged == {"g1-s1", "g2-s1"}
+        assert flagged == {"g1-s1", "g2-s2"}
 
     def test_helix_result_to_dict_round_trips_through_json(
         self, mocker, tmp_path, all_mocks,
@@ -1029,9 +1029,13 @@ class TestLlmUsageBudgetIntegration:
             tmp_path / ".helix",
         )
 
-        # The real backend dispatch must have been hit exactly once.
-        assert mock_run.call_count == 1
-        assert mock_run.call_args.args[0][0] == "claude"
+        # Content-key computation may issue git subprocess probes through the
+        # same patched module; the intended Claude backend dispatch remains
+        # exactly one command.
+        claude_calls = [
+            call for call in mock_run.call_args_list if call.args[0][0] == "claude"
+        ]
+        assert len(claude_calls) == 1
 
         seed_calls = _filter_charge_calls(
             spy, source="seed_generation", candidate_id="g0-s0"
@@ -1154,15 +1158,16 @@ class TestMergeBehavior:
         candidates — so seed and child need complementary instance scores.
         """
         seed = make_candidate("g0-s0")
-        child = make_candidate("g1-s1", generation=1)
         all_mocks["create_seed_worktree"].return_value = seed
-        all_mocks["mutate"].return_value = child
+        all_mocks["mutate"].side_effect = lambda **kwargs: make_candidate(
+            kwargs["new_id"], generation=int(kwargs["new_id"].split("-")[0][1:])
+        )
         all_mocks["merge"].return_value = None  # merge attempt made but returns None
         # find_merge_triplet returns a valid triplet so merge fires
         all_mocks["find_merge_triplet"].return_value = ("g0-s0", "g1-s1", "g0-s0")
 
         def run_eval(candidate, config, split=None, instances=None, **kwargs):
-            if candidate.id == "g1-s1":
+            if candidate.id != "g0-s0":
                 # Complementary instance scores: child better on i1 but worse
                 # on i2 → neither candidate dominates the other → both
                 # non-dominated → merge can fire.
@@ -1240,13 +1245,14 @@ class TestMergeBehavior:
         so merge() is never called.
         """
         seed = make_candidate("g0-s0")
-        child = make_candidate("g1-s1", generation=1)
         all_mocks["create_seed_worktree"].return_value = seed
-        all_mocks["mutate"].return_value = child
+        all_mocks["mutate"].side_effect = lambda **kwargs: make_candidate(
+            kwargs["new_id"], generation=int(kwargs["new_id"].split("-")[0][1:])
+        )
 
         def run_eval(candidate, config, split=None, instances=None, **kwargs):
-            if candidate.id == "g1-s1":
-                return make_eval_result("g1-s1", {"i1": 0.9})
+            if candidate.id != "g0-s0":
+                return make_eval_result(candidate.id, {"i1": 0.9})
             return make_eval_result(candidate.id, {"i1": 0.5})
 
         all_mocks["run_evaluator"].side_effect = run_eval
@@ -1280,16 +1286,14 @@ class TestMergeBehavior:
         legibility.
         """
         seed = make_candidate("g0-s0")
-        merged_cand = make_candidate("g1-m1", generation=1)
-        children = [make_candidate(f"g{i}-s1", generation=i) for i in range(1, 4)]
-        child_iter = iter(children)
+        merged_cand = make_candidate("g2-m1", generation=2)
         all_mocks["create_seed_worktree"].return_value = seed
 
         def make_child(*args, **kwargs):
-            try:
-                return next(child_iter)
-            except StopIteration:
-                return None
+            child_id = kwargs["new_id"]
+            return make_candidate(
+                child_id, generation=int(child_id.split("-")[0][1:])
+            )
 
         all_mocks["mutate"].side_effect = make_child
         # Merge succeeds (returns candidate), so acceptance check will run.
@@ -2014,9 +2018,10 @@ class TestMergeBehavior:
         is satisfied.
         """
         seed = make_candidate("g0-s0")
-        child = make_candidate("g1-s1", generation=1)
         all_mocks["create_seed_worktree"].return_value = seed
-        all_mocks["mutate"].return_value = child
+        all_mocks["mutate"].side_effect = lambda **kwargs: make_candidate(
+            kwargs["new_id"], generation=int(kwargs["new_id"].split("-")[0][1:])
+        )
         # Only seed + 1 child → lineage has 2 entries → gate trips.
         all_mocks["load_lineage"].return_value = {
             "g0-s0": LineageEntry(
@@ -2038,7 +2043,7 @@ class TestMergeBehavior:
         }
 
         def run_eval(candidate, config, split=None, instance_ids=None, **kwargs):
-            if candidate.id == "g1-s1":
+            if candidate.id != "g0-s0":
                 scores = {"1": 0.9, "2": 0.5}
             else:
                 scores = {"1": 0.5, "2": 0.9}

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -638,7 +638,10 @@ class TestGatingInEvolutionLoop:
         assert result.candidate_summaries[-1].to_dict()["parents"] == ["g0-s0"]
 
     def test_helix_result_keeps_multiple_non_dominated_candidates(
-        self, mocker, tmp_path, all_mocks,
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,
     ):
         """Two complementary children should both be flagged non-dominated.
 
@@ -675,7 +678,10 @@ class TestGatingInEvolutionLoop:
         assert flagged == {"g1-s1", "g2-s2"}
 
     def test_helix_result_to_dict_round_trips_through_json(
-        self, mocker, tmp_path, all_mocks,
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,
     ):
         """``HelixResult.to_dict()`` must be JSON-serialisable end to end.
 
@@ -745,16 +751,28 @@ class TestGatingInEvolutionLoop:
         # Static lineage seen by ``_build_helix_result`` at end-of-run.
         all_mocks["load_lineage"].return_value = {
             "g0-s0": LineageEntry(
-                id="g0-s0", parent=None, parents=[], operation="seed",
-                generation=0, files_changed=[],
+                id="g0-s0",
+                parent=None,
+                parents=[],
+                operation="seed",
+                generation=0,
+                files_changed=[],
             ),
             "g1-s1": LineageEntry(
-                id="g1-s1", parent="g0-s0", parents=["g0-s0"],
-                operation="mutate", generation=1, files_changed=["solve.py"],
+                id="g1-s1",
+                parent="g0-s0",
+                parents=["g0-s0"],
+                operation="mutate",
+                generation=1,
+                files_changed=["solve.py"],
             ),
             "g2-m1": LineageEntry(
-                id="g2-m1", parent="g0-s0", parents=["g0-s0", "g1-s1"],
-                operation="merge", generation=2, files_changed=["solve.py"],
+                id="g2-m1",
+                parent="g0-s0",
+                parents=["g0-s0", "g1-s1"],
+                operation="merge",
+                generation=2,
+                files_changed=["solve.py"],
             ),
         }
 
@@ -785,9 +803,7 @@ class TestGatingInEvolutionLoop:
 
         assert "g2-m1" in result.parents, "merged candidate missing from result"
         assert result.parents["g2-m1"] == ["g0-s0", "g1-s1"]
-        merged_summary = next(
-            s for s in result.candidate_summaries if s.id == "g2-m1"
-        )
+        merged_summary = next(s for s in result.candidate_summaries if s.id == "g2-m1")
         assert merged_summary.operation == "merge"
         assert merged_summary.parents == ["g0-s0", "g1-s1"]
 
@@ -809,7 +825,9 @@ class TestGatingInEvolutionLoop:
         def run_eval(candidate, config, split=None, instances=None, **kwargs):
             return make_eval_result(
                 candidate.id,
-                {"i1": 0.9, "i2": 0.9} if candidate.id == "g1-s1" else {"i1": 0.3, "i2": 0.3},
+                {"i1": 0.9, "i2": 0.9}
+                if candidate.id == "g1-s1"
+                else {"i1": 0.3, "i2": 0.3},
             )
 
         all_mocks["run_evaluator"].side_effect = run_eval
@@ -822,7 +840,10 @@ class TestGatingInEvolutionLoop:
             result.run_dir = "/elsewhere"
 
     def test_helix_result_budget_does_not_alias_state(
-        self, mocker, tmp_path, all_mocks,
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,
     ):
         """``_build_helix_result`` must shallow-copy ``state.budget``.
 
@@ -862,11 +883,15 @@ class TestGatingInEvolutionLoop:
         # The snapshot is itself frozen-by-convention via the ``HelixResult``
         # ``frozen=True`` wrapper — reassigning ``result.budget`` raises.
         from dataclasses import FrozenInstanceError
+
         with pytest.raises(FrozenInstanceError):
             result.budget = scratch
 
     def test_helix_result_score_views_recompute_from_summaries(
-        self, mocker, tmp_path, all_mocks,
+        self,
+        mocker,
+        tmp_path,
+        all_mocks,
     ):
         """Score-view properties must recompute from ``candidate_summaries``.
 
@@ -1144,9 +1169,7 @@ class TestMergeBehavior:
     # production ``next_mutation_id`` allocates a fresh id per gen, so the
     # duplicate-discovery warning would never fire there.  Filter it here
     # to keep the suite quiet without weakening the production guard.
-    @pytest.mark.filterwarnings(
-        "ignore:discovery budget already recorded:UserWarning"
-    )
+    @pytest.mark.filterwarnings("ignore:discovery budget already recorded:UserWarning")
     def test_merge_fires_when_new_program_accepted(self, mocker, tmp_path, all_mocks):
         """Merge is triggered in the NEXT generation after acceptance (GEPA parity).
 
@@ -1291,9 +1314,7 @@ class TestMergeBehavior:
 
         def make_child(*args, **kwargs):
             child_id = kwargs["new_id"]
-            return make_candidate(
-                child_id, generation=int(child_id.split("-")[0][1:])
-            )
+            return make_candidate(child_id, generation=int(child_id.split("-")[0][1:]))
 
         all_mocks["mutate"].side_effect = make_child
         # Merge succeeds (returns candidate), so acceptance check will run.
@@ -2562,9 +2583,7 @@ class TestActiveFrontierSyncOnObjectiveMode:
             ),
         }
 
-        snapshot_spy = mocker.spy(
-            ParetoFrontier, "active_frontier_snapshot"
-        )
+        snapshot_spy = mocker.spy(ParetoFrontier, "active_frontier_snapshot")
 
         config = HelixConfig(
             objective="Improve the code",

--- a/tests/unit/test_evolution_adversarial_hardening.py
+++ b/tests/unit/test_evolution_adversarial_hardening.py
@@ -43,7 +43,7 @@ class _InjectedCrash(BaseException):
 def _patch_runtime(
     monkeypatch: pytest.MonkeyPatch,
     *,
-    mutate: Callable[..., Candidate] | None = None,
+    mutate: Callable[..., Candidate | None] | None = None,
     evaluator: Callable[..., EvalResult] | None = None,
     remove: Callable[[Candidate], None] | None = None,
     content_key: Callable[[Candidate], str] | None = None,
@@ -449,6 +449,96 @@ def test_failed_resume_cleanup_blocks_dispatch_then_retries_idempotently(
     repeated = load_state(project_root)
     assert repeated == recovered
     assert cleanup_attempts == ["g1-s1", "g1-s1"]
+
+
+@pytest.mark.parametrize("failure_mode", ["handled_none", "raised_error"])
+def test_failed_mutation_with_live_worktree_retries_cleanup_on_resume(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_mode: str
+) -> None:
+    """A failed mutator cleanup remains a durable, retryable batch barrier."""
+    config = _make_config(p=1, n=1, train_size=1, val_size=1, minibatch_size=1)
+    project_root, base_dir = _new_project(tmp_path)
+    child_dir = base_dir / "worktrees" / "g1-s1"
+
+    def failed_mutate(**kwargs: Any) -> Candidate | None:
+        child_dir.mkdir(parents=True)
+        (child_dir / "partial.txt").write_text("mutation failed\n")
+        if failure_mode == "raised_error":
+            raise RuntimeError("backend transport failed")
+        return None
+
+    cleanup_attempts: list[str] = []
+
+    def flaky_remove(candidate: Candidate) -> None:
+        cleanup_attempts.append(candidate.id)
+        if len(cleanup_attempts) == 1:
+            raise OSError("transient git worktree lock")
+        shutil.rmtree(candidate.worktree_path)
+
+    _patch_runtime(monkeypatch, mutate=failed_mutate, remove=flaky_remove)
+
+    with pytest.raises(ValueError, match="cleanup failed for slots: 0"):
+        evolution.run_evolution(config, project_root, base_dir)
+
+    failed = load_state(project_root)
+    assert failed is not None
+    failed_batch = failed.proposal_batches[0]
+    failed_task = failed_batch.tasks[0]
+    assert failed_batch.phase == "applying"
+    assert failed_task.status == "failed"
+    assert failed_task.cleanup == "failed"
+    assert failed_task.budget_accounted
+    assert child_dir.exists()
+
+    result = evolution.run_evolution(config, project_root, base_dir)
+    assert result.id == "g0-s0"
+    recovered = load_state(project_root)
+    assert recovered is not None
+    recovered_task = recovered.proposal_batches[0].tasks[0]
+    assert recovered.proposal_batches[0].phase == "complete"
+    assert recovered_task.status == "interrupted"
+    assert recovered_task.cleanup == "removed"
+    assert recovered_task.budget_accounted
+    assert not child_dir.exists()
+    assert cleanup_attempts == ["g1-s1", "g1-s1"]
+
+    evolution.run_evolution(config, project_root, base_dir)
+    assert load_state(project_root) == recovered
+    assert cleanup_attempts == ["g1-s1", "g1-s1"]
+
+
+def test_mutation_none_with_live_worktree_journals_successful_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reserved child identity makes a handled failure's cleanup required."""
+    config = _make_config(p=1, n=1, train_size=1, val_size=1, minibatch_size=1)
+    project_root, base_dir = _new_project(tmp_path)
+    child_dir = base_dir / "worktrees" / "g1-s1"
+
+    def failed_mutate(**kwargs: Any) -> None:
+        child_dir.mkdir(parents=True)
+        return None
+
+    cleanup_attempts: list[str] = []
+
+    def remove(candidate: Candidate) -> None:
+        cleanup_attempts.append(candidate.id)
+        shutil.rmtree(candidate.worktree_path)
+
+    _patch_runtime(monkeypatch, mutate=failed_mutate, remove=remove)
+    result = evolution.run_evolution(config, project_root, base_dir)
+
+    assert result.id == "g0-s0"
+    persisted = load_state(project_root)
+    assert persisted is not None
+    [task] = persisted.proposal_batches[0].tasks
+    assert persisted.proposal_batches[0].phase == "complete"
+    assert task.child_id == "g1-s1"
+    assert task.status == "failed"
+    assert task.cleanup == "removed"
+    assert task.budget_accounted
+    assert cleanup_attempts == [task.child_id]
+    assert not child_dir.exists()
 
 
 def test_interrupted_earlier_batch_is_bounded_by_next_batch_budget_snapshot(

--- a/tests/unit/test_evolution_adversarial_hardening.py
+++ b/tests/unit/test_evolution_adversarial_hardening.py
@@ -1,0 +1,617 @@
+"""Adversarial regression coverage for evolution durability and fatal drains."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import threading
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+import helix.evolution as evolution
+from helix.config import HelixConfig
+from helix.display import UsageStats
+from helix.exceptions import HelixError, PromptArtifactCollisionError
+from helix.population import Candidate, EvalResult
+from helix.state import (
+    BudgetState,
+    EvolutionState,
+    ProposalBatchRecord,
+    ProposalTaskRecord,
+    checkpoint_batch_after_apply,
+    checkpoint_batch_before_dispatch,
+    checkpoint_batch_task,
+    load_eval_cache,
+    load_state,
+    save_state,
+)
+from tests.unit.test_parallel_proposals_matrix import (
+    _NullDisplay,
+    _candidate,
+    _eval_result,
+    _make_config,
+)
+
+
+class _InjectedCrash(BaseException):
+    """Simulated process death that ordinary error isolation must not catch."""
+
+
+def _patch_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    mutate: Callable[..., Candidate] | None = None,
+    evaluator: Callable[..., EvalResult] | None = None,
+    remove: Callable[[Candidate], None] | None = None,
+    content_key: Callable[[Candidate], str] | None = None,
+) -> None:
+    """Install deterministic filesystem-only seams around the real loop."""
+
+    def fake_create_seed(_project_root: Path, worktrees_dir: Path) -> Candidate:
+        seed_dir = worktrees_dir / "g0-s0"
+        seed_dir.mkdir(parents=True, exist_ok=False)
+        (seed_dir / "program.txt").write_text("seed\n")
+        return _candidate("g0-s0", seed_dir, operation="seed")
+
+    def default_mutate(**kwargs: Any) -> Candidate:
+        child_id = str(kwargs["new_id"])
+        child_dir = Path(kwargs["base_dir"]) / child_id
+        child_dir.mkdir(parents=True, exist_ok=False)
+        (child_dir / "program.txt").write_text(f"candidate={child_id}\n")
+        return _candidate(child_id, child_dir, parent_id=kwargs["parent"].id)
+
+    def default_evaluator(
+        candidate: Candidate,
+        _config: HelixConfig,
+        split: str = "val",
+        instance_ids: list[str] | None = None,
+        **_kwargs: Any,
+    ) -> EvalResult:
+        ids = [str(value) for value in (instance_ids or ["single-task"])]
+        score = 0.1 if candidate.id == "g0-s0" else 0.8
+        return _eval_result(candidate.id, ids, score)
+
+    def default_remove(candidate: Candidate) -> None:
+        shutil.rmtree(candidate.worktree_path, ignore_errors=True)
+
+    def noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    actual_evaluator = evaluator or default_evaluator
+    actual_mutate = mutate or default_mutate
+    actual_remove = remove or default_remove
+    monkeypatch.setattr(evolution, "create_seed_worktree", fake_create_seed)
+    monkeypatch.setattr(evolution, "mutate", actual_mutate)
+    monkeypatch.setattr("helix.mutator.mutate", actual_mutate)
+    monkeypatch.setattr(evolution, "run_evaluator", actual_evaluator)
+    monkeypatch.setattr("helix.executor.run_evaluator", actual_evaluator)
+    monkeypatch.setattr(evolution, "remove_worktree", actual_remove)
+    monkeypatch.setattr("helix.worktree.remove_worktree", actual_remove)
+    monkeypatch.setattr(
+        evolution, "snapshot_candidate", lambda candidate, _message: candidate.id
+    )
+    monkeypatch.setattr(evolution, "HelixLiveDisplay", _NullDisplay)
+    monkeypatch.setattr(evolution, "_check_evaluator_script_exists", noop)
+    monkeypatch.setattr(evolution, "_refresh_protected_evaluator_files", noop)
+    monkeypatch.setattr(
+        evolution, "_refresh_and_snapshot_protected_evaluator_files", noop
+    )
+    monkeypatch.setattr(
+        evolution, "_build_evaluator_integrity_manifest", lambda **_kwargs: {}
+    )
+    monkeypatch.setattr(evolution, "_write_evaluator_integrity_manifest", noop)
+    monkeypatch.setattr(evolution, "_detect_evaluator_tamper", lambda *_args: [])
+    monkeypatch.setattr(
+        evolution,
+        "_candidate_content_key",
+        content_key or (lambda candidate: candidate.id),
+    )
+    for name in (
+        "set_phase",
+        "print_info",
+        "print_success",
+        "print_warning",
+        "print_error",
+        "render_budget",
+        "render_generation",
+        "render_frontier_table",
+    ):
+        monkeypatch.setattr(evolution, name, noop)
+
+
+def _new_project(root: Path) -> tuple[Path, Path]:
+    project_root = root / "project"
+    project_root.mkdir(parents=True)
+    return project_root, project_root / ".helix"
+
+
+def _batch(
+    batch_id: str = "g1-proposals", *, child_count: int = 2
+) -> ProposalBatchRecord:
+    return ProposalBatchRecord(
+        batch_id=batch_id,
+        generation=1,
+        p=1,
+        n=child_count,
+        tasks=[
+            ProposalTaskRecord(
+                batch_id=batch_id,
+                p=1,
+                n=child_count,
+                task_index=index,
+                parent_group=0,
+                mutation_index=index,
+                parent_id="g0-s0",
+                child_id=f"g1-s{index + 1}",
+            )
+            for index in range(child_count)
+        ],
+    )
+
+
+def test_crash_between_scheduler_and_plan_save_can_only_observe_both(
+    tmp_path: Path,
+) -> None:
+    """The old first save's crash point is now one combined durable image."""
+    state = EvolutionState(
+        generation=1,
+        frontier=["g0-s0"],
+        instance_scores={},
+        budget=BudgetState(evaluations=3),
+        config_hash="atomic-plan",
+    )
+    saves = 0
+
+    def persist_then_crash(value: EvolutionState) -> None:
+        nonlocal saves
+        saves += 1
+        save_state(value, tmp_path)
+        raise _InjectedCrash()
+
+    with pytest.raises(_InjectedCrash):
+        evolution._checkpoint_scheduler_and_batch_plan(
+            state,
+            tmp_path,
+            scheduler_state={"frontier_rng_state": ["advanced"]},
+            batch=_batch(),
+            max_evaluations=100,
+            max_in_flight_evaluations=8,
+            saver=persist_then_crash,
+        )
+
+    assert saves == 1
+    persisted = load_state(tmp_path)
+    assert persisted is not None
+    assert persisted.scheduler_state == {"frontier_rng_state": ["advanced"]}
+    assert [batch.batch_id for batch in persisted.proposal_batches] == ["g1-proposals"]
+    assert [task.child_id for task in persisted.proposal_batches[0].tasks] == [
+        "g1-s1",
+        "g1-s2",
+    ]
+
+
+def test_crash_injection_after_every_proposal_state_barrier_resumes_cleanly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replay a process death after every state barrier reached by one batch."""
+    _patch_runtime(monkeypatch)
+    config = _make_config(
+        p=1,
+        n=1,
+        train_size=1,
+        val_size=1,
+        minibatch_size=1,
+        max_workers=1,
+    )
+
+    control_root, control_base = _new_project(tmp_path / "control")
+    barrier_count = 0
+
+    def count_barriers(_name: str, state: EvolutionState) -> None:
+        nonlocal barrier_count
+        if state.proposal_batches:
+            barrier_count += 1
+
+    monkeypatch.setattr(evolution, "_DURABLE_BARRIER_HOOK", count_barriers)
+    evolution.run_evolution(config, control_root, control_base)
+    assert barrier_count >= 5
+
+    for target in range(1, barrier_count + 1):
+        project_root, base_dir = _new_project(tmp_path / f"barrier-{target}")
+        observed = 0
+
+        def crash_at_target(_name: str, state: EvolutionState) -> None:
+            nonlocal observed
+            if not state.proposal_batches:
+                return
+            observed += 1
+            if observed == target:
+                raise _InjectedCrash()
+
+        monkeypatch.setattr(evolution, "_DURABLE_BARRIER_HOOK", crash_at_target)
+        with pytest.raises(_InjectedCrash):
+            evolution.run_evolution(config, project_root, base_dir)
+
+        crashed = load_state(project_root)
+        assert crashed is not None
+        assert crashed.scheduler_state
+        assert len(crashed.proposal_batches) == 1
+
+        monkeypatch.setattr(evolution, "_DURABLE_BARRIER_HOOK", None)
+        evolution.run_evolution(config, project_root, base_dir)
+        resumed = load_state(project_root)
+        assert resumed is not None
+        batch = resumed.proposal_batches[0]
+        assert batch.phase == "complete"
+        assert all(task.budget_accounted for task in batch.tasks)
+        assert all(task.cleanup != "failed" for task in batch.tasks)
+        assert len({task.child_id for task in batch.tasks}) == len(batch.tasks)
+        assert batch.budget_state_before_dispatch is not None
+        assert sum(task.budget_charge.evaluations for task in batch.tasks) == (
+            resumed.budget.evaluations - batch.budget_state_before_dispatch.evaluations
+        )
+
+
+def test_failed_resume_cleanup_blocks_dispatch_then_retries_idempotently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _make_config(p=1, n=1, train_size=1, val_size=1, minibatch_size=1)
+    project_root, base_dir = _new_project(tmp_path)
+    worktrees_dir = base_dir / "worktrees"
+    worktrees_dir.mkdir(parents=True)
+    seed_dir = worktrees_dir / "g0-s0"
+    seed_dir.mkdir()
+    child_dir = worktrees_dir / "g1-s1"
+    child_dir.mkdir()
+    (base_dir / "evaluations").mkdir()
+    seed_result = _eval_result("g0-s0", ["0"], 0.1)
+    (base_dir / "evaluations" / "g0-s0.json").write_text(
+        json.dumps(seed_result.to_dict())
+    )
+    state = EvolutionState(
+        generation=1,
+        frontier=["g0-s0"],
+        instance_scores={"g0-s0": {"0": 0.1}},
+        budget=BudgetState(evaluations=5),
+        config_hash=evolution._config_hash(config),
+        frontier_type="instance",
+        resume_semantics=evolution._resume_semantics(config),
+    )
+    checkpoint_batch_before_dispatch(
+        state,
+        project_root,
+        _batch(child_count=1),
+        max_evaluations=100,
+        max_in_flight_evaluations=4,
+    )
+
+    cleanup_attempts: list[str] = []
+
+    def flaky_remove(candidate: Candidate) -> None:
+        cleanup_attempts.append(candidate.id)
+        if len(cleanup_attempts) == 1:
+            raise OSError("transient git worktree lock")
+        shutil.rmtree(candidate.worktree_path)
+
+    _patch_runtime(monkeypatch, remove=flaky_remove)
+    with pytest.raises(HelixError, match="Cannot resume until"):
+        evolution.run_evolution(config, project_root, base_dir)
+
+    failed = load_state(project_root)
+    assert failed is not None
+    failed_task = failed.proposal_batches[0].tasks[0]
+    assert failed.proposal_batches[0].phase == "interrupted"
+    assert failed_task.cleanup == "failed"
+    assert not failed_task.budget_accounted
+    assert child_dir.exists()
+
+    result = evolution.run_evolution(config, project_root, base_dir)
+    assert result.id == "g0-s0"
+    recovered = load_state(project_root)
+    assert recovered is not None
+    recovered_task = recovered.proposal_batches[0].tasks[0]
+    assert recovered.proposal_batches[0].phase == "complete"
+    assert recovered_task.cleanup == "removed"
+    assert recovered_task.budget_accounted
+    assert recovered_task.budget_charge == BudgetState()
+    assert recovered.budget == BudgetState(evaluations=5)
+    assert cleanup_attempts == ["g1-s1", "g1-s1"]
+
+    evolution.run_evolution(config, project_root, base_dir)
+    repeated = load_state(project_root)
+    assert repeated == recovered
+    assert cleanup_attempts == ["g1-s1", "g1-s1"]
+
+
+def test_interrupted_earlier_batch_is_bounded_by_next_batch_budget_snapshot(
+    tmp_path: Path,
+) -> None:
+    """Later durable charges cannot leak into an earlier interrupted slot."""
+    state = EvolutionState(
+        generation=2,
+        frontier=["g0-s0"],
+        instance_scores={},
+        budget=BudgetState(evaluations=5, input_tokens=2),
+        config_hash="multi-batch-bound",
+    )
+    first = ProposalBatchRecord(
+        batch_id="g1-b0",
+        generation=1,
+        p=1,
+        n=1,
+        tasks=[
+            ProposalTaskRecord(
+                batch_id="g1-b0",
+                p=1,
+                n=1,
+                task_index=0,
+                parent_group=0,
+                mutation_index=0,
+                parent_id="g0-s0",
+                child_id="g1-s1",
+            )
+        ],
+    )
+    checkpoint_batch_before_dispatch(state, tmp_path, first)
+
+    # The first batch durably consumed 5 evaluations / 5 tokens without
+    # terminalizing its task.  The second batch's pre-dispatch snapshot is the
+    # exact upper bound for those missing facts.
+    state.budget = BudgetState(evaluations=10, input_tokens=7)
+    second = ProposalBatchRecord(
+        batch_id="g2-b0",
+        generation=2,
+        p=1,
+        n=1,
+        tasks=[
+            ProposalTaskRecord(
+                batch_id="g2-b0",
+                p=1,
+                n=1,
+                task_index=0,
+                parent_group=0,
+                mutation_index=0,
+                parent_id="g0-s0",
+                child_id="g2-s2",
+            )
+        ],
+    )
+    checkpoint_batch_before_dispatch(state, tmp_path, second)
+    state.budget = BudgetState(evaluations=19, input_tokens=20)
+    checkpoint_batch_task(
+        state,
+        tmp_path,
+        batch_id=second.batch_id,
+        task_index=0,
+        status="failed",
+        cleanup="missing",
+        budget_charge=BudgetState(evaluations=9, input_tokens=13),
+        budget_accounted=True,
+    )
+    checkpoint_batch_after_apply(state, tmp_path, batch_id=second.batch_id)
+
+    worktrees_dir = tmp_path / ".helix" / "worktrees"
+    worktrees_dir.mkdir(parents=True)
+    reports = evolution.reconcile_interrupted_batches(
+        state,
+        tmp_path,
+        worktrees_dir=worktrees_dir,
+        cleanup_worktree=lambda _candidate_id, _path: True,
+    )
+
+    assert len(reports) == 1
+    first_task = first.tasks[0]
+    assert first_task.budget_accounted
+    assert first_task.budget_charge == BudgetState(
+        evaluations=5,
+        input_tokens=5,
+    )
+    assert state.budget == BudgetState(evaluations=19, input_tokens=20)
+    completed_first = checkpoint_batch_after_apply(
+        state, tmp_path, batch_id=first.batch_id
+    )
+    assert completed_first.budget_after_apply == 10
+
+
+@pytest.mark.parametrize("validation_failure", ["wrong_id", "tamper_detector"])
+def test_successful_mutation_usage_survives_post_validation_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    validation_failure: str,
+) -> None:
+    usage = UsageStats(
+        input_tokens=101,
+        output_tokens=29,
+        cached_input_tokens=7,
+        cache_creation_input_tokens=5,
+        cache_read_input_tokens=3,
+        reasoning_tokens=11,
+        cost_usd=0.42,
+    )
+    removed: list[str] = []
+
+    def mutate_with_usage(**kwargs: Any) -> Candidate:
+        reserved_id = str(kwargs["new_id"])
+        child_id = "wrong-id" if validation_failure == "wrong_id" else reserved_id
+        child_dir = Path(kwargs["base_dir"]) / child_id
+        child_dir.mkdir()
+        child = Candidate(
+            id=child_id,
+            worktree_path=str(child_dir),
+            branch_name=f"helix/{child_id}",
+            generation=1,
+            parent_id=kwargs["parent"].id,
+            parent_ids=[kwargs["parent"].id],
+            operation="mutation",
+        )
+        child.usage = usage
+        return child
+
+    def remove(candidate: Candidate) -> None:
+        removed.append(candidate.id)
+        shutil.rmtree(candidate.worktree_path)
+
+    _patch_runtime(monkeypatch, mutate=mutate_with_usage, remove=remove)
+    if validation_failure == "tamper_detector":
+        monkeypatch.setattr(
+            evolution,
+            "_detect_evaluator_tamper",
+            lambda *_args: (_ for _ in ()).throw(ValueError("detector exploded")),
+        )
+
+    project_root, base_dir = _new_project(tmp_path)
+    config = _make_config(p=1, n=1, train_size=1, val_size=1, minibatch_size=1)
+    with pytest.raises(ValueError):
+        evolution.run_evolution(config, project_root, base_dir)
+
+    persisted = load_state(project_root)
+    assert persisted is not None
+    task = persisted.proposal_batches[0].tasks[0]
+    assert persisted.budget.input_tokens == usage.input_tokens
+    assert persisted.budget.output_tokens == usage.output_tokens
+    assert persisted.budget.cached_input_tokens == usage.cached_input_tokens
+    assert persisted.budget.cache_creation_input_tokens == (
+        usage.cache_creation_input_tokens
+    )
+    assert persisted.budget.cache_read_input_tokens == usage.cache_read_input_tokens
+    assert persisted.budget.reasoning_tokens == usage.reasoning_tokens
+    assert persisted.budget.cost_usd == pytest.approx(usage.cost_usd)
+    assert task.budget_charge.input_tokens == usage.input_tokens
+    assert task.budget_charge.output_tokens == usage.output_tokens
+    assert task.budget_charge.cost_usd == pytest.approx(usage.cost_usd)
+    assert task.budget_accounted
+    assert task.status == "failed"
+    assert task.cleanup == "removed"
+    assert removed == ["wrong-id" if validation_failure == "wrong_id" else "g1-s1"]
+
+
+def test_fatal_full_evaluator_preserves_negative_success_and_dedup_siblings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fatal = PromptArtifactCollisionError("fatal full validation")
+    negative_full_finished = threading.Event()
+    good_full_finished = threading.Event()
+    full_completion_order: list[str] = []
+    evaluator_calls: list[tuple[str, str, tuple[str, ...]]] = []
+    removed: list[str] = []
+
+    def evaluator(
+        candidate: Candidate,
+        _config: HelixConfig,
+        split: str = "val",
+        instance_ids: list[str] | None = None,
+        **_kwargs: Any,
+    ) -> EvalResult:
+        ids = tuple(str(value) for value in (instance_ids or ["single-task"]))
+        evaluator_calls.append((candidate.id, split, ids))
+        is_full_child = candidate.id.startswith("g1-s") and split == "val"
+        if is_full_child and candidate.id == "g1-s1":
+            assert good_full_finished.wait(timeout=2)
+            full_completion_order.append(candidate.id)
+            raise fatal
+        if is_full_child and candidate.id == "g1-s2":
+            full_completion_order.append(candidate.id)
+            negative_full_finished.set()
+        if is_full_child and candidate.id == "g1-s3":
+            assert negative_full_finished.wait(timeout=2)
+            full_completion_order.append(candidate.id)
+            good_full_finished.set()
+        score = 0.1 if candidate.id == "g0-s0" else 0.8
+        return _eval_result(candidate.id, ids, score)
+
+    def mutate_shared(**kwargs: Any) -> Candidate:
+        child_id = str(kwargs["new_id"])
+        child_dir = Path(kwargs["base_dir"]) / child_id
+        child_dir.mkdir()
+        (child_dir / "program.txt").write_text("shared\n")
+        return _candidate(child_id, child_dir, parent_id=kwargs["parent"].id)
+
+    def content_key(candidate: Candidate) -> str:
+        if candidate.id in {"g1-s3", "g1-s4"}:
+            return "shared-success"
+        return candidate.id
+
+    def remove(candidate: Candidate) -> None:
+        removed.append(candidate.id)
+        shutil.rmtree(candidate.worktree_path, ignore_errors=True)
+
+    _patch_runtime(
+        monkeypatch,
+        mutate=mutate_shared,
+        evaluator=evaluator,
+        remove=remove,
+        content_key=content_key,
+    )
+    original_cached_evaluate_batch = evolution._cached_evaluate_batch
+
+    def negative_count_for_one_full_leader(
+        candidate: Candidate,
+        example_ids: list[str],
+        cache: Any,
+        config: HelixConfig,
+        split: str,
+        project_root: Path,
+    ) -> tuple[EvalResult, int]:
+        result, count = original_cached_evaluate_batch(
+            candidate,
+            example_ids,
+            cache,
+            config,
+            split,
+            project_root,
+        )
+        if candidate.id == "g1-s2" and split == "val":
+            return result, -7
+        return result, count
+
+    monkeypatch.setattr(
+        evolution, "_cached_evaluate_batch", negative_count_for_one_full_leader
+    )
+    project_root, base_dir = _new_project(tmp_path)
+    config = _make_config(
+        p=1,
+        n=4,
+        train_size=1,
+        val_size=2,
+        minibatch_size=1,
+        cache=True,
+        max_workers=3,
+    )
+
+    with pytest.raises(PromptArtifactCollisionError) as raised:
+        evolution.run_evolution(config, project_root, base_dir)
+    assert raised.value is fatal
+    assert full_completion_order == ["g1-s2", "g1-s3", "g1-s1"]
+
+    persisted = load_state(project_root)
+    assert persisted is not None
+    batch = persisted.proposal_batches[0]
+    assert persisted.budget.evaluations == 8
+    assert batch.budget_state_before_dispatch is not None
+    assert sum(task.budget_charge.evaluations for task in batch.tasks) == (
+        persisted.budget.evaluations - batch.budget_state_before_dispatch.evaluations
+    )
+    assert [task.budget_charge.evaluations for task in batch.tasks] == [2, 1, 3, 0]
+    assert all(task.budget_accounted for task in batch.tasks)
+    assert all(task.cleanup in {"removed", "missing"} for task in batch.tasks)
+    assert sorted(removed) == ["g1-s1", "g1-s2", "g1-s3", "g1-s4"]
+    assert not any(
+        (base_dir / "worktrees" / candidate_id).exists()
+        for candidate_id in ("g1-s1", "g1-s2", "g1-s3", "g1-s4")
+    )
+
+    child_full_calls = [
+        call
+        for call in evaluator_calls
+        if call[0].startswith("g1-s") and call[1] == "val"
+    ]
+    assert sorted(call[0] for call in child_full_calls) == [
+        "g1-s1",
+        "g1-s2",
+        "g1-s3",
+    ]
+    cache = load_eval_cache(project_root)
+    assert cache is not None
+    assert len(cache) == 9

--- a/tests/unit/test_evolution_adversarial_hardening.py
+++ b/tests/unit/test_evolution_adversarial_hardening.py
@@ -13,6 +13,7 @@ import pytest
 import helix.evolution as evolution
 from helix.config import HelixConfig
 from helix.display import UsageStats
+from helix.eval_cache import EvaluationCache as MinibatchEvalCache
 from helix.exceptions import HelixError, PromptArtifactCollisionError
 from helix.population import Candidate, EvalResult
 from helix.state import (
@@ -252,6 +253,130 @@ def test_crash_injection_after_every_proposal_state_barrier_resumes_cleanly(
         assert sum(task.budget_charge.evaluations for task in batch.tasks) == (
             resumed.budget.evaluations - batch.budget_state_before_dispatch.evaluations
         )
+
+
+def test_cached_sibling_completed_before_checkpoint_is_charged_once_on_resume(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cache-durable sibling execution cannot disappear from the budget.
+
+    Both child evaluators drain before their ordered results are processed.  Slot 0
+    fails, so its terminal checkpoint persists the cache entry already produced by
+    slot 1.  The injected crash lands after that combined state/cache save but before
+    slot 1's ordinary accounting path.  Resume must conserve slot 1's fresh execution
+    even though reading its recovered cache entry correctly reports a zero charge.
+    """
+    evaluator_calls: list[tuple[str, str, tuple[str, ...]]] = []
+
+    def evaluator(
+        candidate: Candidate,
+        _config: HelixConfig,
+        split: str = "val",
+        instance_ids: list[str] | None = None,
+        **_kwargs: Any,
+    ) -> EvalResult:
+        ids = tuple(str(value) for value in (instance_ids or ["single-task"]))
+        evaluator_calls.append((candidate.id, split, ids))
+        if candidate.id == "g1-s1" and split == "train":
+            raise RuntimeError("first child fails after sibling cache fill")
+        score = 0.1 if candidate.id == "g0-s0" else 0.8
+        return _eval_result(candidate.id, ids, score)
+
+    _patch_runtime(monkeypatch, evaluator=evaluator)
+    project_root, base_dir = _new_project(tmp_path)
+    config = _make_config(
+        p=1,
+        n=2,
+        train_size=1,
+        val_size=1,
+        minibatch_size=1,
+        cache=True,
+        max_workers=2,
+    )
+    crashed = False
+
+    def crash_after_failed_sibling_checkpoint(
+        _name: str, state: EvolutionState
+    ) -> None:
+        nonlocal crashed
+        if crashed or not state.proposal_batches:
+            return
+        statuses = [task.status for task in state.proposal_batches[0].tasks]
+        if statuses == ["failed", "running"]:
+            crashed = True
+            raise _InjectedCrash()
+
+    monkeypatch.setattr(
+        evolution, "_DURABLE_BARRIER_HOOK", crash_after_failed_sibling_checkpoint
+    )
+    with pytest.raises(_InjectedCrash):
+        evolution.run_evolution(config, project_root, base_dir)
+    assert crashed
+
+    persisted = load_state(project_root)
+    persisted_cache = load_eval_cache(project_root)
+    assert persisted is not None
+    assert persisted_cache is not None
+    batch = persisted.proposal_batches[0]
+    recovered_task = batch.tasks[1]
+    assert recovered_task.status == "running"
+    assert not recovered_task.budget_accounted
+    assert recovered_task.budget_charge.evaluations == 1
+    # Seed=1, one deduplicated parent evaluation=1, and the successful child=1.
+    assert persisted.budget.evaluations == 3
+
+    child_calls_before_cache_recovery = sum(
+        candidate_id == "g1-s2" and split == "train"
+        for candidate_id, split, _ in evaluator_calls
+    )
+    recovered_cache: MinibatchEvalCache[object, str] = MinibatchEvalCache()
+    recovered_cache._cache.update(persisted_cache)
+    child = _candidate(
+        "g1-s2",
+        base_dir / "worktrees" / "g1-s2",
+        parent_id="g0-s0",
+    )
+    _, recovered_charge = evolution._cached_evaluate_batch(
+        child,
+        ["0"],
+        recovered_cache,
+        config,
+        "train",
+        project_root,
+    )
+    assert recovered_charge == 0
+    assert (
+        sum(
+            candidate_id == "g1-s2" and split == "train"
+            for candidate_id, split, _ in evaluator_calls
+        )
+        == child_calls_before_cache_recovery
+        == 1
+    )
+
+    monkeypatch.setattr(evolution, "_DURABLE_BARRIER_HOOK", None)
+    evolution.run_evolution(config, project_root, base_dir)
+    resumed = load_state(project_root)
+    assert resumed is not None
+    resumed_batch = resumed.proposal_batches[0]
+    resumed_task = resumed_batch.tasks[1]
+    assert resumed_batch.phase == "complete"
+    assert resumed_task.budget_accounted
+    assert resumed_task.budget_charge.evaluations == 1
+    assert resumed.budget.evaluations == 3
+    assert sum(task.budget_charge.evaluations for task in resumed_batch.tasks) == (
+        resumed.budget.evaluations - resumed_batch.budget_before_dispatch
+    )
+
+    evolution.run_evolution(config, project_root, base_dir)
+    assert load_state(project_root) == resumed
+    assert (
+        sum(
+            candidate_id == "g1-s2" and split == "train"
+            for candidate_id, split, _ in evaluator_calls
+        )
+        == 1
+    )
 
 
 def test_failed_resume_cleanup_blocks_dispatch_then_retries_idempotently(

--- a/tests/unit/test_evolution_adversarial_hardening.py
+++ b/tests/unit/test_evolution_adversarial_hardening.py
@@ -322,8 +322,9 @@ def test_cached_sibling_completed_before_checkpoint_is_charged_once_on_resume(
     assert recovered_task.status == "running"
     assert not recovered_task.budget_accounted
     assert recovered_task.budget_charge.evaluations == 1
-    # Seed=1, one deduplicated parent evaluation=1, and the successful child=1.
-    assert persisted.budget.evaluations == 3
+    # Seed=1, one deduplicated parent evaluation=1, failed child=1, and
+    # successful child=1.  The failure cannot erase its dispatched unit.
+    assert persisted.budget.evaluations == 4
 
     child_calls_before_cache_recovery = sum(
         candidate_id == "g1-s2" and split == "train"
@@ -363,7 +364,7 @@ def test_cached_sibling_completed_before_checkpoint_is_charged_once_on_resume(
     assert resumed_batch.phase == "complete"
     assert resumed_task.budget_accounted
     assert resumed_task.budget_charge.evaluations == 1
-    assert resumed.budget.evaluations == 3
+    assert resumed.budget.evaluations == 4
     assert sum(task.budget_charge.evaluations for task in resumed_batch.tasks) == (
         resumed.budget.evaluations - resumed_batch.budget_before_dispatch
     )
@@ -713,12 +714,14 @@ def test_fatal_full_evaluator_preserves_negative_success_and_dedup_siblings(
     persisted = load_state(project_root)
     assert persisted is not None
     batch = persisted.proposal_batches[0]
-    assert persisted.budget.evaluations == 8
+    assert persisted.budget.evaluations == 12
     assert batch.budget_state_before_dispatch is not None
     assert sum(task.budget_charge.evaluations for task in batch.tasks) == (
         persisted.budget.evaluations - batch.budget_state_before_dispatch.evaluations
     )
-    assert [task.budget_charge.evaluations for task in batch.tasks] == [2, 1, 3, 0]
+    # The fatal and negative-count full-validation leaders each dispatched two
+    # real units before returning an error; both remain charged to their owner.
+    assert [task.budget_charge.evaluations for task in batch.tasks] == [4, 3, 3, 0]
     assert all(task.budget_accounted for task in batch.tasks)
     assert all(task.cleanup in {"removed", "missing"} for task in batch.tasks)
     assert sorted(removed) == ["g1-s1", "g1-s2", "g1-s3", "g1-s4"]

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -2066,6 +2066,619 @@ class TestStrictInstanceScoresAccess:
         with pytest.raises(AssertionError, match="missing ids"):
             run_evolution(config, tmp_path, tmp_path / ".helix")
 
+
+# ---------------------------------------------------------------------------
+# Unified P*N scheduler and durable-ledger regressions
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedPxNScheduler:
+    def test_k_by_one_preserves_legacy_rng_and_id_interleaving(
+        self, tmp_path: Path
+    ) -> None:
+        """K*1 planning matches the historical select/sample/reserve loop."""
+        import random
+
+        from helix import budget as budget_api
+        from helix.batch_sampler import EpochShuffledBatchSampler
+        from helix.evolution import _plan_pxn_tasks
+
+        train_path = _write_train_jsonl(tmp_path, n=7)
+        loader = HelixDataLoader(train_path)
+
+        def make_frontier(rng: random.Random) -> ParetoFrontier:
+            frontier = ParetoFrontier(rng=rng)
+            frontier.add(
+                _make_candidate("parent-a"),
+                _make_result("parent-a", {"left": 1.0, "right": 0.0}),
+            )
+            frontier.add(
+                _make_candidate("parent-b"),
+                _make_result("parent-b", {"left": 0.0, "right": 1.0}),
+            )
+            return frontier
+
+        planned_rng = random.Random(91)
+        planned_frontier = make_frontier(planned_rng)
+        planned_sampler = EpochShuffledBatchSampler[str](2, rng=planned_rng)
+        planned_state = EvolutionState(
+            generation=4,
+            frontier=["parent-a", "parent-b"],
+            instance_scores={},
+            budget=BudgetState(),
+            config_hash="test",
+            i=0,
+        )
+        planned = _plan_pxn_tasks(
+            p=3,
+            n=1,
+            frontier=planned_frontier,
+            batch_sampler=planned_sampler,
+            train_loader=loader,
+            state=planned_state,
+            generation=4,
+        )
+
+        legacy_rng = random.Random(91)
+        legacy_frontier = make_frontier(legacy_rng)
+        legacy_sampler = EpochShuffledBatchSampler[str](2, rng=legacy_rng)
+        legacy_state = EvolutionState(
+            generation=4,
+            frontier=["parent-a", "parent-b"],
+            instance_scores={},
+            budget=BudgetState(),
+            config_hash="test",
+            i=0,
+        )
+        legacy: list[tuple[str, tuple[str, ...], str]] = []
+        for group_index in range(3):
+            if group_index:
+                budget_api.advance_proposal_counter(
+                    legacy_state, source="parallel_proposal"
+                )
+            parent = legacy_frontier.select_parent()
+            minibatch = tuple(
+                legacy_sampler.next_minibatch_ids(loader, legacy_state)
+            )
+            child_id = budget_api.next_mutation_id(legacy_state, 4)
+            legacy.append((parent.id, minibatch, child_id))
+
+        assert [
+            (task.parent_candidate.id, task.minibatch_ids, task.reserved_child_id)
+            for task in planned
+        ] == legacy
+        assert [task.batch_index for task in planned] == [0, 1, 2]
+        assert [task.parent_group_index for task in planned] == [0, 1, 2]
+        assert [task.mutation_index for task in planned] == [0, 0, 0]
+        assert planned_state.i == legacy_state.i == 2
+
+    def test_p2_n3_reverse_completion_is_parent_major_and_worker_bounded(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Reverse worker completion cannot perturb IDs, lineage, or ledger order."""
+        import threading
+        import time
+
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        lock = threading.Lock()
+        active_mutations = 0
+        peak_mutations = 0
+        mutation_completions: list[str] = []
+
+        def mutate_reverse(**kwargs: Any) -> Candidate:
+            nonlocal active_mutations, peak_mutations
+            child_id = str(kwargs["new_id"])
+            with lock:
+                active_mutations += 1
+                peak_mutations = max(peak_mutations, active_mutations)
+            try:
+                time.sleep(0.06 if child_id.endswith("s1") else 0.005)
+                return _make_candidate(child_id)
+            finally:
+                with lock:
+                    mutation_completions.append(child_id)
+                    active_mutations -= 1
+
+        all_mocks["mutate"].side_effect = mutate_reverse
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if split == "train" and instance_ids is not None:
+                score = 0.1 if candidate.id == seed.id else 0.9
+                if candidate.id.endswith("s1"):
+                    time.sleep(0.04)
+                return _make_result(candidate.id, {eid: score for eid in instance_ids})
+            return _make_result(candidate.id, {"v": 0.8})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=1,
+            num_parallel_proposals=2,
+            mutations_per_parent=3,
+            max_workers=2,
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        state = all_mocks["save_state"].call_args.args[0]
+        batch = state.proposal_batches[-1]
+        child_ids = [task.child_id for task in batch.tasks]
+        assert child_ids == [f"g1-s{index}" for index in range(1, 7)]
+        assert [task.parent_group for task in batch.tasks] == [0, 0, 0, 1, 1, 1]
+        assert [task.mutation_index for task in batch.tasks] == [0, 1, 2, 0, 1, 2]
+        assert [task.parent_id for task in batch.tasks] == [seed.id] * 6
+        assert all(task.status == "applied" for task in batch.tasks)
+        assert all(task.budget_accounted for task in batch.tasks)
+        assert batch.phase == "complete"
+        assert sum(task.budget_charge.evaluations for task in batch.tasks) == (
+            batch.budget_after_apply - batch.budget_before_dispatch
+        )
+        assert mutation_completions[0] == "g1-s2"
+        assert peak_mutations == 2
+
+        mutation_lineage_ids = [
+            call.args[1].id
+            for call in all_mocks["record_entry"].call_args_list
+            if call.args[1].operation == "mutate"
+        ]
+        assert mutation_lineage_ids == child_ids
+
+    def test_p2_n3_partial_failures_are_isolated_and_terminal(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Mutation and evaluator failures affect only their reserved slots."""
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        def mutate_partial(**kwargs: Any) -> Candidate | None:
+            child_id = str(kwargs["new_id"])
+            if child_id == "g1-s2":
+                raise RuntimeError("ordinary mutation failure")
+            if child_id == "g1-s4":
+                return None
+            return _make_candidate(child_id)
+
+        all_mocks["mutate"].side_effect = mutate_partial
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if split == "train" and instance_ids is not None:
+                if candidate.id == seed.id:
+                    score = 0.2
+                elif candidate.id == "g1-s3":
+                    raise RuntimeError("ordinary evaluator failure")
+                elif candidate.id == "g1-s5":
+                    score = 0.1
+                else:
+                    score = 0.9
+                return _make_result(candidate.id, {eid: score for eid in instance_ids})
+            return _make_result(candidate.id, {"v": 0.8})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=1,
+            num_parallel_proposals=2,
+            mutations_per_parent=3,
+            max_workers=3,
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        state = all_mocks["save_state"].call_args.args[0]
+        batch = state.proposal_batches[-1]
+        assert [task.status for task in batch.tasks] == [
+            "applied",
+            "failed",
+            "failed",
+            "failed",
+            "rejected",
+            "applied",
+        ]
+        assert all(task.is_terminal() for task in batch.tasks)
+        assert all(task.budget_accounted for task in batch.tasks)
+        assert batch.phase == "complete"
+        removed_ids = {
+            call.args[0].id for call in all_mocks["remove_worktree"].call_args_list
+        }
+        assert removed_ids == {"g1-s3", "g1-s5"}
+
+    def test_dispatched_child_batch_drains_before_budget_stop_and_cleans_all(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Crossing the cap after child dispatch accounts and cleans every slot."""
+        train_path = _write_train_jsonl(tmp_path, n=3)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["mutate"].side_effect = lambda **kwargs: _make_candidate(
+            kwargs["new_id"]
+        )
+
+        full_validated_children: list[str] = []
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if split == "train" and instance_ids is not None:
+                score = 0.1 if candidate.id == seed.id else 0.9
+                return _make_result(candidate.id, {eid: score for eid in instance_ids})
+            if candidate.id != seed.id:
+                full_validated_children.append(candidate.id)
+            return _make_result(candidate.id, {"v": 0.8})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=1,
+            max_evaluations=5,
+            num_parallel_proposals=1,
+            mutations_per_parent=3,
+            max_workers=3,
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        state = all_mocks["save_state"].call_args.args[0]
+        batch = state.proposal_batches[-1]
+        assert state.budget.evaluations == 7
+        assert batch.budget_before_dispatch == 1
+        assert batch.budget_after_apply == 7
+        assert [task.budget_charge.evaluations for task in batch.tasks] == [2, 2, 2]
+        assert all(task.status == "rejected" for task in batch.tasks)
+        assert all(task.selection == "selected" for task in batch.tasks)
+        assert all(task.cleanup in {"missing", "removed"} for task in batch.tasks)
+        assert all(task.budget_accounted for task in batch.tasks)
+        assert batch.phase == "complete"
+        assert full_validated_children == []
+        removed_ids = [
+            call.args[0].id for call in all_mocks["remove_worktree"].call_args_list
+        ]
+        assert removed_ids == ["g1-s1", "g1-s2", "g1-s3"]
+
+    def test_selected_evaluated_resume_is_idempotent(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        """All journaled siblings recover once after a crash before first apply."""
+        from copy import deepcopy
+
+        train_path = _write_train_jsonl(tmp_path, n=2)
+        base_dir = tmp_path / ".helix"
+        worktrees_dir = base_dir / "worktrees"
+        worktrees_dir.mkdir(parents=True)
+
+        seed = _make_candidate("g0-s0")
+        seed.worktree_path = str(worktrees_dir / seed.id)
+        Path(seed.worktree_path).mkdir()
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        def mutate_with_worktree(**kwargs: Any) -> Candidate:
+            child = _make_candidate(str(kwargs["new_id"]))
+            child.worktree_path = str(worktrees_dir / child.id)
+            Path(child.worktree_path).mkdir(exist_ok=True)
+            return child
+
+        all_mocks["mutate"].side_effect = mutate_with_worktree
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if split == "train" and instance_ids is not None:
+                score = 0.1 if candidate.id == seed.id else 0.9
+                return _make_result(candidate.id, {eid: score for eid in instance_ids})
+            return _make_result(candidate.id, {"v": 0.8})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+
+        saved_evaluations: dict[str, EvalResult] = {}
+
+        def save_evaluation(_base: Path, result: EvalResult) -> None:
+            saved_evaluations[result.candidate_id] = deepcopy(result)
+
+        def load_evaluation(_base: Path, candidate_id: str) -> EvalResult | None:
+            result = saved_evaluations.get(candidate_id)
+            return None if result is None else deepcopy(result)
+
+        all_mocks["_save_evaluation"].side_effect = save_evaluation
+        all_mocks["_load_evaluation"].side_effect = load_evaluation
+
+        persisted: list[EvolutionState] = []
+        durable_snapshots: list[EvolutionState] = []
+
+        def capture_state(state: EvolutionState, _path: Path) -> None:
+            snapshot = deepcopy(state)
+            durable_snapshots.append(snapshot)
+            persisted[:] = [snapshot]
+
+        all_mocks["save_state"].side_effect = capture_state
+
+        original_add = ParetoFrontier.add
+        crash_before_first_child_apply = [True]
+
+        def add_with_one_crash(
+            frontier: ParetoFrontier,
+            candidate: Candidate,
+            result: EvalResult,
+        ) -> None:
+            if candidate.id != seed.id and crash_before_first_child_apply[0]:
+                crash_before_first_child_apply[0] = False
+                raise RuntimeError("simulated crash before first selected apply")
+            original_add(frontier, candidate, result)
+
+        mocker.patch.object(ParetoFrontier, "add", new=add_with_one_crash)
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=1,
+            num_parallel_proposals=1,
+            mutations_per_parent=2,
+            max_workers=2,
+        )
+
+        with pytest.raises(RuntimeError, match="before first selected apply"):
+            run_evolution(config, tmp_path, base_dir)
+
+        interrupted = deepcopy(persisted[0])
+        interrupted_batch = interrupted.proposal_batches[-1]
+        assert [task.status for task in interrupted_batch.tasks] == [
+            "evaluated",
+            "evaluated",
+        ]
+        assert all(task.selection == "selected" for task in interrupted_batch.tasks)
+        assert all(task.budget_accounted for task in interrupted_batch.tasks)
+        # The all-selected barrier has exactly one durable shape: no state
+        # save may expose full global charges with only a prefix of siblings
+        # selected/evaluated.
+        for snapshot in durable_snapshots:
+            if not snapshot.proposal_batches:
+                continue
+            statuses = [
+                task.status for task in snapshot.proposal_batches[-1].tasks
+            ]
+            assert statuses not in (["evaluated", "running"], ["running", "evaluated"])
+        budget_after_crash = interrupted.budget.evaluations
+
+        all_mocks["load_state"].side_effect = lambda _path: deepcopy(persisted[0])
+        run_evolution(config, tmp_path, base_dir)
+        recovered = deepcopy(persisted[0])
+        recovered_frontier = list(recovered.frontier)
+        cleanup_calls_after_first_resume = all_mocks["remove_worktree"].call_count
+
+        assert recovered_frontier == ["g0-s0", "g1-s1", "g1-s2"]
+        assert recovered.budget.evaluations == budget_after_crash
+        assert recovered.proposal_batches[-1].phase == "complete"
+        assert all(
+            task.status == "applied"
+            for task in recovered.proposal_batches[-1].tasks
+        )
+        assert cleanup_calls_after_first_resume == 0
+
+        run_evolution(config, tmp_path, base_dir)
+        resumed_again = persisted[0]
+        assert resumed_again.frontier == recovered_frontier
+        assert len(resumed_again.frontier) == len(set(resumed_again.frontier))
+        assert resumed_again.budget.evaluations == budget_after_crash
+        assert all(
+            resumed_again.num_metric_calls_by_discovery[candidate_id]
+            == recovered.num_metric_calls_by_discovery[candidate_id]
+            for candidate_id in ("g1-s1", "g1-s2")
+        )
+        assert all_mocks["remove_worktree"].call_count == 0
+
+    def test_recovered_acceptances_restore_deferred_merge_semantics(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Recovered selected children trigger the next merge just like live accepts."""
+        from copy import deepcopy
+
+        from helix.state import ProposalBatchRecord, ProposalTaskRecord
+
+        train_path = _write_train_jsonl(tmp_path, n=2)
+        base_dir = tmp_path / ".helix"
+        worktrees_dir = base_dir / "worktrees"
+        for candidate_id in ("g0-s0", "g1-s1", "g1-s2"):
+            (worktrees_dir / candidate_id).mkdir(parents=True, exist_ok=True)
+
+        batch = ProposalBatchRecord(
+            batch_id="g1-proposals",
+            generation=1,
+            p=1,
+            n=2,
+            phase="applying",
+            budget_before_dispatch=1,
+            max_evaluations=1000,
+            max_in_flight_evaluations=6,
+            maximum_overshoot=0,
+            tasks=[
+                ProposalTaskRecord(
+                    batch_id="g1-proposals",
+                    p=1,
+                    n=2,
+                    task_index=index,
+                    parent_group=0,
+                    mutation_index=index,
+                    parent_id="g0-s0",
+                    child_id=f"g1-s{index + 1}",
+                    status="evaluated",
+                    score_delta=0.4,
+                    selection="selected",
+                    cleanup="not_required",
+                    budget_charge=BudgetState(evaluations=3),
+                    budget_accounted=True,
+                )
+                for index in range(2)
+            ],
+        )
+        resumed_state = EvolutionState(
+            generation=1,
+            frontier=["g0-s0"],
+            instance_scores={"g0-s0": {"v": 0.5}},
+            budget=BudgetState(evaluations=7),
+            config_hash="legacy-test",
+            mutation_counter=2,
+            i=1,
+            proposal_batches=[batch],
+        )
+        all_mocks["load_state"].return_value = deepcopy(resumed_state)
+
+        saved_results = {
+            "g0-s0": _make_result("g0-s0", {"v": 0.5}),
+            "g1-s1": _make_result("g1-s1", {"v": 0.8}),
+            "g1-s2": _make_result("g1-s2", {"v": 0.8}),
+        }
+        all_mocks["_load_evaluation"].side_effect = (
+            lambda _base, candidate_id: deepcopy(saved_results.get(candidate_id))
+        )
+        all_mocks["load_lineage"].return_value = {
+            "placeholder-a": None,
+            "placeholder-b": None,
+            "placeholder-c": None,
+        }
+        all_mocks["find_merge_triplet"].return_value = (
+            "g1-s1",
+            "g1-s2",
+            "g0-s0",
+        )
+        merged = _make_candidate("g2-m1")
+        all_mocks["merge"].return_value = merged
+        all_mocks["snapshot_candidate"].return_value = "merge-sha"
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            score = 0.9 if candidate.id == merged.id else 0.8
+            if instance_ids is not None:
+                return _make_result(
+                    candidate.id, {eid: score for eid in instance_ids}
+                )
+            return _make_result(candidate.id, {"v": score})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=1,
+            max_generations=2,
+            max_evaluations=1000,
+        )
+        config.evolution.merge_enabled = True
+        config.evolution.max_merge_invocations = 1
+        run_evolution(config, tmp_path, base_dir)
+
+        all_mocks["merge"].assert_called_once()
+        all_mocks["mutate"].assert_not_called()
+        state = all_mocks["save_state"].call_args.args[0]
+        assert state.total_merge_invocations == 1
+        assert state.scheduler_state["pending_merges_due"] == 1
+        assert state.scheduler_state["last_iter_found_new_program"] is False
+
+    def test_wrong_mutation_id_cleans_live_child_before_fatal_error(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """A post-return reserved-ID violation cannot orphan its worktree."""
+        train_path = _write_train_jsonl(tmp_path, n=2)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        wrong_path = tmp_path / ".helix" / "worktrees" / "wrong-id"
+        wrong_path.mkdir(parents=True)
+        wrong_child = _make_candidate("wrong-id")
+        wrong_child.worktree_path = str(wrong_path)
+        all_mocks["mutate"].return_value = wrong_child
+        all_mocks["remove_worktree"].side_effect = lambda child: Path(
+            child.worktree_path
+        ).rmdir()
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if instance_ids is not None:
+                return _make_result(candidate.id, {eid: 0.2 for eid in instance_ids})
+            return _make_result(candidate.id, {"v": 0.5})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        config = _make_minibatch_config(train_path, minibatch_size=1)
+        with pytest.raises(ValueError, match="reserved id"):
+            run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert not wrong_path.exists()
+        all_mocks["remove_worktree"].assert_called_once_with(wrong_child)
+        state = all_mocks["save_state"].call_args.args[0]
+        task = state.proposal_batches[-1].tasks[0]
+        assert task.status == "failed"
+        assert task.cleanup == "removed"
+        assert task.budget_accounted
+
+    def test_tamper_detector_exception_cleans_live_child_per_slot(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        """An ordinary detector failure remains local and leaves no worktree."""
+        train_path = _write_train_jsonl(tmp_path, n=2)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        child_path = tmp_path / ".helix" / "worktrees" / "g1-s1"
+        child_path.mkdir(parents=True)
+        child = _make_candidate("g1-s1")
+        child.worktree_path = str(child_path)
+        all_mocks["mutate"].return_value = child
+        all_mocks["remove_worktree"].side_effect = lambda candidate: Path(
+            candidate.worktree_path
+        ).rmdir()
+        mocker.patch(
+            "helix.evolution._detect_evaluator_tamper",
+            side_effect=RuntimeError("tamper detector unavailable"),
+        )
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            if instance_ids is not None:
+                return _make_result(candidate.id, {eid: 0.2 for eid in instance_ids})
+            return _make_result(candidate.id, {"v": 0.5})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        config = _make_minibatch_config(train_path, minibatch_size=1)
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert not child_path.exists()
+        all_mocks["remove_worktree"].assert_called_once_with(child)
+        state = all_mocks["save_state"].call_args.args[0]
+        batch = state.proposal_batches[-1]
+        assert batch.phase == "complete"
+        assert batch.tasks[0].status == "failed"
+        assert batch.tasks[0].cleanup == "removed"
+        assert batch.tasks[0].budget_accounted
+
+
+class TestStrictCachedInstanceScoresAccess:
     def test_missing_id_in_cached_evaluator_raises(
         self, tmp_path: Path, all_mocks: dict[str, Any]
     ) -> None:

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -2196,6 +2196,8 @@ class TestUnifiedPxNScheduler:
                 if candidate.id.endswith("s1"):
                     time.sleep(0.04)
                 return _make_result(candidate.id, {eid: score for eid in instance_ids})
+            if instance_ids is not None:
+                return _make_result(candidate.id, {eid: 0.8 for eid in instance_ids})
             return _make_result(candidate.id, {"v": 0.8})
 
         all_mocks["run_evaluator"].side_effect = run_eval
@@ -2266,6 +2268,8 @@ class TestUnifiedPxNScheduler:
                 else:
                     score = 0.9
                 return _make_result(candidate.id, {eid: score for eid in instance_ids})
+            if instance_ids is not None:
+                return _make_result(candidate.id, {eid: 0.8 for eid in instance_ids})
             return _make_result(candidate.id, {"v": 0.8})
 
         all_mocks["run_evaluator"].side_effect = run_eval
@@ -2321,13 +2325,15 @@ class TestUnifiedPxNScheduler:
                 return _make_result(candidate.id, {eid: score for eid in instance_ids})
             if candidate.id != seed.id:
                 full_validated_children.append(candidate.id)
+            if instance_ids is not None:
+                return _make_result(candidate.id, {eid: 0.8 for eid in instance_ids})
             return _make_result(candidate.id, {"v": 0.8})
 
         all_mocks["run_evaluator"].side_effect = run_eval
         config = _make_minibatch_config(
             train_path,
             minibatch_size=1,
-            max_evaluations=5,
+            max_evaluations=7,
             num_parallel_proposals=1,
             mutations_per_parent=3,
             max_workers=3,
@@ -2336,9 +2342,9 @@ class TestUnifiedPxNScheduler:
 
         state = all_mocks["save_state"].call_args.args[0]
         batch = state.proposal_batches[-1]
-        assert state.budget.evaluations == 7
-        assert batch.budget_before_dispatch == 1
-        assert batch.budget_after_apply == 7
+        assert state.budget.evaluations == 9
+        assert batch.budget_before_dispatch == 3
+        assert batch.budget_after_apply == 9
         assert [task.budget_charge.evaluations for task in batch.tasks] == [2, 2, 2]
         assert all(task.status == "rejected" for task in batch.tasks)
         assert all(task.selection == "selected" for task in batch.tasks)
@@ -2385,6 +2391,8 @@ class TestUnifiedPxNScheduler:
             if split == "train" and instance_ids is not None:
                 score = 0.1 if candidate.id == seed.id else 0.9
                 return _make_result(candidate.id, {eid: score for eid in instance_ids})
+            if instance_ids is not None:
+                return _make_result(candidate.id, {eid: 0.8 for eid in instance_ids})
             return _make_result(candidate.id, {"v": 0.8})
 
         all_mocks["run_evaluator"].side_effect = run_eval

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -262,7 +262,10 @@ class TestMinibatchGateIntegration:
         all_mocks["run_evaluator"].side_effect = run_eval
 
         config = _make_minibatch_config(
-            train_path, minibatch_size=2, max_generations=1, max_evaluations=100,
+            train_path,
+            minibatch_size=2,
+            max_generations=1,
+            max_evaluations=100,
         )
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
@@ -305,7 +308,10 @@ class TestMinibatchGateIntegration:
         all_mocks["run_evaluator"].side_effect = run_eval
 
         config = _make_minibatch_config(
-            train_path, minibatch_size=2, max_generations=1, max_evaluations=100,
+            train_path,
+            minibatch_size=2,
+            max_generations=1,
+            max_evaluations=100,
         )
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
@@ -321,9 +327,9 @@ class TestMinibatchGateIntegration:
         attempt_path = tmp_path / ".helix" / "attempts" / "g1-s1.json"
         assert attempt_path.exists()
         attempt = json.loads(attempt_path.read_text())
-        child_train_ids = [
-            c[2] for c in calls if c[0] == "g1-s1" and c[1] == "train"
-        ][0]
+        child_train_ids = [c[2] for c in calls if c[0] == "g1-s1" and c[1] == "train"][
+            0
+        ]
         assert attempt["candidate_id"] == "g1-s1"
         assert attempt["attempt"] == {
             "status": "rejected",
@@ -511,7 +517,9 @@ class TestMinibatchGateIntegration:
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
         attempt_path = tmp_path / ".helix" / "attempts" / "g1-s1.json"
-        assert attempt_path.exists(), "attempts/g1-s1.json should be written on train_gate reject"
+        assert attempt_path.exists(), (
+            "attempts/g1-s1.json should be written on train_gate reject"
+        )
         attempt = json.loads(attempt_path.read_text())
         assert attempt["candidate_id"] == "g1-s1"
         assert attempt["attempt"]["status"] == "rejected"
@@ -551,7 +559,9 @@ class TestMinibatchGateIntegration:
                 if split == "train":
                     # Parent scores low on minibatch; child scores high → passes gate.
                     if candidate.id == seed.id:
-                        return _make_result(candidate.id, {i: 0.1 for i in instance_ids})
+                        return _make_result(
+                            candidate.id, {i: 0.1 for i in instance_ids}
+                        )
                     return _make_result(candidate.id, {i: 0.9 for i in instance_ids})
                 # val evals
                 if split == "val":
@@ -577,7 +587,9 @@ class TestMinibatchGateIntegration:
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
         attempt_path = tmp_path / ".helix" / "attempts" / "g1-s1.json"
-        assert attempt_path.exists(), "attempts/g1-s1.json should be written on val_stage reject"
+        assert attempt_path.exists(), (
+            "attempts/g1-s1.json should be written on val_stage reject"
+        )
         attempt = json.loads(attempt_path.read_text())
         assert attempt["candidate_id"] == "g1-s1"
         assert attempt["attempt"]["status"] == "rejected"
@@ -612,11 +624,7 @@ class TestMinibatchGateIntegration:
             instance_ids: list[str] | None = None,
             **kwargs: Any,
         ) -> EvalResult:
-            if (
-                candidate.id == "g1-s1"
-                and split == "val"
-                and instance_ids is not None
-            ):
+            if candidate.id == "g1-s1" and split == "val" and instance_ids is not None:
                 child_val_calls.append(list(instance_ids))
             if instance_ids is not None:
                 if candidate.id == seed.id:
@@ -627,7 +635,10 @@ class TestMinibatchGateIntegration:
         all_mocks["run_evaluator"].side_effect = run_eval
 
         config = _make_minibatch_config(
-            train_path, minibatch_size=2, max_generations=1, max_evaluations=100,
+            train_path,
+            minibatch_size=2,
+            max_generations=1,
+            max_evaluations=100,
         )
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
@@ -655,16 +666,28 @@ class TestMinibatchGateIntegration:
         ) -> EvalResult:
             if split == "val" and instance_ids is not None and candidate.id == "g1-s1":
                 child_val_calls.append(list(instance_ids))
-            if split == "val" and instance_ids == ["0", "1", "2", "3"] and candidate.id == seed.id:
-                return _make_result(candidate.id, {"0": 0.8, "1": 0.8, "2": 0.8, "3": 0.8})
+            if (
+                split == "val"
+                and instance_ids == ["0", "1", "2", "3"]
+                and candidate.id == seed.id
+            ):
+                return _make_result(
+                    candidate.id, {"0": 0.8, "1": 0.8, "2": 0.8, "3": 0.8}
+                )
             if split == "train" and instance_ids is not None:
                 if candidate.id == seed.id:
                     return _make_result(candidate.id, {i: 0.1 for i in instance_ids})
                 return _make_result(candidate.id, {i: 0.9 for i in instance_ids})
-            if split == "val" and instance_ids == ["0", "1"] and candidate.id == "g1-s1":
+            if (
+                split == "val"
+                and instance_ids == ["0", "1"]
+                and candidate.id == "g1-s1"
+            ):
                 return _make_result(candidate.id, {"0": 0.1, "1": 0.1})
             if split == "val" and instance_ids is not None and candidate.id == "g1-s1":
-                pytest.fail(f"Unexpected child full-val call after stage reject: {instance_ids}")
+                pytest.fail(
+                    f"Unexpected child full-val call after stage reject: {instance_ids}"
+                )
             return _make_result(candidate.id, {"v1": 0.0})
 
         all_mocks["run_evaluator"].side_effect = run_eval
@@ -703,15 +726,29 @@ class TestMinibatchGateIntegration:
         ) -> EvalResult:
             if split == "val" and instance_ids is not None and candidate.id == "g1-s1":
                 child_val_calls.append(list(instance_ids))
-            if split == "val" and instance_ids == ["0", "1", "2", "3"] and candidate.id == seed.id:
-                return _make_result(candidate.id, {"0": 0.2, "1": 0.2, "2": 0.2, "3": 0.2})
+            if (
+                split == "val"
+                and instance_ids == ["0", "1", "2", "3"]
+                and candidate.id == seed.id
+            ):
+                return _make_result(
+                    candidate.id, {"0": 0.2, "1": 0.2, "2": 0.2, "3": 0.2}
+                )
             if split == "train" and instance_ids is not None:
                 if candidate.id == seed.id:
                     return _make_result(candidate.id, {i: 0.1 for i in instance_ids})
                 return _make_result(candidate.id, {i: 0.9 for i in instance_ids})
-            if split == "val" and instance_ids == ["0", "1"] and candidate.id == "g1-s1":
+            if (
+                split == "val"
+                and instance_ids == ["0", "1"]
+                and candidate.id == "g1-s1"
+            ):
                 return _make_result(candidate.id, {"0": 0.8, "1": 0.8})
-            if split == "val" and instance_ids == ["2", "3"] and candidate.id == "g1-s1":
+            if (
+                split == "val"
+                and instance_ids == ["2", "3"]
+                and candidate.id == "g1-s1"
+            ):
                 return _make_result(candidate.id, {"2": 0.7, "3": 0.6})
             return _make_result(candidate.id, {"v1": 0.0})
 
@@ -895,9 +932,7 @@ class TestMinibatchGateIntegration:
             **kwargs: Any,
         ) -> EvalResult:
             if instance_ids is not None:
-                return _make_result(
-                    candidate.id, {i: 0.5 for i in instance_ids}
-                )
+                return _make_result(candidate.id, {i: 0.5 for i in instance_ids})
             return _make_result(candidate.id, {"v1": 0.5})
 
         all_mocks["run_evaluator"].side_effect = run_eval
@@ -965,7 +1000,12 @@ class TestCachedEvaluateBatch:
         write_batch_mock = mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand,
+            ["0", "1", "2"],
+            cache,
+            self._trivial_config(),
+            "train",
+            Path("/tmp"),
         )
 
         assert run_eval_mock.call_count == 0, (
@@ -1000,7 +1040,12 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand_b, ["0", "1"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand_b,
+            ["0", "1"],
+            cache,
+            self._trivial_config(),
+            "train",
+            Path("/tmp"),
         )
 
         assert num_actual == 0
@@ -1049,7 +1094,12 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand_b, ["0", "1"], cache, self._trivial_config(), "train", tmp_path,
+            cand_b,
+            ["0", "1"],
+            cache,
+            self._trivial_config(),
+            "train",
+            tmp_path,
         )
 
         assert num_actual == 0
@@ -1108,7 +1158,12 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand_b, ["0", "1"], cache, self._trivial_config(), "train", tmp_path,
+            cand_b,
+            ["0", "1"],
+            cache,
+            self._trivial_config(),
+            "train",
+            tmp_path,
         )
 
         assert seen_instance_ids == [["0", "1"]]
@@ -1170,7 +1225,12 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand,
+            ["0", "1", "2"],
+            cache,
+            self._trivial_config(),
+            "train",
+            Path("/tmp"),
         )
 
         assert seen_instance_ids == [["0", "1", "2"]], (
@@ -1202,10 +1262,20 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         first, first_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/tmp"),
+            cand,
+            ["0", "1"],
+            None,
+            self._trivial_config(),
+            "train",
+            Path("/tmp"),
         )
         second, second_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/tmp"),
+            cand,
+            ["0", "1"],
+            None,
+            self._trivial_config(),
+            "train",
+            Path("/tmp"),
         )
 
         assert seen_instance_ids == [["0", "1"], ["0", "1"]]
@@ -1248,12 +1318,15 @@ class TestCachedEvaluateBatch:
             written_batches.append(list(example_ids))
 
         mocker.patch("helix.evolution.run_evaluator", side_effect=fake_run)
-        mocker.patch(
-            "helix.evolution._write_helix_batch", side_effect=fake_write
-        )
+        mocker.patch("helix.evolution._write_helix_batch", side_effect=fake_write)
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand,
+            ["0", "1", "2"],
+            cache,
+            self._trivial_config(),
+            "train",
+            Path("/tmp"),
         )
 
         # Evaluator called exactly once, with only the missing id.
@@ -1327,17 +1400,19 @@ class TestCachedEvaluateBatch:
                     {"trajectory": f"fresh_trace_{eid}", "rollout_id": f"fresh__{eid}"}
                     for eid in ids
                 ],
-                objective_scores=[
-                    {"obj_alpha": 0.22, "obj_beta": 0.5}
-                    for _ in ids
-                ],
+                objective_scores=[{"obj_alpha": 0.22, "obj_beta": 0.5} for _ in ids],
             )
 
         mocker.patch("helix.evolution.run_evaluator", side_effect=fake_run)
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1", "2"], cache, self._trivial_config(), "train", Path("/tmp"),
+            cand,
+            ["0", "1", "2"],
+            cache,
+            self._trivial_config(),
+            "train",
+            Path("/tmp"),
         )
 
         # instance_scores merge: cached 0/2 + fresh 1 (established
@@ -1350,18 +1425,18 @@ class TestCachedEvaluateBatch:
         # ``example_ids``:
         assert result.objective_scores is not None
         assert result.objective_scores == [
-            {"obj_alpha": 0.11, "obj_beta": 0.8},     # cached id "0"
-            {"obj_alpha": 0.22, "obj_beta": 0.5},     # fresh id "1"
-            {"obj_alpha": 0.33, "obj_beta": 0.1},     # cached id "2"
+            {"obj_alpha": 0.11, "obj_beta": 0.8},  # cached id "0"
+            {"obj_alpha": 0.22, "obj_beta": 0.5},  # fresh id "1"
+            {"obj_alpha": 0.33, "obj_beta": 0.1},  # cached id "2"
         ]
 
         # per_example_side_info round-trips by example id through the cache;
         # the fresh miss position gets the dict we returned from fake_run.
         assert result.per_example_side_info is not None
         assert result.per_example_side_info == [
-            {"trajectory": "cached_trace_0", "rollout_id": "cached__0"},       # cached "0"
-            {"trajectory": "fresh_trace_1", "rollout_id": "fresh__1"},         # fresh "1"
-            {"trajectory": "cached_trace_2", "rollout_id": "cached__2"},       # cached "2"
+            {"trajectory": "cached_trace_0", "rollout_id": "cached__0"},  # cached "0"
+            {"trajectory": "fresh_trace_1", "rollout_id": "fresh__1"},  # fresh "1"
+            {"trajectory": "cached_trace_2", "rollout_id": "cached__2"},  # cached "2"
         ]
 
     def test_cache_populates_after_fresh_eval(self, mocker: Any) -> None:
@@ -1393,7 +1468,12 @@ class TestCachedEvaluateBatch:
 
         # First call: full miss → evaluator runs once.
         first_result, first_num_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], cache, cfg, "train", Path("/tmp"),
+            cand,
+            ["0", "1"],
+            cache,
+            cfg,
+            "train",
+            Path("/tmp"),
         )
         assert call_count["n"] == 1
         assert first_num_actual == 2
@@ -1401,7 +1481,12 @@ class TestCachedEvaluateBatch:
 
         # Second call with the same (candidate, ids): full hit → no re-run.
         second_result, second_num_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], cache, cfg, "train", Path("/tmp"),
+            cand,
+            ["0", "1"],
+            cache,
+            cfg,
+            "train",
+            Path("/tmp"),
         )
         assert call_count["n"] == 1, (
             "Evaluator must not be invoked a second time for cached ids"
@@ -1439,7 +1524,12 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0"], cache, self._trivial_config(), "val", Path("/tmp"),
+            cand,
+            ["0"],
+            cache,
+            self._trivial_config(),
+            "val",
+            Path("/tmp"),
         )
 
         assert seen_splits == ["val"]
@@ -1470,7 +1560,12 @@ class TestCachedEvaluateBatch:
         mocker.patch("helix.evolution._write_helix_batch")
 
         result, num_actual = _cached_evaluate_batch(
-            cand, ["0", "1"], None, self._trivial_config(), "train", Path("/tmp"),
+            cand,
+            ["0", "1"],
+            None,
+            self._trivial_config(),
+            "train",
+            Path("/tmp"),
         )
 
         assert seen_instance_ids == [["0", "1"]]
@@ -1508,9 +1603,7 @@ class TestWriteHelixBatchStringIds:
         # Explicit: every element is a str (no silent numeric coercion).
         assert all(isinstance(x, str) for x in written)
 
-    def test_stringified_int_ids_still_written_as_strings(
-        self, tmp_path: Path
-    ) -> None:
+    def test_stringified_int_ids_still_written_as_strings(self, tmp_path: Path) -> None:
         """The default ``_RangeDataLoader`` emits ``"0"``, ``"1"``, … — these
         now round-trip as strings too, not ints.  Evaluators that previously
         relied on reading ``list[int]`` must cast on their side."""
@@ -2028,8 +2121,7 @@ class TestEvaluationCacheThreadSafety:
             cache.put_batch(cand, ids, [None] * 50, [float(i) for i in range(50)])
 
         threads = [
-            threading.Thread(target=worker, args=(f"c-{k}", k * 100))
-            for k in range(8)
+            threading.Thread(target=worker, args=(f"c-{k}", k * 100)) for k in range(8)
         ]
         for t in threads:
             t.start()
@@ -2221,9 +2313,7 @@ class TestUnifiedPxNScheduler:
                     legacy_state, source="parallel_proposal"
                 )
             parent = legacy_frontier.select_parent()
-            minibatch = tuple(
-                legacy_sampler.next_minibatch_ids(loader, legacy_state)
-            )
+            minibatch = tuple(legacy_sampler.next_minibatch_ids(loader, legacy_state))
             child_id = budget_api.next_mutation_id(legacy_state, 4)
             legacy.append((parent.id, minibatch, child_id))
 
@@ -2584,9 +2674,7 @@ class TestUnifiedPxNScheduler:
         for snapshot in durable_snapshots:
             if not snapshot.proposal_batches:
                 continue
-            statuses = [
-                task.status for task in snapshot.proposal_batches[-1].tasks
-            ]
+            statuses = [task.status for task in snapshot.proposal_batches[-1].tasks]
             assert statuses not in (["evaluated", "running"], ["running", "evaluated"])
         budget_after_crash = interrupted.budget.evaluations
 
@@ -2600,8 +2688,7 @@ class TestUnifiedPxNScheduler:
         assert recovered.budget.evaluations == budget_after_crash
         assert recovered.proposal_batches[-1].phase == "complete"
         assert all(
-            task.status == "applied"
-            for task in recovered.proposal_batches[-1].tasks
+            task.status == "applied" for task in recovered.proposal_batches[-1].tasks
         )
         assert cleanup_calls_after_first_resume == 0
 
@@ -2678,8 +2765,8 @@ class TestUnifiedPxNScheduler:
             "g1-s1": _make_result("g1-s1", {"v": 0.8}),
             "g1-s2": _make_result("g1-s2", {"v": 0.8}),
         }
-        all_mocks["_load_evaluation"].side_effect = (
-            lambda _base, candidate_id: deepcopy(saved_results.get(candidate_id))
+        all_mocks["_load_evaluation"].side_effect = lambda _base, candidate_id: (
+            deepcopy(saved_results.get(candidate_id))
         )
         all_mocks["load_lineage"].return_value = {
             "placeholder-a": None,
@@ -2704,9 +2791,7 @@ class TestUnifiedPxNScheduler:
         ) -> EvalResult:
             score = 0.9 if candidate.id == merged.id else 0.8
             if instance_ids is not None:
-                return _make_result(
-                    candidate.id, {eid: score for eid in instance_ids}
-                )
+                return _make_result(candidate.id, {eid: score for eid in instance_ids})
             return _make_result(candidate.id, {"v": score})
 
         all_mocks["run_evaluator"].side_effect = run_eval
@@ -2974,7 +3059,9 @@ class TestResumeAttemptReconciliation:
         assert state.frontier == ["g0-s0", "g1-s1"]
         assert state.active_frontier == {"x": ["g1-s1"]}
         remove_mock.assert_called_once()
-        remaining_ids = {record["id"] for record in json.loads(lineage_path.read_text())}
+        remaining_ids = {
+            record["id"] for record in json.loads(lineage_path.read_text())
+        }
         assert remaining_ids == {"g0-s0", "g1-s1"}
 
     def test_orphan_worktree_without_lineage_is_removed(
@@ -3023,7 +3110,9 @@ class TestResumeAttemptReconciliation:
         assert state.generation == 4
         assert state.mutation_counter == 4
         remove_mock.assert_called_once()
-        remaining_ids = {record["id"] for record in json.loads(lineage_path.read_text())}
+        remaining_ids = {
+            record["id"] for record in json.loads(lineage_path.read_text())
+        }
         assert remaining_ids == {"g1-s1"}
 
     def test_historical_missing_worktree_entries_are_left_intact(
@@ -3079,7 +3168,9 @@ class TestResumeAttemptReconciliation:
         assert state.generation == 2
         assert state.mutation_counter == 2
         remove_mock.assert_not_called()
-        remaining_ids = {record["id"] for record in json.loads(lineage_path.read_text())}
+        remaining_ids = {
+            record["id"] for record in json.loads(lineage_path.read_text())
+        }
         assert remaining_ids == {"g0-s0", "g2-s2"}
 
 
@@ -3190,7 +3281,7 @@ class TestStoppingConditionValidation:
             evaluator=EvaluatorConfig(command="pytest -q"),
             dataset=DatasetConfig(),
             evolution=EvolutionConfig(
-                max_generations=0,   # loop bound disabled
+                max_generations=0,  # loop bound disabled
                 max_evaluations=-1,  # budget cap disabled
             ),
         )
@@ -3207,7 +3298,7 @@ class TestStoppingConditionValidation:
             dataset=DatasetConfig(),
             evolution=EvolutionConfig(
                 max_generations=-1,  # loop bound disabled
-                max_evaluations=0,   # also disabled
+                max_evaluations=0,  # also disabled
             ),
         )
         with pytest.raises(ValueError, match="stopping condition"):
@@ -3243,6 +3334,8 @@ class TestStoppingConditionValidation:
         )
         # Must NOT raise — max_generations=1 is a valid stopping condition.
         run_evolution(config, tmp_path, tmp_path / ".helix")
+
+
 # ---------------------------------------------------------------------------
 # Atomic Proposal Worker Tests
 #
@@ -3420,7 +3513,9 @@ class TestAtomicProposalWorker:
                 _call_counter[0] += 1
                 is_first = _call_counter[0] == 1
             if is_first:
-                raise RuntimeError("simulated LLM failure — atomic-worker isolation test")
+                raise RuntimeError(
+                    "simulated LLM failure — atomic-worker isolation test"
+                )
             return _make_candidate(kw["new_id"])
 
         all_mocks["mutate"].side_effect = _mutate_fail_first

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -1932,6 +1932,90 @@ class TestParentMinibatchBudgetCharge:
 
 
 class TestEvaluationCacheThreadSafety:
+    def test_failed_singleflight_owner_and_waiter_report_exact_attempts(
+        self, tmp_path: Path, mocker: Any
+    ) -> None:
+        """A failed owner is charged; its waiter charges only owned work and retry."""
+        import threading
+
+        from helix.eval_cache import EvaluationCache
+        from helix.evolution import _cached_evaluate_batch
+        from helix.executor import EvalBatchItem, run_evaluator_batch
+
+        cache: EvaluationCache[object, str] = EvaluationCache()
+        first_seven_started = threading.Event()
+        eight_finished = threading.Event()
+        calls_lock = threading.Lock()
+        calls: list[tuple[str, tuple[str, ...]]] = []
+        seven_attempts = 0
+
+        mocker.patch("helix.evolution._candidate_content_key", return_value="K")
+        mocker.patch("helix.evolution._refresh_protected_evaluator_files")
+        mocker.patch("helix.evolution._write_helix_batch")
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            nonlocal seven_attempts
+            ids = tuple(instance_ids or ())
+            with calls_lock:
+                calls.append((candidate.id, ids))
+                if ids == ("7",):
+                    seven_attempts += 1
+                    attempt = seven_attempts
+                else:
+                    attempt = 0
+            if ids == ("7",) and attempt == 1:
+                first_seven_started.set()
+                assert eight_finished.wait(timeout=2)
+                raise RuntimeError("single-flight owner failed")
+            if ids == ("8",):
+                eight_finished.set()
+            return _make_result(candidate.id, {eid: 0.5 for eid in ids})
+
+        mocker.patch("helix.evolution.run_evaluator", side_effect=run_eval)
+        config = HelixConfig(
+            objective="single-flight accounting",
+            evaluator=EvaluatorConfig(command="pytest -q"),
+        )
+        first = _make_candidate("first")
+        second = _make_candidate("second")
+        items = [
+            EvalBatchItem(first, "K", "train", ("7",)),
+            EvalBatchItem(second, "K", "train", ("7", "8")),
+        ]
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            if item.candidate.id == "second":
+                assert first_seven_started.wait(timeout=2)
+            assert item.instance_ids is not None
+            return _cached_evaluate_batch(
+                item.candidate,
+                list(item.instance_ids),
+                cache,
+                config,
+                item.split,
+                tmp_path,
+            )
+
+        results = run_evaluator_batch(items, runner, max_workers=2)
+
+        assert isinstance(results[0].error, RuntimeError)
+        assert results[0].num_actual_evaluations == 1
+        assert results[1].error is None
+        assert results[1].num_actual_evaluations == 2
+        assert sum(result.num_actual_evaluations for result in results) == 3
+        assert calls == [
+            ("first", ("7",)),
+            ("second", ("8",)),
+            ("second", ("7",)),
+        ]
+        assert cache._in_flight == {}
+
     def test_concurrent_put_batch_preserves_all_entries(self) -> None:
         import threading
         from helix.eval_cache import EvaluationCache as MBCache
@@ -2299,6 +2383,48 @@ class TestUnifiedPxNScheduler:
             call.args[0].id for call in all_mocks["remove_worktree"].call_args_list
         }
         assert removed_ids == {"g1-s3", "g1-s5"}
+
+    def test_failed_parent_evaluator_units_are_charged_and_journaled(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """A failed two-example leader still advances the durable budget by two."""
+        train_path = _write_train_jsonl(tmp_path, n=2)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        def run_eval(
+            candidate: Candidate,
+            config: HelixConfig,
+            split: str = "val",
+            instance_ids: list[str] | None = None,
+            **kwargs: Any,
+        ) -> EvalResult:
+            assert instance_ids == ["0", "1"]
+            if split == "train":
+                raise RuntimeError("failed after two uncached units")
+            return _make_result(candidate.id, {eid: 0.5 for eid in instance_ids})
+
+        all_mocks["run_evaluator"].side_effect = run_eval
+        config = _make_minibatch_config(
+            train_path,
+            minibatch_size=2,
+            max_generations=1,
+            max_evaluations=1000,
+        )
+
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        state = all_mocks["save_state"].call_args.args[0]
+        batch = state.proposal_batches[-1]
+        [task] = batch.tasks
+        assert batch.budget_before_dispatch == 2
+        assert state.budget.evaluations == 4
+        assert batch.budget_after_apply == 4
+        assert task.status == "failed"
+        assert task.budget_charge.evaluations == 2
+        assert task.budget_accounted
+        assert batch.phase == "complete"
+        all_mocks["mutate"].assert_not_called()
 
     def test_dispatched_child_batch_drains_before_budget_stop_and_cleans_all(
         self, tmp_path: Path, all_mocks: dict[str, Any]

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -116,6 +116,9 @@ def _make_minibatch_config(
     max_generations: int = 1,
     max_evaluations: int = 1000,
     num_parallel_proposals: int = 1,
+    mutations_per_parent: int = 1,
+    proposal_selection: str = "all_improvements",
+    proposal_top_k: int | None = None,
     cache_evaluation: bool = True,
     acceptance_criterion: str = "strict_improvement",
     max_workers: int | None = None,
@@ -126,6 +129,9 @@ def _make_minibatch_config(
         perfect_score_threshold=None,
         minibatch_size=minibatch_size,
         num_parallel_proposals=num_parallel_proposals,
+        mutations_per_parent=mutations_per_parent,
+        proposal_selection=proposal_selection,
+        proposal_top_k=proposal_top_k,
         cache_evaluation=cache_evaluation,
         acceptance_criterion=acceptance_criterion,
         val_stage_size=val_stage_size,
@@ -783,8 +789,7 @@ class TestMinibatchGateIntegration:
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
 
-        mut_ids = iter(["g1-s1", "g1-s2", "g1-s3"])
-        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(next(mut_ids))
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
 
         parent_minibatches: list[list[str]] = []
 
@@ -1552,8 +1557,7 @@ class TestParentMinibatchParallelism:
         train_path = _write_train_jsonl(tmp_path, n=6)
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
-        mut_ids = iter(["g1-s1", "g1-s2", "g1-s3"])
-        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(next(mut_ids))
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
 
         import time
 
@@ -1637,8 +1641,7 @@ class TestMaxWorkersBoundsParentEvalPool:
         train_path = _write_train_jsonl(tmp_path, n=6)
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
-        mut_ids = iter(["g1-s1", "g1-s2", "g1-s3"])
-        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(next(mut_ids))
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
 
         concurrency_lock = threading.Lock()
         current_parent_evals = 0
@@ -1696,8 +1699,7 @@ class TestParentEvalExceptionDoesNotAbortGeneration:
         train_path = _write_train_jsonl(tmp_path, n=6)
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
-        mut_ids = iter(["g1-s1", "g1-s2", "g1-s3"])
-        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(next(mut_ids))
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
 
         parent_eval_attempts: list[bool] = []
         mutate_calls: list[str] = []
@@ -1733,7 +1735,7 @@ class TestParentEvalExceptionDoesNotAbortGeneration:
 
         def _mutate_record(**kw: Any) -> Candidate:
             mutate_calls.append(kw.get("new_id", ""))
-            return _make_candidate(next(mut_ids))
+            return _make_candidate(kw["new_id"])
 
         all_mocks["mutate"].side_effect = _mutate_record
 
@@ -1775,8 +1777,7 @@ class TestParentMinibatchBudgetCharge:
         train_path = _write_train_jsonl(tmp_path, n=2)  # 2 ids → minibatch always [0,1]
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
-        mut_ids = iter(["g1-s1", "g1-s2", "g1-s3", "g1-s4"])
-        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(next(mut_ids))
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
 
         # All mutated children produce the same worktree path as seed so that
         # we can more easily route scores; scores chosen so child < parent and
@@ -2536,8 +2537,7 @@ class TestAtomicProposalWorker:
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
 
-        mut_ids = iter(["g1-s1", "g1-s2"])
-        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(next(mut_ids))
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
 
         main_thread_id = threading.get_ident()
         parent_eval_threads: set[int] = set()
@@ -2665,7 +2665,6 @@ class TestAtomicProposalWorker:
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
 
-        mut_ids = iter(["g1-s1", "g1-s2"])
         _lock = threading.Lock()
         _call_counter: list[int] = [0]
 
@@ -2675,7 +2674,7 @@ class TestAtomicProposalWorker:
                 is_first = _call_counter[0] == 1
             if is_first:
                 raise RuntimeError("simulated LLM failure — atomic-worker isolation test")
-            return _make_candidate(next(mut_ids))
+            return _make_candidate(kw["new_id"])
 
         all_mocks["mutate"].side_effect = _mutate_fail_first
 
@@ -2733,8 +2732,7 @@ class TestAtomicProposalWorker:
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
 
-        mut_ids = iter(["g1-s1", "g1-s2", "g1-s3"])
-        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(next(mut_ids))
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
 
         main_thread_id = threading.get_ident()
         parent_eval_threads: set[int] = set()
@@ -2800,8 +2798,7 @@ class TestAtomicProposalWorker:
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
 
-        mut_ids = iter(["g1-s1", "g1-s2"])
-        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(next(mut_ids))
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
 
         def run_eval(
             candidate: Candidate,

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -2,13 +2,27 @@
 
 from __future__ import annotations
 
+import dataclasses
 import sys
+import threading
 from unittest.mock import MagicMock
 
+import pytest
 
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig, EvaluatorConfig
-from helix.executor import run_evaluator
+from helix.exceptions import (
+    EvaluatorError,
+    PromptArtifactCollisionError,
+    ResumeIncompatibleError,
+)
+from helix.executor import (
+    EvalBatchItem,
+    EvalBatchResult,
+    make_default_batch_runner,
+    run_evaluator,
+    run_evaluator_batch,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -279,3 +293,418 @@ class TestRunEvaluatorWithPytestParser:
 
         assert result.instance_scores["tests/test_foo.py::test_a"] == 1.0
         assert result.instance_scores["tests/test_foo.py::test_b"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: run_evaluator_batch — ordered cross-candidate evaluator batching
+# ---------------------------------------------------------------------------
+
+
+def _batch_candidate(cid: str, worktree: str) -> Candidate:
+    return Candidate(
+        id=cid,
+        worktree_path=worktree,
+        branch_name=f"helix/{cid}",
+        generation=1,
+        parent_id=None,
+        parent_ids=[],
+        operation="mutate",
+    )
+
+
+def make_item(
+    cid: str,
+    worktree: str,
+    *,
+    content_key: str | None = None,
+    split: str = "val",
+    instance_ids: tuple[str, ...] | None = ("0",),
+) -> EvalBatchItem:
+    return EvalBatchItem(
+        candidate=_batch_candidate(cid, worktree),
+        content_key=content_key if content_key is not None else cid,
+        split=split,
+        instance_ids=instance_ids,
+    )
+
+
+def make_eval_result(
+    cid: str, instance_scores: dict[str, float] | None = None
+) -> EvalResult:
+    return EvalResult(
+        candidate_id=cid,
+        scores={"success": 1.0},
+        asi={},
+        instance_scores=instance_scores if instance_scores is not None else {"0": 1.0},
+    )
+
+
+class TestRunEvaluatorBatchOrdering:
+    def test_results_in_input_order_under_reverse_completion(self):
+        # Force leaders to COMPLETE in reverse of input order; results must
+        # still be positional to the input sequence.
+        n = 4
+        start_barrier = threading.Barrier(n)
+        gate = [threading.Event() for _ in range(n)]
+        completion_order: list[int] = []
+        lock = threading.Lock()
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            idx = int(item.candidate.id)
+            start_barrier.wait()  # all n leaders in flight concurrently
+            if idx < n - 1:
+                gate[idx].wait()  # wait until the higher index finishes first
+            with lock:
+                completion_order.append(idx)
+            if idx > 0:
+                gate[idx - 1].set()  # release the next-lower index
+            return make_eval_result(item.candidate.id), 1
+
+        items = [
+            make_item(str(i), f"/wt/{i}", instance_ids=(str(i),)) for i in range(n)
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=n)
+
+        # Completion happened newest-first, proving out-of-order execution...
+        assert completion_order == [3, 2, 1, 0]
+        # ...yet results are returned strictly in input order.
+        assert [r.item.candidate.id for r in results] == ["0", "1", "2", "3"]
+        assert all(r.result is not None for r in results)
+
+    def test_result_count_and_order_match_input(self):
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            return make_eval_result(item.candidate.id), 1
+
+        items = [make_item(f"c{i}", f"/w{i}", instance_ids=(str(i),)) for i in range(5)]
+        results = run_evaluator_batch(items, runner, max_workers=2)
+
+        assert len(results) == 5
+        assert [r.item.candidate.id for r in results] == ["c0", "c1", "c2", "c3", "c4"]
+
+    def test_empty_items_returns_empty(self):
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            raise AssertionError("runner must not be called for empty input")
+
+        assert run_evaluator_batch([], runner, max_workers=2) == []
+
+
+class TestRunEvaluatorBatchConcurrency:
+    def test_same_worktree_leaders_are_serialized(self):
+        # Two leaders that share a worktree must NOT run concurrently: a
+        # 2-party barrier can never rendezvous, so both time out (broken).
+        barrier = threading.Barrier(2, timeout=0.5)
+        overlapped: list[bool] = []
+        lock = threading.Lock()
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            try:
+                barrier.wait()
+                ok = True
+            except threading.BrokenBarrierError:
+                ok = False
+            with lock:
+                overlapped.append(ok)
+            return make_eval_result(item.candidate.id), 1
+
+        items = [
+            make_item("a", "/same-wt", instance_ids=("1",)),
+            make_item("b", "/same-wt", instance_ids=("2",)),
+        ]
+        run_evaluator_batch(items, runner, max_workers=2)
+
+        # Neither leader ever saw the other inside the runner → serialized.
+        assert overlapped == [False, False]
+
+    def test_distinct_worktrees_run_concurrently(self):
+        # Different worktrees may overlap: a 2-party barrier rendezvous proves
+        # both leaders were inside the runner at the same time.
+        barrier = threading.Barrier(2, timeout=2.0)
+        rendezvous: list[bool] = []
+        lock = threading.Lock()
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            try:
+                barrier.wait()
+                ok = True
+            except threading.BrokenBarrierError:
+                ok = False
+            with lock:
+                rendezvous.append(ok)
+            return make_eval_result(item.candidate.id), 1
+
+        items = [
+            make_item("a", "/wt-a", instance_ids=("1",)),
+            make_item("b", "/wt-b", instance_ids=("2",)),
+        ]
+        run_evaluator_batch(items, runner, max_workers=2)
+
+        assert rendezvous == [True, True]
+
+
+class TestRunEvaluatorBatchDedup:
+    def test_identical_requests_run_once_and_follower_reuses(self):
+        calls: list[str] = []
+        lock = threading.Lock()
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            with lock:
+                calls.append(item.candidate.id)
+            return make_eval_result(item.candidate.id), 5
+
+        # Distinct candidate ids, identical (content_key, split, instance_ids).
+        items = [
+            make_item("a", "/wt-a", content_key="K", instance_ids=("1", "2")),
+            make_item("b", "/wt-b", content_key="K", instance_ids=("1", "2")),
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=2)
+
+        assert calls == ["a"]  # only the leader was dispatched
+        # Leader
+        assert results[0].deduplicated_from is None
+        assert results[0].num_actual_evaluations == 5
+        assert results[0].error is None
+        assert results[0].result is not None
+        assert results[0].result.candidate_id == "a"
+        # Follower: independent clone, relabeled to its own candidate, zero charge.
+        assert results[1].deduplicated_from == 0
+        assert results[1].num_actual_evaluations == 0
+        assert results[1].result is not None
+        assert results[1].result is not results[0].result  # distinct object
+        assert results[1].result.candidate_id == "b"  # positional identity
+        assert (
+            results[1].result.instance_scores == results[0].result.instance_scores
+        )  # equal payload
+        # Mutating the follower must not corrupt the leader (no dict aliasing).
+        results[1].result.instance_scores["0"] = 999.0
+        assert results[0].result.instance_scores["0"] != 999.0
+
+    def test_instance_id_order_is_significant(self):
+        calls: list[str] = []
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            calls.append(item.candidate.id)
+            return make_eval_result(item.candidate.id), 1
+
+        items = [
+            make_item("a", "/wa", content_key="K", instance_ids=("1", "2")),
+            make_item("b", "/wb", content_key="K", instance_ids=("2", "1")),
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=2)
+
+        assert sorted(calls) == ["a", "b"]  # reordered minibatch → not deduped
+        assert results[1].deduplicated_from is None
+
+    def test_split_and_content_key_partition_dedup(self):
+        calls: list[str] = []
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            calls.append(item.candidate.id)
+            return make_eval_result(item.candidate.id), 1
+
+        items = [
+            make_item("a", "/wa", content_key="K", split="val", instance_ids=("1",)),
+            make_item("b", "/wb", content_key="K", split="train", instance_ids=("1",)),
+            make_item("c", "/wc", content_key="J", split="val", instance_ids=("1",)),
+            make_item("d", "/wd", content_key="K", split="val", instance_ids=("1",)),
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=4)
+
+        # a/b differ by split, a/c differ by content_key → all leaders; d==a.
+        assert sorted(calls) == ["a", "b", "c"]
+        assert results[3].deduplicated_from == 0
+
+    def test_dedup_preserves_budget_accounting(self):
+        total_real_evals = 0
+        lock = threading.Lock()
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            nonlocal total_real_evals
+            assert item.instance_ids is not None
+            with lock:
+                total_real_evals += len(item.instance_ids)
+            return make_eval_result(item.candidate.id), len(item.instance_ids)
+
+        items = [
+            make_item("a", "/wa", content_key="K", instance_ids=("1", "2", "3")),
+            make_item("b", "/wb", content_key="K", instance_ids=("1", "2", "3")),  # dup
+            make_item("c", "/wc", content_key="J", instance_ids=("9",)),
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=3)
+
+        charged = sum(r.num_actual_evaluations for r in results)
+        assert total_real_evals == 4  # leader K (3) + leader J (1); dup ran 0
+        assert charged == 4  # 3 (leader) + 0 (follower) + 1 (leader)
+
+
+class TestRunEvaluatorBatchFailures:
+    def test_ordinary_failure_is_isolated(self):
+        class Boom(Exception):
+            pass
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            if item.candidate.id == "bad":
+                raise Boom("nope")
+            return make_eval_result(item.candidate.id), 2
+
+        items = [
+            make_item("good", "/wa", instance_ids=("1",)),
+            make_item("bad", "/wb", instance_ids=("2",)),
+            make_item("good2", "/wc", instance_ids=("3",)),
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=3)
+
+        assert results[0].result is not None and results[0].error is None
+        assert results[1].result is None
+        assert isinstance(results[1].error, Boom)
+        assert results[1].num_actual_evaluations == 0
+        assert results[1].deduplicated_from is None
+        assert results[2].result is not None and results[2].error is None
+
+    def test_failed_leader_propagates_error_to_followers(self):
+        class Boom(Exception):
+            pass
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            raise Boom("x")
+
+        items = [
+            make_item("a", "/wa", content_key="K", instance_ids=("1",)),
+            make_item("b", "/wb", content_key="K", instance_ids=("1",)),
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=2)
+
+        assert isinstance(results[0].error, Boom)
+        assert results[0].deduplicated_from is None
+        assert results[1].deduplicated_from == 0
+        assert results[1].error is results[0].error
+        assert results[1].result is None
+        assert results[1].num_actual_evaluations == 0
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            PromptArtifactCollisionError("collision"),
+            ResumeIncompatibleError("resume"),
+            KeyboardInterrupt(),
+            SystemExit(1),
+        ],
+    )
+    def test_fatal_exceptions_propagate(self, exc: BaseException):
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            raise exc
+
+        items = [make_item("a", "/wa", instance_ids=("1",))]
+        with pytest.raises(type(exc)):
+            run_evaluator_batch(items, runner, max_workers=1)
+
+
+class TestRunEvaluatorBatchCardinalityAndConfig:
+    def test_max_workers_must_be_positive(self):
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            return make_eval_result(item.candidate.id), 1
+
+        with pytest.raises(ValueError):
+            run_evaluator_batch(
+                [make_item("a", "/wa", instance_ids=("1",))], runner, max_workers=0
+            )
+
+    def test_pre_dispatch_bad_command_propagates_without_dispatch(self):
+        config = make_config(command="'unterminated")  # shlex parse failure
+        called: list[str] = []
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            called.append(item.candidate.id)
+            return make_eval_result(item.candidate.id), 1
+
+        with pytest.raises(EvaluatorError):
+            run_evaluator_batch(
+                [make_item("a", "/wa", instance_ids=("1",))],
+                runner,
+                max_workers=1,
+                config=config,
+            )
+        assert called == []  # failed before any leader dispatched
+
+    def test_negative_runner_count_is_rejected(self):
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            return make_eval_result(item.candidate.id), -1
+
+        with pytest.raises(ValueError, match="negative num_actual_evaluations"):
+            run_evaluator_batch(
+                [make_item("a", "/wa", instance_ids=("1",))], runner, max_workers=1
+            )
+
+    def test_result_positional_to_input_with_dedup_and_failure(self):
+        class Boom(Exception):
+            pass
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            if item.candidate.id == "bad":
+                raise Boom("x")
+            return make_eval_result(item.candidate.id), 1
+
+        items = [
+            make_item("a", "/wa", content_key="K", instance_ids=("1",)),
+            make_item("bad", "/wb", content_key="B", instance_ids=("1",)),
+            make_item("a2", "/wc", content_key="K", instance_ids=("1",)),  # dup of a
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=3)
+
+        assert len(results) == 3
+        assert [r.item.candidate.id for r in results] == ["a", "bad", "a2"]
+        assert results[0].error is None and results[0].deduplicated_from is None
+        assert isinstance(results[1].error, Boom)
+        assert results[2].deduplicated_from == 0
+        assert results[2].result is not results[0].result  # independent clone
+        assert results[2].result is not None
+        assert results[2].result.candidate_id == "a2"
+
+
+class TestMakeDefaultBatchRunner:
+    def test_counts_minibatch_and_forwards_args(self, mocker):
+        fake = make_eval_result("a", instance_scores={"1": 1.0, "2": 0.0})
+        m = mocker.patch("helix.executor.run_evaluator", return_value=fake)
+        config = make_config()
+        runner = make_default_batch_runner(config)
+
+        item = make_item("a", "/w", split="train", instance_ids=("1", "2"))
+        result, count = runner(item)
+
+        assert result is fake
+        assert count == 2
+        m.assert_called_once()
+        _, kwargs = m.call_args
+        assert kwargs["split"] == "train"
+        assert kwargs["instance_ids"] == ["1", "2"]
+
+    def test_whole_split_counts_instance_scores(self, mocker):
+        fake = make_eval_result("a", instance_scores={"1": 1.0, "2": 0.0, "3": 1.0})
+        mocker.patch("helix.executor.run_evaluator", return_value=fake)
+        runner = make_default_batch_runner(make_config())
+
+        item = make_item("a", "/w", instance_ids=None)
+        _, count = runner(item)
+
+        assert count == 3
+
+
+class TestEvalBatchDataclasses:
+    def test_item_is_frozen_and_exposes_dedup_key(self):
+        item = make_item("a", "/w", content_key="K", split="val", instance_ids=("1",))
+        assert item.dedup_key.content_key == "K"
+        assert item.dedup_key.split == "val"
+        assert item.dedup_key.instance_ids == ("1",)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            item.split = "train"  # type: ignore[misc]
+
+    def test_result_is_frozen(self):
+        item = make_item("a", "/w", instance_ids=("1",))
+        res = EvalBatchResult(
+            item=item,
+            result=make_eval_result("a"),
+            error=None,
+            num_actual_evaluations=1,
+            deduplicated_from=None,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            res.num_actual_evaluations = 0  # type: ignore[misc]

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -580,6 +580,79 @@ class TestRunEvaluatorBatchFailures:
         assert results[1].result is None
         assert results[1].num_actual_evaluations == 0
 
+    def test_fatal_leader_returns_successful_and_deduplicated_siblings(self):
+        """A later successful leader drains before an earlier fatal slot returns."""
+        fatal = PromptArtifactCollisionError("collision")
+        successful_leader_finished = threading.Event()
+        completion_order: list[str] = []
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            if item.candidate.id == "fatal":
+                assert successful_leader_finished.wait(timeout=2)
+                completion_order.append("fatal")
+                raise fatal
+            completion_order.append(item.candidate.id)
+            successful_leader_finished.set()
+            return make_eval_result(item.candidate.id), 3
+
+        items = [
+            make_item("fatal", "/fatal", content_key="F", instance_ids=("1",)),
+            make_item("good", "/good", content_key="K", instance_ids=("1",)),
+            make_item("good-dup", "/dup", content_key="K", instance_ids=("1",)),
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=3)
+
+        assert completion_order == ["good", "fatal"]
+        assert results[0].error is fatal
+        assert results[1].result is not None
+        assert results[1].num_actual_evaluations == 3
+        assert results[2].result is not None
+        assert results[2].deduplicated_from == 1
+        assert results[2].num_actual_evaluations == 0
+        assert sum(result.num_actual_evaluations for result in results) == 3
+
+    def test_original_fatal_precedes_later_negative_count_and_keeps_partials(self):
+        fatal = PromptArtifactCollisionError("primary fatal")
+        negative_finished = threading.Event()
+        good_finished = threading.Event()
+        completion_order: list[str] = []
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            candidate_id = item.candidate.id
+            if candidate_id == "fatal":
+                assert good_finished.wait(timeout=2)
+                completion_order.append(candidate_id)
+                raise fatal
+            if candidate_id == "negative":
+                completion_order.append(candidate_id)
+                negative_finished.set()
+                return make_eval_result(candidate_id), -7
+            assert candidate_id == "good"
+            assert negative_finished.wait(timeout=2)
+            completion_order.append(candidate_id)
+            good_finished.set()
+            return make_eval_result(candidate_id), 3
+
+        items = [
+            make_item("fatal", "/fatal", content_key="F", instance_ids=("1",)),
+            make_item("negative", "/negative", content_key="N", instance_ids=("1",)),
+            make_item("good", "/good", content_key="K", instance_ids=("1",)),
+            make_item("good-dup", "/dup", content_key="K", instance_ids=("1",)),
+        ]
+        results = run_evaluator_batch(items, runner, max_workers=4)
+
+        assert completion_order == ["negative", "good", "fatal"]
+        assert results[0].error is fatal
+        assert isinstance(results[1].error, ValueError)
+        assert "negative num_actual_evaluations" in str(results[1].error)
+        assert results[1].num_actual_evaluations == 0
+        assert results[2].result is not None
+        assert results[2].num_actual_evaluations == 3
+        assert results[3].result is not None
+        assert results[3].deduplicated_from == 2
+        assert results[3].num_actual_evaluations == 0
+        assert sum(result.num_actual_evaluations for result in results) == 3
+
     @pytest.mark.parametrize(
         "exc",
         [
@@ -589,13 +662,19 @@ class TestRunEvaluatorBatchFailures:
             SystemExit(1),
         ],
     )
-    def test_fatal_exceptions_propagate(self, exc: BaseException):
+    def test_fatal_exceptions_are_returned_for_phase_owned_reraise(
+        self, exc: BaseException
+    ):
         def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
             raise exc
 
         items = [make_item("a", "/wa", instance_ids=("1",))]
-        with pytest.raises(type(exc)):
-            run_evaluator_batch(items, runner, max_workers=1)
+        results = run_evaluator_batch(items, runner, max_workers=1)
+
+        assert len(results) == 1
+        assert results[0].result is None
+        assert results[0].error is exc
+        assert results[0].num_actual_evaluations == 0
 
 
 class TestRunEvaluatorBatchCardinalityAndConfig:
@@ -629,10 +708,14 @@ class TestRunEvaluatorBatchCardinalityAndConfig:
         def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
             return make_eval_result(item.candidate.id), -1
 
-        with pytest.raises(ValueError, match="negative num_actual_evaluations"):
-            run_evaluator_batch(
-                [make_item("a", "/wa", instance_ids=("1",))], runner, max_workers=1
-            )
+        results = run_evaluator_batch(
+            [make_item("a", "/wa", instance_ids=("1",))], runner, max_workers=1
+        )
+        assert len(results) == 1
+        assert results[0].result is None
+        assert isinstance(results[0].error, ValueError)
+        assert "negative num_actual_evaluations" in str(results[0].error)
+        assert results[0].num_actual_evaluations == 0
 
     def test_result_positional_to_input_with_dedup_and_failure(self):
         class Boom(Exception):

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -20,6 +20,7 @@ from helix.executor import (
     EvalBatchItem,
     EvalBatchResult,
     make_default_batch_runner,
+    record_evaluator_units,
     run_evaluator,
     run_evaluator_batch,
 )
@@ -537,6 +538,27 @@ class TestRunEvaluatorBatchDedup:
 
 
 class TestRunEvaluatorBatchFailures:
+    def test_failed_leader_progress_is_isolated_per_concurrent_worker(self):
+        start = threading.Barrier(2)
+
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            units = 1 if item.candidate.id == "one" else 3
+            record_evaluator_units(units)
+            start.wait(timeout=2)
+            raise RuntimeError(item.candidate.id)
+
+        results = run_evaluator_batch(
+            [
+                make_item("one", "/w-one", instance_ids=("1",)),
+                make_item("three", "/w-three", instance_ids=("1", "2", "3")),
+            ],
+            runner,
+            max_workers=2,
+        )
+
+        assert [result.num_actual_evaluations for result in results] == [1, 3]
+        assert [str(result.error) for result in results] == ["one", "three"]
+
     def test_ordinary_failure_is_isolated(self):
         class Boom(Exception):
             pass
@@ -744,6 +766,51 @@ class TestRunEvaluatorBatchCardinalityAndConfig:
 
 
 class TestMakeDefaultBatchRunner:
+    def test_failed_minibatch_leader_reports_attempted_units(self, mocker):
+        evaluator = mocker.patch(
+            "helix.executor.run_evaluator",
+            side_effect=RuntimeError("failed after evaluator dispatch"),
+        )
+        runner = make_default_batch_runner(make_config())
+
+        calls = run_evaluator_batch(
+            [
+                make_item(
+                    "leader", "/leader", content_key="K", instance_ids=("1", "2")
+                ),
+                make_item(
+                    "follower",
+                    "/follower",
+                    content_key="K",
+                    instance_ids=("1", "2"),
+                ),
+            ],
+            runner,
+            max_workers=2,
+        )
+
+        assert evaluator.call_count == 1
+        assert isinstance(calls[0].error, RuntimeError)
+        assert calls[0].num_actual_evaluations == 2
+        assert calls[0].deduplicated_from is None
+        assert calls[1].error is calls[0].error
+        assert calls[1].num_actual_evaluations == 0
+        assert calls[1].deduplicated_from == 0
+
+    def test_successful_progress_report_does_not_double_returned_count(self):
+        def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+            record_evaluator_units(2)
+            return make_eval_result(item.candidate.id), 2
+
+        [call] = run_evaluator_batch(
+            [make_item("a", "/w", instance_ids=("1", "2"))],
+            runner,
+            max_workers=1,
+        )
+
+        assert call.error is None
+        assert call.num_actual_evaluations == 2
+
     def test_counts_minibatch_and_forwards_args(self, mocker):
         fake = make_eval_result("a", instance_scores={"1": 1.0, "2": 0.0})
         m = mocker.patch("helix.executor.run_evaluator", return_value=fake)

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -94,7 +94,7 @@ class TestBuildMutationPrompt:
         er = make_eval_result(
             asi={
                 "stdout": (
-                    "HELIX_RESULT=[[1.0, {\"task_completed\": true}]]\n"
+                    'HELIX_RESULT=[[1.0, {"task_completed": true}]]\n'
                     "human fallback line\n"
                 ),
                 "stderr": "",
@@ -1643,7 +1643,8 @@ class TestCountCodexStdoutToolEvents:
 
         stdout = tmp_path / "stdout.jsonl"
         stdout.write_text(
-            json.dumps({"type": "thread.started", "thread_id": "abc"}) + "\n"
+            json.dumps({"type": "thread.started", "thread_id": "abc"})
+            + "\n"
             + json.dumps(
                 {
                     "type": "item.completed",
@@ -1681,8 +1682,10 @@ class TestCountCodexStdoutToolEvents:
 
         stdout = tmp_path / "stdout.jsonl"
         stdout.write_text(
-            json.dumps({"type": "thread.started"}) + "\n"
-            + json.dumps({"type": "turn.completed"}) + "\n"
+            json.dumps({"type": "thread.started"})
+            + "\n"
+            + json.dumps({"type": "turn.completed"})
+            + "\n"
         )
 
         count, names = _count_codex_stdout_tool_events(stdout)
@@ -1702,9 +1705,7 @@ class TestCountCodexStdoutToolEvents:
 class TestCountCursorStdoutToolEvents:
     """Tests for ``_count_cursor_stdout_tool_events``."""
 
-    def test_counts_only_started_events_not_completed(
-        self, tmp_path: Path
-    ) -> None:
+    def test_counts_only_started_events_not_completed(self, tmp_path: Path) -> None:
         from helix.mutator import _count_cursor_stdout_tool_events
 
         stdout = tmp_path / "stdout.jsonl"
@@ -1859,9 +1860,7 @@ class TestCountTranscriptToolEventsDispatcher:
         assert count == 0
         assert names == []
 
-    def test_missing_file_returns_zero_for_known_backend(
-        self, tmp_path: Path
-    ) -> None:
+    def test_missing_file_returns_zero_for_known_backend(self, tmp_path: Path) -> None:
         from helix.mutator import _count_transcript_tool_events
 
         count, names = _count_transcript_tool_events(
@@ -1897,9 +1896,7 @@ class TestCountTranscriptToolEventsDispatcher:
         from helix.mutator import _count_transcript_tool_events
 
         stdout = tmp_path / "stdout.jsonl"
-        stdout.write_text(
-            json.dumps({"type": "tool_use", "tool_name": "grep"}) + "\n"
-        )
+        stdout.write_text(json.dumps({"type": "tool_use", "tool_name": "grep"}) + "\n")
 
         count, names = _count_transcript_tool_events(stdout, "gemini")
 
@@ -1920,7 +1917,9 @@ class TestTranscriptToolPatchesUsageInArtifact:
         )
 
         # Set up a fake transcript with 3 tool_use events
-        transcript_root = tmp_path / "claude-home" / ".claude" / "projects" / "-workspace"
+        transcript_root = (
+            tmp_path / "claude-home" / ".claude" / "projects" / "-workspace"
+        )
         transcript_root.mkdir(parents=True)
         (transcript_root / "sess_tool.jsonl").write_text(
             json.dumps(
@@ -2064,13 +2063,16 @@ class TestOpenCodeSubprocessIsolation:
         )
 
         invoke_claude_code(
-            str(tmp_path), "prompt", AgentConfig(backend="opencode"),
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend="opencode"),
             passthrough_env=["PATH", "HOME"],
         )
 
         env = mock_run.call_args[1]["env"]
         # PATH and HOME are passed through from the parent process environment
         import os
+
         if "PATH" in os.environ:
             assert "PATH" in env, "PATH must survive the env scrub for opencode"
         if "HOME" in os.environ:
@@ -2086,9 +2088,7 @@ class TestOpenCodeSubprocessIsolation:
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
 
         for backend in ("claude", "codex", "cursor", "gemini"):
-            invoke_claude_code(
-                str(tmp_path), "prompt", AgentConfig(backend=backend)
-            )
+            invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend=backend))
             env = mock_run.call_args[1]["env"]
             assert "XDG_DATA_HOME" not in env, (
                 f"XDG_DATA_HOME must not be injected for {backend} backend"
@@ -2103,9 +2103,7 @@ class TestOpenCodeSubprocessIsolation:
             returncode=0,
         )
 
-        invoke_claude_code(
-            str(tmp_path), "prompt", AgentConfig(backend="opencode")
-        )
+        invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="opencode"))
 
         gitignore_path = tmp_path / ".gitignore"
         assert gitignore_path.exists(), ".gitignore must be created in the worktree"

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1213,6 +1213,75 @@ class TestMutate:
         assert result is None
         mock_remove.assert_called_once_with(child)
 
+    def test_mutation_error_cleanup_failure_leaves_reserved_child_visible(
+        self, tmp_path: Path, mocker
+    ) -> None:
+        """A handled backend failure does not conceal its failed worktree remove."""
+        parent = make_candidate("g0-s0")
+        child_path = tmp_path / "g1-s0"
+        child_path.mkdir()
+        child = make_candidate("g1-s0", str(child_path))
+        mocker.patch("helix.mutator.clone_candidate", return_value=child)
+        mocker.patch(
+            "helix.mutator.invoke_claude_code",
+            side_effect=MutationError("backend failed"),
+        )
+        cleanup_error = OSError("git worktree is locked")
+        mock_remove = mocker.patch(
+            "helix.mutator.remove_worktree", side_effect=cleanup_error
+        )
+        mock_warning = mocker.patch("helix.mutator.print_warning")
+
+        result = mutate(
+            parent,
+            make_eval_result(),
+            child.id,
+            make_config(),
+            tmp_path,
+        )
+
+        assert result is None
+        assert child_path.exists()
+        assert child.id == "g1-s0"
+        mock_remove.assert_called_once_with(child)
+        mock_warning.assert_called_once()
+        assert child.id in mock_warning.call_args.args[0]
+        assert str(cleanup_error) in mock_warning.call_args.args[0]
+
+    def test_generic_mutation_failure_preserves_error_and_reports_cleanup_failure(
+        self, tmp_path: Path, mocker
+    ) -> None:
+        """A propagated backend error keeps its type while cleanup remains visible."""
+        parent = make_candidate("g0-s0")
+        child_path = tmp_path / "g1-s0"
+        child_path.mkdir()
+        child = make_candidate("g1-s0", str(child_path))
+        backend_error = RuntimeError("backend transport failed")
+        cleanup_error = OSError("git worktree is locked")
+        mocker.patch("helix.mutator.clone_candidate", return_value=child)
+        mocker.patch("helix.mutator.invoke_claude_code", side_effect=backend_error)
+        mock_remove = mocker.patch(
+            "helix.mutator.remove_worktree", side_effect=cleanup_error
+        )
+        mock_warning = mocker.patch("helix.mutator.print_warning")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mutate(
+                parent,
+                make_eval_result(),
+                child.id,
+                make_config(),
+                tmp_path,
+            )
+
+        assert exc_info.value is backend_error
+        assert child_path.exists()
+        mock_remove.assert_called_once_with(child)
+        mock_warning.assert_called_once()
+        assert child.id in mock_warning.call_args.args[0]
+        assert type(backend_error).__name__ in mock_warning.call_args.args[0]
+        assert str(cleanup_error) in mock_warning.call_args.args[0]
+
     def test_removes_worktree_on_failure(self, tmp_path: Path, mocker):
         parent = make_candidate("g0-s0")
         er = make_eval_result()

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 from pathlib import Path
+import subprocess
+import threading
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -11,6 +14,8 @@ import pytest
 
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, EvaluatorConfig, SandboxConfig
+from helix.display import UsageStats
+from helix.exceptions import PromptArtifactCollisionError
 from helix.mutator import (
     MutationError,
     BACKEND_RESULT_ARTIFACT_NAME,
@@ -1164,11 +1169,12 @@ class TestMutate:
             "helix.mutator.invoke_claude_code", return_value=({"result": "ok"}, {})
         )
         mocker.patch("helix.mutator.snapshot_candidate", return_value="abc123")
-        mocker.patch("helix.mutator.remove_worktree")
+        mock_remove = mocker.patch("helix.mutator.remove_worktree")
 
         result = mutate(parent, er, "g1-s0", config, Path("/tmp"))
 
         assert result is child
+        mock_remove.assert_not_called()
 
     def test_sets_operation_to_mutate(self, tmp_path: Path, mocker):
         parent = make_candidate("g0-s0")
@@ -1226,6 +1232,145 @@ class TestMutate:
         mutate(parent, er, "g1-s0", config, Path("/tmp"))
 
         mock_remove.assert_called_once_with(child)
+
+    def test_removes_worktree_and_preserves_preparation_error(
+        self, tmp_path: Path, mocker
+    ):
+        """Any fatal failure after clone cleans up and propagates unchanged."""
+        parent = make_candidate("g0-s0")
+        er = make_eval_result()
+        config = make_config()
+
+        child_path = tmp_path / "g1-s0"
+        child_path.mkdir()
+        child = make_candidate("g1-s0", str(child_path))
+        mocker.patch("helix.mutator.clone_candidate", return_value=child)
+        mock_remove = mocker.patch("helix.mutator.remove_worktree")
+        failure = RuntimeError("candidate preparation failed")
+
+        def fail_preparation(candidate: Candidate) -> None:
+            assert candidate is child
+            raise failure
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mutate(
+                parent,
+                er,
+                "g1-s0",
+                config,
+                Path("/tmp"),
+                prepare_worktree=fail_preparation,
+            )
+
+        assert exc_info.value is failure
+        mock_remove.assert_called_once_with(child)
+
+    def test_prompt_collision_cleans_worktree_and_preserves_error(
+        self, tmp_path: Path, mocker
+    ):
+        parent = make_candidate("g0-s0")
+        child_path = tmp_path / "g1-s0"
+        child_path.mkdir()
+        child = make_candidate("g1-s0", str(child_path))
+        failure = PromptArtifactCollisionError("reserved prompt path exists")
+        mocker.patch("helix.mutator.clone_candidate", return_value=child)
+        mocker.patch(
+            "helix.mutator._write_mutation_prompt_artifact", side_effect=failure
+        )
+        mock_remove = mocker.patch("helix.mutator.remove_worktree")
+
+        with pytest.raises(PromptArtifactCollisionError) as exc_info:
+            mutate(
+                parent,
+                make_eval_result(),
+                "g1-s0",
+                make_config(),
+                Path("/tmp"),
+            )
+
+        assert exc_info.value is failure
+        mock_remove.assert_called_once_with(child)
+
+    def test_parallel_mutations_use_distinct_real_git_worktrees(
+        self, tmp_path: Path, mocker
+    ):
+        """Two overlapping proposal calls clone and operate in separate worktrees."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "config", "user.name", "HELIX Test"], cwd=repo, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "helix-test@example.invalid"],
+            cwd=repo,
+            check=True,
+        )
+        (repo / "candidate.py").write_text("value = 1\n")
+        subprocess.run(["git", "add", "candidate.py"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=repo, check=True)
+
+        parent = make_candidate("g0-s0", str(repo))
+        eval_result = make_eval_result()
+        config = make_config()
+        base_dir = tmp_path / "worktrees"
+        overlap = threading.Barrier(2)
+        lock = threading.Lock()
+        active = 0
+        peak_active = 0
+        seen_paths: set[str] = set()
+
+        def fake_invoke(
+            worktree_path: str, prompt: str, agent_config: AgentConfig, **kwargs: Any
+        ) -> tuple[dict[str, Any], UsageStats]:
+            del prompt, agent_config, kwargs
+            nonlocal active, peak_active
+            assert Path(worktree_path).is_dir()
+            with lock:
+                seen_paths.add(worktree_path)
+                active += 1
+                peak_active = max(peak_active, active)
+            try:
+                overlap.wait(timeout=10)
+            finally:
+                with lock:
+                    active -= 1
+            return {}, UsageStats()
+
+        mocker.patch("helix.mutator.invoke_claude_code", side_effect=fake_invoke)
+
+        children: list[Candidate] = []
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [
+                    pool.submit(
+                        mutate,
+                        parent,
+                        eval_result,
+                        child_id,
+                        config,
+                        base_dir,
+                    )
+                    for child_id in ("g1-s0", "g1-s1")
+                ]
+                results = [future.result(timeout=15) for future in futures]
+            children = [child for child in results if child is not None]
+
+            assert len(children) == 2
+            assert peak_active == 2
+            assert seen_paths == {
+                str(base_dir / "g1-s0"),
+                str(base_dir / "g1-s1"),
+            }
+            assert len({child.worktree_path for child in children}) == 2
+            assert all(
+                (Path(child.worktree_path) / ".git").exists() for child in children
+            )
+        finally:
+            from helix.worktree import remove_worktree
+
+            for child in children:
+                remove_worktree(child)
 
     def test_snapshot_not_called_by_mutate_on_success(self, tmp_path: Path, mocker):
         """mutate() must NOT call snapshot_candidate — the caller owns that step.
@@ -1858,6 +2003,29 @@ class TestOpenCodeSubprocessIsolation:
         assert xdg.startswith(str(tmp_path)), (
             f"XDG_DATA_HOME={xdg!r} should be under the candidate worktree {tmp_path}"
         )
+
+    def test_opencode_sandbox_state_uses_isolated_workspace(
+        self, tmp_path: Path, mocker
+    ):
+        """The shared auth home must not also hold sandboxed OpenCode state."""
+        mock_run = mocker.patch(
+            "helix.mutator.run_sandboxed_command",
+            return_value=subprocess.CompletedProcess(
+                args=["opencode"], returncode=0, stdout="{}", stderr=""
+            ),
+        )
+
+        invoke_claude_code(
+            str(tmp_path),
+            "fix the bug",
+            AgentConfig(backend="opencode"),
+            sandbox=SandboxConfig(enabled=True, image="helix-test:latest"),
+        )
+
+        assert mock_run.call_args.kwargs["env"]["XDG_DATA_HOME"] == (
+            "/workspace/.helix_opencode_state"
+        )
+        assert not (tmp_path / ".helix_opencode_state").exists()
 
     def test_opencode_subprocess_isolation_unique_per_candidate(
         self, tmp_path: Path, mocker

--- a/tests/unit/test_parallel_proposals_matrix.py
+++ b/tests/unit/test_parallel_proposals_matrix.py
@@ -566,7 +566,15 @@ def test_best_improvement_uses_stable_first_tie_and_cleans_other_siblings(
     )
 
     assert scenario.result.frontier_ids == ["g0-s0", "g1-s1"]
-    assert scenario.snapshotted_ids == ["g1-s1"]
+    # HELIX snapshots every viable mutation before child scoring so content
+    # hashes and lineage remain stable; selection then retains only the first
+    # tied improvement and cleans the other snapshotted worktrees.
+    assert scenario.snapshotted_ids == [
+        "g1-s1",
+        "g1-s2",
+        "g1-s3",
+        "g1-s4",
+    ]
     assert set(scenario.removed_ids) == {"g1-s2", "g1-s3", "g1-s4"}
     for candidate_id in scenario.removed_ids:
         assert not (scenario.base_dir / "worktrees" / candidate_id).exists()

--- a/tests/unit/test_parallel_proposals_matrix.py
+++ b/tests/unit/test_parallel_proposals_matrix.py
@@ -703,14 +703,14 @@ def test_omitted_n_matches_explicit_n1_for_existing_k_by_1_runs(
             "before_worker_dispatch",
             set(),
             {"g1-s1", "g1-s2"},
-            set(),
+            {"g1-s1", "g1-s2"},
             id="before-dispatch",
         ),
         pytest.param(
             "mid_worker",
             {"g1-s1"},
             {"g1-s2"},
-            set(),
+            {"g1-s1", "g1-s2"},
             id="mid-worker",
         ),
         pytest.param(

--- a/tests/unit/test_parallel_proposals_matrix.py
+++ b/tests/unit/test_parallel_proposals_matrix.py
@@ -1,0 +1,878 @@
+"""Black-box contract matrix for the P-by-N proposal scheduler.
+
+These tests deliberately exercise :func:`helix.evolution.run_evolution` rather
+than reimplementing the scheduler in a test double.  The expensive external
+boundaries remain mocked at the seams HELIX already exposes: parent selection,
+the coding-agent mutator, evaluator invocation, snapshots, and worktree
+removal.  Everything observable above those seams -- planning order, stable
+IDs, selection, budget/cache accounting, persistence, and resume cleanup -- is
+owned by the production runtime.
+
+The module is collected on the pre-P-by-N baseline too.  It is skipped there
+with one explicit reason instead of failing import/collection merely because
+``EvolutionConfig.mutations_per_parent`` has not landed yet.  Once that public
+configuration field exists, every assertion becomes active.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping, Sequence
+
+import pytest
+
+from helix.config import DatasetConfig, EvaluatorConfig, EvolutionConfig, HelixConfig
+from helix.evolution import run_evolution
+from helix.population import Candidate, EvalResult, HelixResult, ParetoFrontier
+from helix.state import BudgetState, EvolutionState, load_eval_cache, load_state
+from helix.trace import Event, TRACE
+
+
+_HAS_P_BY_N_CONFIG = "mutations_per_parent" in EvolutionConfig.model_fields
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_P_BY_N_CONFIG,
+    reason=(
+        "expected pre-implementation baseline: "
+        "EvolutionConfig.mutations_per_parent is not available"
+    ),
+)
+
+
+def _slot(candidate_id: str) -> int:
+    """Return the one-based stable proposal slot from ``gN-sM``."""
+    return int(candidate_id.rsplit("-s", 1)[1])
+
+
+def _candidate(
+    candidate_id: str,
+    worktree: Path,
+    *,
+    parent_id: str | None = None,
+    operation: str = "mutation",
+) -> Candidate:
+    return Candidate(
+        id=candidate_id,
+        worktree_path=str(worktree),
+        branch_name=f"helix/{candidate_id}",
+        generation=int(candidate_id.split("-", 1)[0].lstrip("g")),
+        parent_id=parent_id,
+        parent_ids=[] if parent_id is None else [parent_id],
+        operation=operation,
+    )
+
+
+def _eval_result(candidate_id: str, ids: Sequence[str], score: float) -> EvalResult:
+    return EvalResult(
+        candidate_id=candidate_id,
+        scores={},
+        asi={},
+        instance_scores={example_id: score for example_id in ids},
+    )
+
+
+class _NullDisplay:
+    """Minimal live-display boundary; assertions inspect durable output instead."""
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.gen = 0
+        self.current_usage = None
+
+    def __enter__(self) -> _NullDisplay:
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def update(self, **_kwargs: Any) -> None:
+        return None
+
+
+class _CompletionGate:
+    """Event-driven completion controller with no timing-based ordering claim."""
+
+    def __init__(self, candidate_ids: Sequence[str]) -> None:
+        self._expected = tuple(candidate_ids)
+        self._lock = threading.Lock()
+        self._started: set[str] = set()
+        self.all_started = threading.Event()
+        self.release = {
+            candidate_id: threading.Event() for candidate_id in candidate_ids
+        }
+        self.finished = {
+            candidate_id: threading.Event() for candidate_id in candidate_ids
+        }
+        self.completion_order: list[str] = []
+
+    def wait_for_release(self, candidate_id: str) -> None:
+        assert candidate_id in self.release, f"unexpected proposal id {candidate_id}"
+        with self._lock:
+            self._started.add(candidate_id)
+            if self._started == set(self._expected):
+                self.all_started.set()
+
+        if not self.release[candidate_id].wait(timeout=10):
+            raise AssertionError(f"test did not release proposal {candidate_id}")
+
+        with self._lock:
+            self.completion_order.append(candidate_id)
+        self.finished[candidate_id].set()
+
+
+@dataclass
+class _Scenario:
+    result: HelixResult
+    project_root: Path
+    base_dir: Path
+    selector_parent_ids: list[str]
+    mutation_parent_by_child: dict[str, str]
+    evaluator_calls: list[tuple[str, str, tuple[str, ...]]]
+    removed_ids: list[str]
+    snapshotted_ids: list[str]
+    events: list[Event]
+    completion_order: list[str]
+
+    @property
+    def child_ids(self) -> list[str]:
+        return sorted(self.mutation_parent_by_child, key=_slot)
+
+    @property
+    def lineage(self) -> list[dict[str, Any]]:
+        path = self.base_dir / "lineage.json"
+        if not path.exists():
+            return []
+        loaded = json.loads(path.read_text())
+        assert isinstance(loaded, list)
+        return loaded
+
+    @property
+    def task_rows(self) -> list[dict[str, Any]]:
+        """Find the durable per-slot rows without depending on their container file.
+
+        The work plan fixes the information contract, not whether task rows live
+        in ``state.json``, a batch journal, or attempt artifacts.  Search all
+        durable JSON and choose the richest row for each reserved child.
+        """
+        expected = set(self.child_ids)
+        richest: dict[str, dict[str, Any]] = {}
+        for path in self.base_dir.rglob("*.json"):
+            try:
+                payload = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            for row in _walk_dicts(payload):
+                child_id = _child_id(row)
+                if child_id not in expected or _parent_group(row) is None:
+                    continue
+                if len(row) > len(richest.get(child_id, {})):
+                    richest[child_id] = row
+        return [
+            richest[candidate_id]
+            for candidate_id in self.child_ids
+            if candidate_id in richest
+        ]
+
+
+def _walk_dicts(value: Any) -> Iterator[dict[str, Any]]:
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_dicts(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_dicts(child)
+
+
+def _first(mapping: Mapping[str, Any], names: Iterable[str]) -> Any:
+    for name in names:
+        if name in mapping:
+            return mapping[name]
+    return None
+
+
+def _child_id(row: Mapping[str, Any]) -> str | None:
+    value = _first(row, ("child_id", "reserved_child_id", "candidate_id"))
+    return value if isinstance(value, str) else None
+
+
+def _parent_group(row: Mapping[str, Any]) -> int | None:
+    value = _first(row, ("parent_group_index", "parent_group"))
+    return value if isinstance(value, int) else None
+
+
+def _mutation_index(row: Mapping[str, Any]) -> int | None:
+    value = _first(row, ("mutation_index", "mutation_index_within_parent"))
+    return value if isinstance(value, int) else None
+
+
+def _status(row: Mapping[str, Any]) -> str:
+    value = _first(row, ("status", "terminal_status", "outcome"))
+    return str(value).lower() if value is not None else ""
+
+
+def _make_config(
+    *,
+    p: int,
+    n: int | None,
+    seed: int = 17,
+    selection: str = "all_improvements",
+    top_k: int | None = None,
+    train_size: int = 16,
+    val_size: int = 2,
+    minibatch_size: int = 2,
+    cache: bool = False,
+    max_workers: int | None = None,
+    max_evaluations: int = 10_000,
+) -> HelixConfig:
+    evolution: dict[str, Any] = {
+        "max_generations": 1,
+        "max_evaluations": max_evaluations,
+        "perfect_score_threshold": None,
+        "num_parallel_proposals": p,
+        "proposal_selection": selection,
+        "minibatch_size": minibatch_size,
+        "cache_evaluation": cache,
+        "max_workers": max_workers or max(1, p * (n or 1)),
+        "frontier_type": "instance",
+    }
+    if n is not None:
+        evolution["mutations_per_parent"] = n
+    if top_k is not None:
+        evolution["proposal_top_k"] = top_k
+
+    return HelixConfig(
+        objective="parallel proposal black-box matrix",
+        evaluator=EvaluatorConfig(command="python evaluate.py"),
+        dataset=DatasetConfig(train_size=train_size, val_size=val_size),
+        evolution=EvolutionConfig(**evolution),
+        rng_seed=seed,
+    )
+
+
+def _run_scenario(
+    root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    p: int,
+    n: int | None,
+    scores: Sequence[float] | None = None,
+    selection: str = "all_improvements",
+    top_k: int | None = None,
+    seed: int = 17,
+    completion_order: Sequence[str] | None = None,
+    fail_child_eval: frozenset[str] = frozenset(),
+    cache: bool = False,
+    shared_child_content: bool = False,
+    train_size: int = 16,
+    val_size: int = 2,
+    minibatch_size: int = 2,
+    max_workers: int | None = None,
+    max_evaluations: int = 10_000,
+) -> _Scenario:
+    """Run one real scheduler step behind deterministic I/O seams."""
+    effective_n = 1 if n is None else n
+    task_count = p * effective_n
+    child_ids = [f"g1-s{index}" for index in range(1, task_count + 1)]
+    score_vector = list(scores or [0.8] * task_count)
+    assert len(score_vector) == task_count
+
+    project_root = root / "project"
+    project_root.mkdir(parents=True)
+    base_dir = project_root / ".helix"
+    worktrees_dir = base_dir / "worktrees"
+
+    selector_parent_ids: list[str] = []
+    mutation_parent_by_child: dict[str, str] = {}
+    evaluator_calls: list[tuple[str, str, tuple[str, ...]]] = []
+    removed_ids: list[str] = []
+    snapshotted_ids: list[str] = []
+    calls_lock = threading.Lock()
+
+    gate = _CompletionGate(child_ids) if completion_order is not None else None
+
+    def fake_create_seed(_project_root: Path, _worktrees_dir: Path) -> Candidate:
+        seed_dir = worktrees_dir / "g0-s0"
+        seed_dir.mkdir(parents=True, exist_ok=False)
+        (seed_dir / "program.txt").write_text("seed\n")
+        return _candidate("g0-s0", seed_dir, parent_id=None, operation="seed")
+
+    def fake_mutate(**kwargs: Any) -> Candidate:
+        parent = kwargs["parent"]
+        new_id = kwargs["new_id"]
+        child_dir = Path(kwargs["base_dir"]) / new_id
+        child_dir.mkdir(parents=True, exist_ok=False)
+        content = "shared\n" if shared_child_content else f"slot={new_id}\n"
+        (child_dir / "program.txt").write_text(content)
+        child = _candidate(new_id, child_dir, parent_id=parent.id)
+        with calls_lock:
+            mutation_parent_by_child[new_id] = parent.id
+        if gate is not None:
+            gate.wait_for_release(new_id)
+        return child
+
+    def fake_run_evaluator(
+        candidate: Candidate,
+        _config: HelixConfig,
+        split: str = "val",
+        instance_ids: list[str] | None = None,
+        **_kwargs: Any,
+    ) -> EvalResult:
+        ids = tuple(str(value) for value in (instance_ids or ["single-task"]))
+        with calls_lock:
+            evaluator_calls.append((candidate.id, split, ids))
+
+        if candidate.id in fail_child_eval and split == "train":
+            raise RuntimeError(f"simulated child evaluator failure for {candidate.id}")
+        if candidate.id == "g0-s0" and split == "val":
+            score = 0.1
+        elif candidate.id.startswith("g1-s"):
+            score = score_vector[_slot(candidate.id) - 1]
+        else:
+            score = 0.2
+        return _eval_result(candidate.id, ids, score)
+
+    def fake_remove(candidate: Candidate) -> None:
+        with calls_lock:
+            removed_ids.append(candidate.id)
+        shutil.rmtree(candidate.worktree_path, ignore_errors=True)
+
+    def fake_snapshot(candidate: Candidate, _message: str) -> str:
+        with calls_lock:
+            snapshotted_ids.append(candidate.id)
+        return f"snapshot-{candidate.id}"
+
+    original_select_parent = ParetoFrontier.select_parent
+
+    def select_parent(frontier: ParetoFrontier) -> Candidate:
+        parent = original_select_parent(frontier)
+        selector_parent_ids.append(parent.id)
+        return parent
+
+    def content_key(candidate: Candidate) -> str:
+        if shared_child_content and candidate.id.startswith("g1-s"):
+            return "shared-child-content"
+        return candidate.id
+
+    def noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    with monkeypatch.context() as patcher:
+        patcher.setattr("helix.evolution.create_seed_worktree", fake_create_seed)
+        patcher.setattr("helix.evolution.mutate", fake_mutate)
+        patcher.setattr("helix.mutator.mutate", fake_mutate)
+        patcher.setattr("helix.evolution.run_evaluator", fake_run_evaluator)
+        patcher.setattr("helix.executor.run_evaluator", fake_run_evaluator)
+        patcher.setattr("helix.evolution.remove_worktree", fake_remove)
+        patcher.setattr("helix.worktree.remove_worktree", fake_remove)
+        patcher.setattr("helix.evolution.snapshot_candidate", fake_snapshot)
+        patcher.setattr("helix.worktree.snapshot_candidate", fake_snapshot)
+        patcher.setattr("helix.evolution.HelixLiveDisplay", _NullDisplay)
+        patcher.setattr("helix.evolution._check_evaluator_script_exists", noop)
+        patcher.setattr("helix.evolution._refresh_protected_evaluator_files", noop)
+        patcher.setattr(
+            "helix.evolution._refresh_and_snapshot_protected_evaluator_files", noop
+        )
+        patcher.setattr(
+            "helix.evolution._build_evaluator_integrity_manifest",
+            lambda **_kwargs: {},
+        )
+        patcher.setattr("helix.evolution._write_evaluator_integrity_manifest", noop)
+        patcher.setattr("helix.evolution._detect_evaluator_tamper", lambda *_a: [])
+        patcher.setattr("helix.evolution._candidate_content_key", content_key)
+        patcher.setattr(ParetoFrontier, "select_parent", select_parent)
+        for name in (
+            "set_phase",
+            "print_info",
+            "print_success",
+            "print_warning",
+            "print_error",
+            "render_budget",
+            "render_generation",
+            "render_frontier_table",
+        ):
+            patcher.setattr(f"helix.evolution.{name}", noop)
+
+        config = _make_config(
+            p=p,
+            n=n,
+            seed=seed,
+            selection=selection,
+            top_k=top_k,
+            train_size=train_size,
+            val_size=val_size,
+            minibatch_size=minibatch_size,
+            cache=cache,
+            max_workers=max_workers,
+            max_evaluations=max_evaluations,
+        )
+
+        def invoke() -> tuple[HelixResult, list[Event]]:
+            with TRACE.record() as recorded:
+                result = run_evolution(config, project_root, base_dir)
+                return result, list(recorded)
+
+        if gate is None:
+            result, events = invoke()
+        else:
+            assert completion_order is not None
+            with ThreadPoolExecutor(max_workers=1) as driver:
+                future = driver.submit(invoke)
+                assert gate.all_started.wait(timeout=10), (
+                    "all proposal mutations must become active; this also proves "
+                    "the worker bound permits overlap without using sleep"
+                )
+                for candidate_id in completion_order:
+                    gate.release[candidate_id].set()
+                    assert gate.finished[candidate_id].wait(timeout=10)
+                result, events = future.result(timeout=10)
+
+    return _Scenario(
+        result=result,
+        project_root=project_root,
+        base_dir=base_dir,
+        selector_parent_ids=selector_parent_ids,
+        mutation_parent_by_child=mutation_parent_by_child,
+        evaluator_calls=evaluator_calls,
+        removed_ids=removed_ids,
+        snapshotted_ids=snapshotted_ids,
+        events=events,
+        completion_order=[] if gate is None else list(gate.completion_order),
+    )
+
+
+def _group_coordinates(scenario: _Scenario) -> list[tuple[int | None, int | None]]:
+    assert len(scenario.task_rows) == len(scenario.child_ids), (
+        "every planned P*N slot must have one durable task record"
+    )
+    return [(_parent_group(row), _mutation_index(row)) for row in scenario.task_rows]
+
+
+def _normalized(scenario: _Scenario) -> dict[str, Any]:
+    """Normalize away filesystem roots while retaining semantic state."""
+    budget = asdict(scenario.result.budget)
+    lineage = [
+        {
+            "id": row["id"],
+            "parent": row.get("parent"),
+            "parents": row.get("parents", []),
+            "operation": row["operation"],
+            "generation": row["generation"],
+        }
+        for row in scenario.lineage
+    ]
+    tasks = [
+        {
+            "child_id": _child_id(row),
+            "parent_group": _parent_group(row),
+            "mutation_index": _mutation_index(row),
+            "status": _status(row),
+        }
+        for row in scenario.task_rows
+    ]
+    minibatches = sorted(
+        (
+            candidate_id,
+            split,
+            ids,
+        )
+        for candidate_id, split, ids in scenario.evaluator_calls
+    )
+    return {
+        "frontier_ids": scenario.result.frontier_ids,
+        "best_id": scenario.result.id,
+        "parents": scenario.result.parents,
+        "instance_scores": scenario.result.instance_scores,
+        "budget": budget,
+        "lineage": lineage,
+        "tasks": tasks,
+        "minibatches": minibatches,
+    }
+
+
+def test_1x4_and_4x1_have_equal_width_but_different_selection_and_grouping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    one_by_four = _run_scenario(tmp_path / "1x4", monkeypatch, p=1, n=4)
+    four_by_one = _run_scenario(tmp_path / "4x1", monkeypatch, p=4, n=1)
+
+    assert len(one_by_four.child_ids) == len(four_by_one.child_ids) == 4
+    assert one_by_four.selector_parent_ids == ["g0-s0"]
+    assert four_by_one.selector_parent_ids == ["g0-s0"] * 4
+    assert _group_coordinates(one_by_four) == [(0, 0), (0, 1), (0, 2), (0, 3)]
+    assert _group_coordinates(four_by_one) == [(0, 0), (1, 0), (2, 0), (3, 0)]
+
+
+def test_duplicate_parent_selections_remain_distinct_parent_groups(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scenario = _run_scenario(tmp_path, monkeypatch, p=2, n=2)
+
+    assert scenario.selector_parent_ids == ["g0-s0", "g0-s0"]
+    assert [scenario.mutation_parent_by_child[cid] for cid in scenario.child_ids] == [
+        "g0-s0",
+        "g0-s0",
+        "g0-s0",
+        "g0-s0",
+    ]
+    assert _group_coordinates(scenario) == [(0, 0), (0, 1), (1, 0), (1, 1)]
+    assert len(set(scenario.child_ids)) == 4
+
+
+def test_reverse_completion_preserves_ids_lineage_task_order_and_apply_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reverse = ["g1-s4", "g1-s3", "g1-s2", "g1-s1"]
+    scenario = _run_scenario(
+        tmp_path,
+        monkeypatch,
+        p=1,
+        n=4,
+        scores=[0.4, 0.5, 0.6, 0.7],
+        completion_order=reverse,
+        max_workers=4,
+    )
+
+    assert scenario.completion_order == reverse
+    assert scenario.result.frontier_ids == ["g0-s0", "g1-s1", "g1-s2", "g1-s3", "g1-s4"]
+    assert [row["id"] for row in scenario.lineage] == [
+        "g0-s0",
+        "g1-s1",
+        "g1-s2",
+        "g1-s3",
+        "g1-s4",
+    ]
+    assert [_child_id(row) for row in scenario.task_rows] == scenario.child_ids
+    assert scenario.snapshotted_ids == scenario.child_ids
+
+
+def test_best_improvement_uses_stable_first_tie_and_cleans_other_siblings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reverse = ["g1-s4", "g1-s3", "g1-s2", "g1-s1"]
+    scenario = _run_scenario(
+        tmp_path,
+        monkeypatch,
+        p=1,
+        n=4,
+        scores=[0.8, 0.8, 0.8, 0.8],
+        selection="best_improvement",
+        completion_order=reverse,
+        max_workers=4,
+    )
+
+    assert scenario.result.frontier_ids == ["g0-s0", "g1-s1"]
+    assert scenario.snapshotted_ids == ["g1-s1"]
+    assert set(scenario.removed_ids) == {"g1-s2", "g1-s3", "g1-s4"}
+    for candidate_id in scenario.removed_ids:
+        assert not (scenario.base_dir / "worktrees" / candidate_id).exists()
+
+
+def test_one_child_evaluation_failure_does_not_discard_successful_siblings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scenario = _run_scenario(
+        tmp_path,
+        monkeypatch,
+        p=1,
+        n=3,
+        scores=[0.6, 0.7, 0.8],
+        fail_child_eval=frozenset({"g1-s2"}),
+        max_workers=3,
+    )
+
+    assert scenario.result.frontier_ids == ["g0-s0", "g1-s1", "g1-s3"]
+    assert set(scenario.removed_ids) == {"g1-s2"}
+    assert not (scenario.base_dir / "worktrees" / "g1-s2").exists()
+    failed_row = next(row for row in scenario.task_rows if _child_id(row) == "g1-s2")
+    assert any(word in _status(failed_row) for word in ("fail", "error"))
+
+
+def test_top_k_cleans_every_unselected_worktree_and_records_terminal_slots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scenario = _run_scenario(
+        tmp_path,
+        monkeypatch,
+        p=2,
+        n=2,
+        scores=[0.4, 0.9, 0.8, 0.7],
+        selection="top_k",
+        top_k=2,
+    )
+
+    assert set(scenario.result.frontier_ids[1:]) == {"g1-s2", "g1-s3"}
+    assert set(scenario.removed_ids) == {"g1-s1", "g1-s4"}
+    assert len(scenario.task_rows) == 4
+    assert all(_status(row) for row in scenario.task_rows)
+    for candidate_id in scenario.removed_ids:
+        assert not (scenario.base_dir / "worktrees" / candidate_id).exists()
+
+
+def test_exact_budget_and_cache_accounting_for_identical_sibling_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scenario = _run_scenario(
+        tmp_path,
+        monkeypatch,
+        p=1,
+        n=2,
+        scores=[0.8, 0.8],
+        train_size=4,
+        val_size=2,
+        minibatch_size=2,
+        cache=True,
+        shared_child_content=True,
+    )
+
+    # seed full-val: 2; two distinct parent minibatches: 4; two distinct
+    # child minibatches: 4; one deduplicated/cached shared full-val: 2.
+    assert scenario.result.budget.evaluations == 12
+    assert len(scenario.evaluator_calls) == 6
+    child_full_val = [
+        call
+        for call in scenario.evaluator_calls
+        if call[0].startswith("g1-s") and call[1] == "val"
+    ]
+    assert len(child_full_val) == 1
+
+    cache = load_eval_cache(scenario.project_root)
+    assert cache is not None
+    assert len(cache) == 8
+    persisted = load_state(scenario.project_root)
+    assert persisted is not None
+    assert persisted.budget.evaluations == 12
+
+
+def test_same_seed_is_deterministic_across_opposite_completion_schedules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    forward = ["g1-s1", "g1-s2", "g1-s3", "g1-s4"]
+    reverse = list(reversed(forward))
+    first = _run_scenario(
+        tmp_path / "forward",
+        monkeypatch,
+        p=2,
+        n=2,
+        seed=2026,
+        scores=[0.4, 0.5, 0.6, 0.7],
+        completion_order=forward,
+        max_workers=4,
+    )
+    second = _run_scenario(
+        tmp_path / "reverse",
+        monkeypatch,
+        p=2,
+        n=2,
+        seed=2026,
+        scores=[0.4, 0.5, 0.6, 0.7],
+        completion_order=reverse,
+        max_workers=4,
+    )
+
+    assert first.completion_order != second.completion_order
+    assert _normalized(first) == _normalized(second)
+
+
+@pytest.mark.parametrize("p", [1, 2, 4])
+def test_omitted_n_matches_explicit_n1_for_existing_k_by_1_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, p: int
+) -> None:
+    omitted = _run_scenario(tmp_path / f"p{p}-omitted", monkeypatch, p=p, n=None)
+    explicit = _run_scenario(tmp_path / f"p{p}-explicit", monkeypatch, p=p, n=1)
+
+    assert _normalized(omitted) == _normalized(explicit)
+
+
+@pytest.mark.parametrize(
+    ("boundary", "expected_cleaned", "expected_missing", "expected_accounted"),
+    [
+        pytest.param(
+            "before_worker_dispatch",
+            set(),
+            {"g1-s1", "g1-s2"},
+            set(),
+            id="before-dispatch",
+        ),
+        pytest.param(
+            "mid_worker",
+            {"g1-s1"},
+            {"g1-s2"},
+            set(),
+            id="mid-worker",
+        ),
+        pytest.param(
+            "after_evaluation",
+            {"g1-s1", "g1-s2"},
+            set(),
+            {"g1-s1", "g1-s2"},
+            id="after-evaluation",
+        ),
+        pytest.param(
+            "mid_apply",
+            {"g1-s2"},
+            set(),
+            {"g1-s1", "g1-s2"},
+            id="mid-apply",
+        ),
+    ],
+)
+def test_resume_reconciles_each_batch_phase_without_double_charge_apply_or_orphans(
+    tmp_path: Path,
+    boundary: str,
+    expected_cleaned: set[str],
+    expected_missing: set[str],
+    expected_accounted: set[str],
+) -> None:
+    """Exercise the durable batch ledger at all four crash boundaries.
+
+    This intentionally targets the Step-7 persistence API directly: the
+    runtime owns when checkpoints are called, while the state layer owns the
+    idempotent facts a resumed process consumes.
+    """
+    import helix.state as state_api
+
+    task_record_type = getattr(state_api, "ProposalTaskRecord")
+    batch_record_type = getattr(state_api, "ProposalBatchRecord")
+    checkpoint_before = getattr(state_api, "checkpoint_batch_before_dispatch")
+    checkpoint_task = getattr(state_api, "checkpoint_batch_task")
+    reconcile = getattr(state_api, "reconcile_interrupted_batches")
+    reserved_ids = getattr(state_api, "reserved_candidate_ids")
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    worktrees_dir = project_root / ".helix" / "worktrees"
+    worktrees_dir.mkdir(parents=True)
+
+    state = EvolutionState(
+        generation=1,
+        frontier=["g0-s0"],
+        instance_scores={"g0-s0": {"0": 0.1}},
+        budget=BudgetState(),
+        config_hash="matrix",
+        frontier_type="instance",
+    )
+    tasks = [
+        task_record_type(
+            batch_id="g1-b1",
+            p=1,
+            n=2,
+            task_index=index,
+            parent_group=0,
+            mutation_index=index,
+            parent_id="g0-s0",
+            child_id=f"g1-s{index + 1}",
+        )
+        for index in range(2)
+    ]
+    batch = batch_record_type(
+        batch_id="g1-b1",
+        generation=1,
+        p=1,
+        n=2,
+        tasks=tasks,
+    )
+    checkpoint_before(
+        state,
+        project_root,
+        batch,
+        max_evaluations=100,
+        max_in_flight_evaluations=8,
+    )
+
+    if boundary == "mid_worker":
+        (worktrees_dir / "g1-s1").mkdir()
+        checkpoint_task(
+            state,
+            project_root,
+            batch_id="g1-b1",
+            task_index=0,
+            status="running",
+        )
+    elif boundary in {"after_evaluation", "mid_apply"}:
+        state.budget.evaluations = 8
+        for index in range(2):
+            (worktrees_dir / f"g1-s{index + 1}").mkdir()
+            checkpoint_task(
+                state,
+                project_root,
+                batch_id="g1-b1",
+                task_index=index,
+                status="evaluated",
+                score_delta=0.5 + index,
+                budget_charge=BudgetState(evaluations=4),
+                budget_accounted=True,
+            )
+        if boundary == "mid_apply":
+            checkpoint_task(
+                state,
+                project_root,
+                batch_id="g1-b1",
+                task_index=0,
+                status="applied",
+                selection="selected",
+                cleanup="not_required",
+                applied=True,
+            )
+            state.frontier.append("g1-s1")
+
+    cleaned_by_callback: list[str] = []
+
+    def cleanup_worktree(candidate_id: str, path: Path) -> bool:
+        cleaned_by_callback.append(candidate_id)
+        shutil.rmtree(path)
+        return True
+
+    budget_before_resume = state.budget.evaluations
+    summaries = reconcile(
+        state,
+        project_root,
+        worktrees_dir=worktrees_dir,
+        cleanup_worktree=cleanup_worktree,
+    )
+
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert set(summary.reserved_child_ids) == {"g1-s1", "g1-s2"}
+    assert set(summary.cleaned_child_ids) == expected_cleaned
+    assert set(summary.missing_child_ids) == expected_missing
+    assert set(summary.accounted_child_ids) == expected_accounted
+    assert set(cleaned_by_callback) == expected_cleaned
+    assert state.budget.evaluations == budget_before_resume
+    assert reserved_ids(state) >= {"g0-s0", "g1-s1", "g1-s2"}
+    assert state.frontier.count("g1-s1") <= 1
+
+    if boundary == "mid_apply":
+        assert set(summary.applied_child_ids) == {"g1-s1"}
+        assert (worktrees_dir / "g1-s1").exists()
+        assert not (worktrees_dir / "g1-s2").exists()
+    else:
+        assert set(summary.applied_child_ids) == set()
+        assert all(
+            not (worktrees_dir / candidate_id).exists()
+            for candidate_id in ("g1-s1", "g1-s2")
+        )
+
+    loaded = load_state(project_root)
+    assert loaded is not None
+    persisted_batch = getattr(loaded, "proposal_batches")[-1]
+    assert persisted_batch.phase == "interrupted"
+    assert [task.child_id for task in persisted_batch.tasks] == ["g1-s1", "g1-s2"]
+
+    # A second resume is a no-op: no double cleanup, charge, or frontier add.
+    assert (
+        reconcile(
+            loaded,
+            project_root,
+            worktrees_dir=worktrees_dir,
+            cleanup_worktree=cleanup_worktree,
+        )
+        == []
+    )
+    assert set(cleaned_by_callback) == expected_cleaned
+    assert loaded.budget.evaluations == budget_before_resume
+    assert loaded.frontier.count("g1-s1") <= 1

--- a/tests/unit/test_proposal_duplicate_minibatch_scores.py
+++ b/tests/unit/test_proposal_duplicate_minibatch_scores.py
@@ -1,0 +1,213 @@
+"""Regression tests for proposal scoring on padded minibatches.
+
+The epoch sampler deliberately pads a short epoch by repeating example IDs.
+Evaluation results and caches are keyed by ID, so proposal scoring must recover
+the original multiplicity from ``ProposalTask.minibatch_ids``.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import cast
+
+import pytest
+
+from helix.eval_cache import EvaluationCache
+from helix.eval_policy import StrictImprovementAcceptance
+from helix.executor import EvalBatchItem, run_evaluator_batch
+from helix.population import Candidate, EvalResult
+from helix.proposals import (
+    AllImprovements,
+    EvaluatedProposal,
+    ProposalAcceptanceCriterion,
+    ProposalTask,
+)
+
+
+PADDED_IDS = ("rare", "other", "rare")
+
+
+def _candidate(candidate_id: str) -> Candidate:
+    return Candidate(
+        id=candidate_id,
+        worktree_path=f"/tmp/{candidate_id}",
+        branch_name=f"helix/{candidate_id}",
+        generation=1,
+        parent_id="parent" if candidate_id != "parent" else None,
+        parent_ids=[] if candidate_id == "parent" else ["parent"],
+        operation="mutation",
+    )
+
+
+def _result(candidate_id: str, *, rare: float, other: float) -> EvalResult:
+    return EvalResult(
+        candidate_id=candidate_id,
+        scores={},
+        asi={},
+        instance_scores={"rare": rare, "other": other},
+    )
+
+
+def _proposal(
+    index: int,
+    child: Candidate,
+    parent_result: EvalResult,
+    child_result: EvalResult,
+) -> EvaluatedProposal:
+    return EvaluatedProposal(
+        task=ProposalTask(
+            batch_index=index,
+            parent_group_index=0,
+            mutation_index=index,
+            parent_candidate=_candidate("parent"),
+            minibatch_ids=PADDED_IDS,
+            reserved_child_id=child.id,
+        ),
+        parent_eval_result=parent_result,
+        child_candidate=child,
+        child_eval_result=child_result,
+    )
+
+
+def _strict_criterion() -> ProposalAcceptanceCriterion:
+    return cast(ProposalAcceptanceCriterion, StrictImprovementAcceptance())
+
+
+def test_padded_minibatch_multiplicity_can_flip_acceptance() -> None:
+    """The repeated padding slot must carry the repeated example's score."""
+
+    proposal = _proposal(
+        0,
+        _candidate("child"),
+        _result("parent", rare=0.9, other=0.0),
+        _result("child", rare=0.5, other=0.6),
+    )
+
+    assert proposal.subsample_scores_before == [0.9, 0.0, 0.9]
+    assert proposal.subsample_scores_after == [0.5, 0.6, 0.5]
+    assert proposal.improvement == pytest.approx(-0.2)
+    assert not _strict_criterion().should_accept(proposal)
+
+
+def _cached_result(
+    candidate_id: str,
+    *,
+    cached_scores: dict[str, float],
+    fresh_scores: dict[str, float],
+) -> tuple[EvalResult, int, list[tuple[str, ...]]]:
+    cache: EvaluationCache[object, str] = EvaluationCache()
+    candidate_key = {"content_key": candidate_id, "split": "train"}
+    for example_id, score in cached_scores.items():
+        cache.put(candidate_key, example_id, None, score)
+
+    fetched: list[tuple[str, ...]] = []
+
+    def fetcher(example_ids: list[str]) -> list[str]:
+        fetched.append(tuple(example_ids))
+        return example_ids
+
+    def evaluator(
+        batch: list[str], _candidate_key: dict[str, str]
+    ) -> tuple[list[object], list[float], None, None]:
+        return [None] * len(batch), [fresh_scores[eid] for eid in batch], None, None
+
+    _, scores_by_id, _, _, n_uncached = cache.evaluate_with_cache_full(
+        candidate_key,
+        list(PADDED_IDS),
+        fetcher,
+        evaluator,
+    )
+    return (
+        EvalResult(
+            candidate_id=candidate_id,
+            scores={},
+            asi={},
+            instance_scores=scores_by_id,
+        ),
+        n_uncached,
+        fetched,
+    )
+
+
+def test_partial_cache_collapse_does_not_remove_padding_weight() -> None:
+    """A cache returns one dict entry per ID; the task restores slot weight."""
+
+    parent_result, parent_uncached, parent_fetches = _cached_result(
+        "parent",
+        cached_scores={"rare": 0.8, "other": 0.0},
+        fresh_scores={},
+    )
+    child_result, child_uncached, child_fetches = _cached_result(
+        "child",
+        cached_scores={"rare": 0.55},
+        fresh_scores={"other": 0.6},
+    )
+    proposal = _proposal(
+        0,
+        _candidate("child"),
+        parent_result,
+        child_result,
+    )
+
+    assert parent_result.instance_scores == {"rare": 0.8, "other": 0.0}
+    assert child_result.instance_scores == {"rare": 0.55, "other": 0.6}
+    assert (parent_uncached, parent_fetches) == (0, [])
+    assert (child_uncached, child_fetches) == (1, [("other",)])
+    assert proposal.subsample_scores_before == [0.8, 0.0, 0.8]
+    assert proposal.subsample_scores_after == [0.55, 0.6, 0.55]
+    assert proposal.improvement == pytest.approx(0.1)
+
+
+def test_reverse_completion_and_dedup_preserve_padded_selection() -> None:
+    """Batch completion and follower reuse cannot erase repeated slot scores."""
+
+    children = [_candidate(f"child-{index}") for index in range(3)]
+    items = [
+        EvalBatchItem(children[0], "shared", "train", PADDED_IDS),
+        EvalBatchItem(children[1], "unique", "train", PADDED_IDS),
+        EvalBatchItem(children[2], "shared", "train", PADDED_IDS),
+    ]
+    both_leaders_started = threading.Event()
+    unique_finished = threading.Event()
+    lock = threading.Lock()
+    started: set[str] = set()
+    completion_order: list[str] = []
+
+    def runner(item: EvalBatchItem) -> tuple[EvalResult, int]:
+        with lock:
+            started.add(item.candidate.id)
+            if len(started) == 2:
+                both_leaders_started.set()
+        assert both_leaders_started.wait(timeout=5)
+
+        if item.candidate.id == "child-0":
+            assert unique_finished.wait(timeout=5)
+            result = _result(item.candidate.id, rare=0.55, other=0.6)
+        else:
+            result = _result(item.candidate.id, rare=0.65, other=0.3)
+
+        completion_order.append(item.candidate.id)
+        if item.candidate.id == "child-1":
+            unique_finished.set()
+        return result, len(PADDED_IDS)
+
+    batch_results = run_evaluator_batch(items, runner, max_workers=2)
+
+    assert completion_order == ["child-1", "child-0"]
+    assert [result.deduplicated_from for result in batch_results] == [None, None, 0]
+    assert [result.num_actual_evaluations for result in batch_results] == [3, 3, 0]
+    assert all(result.result is not None for result in batch_results)
+
+    parent_result = _result("parent", rare=0.8, other=0.0)
+    proposals = [
+        _proposal(index, child, parent_result, batch_result.result)
+        for index, (child, batch_result) in enumerate(zip(children, batch_results))
+        if batch_result.result is not None
+    ]
+    selected = AllImprovements().select(proposals, _strict_criterion())
+
+    assert [item.proposal.child_candidate.id for item in selected] == [
+        "child-0",
+        "child-2",
+    ]
+    assert [item.improvement for item in selected] == pytest.approx([0.1, 0.1])

--- a/tests/unit/test_proposals.py
+++ b/tests/unit/test_proposals.py
@@ -43,31 +43,34 @@ def make_candidate(candidate_id: str) -> Candidate:
     )
 
 
-def make_eval(candidate_id: str, score: float) -> EvalResult:
+def make_eval(
+    candidate_id: str, score: float, example_id: str = "example"
+) -> EvalResult:
     return EvalResult(
         candidate_id=candidate_id,
         scores={"score": score},
         asi={},
-        instance_scores={"example": score},
+        instance_scores={example_id: score},
     )
 
 
 def make_evaluated(index: int, before: float, after: float) -> EvaluatedProposal:
     parent = make_candidate(f"parent-{index}")
     child = make_candidate(f"child-{index}")
+    example_id = f"example-{index}"
     task = ProposalTask(
         batch_index=index,
         parent_group_index=index,
         mutation_index=0,
         parent_candidate=parent,
-        minibatch_ids=(f"example-{index}",),
+        minibatch_ids=(example_id,),
         reserved_child_id=child.id,
     )
     return EvaluatedProposal(
         task=task,
-        parent_eval_result=make_eval(parent.id, before),
+        parent_eval_result=make_eval(parent.id, before, example_id),
         child_candidate=child,
-        child_eval_result=make_eval(child.id, after),
+        child_eval_result=make_eval(child.id, after, example_id),
     )
 
 
@@ -123,9 +126,7 @@ class TestSamplingStrategies:
             reserve_child_id=reserve,
         )
 
-        assert tasks == [
-            ProposalTask(0, 0, 0, parent, ("mb-0",), "g1-s0")
-        ]
+        assert tasks == [ProposalTask(0, 0, 0, parent, ("mb-0",), "g1-s0")]
         with pytest.raises(FrozenInstanceError):
             setattr(tasks[0], "batch_index", 10)
 

--- a/tests/unit/test_proposals.py
+++ b/tests/unit/test_proposals.py
@@ -1,0 +1,324 @@
+"""GEPA-parity tests for HELIX proposal planning and selection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import FrozenInstanceError
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from helix.eval_policy import StrictImprovementAcceptance
+from helix.population import Candidate, EvalResult
+from helix.proposals import (
+    DEFAULT_SAMPLING_STRATEGY,
+    DEFAULT_SELECTION_STRATEGY,
+    AllImprovements,
+    BestImprovement,
+    EvaluatedProposal,
+    FailedProposal,
+    IndependentSampling,
+    ProposalAcceptanceCriterion,
+    ProposalTask,
+    PxNSampling,
+    SameParentSampling,
+    SelectedProposal,
+    SingleMutationSampling,
+    SkippedProposal,
+    TamperedProposal,
+    TopKImprovements,
+)
+
+
+def make_candidate(candidate_id: str) -> Candidate:
+    return Candidate(
+        id=candidate_id,
+        worktree_path=f"/tmp/{candidate_id}",
+        branch_name=f"helix/{candidate_id}",
+        generation=0,
+        parent_id=None,
+        parent_ids=[],
+        operation="mutation",
+    )
+
+
+def make_eval(candidate_id: str, score: float) -> EvalResult:
+    return EvalResult(
+        candidate_id=candidate_id,
+        scores={"score": score},
+        asi={},
+        instance_scores={"example": score},
+    )
+
+
+def make_evaluated(index: int, before: float, after: float) -> EvaluatedProposal:
+    parent = make_candidate(f"parent-{index}")
+    child = make_candidate(f"child-{index}")
+    task = ProposalTask(
+        batch_index=index,
+        parent_group_index=index,
+        mutation_index=0,
+        parent_candidate=parent,
+        minibatch_ids=(f"example-{index}",),
+        reserved_child_id=child.id,
+    )
+    return EvaluatedProposal(
+        task=task,
+        parent_eval_result=make_eval(parent.id, before),
+        child_candidate=child,
+        child_eval_result=make_eval(child.id, after),
+    )
+
+
+def strict_criterion() -> ProposalAcceptanceCriterion:
+    # The existing HELIX criterion consumes the two GEPA-compatible score
+    # properties exposed by EvaluatedProposal.  The cast only bridges the
+    # independently declared structural protocols for static type checkers.
+    return cast(ProposalAcceptanceCriterion, StrictImprovementAcceptance())
+
+
+def sampling_callbacks(
+    parents: list[Candidate],
+) -> tuple[MagicMock, MagicMock, MagicMock]:
+    parent_index = 0
+    minibatch_index = 0
+    child_index = 0
+
+    def select_parent() -> Candidate:
+        nonlocal parent_index
+        parent = parents[parent_index]
+        parent_index += 1
+        return parent
+
+    def sample_minibatch() -> list[str]:
+        nonlocal minibatch_index
+        minibatch = [f"mb-{minibatch_index}"]
+        minibatch_index += 1
+        return minibatch
+
+    def reserve_child_id() -> str:
+        nonlocal child_index
+        child_id = f"g1-s{child_index}"
+        child_index += 1
+        return child_id
+
+    return (
+        MagicMock(side_effect=select_parent),
+        MagicMock(side_effect=sample_minibatch),
+        MagicMock(side_effect=reserve_child_id),
+    )
+
+
+class TestSamplingStrategies:
+    """Adapt GEPA's four proposal-sampling cases to HELIX candidates."""
+
+    def test_single_mutation(self) -> None:
+        parent = make_candidate("parent")
+        select, minibatch, reserve = sampling_callbacks([parent])
+
+        tasks = SingleMutationSampling().sample_tasks(
+            select_parent=select,
+            sample_minibatch=minibatch,
+            reserve_child_id=reserve,
+        )
+
+        assert tasks == [
+            ProposalTask(0, 0, 0, parent, ("mb-0",), "g1-s0")
+        ]
+        with pytest.raises(FrozenInstanceError):
+            setattr(tasks[0], "batch_index", 10)
+
+    def test_same_parent_sampling(self) -> None:
+        parent = make_candidate("parent")
+        select, minibatch, reserve = sampling_callbacks([parent])
+
+        tasks = SameParentSampling(n=3).sample_tasks(
+            select_parent=select,
+            sample_minibatch=minibatch,
+            reserve_child_id=reserve,
+        )
+
+        assert select.call_count == 1
+        assert [task.parent_candidate for task in tasks] == [parent, parent, parent]
+        assert [task.mutation_index for task in tasks] == [0, 1, 2]
+        assert [task.minibatch_ids for task in tasks] == [
+            ("mb-0",),
+            ("mb-1",),
+            ("mb-2",),
+        ]
+
+    def test_independent_sampling(self) -> None:
+        parents = [make_candidate(f"parent-{index}") for index in range(4)]
+        select, minibatch, reserve = sampling_callbacks(parents)
+
+        tasks = IndependentSampling(n=4).sample_tasks(
+            select_parent=select,
+            sample_minibatch=minibatch,
+            reserve_child_id=reserve,
+        )
+
+        assert select.call_count == 4
+        assert [task.parent_candidate for task in tasks] == parents
+        assert [task.parent_group_index for task in tasks] == [0, 1, 2, 3]
+        assert [task.mutation_index for task in tasks] == [0, 0, 0, 0]
+
+    def test_pxn_sampling_is_parent_major_and_allows_replacement(self) -> None:
+        # Returning the same object twice demonstrates that parent selection is
+        # with replacement; the strategy neither deduplicates nor reorders it.
+        parent = make_candidate("parent")
+        select, minibatch, reserve = sampling_callbacks([parent, parent])
+
+        tasks = PxNSampling(p=2, n=3).sample_tasks(
+            select_parent=select,
+            sample_minibatch=minibatch,
+            reserve_child_id=reserve,
+        )
+
+        assert len(tasks) == 6
+        assert select.call_count == 2
+        assert [task.batch_index for task in tasks] == list(range(6))
+        assert [task.parent_group_index for task in tasks] == [0, 0, 0, 1, 1, 1]
+        assert [task.mutation_index for task in tasks] == [0, 1, 2, 0, 1, 2]
+        assert [task.reserved_child_id for task in tasks] == [
+            "g1-s0",
+            "g1-s1",
+            "g1-s2",
+            "g1-s3",
+            "g1-s4",
+            "g1-s5",
+        ]
+        assert sorted(reversed(tasks)) == tasks
+
+
+class TestSelectionStrategies:
+    """Adapt GEPA's four proposal-selection cases to EvalResult scores."""
+
+    def test_all_improvements(self) -> None:
+        proposals = [
+            make_evaluated(0, 0.5, 0.8),
+            make_evaluated(1, 0.5, 0.3),
+            make_evaluated(2, 0.5, 0.6),
+        ]
+
+        selected = AllImprovements().select(proposals, strict_criterion())
+
+        assert [item.proposal.task.batch_index for item in selected] == [0, 2]
+
+    def test_best_improvement_is_stable_on_ties(self) -> None:
+        proposals = [
+            make_evaluated(0, 0.5, 0.9),
+            make_evaluated(1, 0.4, 0.8),  # equal +0.4; first proposal wins
+            make_evaluated(2, 0.5, 0.6),
+        ]
+
+        selected = BestImprovement().select(proposals, strict_criterion())
+
+        assert len(selected) == 1
+        assert selected[0].proposal.task.batch_index == 0
+        assert selected[0].improvement == pytest.approx(0.4)
+
+    def test_best_improvement_none_pass(self) -> None:
+        proposals = [make_evaluated(0, 0.5, 0.3)]
+
+        selected = BestImprovement().select(proposals, strict_criterion())
+
+        assert selected == []
+
+    def test_top_k_improvements_is_ranked_and_stable_on_ties(self) -> None:
+        proposals = [
+            make_evaluated(0, 0.5, 0.9),
+            make_evaluated(1, 0.5, 0.6),
+            make_evaluated(2, 0.4, 0.8),  # ties task 0 at +0.4
+            make_evaluated(3, 0.5, 0.3),
+        ]
+
+        selected = TopKImprovements(k=2).select(proposals, strict_criterion())
+
+        assert [item.proposal.task.batch_index for item in selected] == [0, 2]
+
+
+class TestSequentialPlanningFallback:
+    """Adapt GEPA's sequential fallback test to HELIX task preparation."""
+
+    def test_sampling_callbacks_execute_sequentially(self) -> None:
+        events: list[str] = []
+        parent = make_candidate("parent")
+
+        def select_parent() -> Candidate:
+            events.append("parent")
+            return parent
+
+        def sample_minibatch() -> list[str]:
+            events.append("minibatch")
+            return [str(events.count("minibatch"))]
+
+        def reserve_child_id() -> str:
+            events.append("reserve")
+            return f"child-{events.count('reserve')}"
+
+        tasks = PxNSampling(p=2, n=2).sample_tasks(
+            select_parent=select_parent,
+            sample_minibatch=sample_minibatch,
+            reserve_child_id=reserve_child_id,
+        )
+
+        assert len(tasks) == 4
+        assert events == [
+            "parent",
+            "minibatch",
+            "reserve",
+            "minibatch",
+            "reserve",
+            "parent",
+            "minibatch",
+            "reserve",
+            "minibatch",
+            "reserve",
+        ]
+
+
+class TestDefaultStrategiesRetainBehavior:
+    """Adapt GEPA's two default-strategy contract tests."""
+
+    def test_single_mutation_is_default_sampling(self) -> None:
+        assert isinstance(DEFAULT_SAMPLING_STRATEGY, SingleMutationSampling)
+        assert hasattr(DEFAULT_SAMPLING_STRATEGY, "sample_tasks")
+
+    def test_all_improvements_is_default_selection(self) -> None:
+        assert isinstance(DEFAULT_SELECTION_STRATEGY, AllImprovements)
+        assert hasattr(DEFAULT_SELECTION_STRATEGY, "select")
+
+
+class TestTypedOutcomes:
+    def test_outcomes_retain_immutable_task_and_typed_results(self) -> None:
+        evaluated = make_evaluated(0, 0.5, 0.8)
+        task = evaluated.task
+        parent_result = evaluated.parent_eval_result
+        child = evaluated.child_candidate
+
+        skipped = SkippedProposal(task, parent_result, "perfect_parent")
+        failed = FailedProposal(task, "mutation", "agent failed", parent_result)
+        tampered = TamperedProposal(task, parent_result, child, ("evaluate.py",))
+        selected = SelectedProposal(evaluated, evaluated.improvement)
+
+        assert skipped.task is task
+        assert failed.task is task
+        assert tampered.task is task
+        assert evaluated.task is task
+        assert selected.proposal.task is task
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: SameParentSampling(0),
+        lambda: IndependentSampling(-1),
+        lambda: PxNSampling(0, 1),
+        lambda: PxNSampling(1, 0),
+        lambda: TopKImprovements(0),
+    ],
+)
+def test_strategy_widths_must_be_positive(factory: Callable[[], object]) -> None:
+    with pytest.raises(ValueError, match="must be >= 1"):
+        factory()

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -195,6 +195,7 @@ def test_interrupted_batch_reconciles_every_planned_id_without_rewind(
         budget_charge=BudgetState(evaluations=4),
         budget_accounted=True,
     )
+    state.budget.evaluations += 4
     checkpoint_batch_task(
         state,
         tmp_path,
@@ -227,7 +228,7 @@ def test_interrupted_batch_reconciles_every_planned_id_without_rewind(
     report = reports[0]
     assert report.reserved_child_ids == tuple(task.child_id for task in batch.tasks)
     assert report.applied_child_ids == (batch.tasks[0].child_id,)
-    assert report.accounted_child_ids == (batch.tasks[1].child_id,)
+    assert report.accounted_child_ids == tuple(task.child_id for task in batch.tasks)
     assert report.cleaned_child_ids == (
         batch.tasks[1].child_id,
         batch.tasks[2].child_id,
@@ -238,7 +239,7 @@ def test_interrupted_batch_reconciles_every_planned_id_without_rewind(
     assert batch.phase == "interrupted"
     assert all(task.is_terminal() for task in batch.tasks)
     assert state.mutation_counter == 13
-    assert state.budget.evaluations == 15
+    assert state.budget.evaluations == 19
     assert set(task.child_id for task in batch.tasks) <= reserved_candidate_ids(state)
     assert saver_calls == 1
 

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -76,8 +76,8 @@ def make_proposal_batch() -> ProposalBatchRecord:
 # ---------------------------------------------------------------------------
 
 
-def test_state_saved_before_crash(tmp_path: Path) -> None:
-    """State.json must be written before an exception propagates out of run_evolution."""
+def test_ordinary_evaluator_failure_is_persisted_per_slot(tmp_path: Path) -> None:
+    """Ordinary evaluator errors terminalize their slots without aborting."""
     from helix.config import (
         AgentConfig,
         DatasetConfig,
@@ -119,9 +119,10 @@ def test_state_saved_before_crash(tmp_path: Path) -> None:
         asi={},
     )
 
-    boom_error = RuntimeError("simulated crash mid-generation")
+    evaluator_error = RuntimeError("simulated evaluator failure")
 
-    # Patch create_seed_worktree and run_evaluator so we control when to crash.
+    # Seed evaluation succeeds; every proposal parent evaluation fails in an
+    # ordinary, slot-local way.
     call_count = [0]
 
     def fake_run_evaluator(candidate, cfg, split=None, instances=None, **kwargs):
@@ -129,8 +130,7 @@ def test_state_saved_before_crash(tmp_path: Path) -> None:
         if call_count[0] == 1:
             # First call = seed evaluation — succeed
             return seed_result
-        # Second call (gen 1 train eval) — crash
-        raise boom_error
+        raise evaluator_error
 
     # Make HelixProgress a no-op context manager
     mock_ctx = MagicMock()
@@ -143,10 +143,9 @@ def test_state_saved_before_crash(tmp_path: Path) -> None:
         patch("helix.evolution.HelixLiveDisplay", return_value=mock_ctx),
     ):
 
-        with pytest.raises(RuntimeError, match="simulated crash"):
-            run_evolution(config, project_root, base_dir)
+        run_evolution(config, project_root, base_dir)
 
-    # State file must have been written even though an exception propagated
+    # State and the complete ordered failure ledger remain durable.
     state_file = project_root / ".helix" / "state.json"
     assert state_file.exists(), "state.json was not written before crash propagated"
 
@@ -154,6 +153,16 @@ def test_state_saved_before_crash(tmp_path: Path) -> None:
     assert loaded is not None, "Could not load state after crash"
     # The seed was evaluated successfully so it should be in the frontier
     assert "g0-s0" in loaded.frontier, "Seed should be in frontier after successful seed eval"
+    assert len(loaded.proposal_batches) == 3
+    assert all(batch.phase == "complete" for batch in loaded.proposal_batches)
+    assert all(
+        task.status == "failed"
+        and task.budget_accounted
+        and task.detail is not None
+        and "parent_eval" in task.detail
+        for batch in loaded.proposal_batches
+        for task in batch.tasks
+    )
 
 
 def test_interrupted_batch_reconciles_every_planned_id_without_rewind(

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -16,7 +16,18 @@ import pytest
 
 from helix.exceptions import RateLimitError, ResumeIncompatibleError
 from helix.mutator import MutationError, invoke_claude_code, _looks_like_rate_limit
-from helix.state import BudgetState, EvolutionState, load_state, save_state
+from helix.state import (
+    BudgetState,
+    EvolutionState,
+    ProposalBatchRecord,
+    ProposalTaskRecord,
+    checkpoint_batch_before_dispatch,
+    checkpoint_batch_task,
+    load_state,
+    reconcile_interrupted_batches,
+    reserved_candidate_ids,
+    save_state,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -34,6 +45,29 @@ def make_state(
         instance_scores={},
         budget=BudgetState(evaluations=5),
         config_hash="abc123",
+    )
+
+
+def make_proposal_batch() -> ProposalBatchRecord:
+    batch_id = "g3-b0"
+    return ProposalBatchRecord(
+        batch_id=batch_id,
+        generation=3,
+        p=2,
+        n=2,
+        tasks=[
+            ProposalTaskRecord(
+                batch_id=batch_id,
+                p=2,
+                n=2,
+                task_index=index,
+                parent_group=index // 2,
+                mutation_index=index % 2,
+                parent_id="g1-s1" if index < 2 else "g2-s2",
+                child_id=f"g3-s{10 + index}",
+            )
+            for index in range(4)
+        ],
     )
 
 
@@ -121,6 +155,157 @@ def test_state_saved_before_crash(tmp_path: Path) -> None:
     # The seed was evaluated successfully so it should be in the frontier
     assert "g0-s0" in loaded.frontier, "Seed should be in frontier after successful seed eval"
 
+
+def test_interrupted_batch_reconciles_every_planned_id_without_rewind(
+    tmp_path: Path,
+) -> None:
+    """Resume preserves applied/charged facts and cleans every other slot."""
+    state = EvolutionState(
+        generation=3,
+        frontier=["g0-s0", "g1-s1", "g2-s2"],
+        instance_scores={},
+        budget=BudgetState(evaluations=15),
+        config_hash="h",
+        mutation_counter=13,
+    )
+    batch = checkpoint_batch_before_dispatch(state, tmp_path, make_proposal_batch())
+    worktrees_dir = tmp_path / ".helix" / "worktrees"
+    worktrees_dir.mkdir(parents=True)
+    for task in batch.tasks[:3]:
+        (worktrees_dir / task.child_id).mkdir()
+
+    # Crash windows: slot 0 reached frontier before its task marker; slot 1
+    # was charged and evaluated; slots 2/3 were running/not started.
+    state.frontier.append(batch.tasks[0].child_id)
+    checkpoint_batch_task(
+        state,
+        tmp_path,
+        batch_id=batch.batch_id,
+        task_index=1,
+        status="evaluated",
+        budget_charge=BudgetState(evaluations=4),
+        budget_accounted=True,
+    )
+    checkpoint_batch_task(
+        state,
+        tmp_path,
+        batch_id=batch.batch_id,
+        task_index=2,
+        status="running",
+    )
+    removed: list[str] = []
+    saver_calls = 0
+
+    def cleanup(child_id: str, path: Path) -> bool:
+        path.rmdir()
+        removed.append(child_id)
+        return True
+
+    def saver(value: EvolutionState) -> None:
+        nonlocal saver_calls
+        saver_calls += 1
+        save_state(value, tmp_path)
+
+    reports = reconcile_interrupted_batches(
+        state,
+        tmp_path,
+        worktrees_dir=worktrees_dir,
+        cleanup_worktree=cleanup,
+        saver=saver,
+    )
+
+    assert len(reports) == 1
+    report = reports[0]
+    assert report.reserved_child_ids == tuple(task.child_id for task in batch.tasks)
+    assert report.applied_child_ids == (batch.tasks[0].child_id,)
+    assert report.accounted_child_ids == (batch.tasks[1].child_id,)
+    assert report.cleaned_child_ids == (
+        batch.tasks[1].child_id,
+        batch.tasks[2].child_id,
+    )
+    assert report.missing_child_ids == (batch.tasks[3].child_id,)
+    assert removed == [batch.tasks[1].child_id, batch.tasks[2].child_id]
+    assert (worktrees_dir / batch.tasks[0].child_id).exists()
+    assert batch.phase == "interrupted"
+    assert all(task.is_terminal() for task in batch.tasks)
+    assert state.mutation_counter == 13
+    assert state.budget.evaluations == 15
+    assert set(task.child_id for task in batch.tasks) <= reserved_candidate_ids(state)
+    assert saver_calls == 1
+
+    # Reconciliation itself is idempotent and never re-cleans or re-charges.
+    assert reconcile_interrupted_batches(
+        state,
+        tmp_path,
+        worktrees_dir=worktrees_dir,
+        cleanup_worktree=cleanup,
+        saver=saver,
+    ) == []
+    assert saver_calls == 1
+
+
+def test_interrupted_cleanup_is_verified_and_retryable(tmp_path: Path) -> None:
+    state = EvolutionState(
+        generation=1,
+        frontier=["g0-s0"],
+        instance_scores={},
+        budget=BudgetState(),
+        config_hash="h",
+        mutation_counter=1,
+    )
+    batch_id = "g1-b0"
+    batch = ProposalBatchRecord(
+        batch_id=batch_id,
+        generation=1,
+        p=1,
+        n=1,
+        tasks=[
+            ProposalTaskRecord(
+                batch_id=batch_id,
+                p=1,
+                n=1,
+                task_index=0,
+                parent_group=0,
+                mutation_index=0,
+                parent_id="g0-s0",
+                child_id="g1-s1",
+            )
+        ],
+    )
+    checkpoint_batch_before_dispatch(state, tmp_path, batch)
+    worktrees_dir = tmp_path / ".helix" / "worktrees"
+    child_path = worktrees_dir / "g1-s1"
+    child_path.mkdir(parents=True)
+
+    first = reconcile_interrupted_batches(
+        state,
+        tmp_path,
+        worktrees_dir=worktrees_dir,
+        cleanup_worktree=lambda _child_id, _path: True,
+    )
+    assert first[0].cleanup_failed_child_ids == ("g1-s1",)
+    assert child_path.exists()
+    assert batch.tasks[0].cleanup == "failed"
+
+    def remove(_child_id: str, path: Path) -> bool:
+        path.rmdir()
+        return True
+
+    second = reconcile_interrupted_batches(
+        state,
+        tmp_path,
+        worktrees_dir=worktrees_dir,
+        cleanup_worktree=remove,
+    )
+    assert second[0].cleaned_child_ids == ("g1-s1",)
+    assert not child_path.exists()
+    assert batch.tasks[0].cleanup == "removed"
+    assert reconcile_interrupted_batches(
+        state,
+        tmp_path,
+        worktrees_dir=worktrees_dir,
+        cleanup_worktree=remove,
+    ) == []
 
 # ---------------------------------------------------------------------------
 # test_rate_limit_triggers_clean_exit

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -142,7 +142,6 @@ def test_ordinary_evaluator_failure_is_persisted_per_slot(tmp_path: Path) -> Non
         patch("helix.evolution.run_evaluator", side_effect=fake_run_evaluator),
         patch("helix.evolution.HelixLiveDisplay", return_value=mock_ctx),
     ):
-
         run_evolution(config, project_root, base_dir)
 
     # State and the complete ordered failure ledger remain durable.
@@ -152,7 +151,9 @@ def test_ordinary_evaluator_failure_is_persisted_per_slot(tmp_path: Path) -> Non
     loaded = load_state(project_root)
     assert loaded is not None, "Could not load state after crash"
     # The seed was evaluated successfully so it should be in the frontier
-    assert "g0-s0" in loaded.frontier, "Seed should be in frontier after successful seed eval"
+    assert "g0-s0" in loaded.frontier, (
+        "Seed should be in frontier after successful seed eval"
+    )
     assert len(loaded.proposal_batches) == 3
     assert all(batch.phase == "complete" for batch in loaded.proposal_batches)
     assert all(
@@ -244,13 +245,16 @@ def test_interrupted_batch_reconciles_every_planned_id_without_rewind(
     assert saver_calls == 1
 
     # Reconciliation itself is idempotent and never re-cleans or re-charges.
-    assert reconcile_interrupted_batches(
-        state,
-        tmp_path,
-        worktrees_dir=worktrees_dir,
-        cleanup_worktree=cleanup,
-        saver=saver,
-    ) == []
+    assert (
+        reconcile_interrupted_batches(
+            state,
+            tmp_path,
+            worktrees_dir=worktrees_dir,
+            cleanup_worktree=cleanup,
+            saver=saver,
+        )
+        == []
+    )
     assert saver_calls == 1
 
 
@@ -310,12 +314,16 @@ def test_interrupted_cleanup_is_verified_and_retryable(tmp_path: Path) -> None:
     assert second[0].cleaned_child_ids == ("g1-s1",)
     assert not child_path.exists()
     assert batch.tasks[0].cleanup == "removed"
-    assert reconcile_interrupted_batches(
-        state,
-        tmp_path,
-        worktrees_dir=worktrees_dir,
-        cleanup_worktree=remove,
-    ) == []
+    assert (
+        reconcile_interrupted_batches(
+            state,
+            tmp_path,
+            worktrees_dir=worktrees_dir,
+            cleanup_worktree=remove,
+        )
+        == []
+    )
+
 
 # ---------------------------------------------------------------------------
 # test_rate_limit_triggers_clean_exit
@@ -370,11 +378,13 @@ def test_rate_limit_in_json_result(tmp_path: Path) -> None:
 
     config = AgentConfig()
 
-    json_payload = json.dumps({
-        "is_error": True,
-        "error": "Claude is overloaded",
-        "result": "",
-    })
+    json_payload = json.dumps(
+        {
+            "is_error": True,
+            "error": "Claude is overloaded",
+            "result": "",
+        }
+    )
     fake_result = MagicMock()
     fake_result.returncode = 0
     fake_result.stderr = ""
@@ -437,7 +447,9 @@ def test_resume_skips_missing_worktrees(tmp_path: Path, capsys) -> None:
     )
 
 
-def test_resume_keyboard_interrupt_preserves_state_and_prints_clean_hint(tmp_path: Path) -> None:
+def test_resume_keyboard_interrupt_preserves_state_and_prints_clean_hint(
+    tmp_path: Path,
+) -> None:
     """CLI resume should exit cleanly on Ctrl+C and guide the user toward resume/clean."""
     from click.testing import CliRunner
     from helix.cli import cli
@@ -791,7 +803,9 @@ def test_evolve_success_prints_clean_hint(tmp_path: Path) -> None:
         'objective = "test"\n\n[evaluator]\ncommand = "echo 1"\n'
     )
 
-    with patch("helix.evolution.run_evolution", return_value=MagicMock()) as mock_evolve:
+    with patch(
+        "helix.evolution.run_evolution", return_value=MagicMock()
+    ) as mock_evolve:
         runner = CliRunner()
         result = runner.invoke(cli, ["evolve", "--dir", str(project_root)])
 
@@ -799,4 +813,6 @@ def test_evolve_success_prints_clean_hint(tmp_path: Path) -> None:
     assert "helix clean" in result.output.lower(), result.output
 
     # run_evolution should still have been called
-    assert mock_evolve.called, "run_evolution should be called even after dropping worktrees"
+    assert mock_evolve.called, (
+        "run_evolution should be called even after dropping worktrees"
+    )

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import concurrent.futures
 import os
 import subprocess
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -210,8 +212,6 @@ def test_sidecar_runtime_switches_evaluator_to_private_network(tmp_path: Path, m
 
 
 def test_sidecar_runtime_is_visible_to_worker_threads():
-    import concurrent.futures
-
     runtime = EvaluatorSidecarRuntime(
         network="helix-eval-private",
         container_name="helix-evaluator-test",
@@ -229,6 +229,113 @@ def test_sidecar_runtime_is_visible_to_worker_threads():
     assert seen == [runtime]
     # Stack must be empty after the context manager exits.
     assert current_evaluator_sidecar_runtime() is None
+
+
+def test_parallel_sandboxes_use_distinct_mounts_and_sidecar_runtime(
+    tmp_path: Path, mocker
+):
+    """Parallel evaluators inherit the sidecar and get disposable containers."""
+    sources = [tmp_path / "candidate-a", tmp_path / "candidate-b"]
+    for index, source in enumerate(sources):
+        source.mkdir()
+        (source / "candidate.txt").write_text(f"candidate-{index}\n")
+
+    primary_runs: list[list[str]] = []
+    cleanup_runs: list[list[str]] = []
+    lock = threading.Lock()
+    overlap = threading.Barrier(2)
+
+    def fake_run(args, **kwargs):
+        if args[:2] == ["docker", "run"] and "--name" in args:
+            with lock:
+                primary_runs.append(args)
+            overlap.wait(timeout=10)
+        elif args[:3] == ["docker", "rm", "-f"]:
+            with lock:
+                cleanup_runs.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+    runtime = EvaluatorSidecarRuntime(
+        network="helix-eval-private",
+        container_name="helix-evaluator-test",
+        endpoint="http://helix-evaluator:8080/evaluate",
+    )
+
+    with evaluator_sidecar_runtime(runtime):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [
+                pool.submit(
+                    run_sandboxed_command,
+                    ["sh", "-c", "true"],
+                    cwd=source,
+                    env={},
+                    sandbox=SandboxConfig(enabled=True),
+                    scope="evaluator",
+                    sync_back=False,
+                    image="helix-test:latest",
+                )
+                for source in sources
+            ]
+            for future in futures:
+                assert future.result(timeout=15).returncode == 0
+
+    assert len(primary_runs) == 2
+    mounts = {call[call.index("-v") + 1] for call in primary_runs}
+    assert len(mounts) == 2
+    assert all(mount.endswith(":/workspace:rw") for mount in mounts)
+    container_names = {call[call.index("--name") + 1] for call in primary_runs}
+    assert len(container_names) == 2
+    assert all("--rm" in call for call in primary_runs)
+    assert all(
+        call[call.index("--network") + 1] == runtime.network for call in primary_runs
+    )
+    assert all(
+        f"HELIX_EVALUATOR_ENDPOINT={runtime.endpoint}" in call for call in primary_runs
+    )
+    assert {call[-1] for call in cleanup_runs} == container_names
+    assert current_evaluator_sidecar_runtime() is None
+
+
+def test_sandbox_exception_forces_container_and_workspace_cleanup(
+    tmp_path: Path, mocker
+):
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "main.py").write_text("print('hi')\n")
+    container_name: str | None = None
+    workspace: Path | None = None
+    cleanup_names: list[str] = []
+
+    def fake_run(args, **kwargs):
+        nonlocal container_name, workspace
+        if args[:2] == ["docker", "run"] and "--name" in args:
+            container_name = args[args.index("--name") + 1]
+            workspace = Path(args[args.index("-v") + 1].split(":/workspace:rw", 1)[0])
+            raise subprocess.TimeoutExpired(args, timeout=1)
+        if args[:3] == ["docker", "rm", "-f"]:
+            cleanup_names.append(args[-1])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_sandboxed_command(
+            ["sh", "-c", "true"],
+            cwd=source,
+            env={},
+            sandbox=SandboxConfig(enabled=True, timeout_seconds=1),
+            scope="evaluator",
+            sync_back=False,
+            image="helix-test:latest",
+        )
+
+    assert container_name is not None
+    assert cleanup_names == [container_name]
+    assert workspace is not None
+    assert not workspace.parent.exists()
 
 
 def test_sidecar_runtime_nested_same_runtime_restores_outer():

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -89,6 +89,132 @@ _SYNTHETIC_STRUCTURED_ENDPOINTS = [
 ]
 
 
+_SYNTHETIC_ENDPOINT_COMPONENT_CASES = [
+    pytest.param(
+        "https://example.invalid/execute?synthetic-query-bare-sentinel",
+        ("synthetic-query-bare-sentinel",),
+        id="query-bare",
+    ),
+    pytest.param(
+        "https://example.invalid/execute?synthetic-query-blank-sentinel=",
+        (
+            "synthetic-query-blank-sentinel=",
+            "synthetic-query-blank-sentinel",
+        ),
+        id="query-blank-value",
+    ),
+    pytest.param(
+        "https://example.invalid/execute?"
+        "synthetic-query-key-sentinel=synthetic-query-value-sentinel",
+        (
+            "synthetic-query-key-sentinel=synthetic-query-value-sentinel",
+            "synthetic-query-key-sentinel",
+            "synthetic-query-value-sentinel",
+        ),
+        id="query-key-value",
+    ),
+    pytest.param(
+        "https://example.invalid/execute?"
+        "synthetic-query%2Fkey-sentinel=synthetic-query%2Fvalue-sentinel",
+        (
+            "synthetic-query%2Fkey-sentinel=synthetic-query%2Fvalue-sentinel",
+            "synthetic-query%2Fkey-sentinel",
+            "synthetic-query/key-sentinel",
+            "synthetic-query%2Fvalue-sentinel",
+            "synthetic-query/value-sentinel",
+        ),
+        id="query-percent-decoded-key-value",
+    ),
+    pytest.param(
+        "https://example.invalid/execute?"
+        "synthetic+query+key+sentinel=synthetic+query+value+sentinel",
+        (
+            "synthetic+query+key+sentinel=synthetic+query+value+sentinel",
+            "synthetic+query+key+sentinel",
+            "synthetic query key sentinel",
+            "synthetic+query+value+sentinel",
+            "synthetic query value sentinel",
+        ),
+        id="query-plus-decoded-key-value",
+    ),
+    pytest.param(
+        "https://example.invalid/execute?"
+        "synthetic-query-first-key=synthetic-query-first-value&"
+        "synthetic-query-second-bare",
+        (
+            "synthetic-query-first-key=synthetic-query-first-value&"
+            "synthetic-query-second-bare",
+            "synthetic-query-first-key=synthetic-query-first-value",
+            "synthetic-query-first-key",
+            "synthetic-query-first-value",
+            "synthetic-query-second-bare",
+        ),
+        id="query-segments",
+    ),
+    pytest.param(
+        "https://example.invalid/execute#synthetic-fragment-bare-sentinel",
+        ("synthetic-fragment-bare-sentinel",),
+        id="fragment-bare",
+    ),
+    pytest.param(
+        "https://example.invalid/execute#synthetic-fragment-blank-sentinel=",
+        (
+            "synthetic-fragment-blank-sentinel=",
+            "synthetic-fragment-blank-sentinel",
+        ),
+        id="fragment-blank-value",
+    ),
+    pytest.param(
+        "https://example.invalid/execute#"
+        "synthetic-fragment-key-sentinel=synthetic-fragment-value-sentinel",
+        (
+            "synthetic-fragment-key-sentinel=synthetic-fragment-value-sentinel",
+            "synthetic-fragment-key-sentinel",
+            "synthetic-fragment-value-sentinel",
+        ),
+        id="fragment-key-value",
+    ),
+    pytest.param(
+        "https://example.invalid/execute#"
+        "synthetic-fragment%2Fkey-sentinel=synthetic-fragment%2Fvalue-sentinel",
+        (
+            "synthetic-fragment%2Fkey-sentinel=synthetic-fragment%2Fvalue-sentinel",
+            "synthetic-fragment%2Fkey-sentinel",
+            "synthetic-fragment/key-sentinel",
+            "synthetic-fragment%2Fvalue-sentinel",
+            "synthetic-fragment/value-sentinel",
+        ),
+        id="fragment-percent-decoded-key-value",
+    ),
+    pytest.param(
+        "https://example.invalid/execute#"
+        "synthetic+fragment+key+sentinel=synthetic+fragment+value+sentinel",
+        (
+            "synthetic+fragment+key+sentinel=synthetic+fragment+value+sentinel",
+            "synthetic+fragment+key+sentinel",
+            "synthetic fragment key sentinel",
+            "synthetic+fragment+value+sentinel",
+            "synthetic fragment value sentinel",
+        ),
+        id="fragment-plus-decoded-key-value",
+    ),
+    pytest.param(
+        "https://example.invalid/execute#"
+        "synthetic-fragment-first-key=synthetic-fragment-first-value&"
+        "synthetic-fragment-second-bare",
+        (
+            "synthetic-fragment-first-key=synthetic-fragment-first-value&"
+            "synthetic-fragment-second-bare",
+            "synthetic-fragment-first-key=synthetic-fragment-first-value",
+            "synthetic-fragment-first-key",
+            "synthetic-fragment-first-value",
+            "synthetic-fragment-second-bare",
+        ),
+        id="fragment-segments",
+    ),
+]
+
+
 def _endpoint_duplicated_argv(
     endpoint: str,
     raw_component: str,
@@ -440,6 +566,184 @@ def test_docker_argv_redaction_preserves_key_for_all_env_forms(env_args):
 
 
 @pytest.mark.parametrize(
+    ("endpoint", "components"), _SYNTHETIC_ENDPOINT_COMPONENT_CASES
+)
+def test_endpoint_component_redaction_values_cover_structured_fields(
+    endpoint: str, components: tuple[str, ...]
+):
+    values = sandbox_module._endpoint_component_redaction_values(endpoint)
+
+    assert set(components) <= values
+    assert "" not in values
+    assert not {"https", "example.invalid", "/execute"} & values
+
+
+def test_short_query_key_redaction_does_not_corrupt_harmless_url_context():
+    endpoint = "https://example.invalid/execute?x=synthetic-short-key-value-sentinel"
+    values = sandbox_module._endpoint_component_redaction_values(endpoint)
+    diagnostic = "https://example.invalid/execute failed for query key x"
+
+    rendered = sandbox_module._redact_diagnostic_output(
+        diagnostic, tuple(sorted(values, key=len, reverse=True))
+    )
+
+    assert "x" in values
+    assert rendered == (
+        "https://example.invalid/execute failed for query key <redacted>"
+    )
+
+
+@pytest.mark.parametrize(
+    "form",
+    ["short-separated", "long-separated", "short-joined", "long-joined"],
+)
+@pytest.mark.parametrize(
+    ("endpoint", "components"), _SYNTHETIC_ENDPOINT_COMPONENT_CASES
+)
+def test_docker_argv_redacts_all_endpoint_component_variants(
+    endpoint: str, components: tuple[str, ...], form: str
+):
+    raw_args = [
+        "docker",
+        "run",
+        *_endpoint_env_args(endpoint, form),
+        f"--endpoint={endpoint}",
+        *(f"--duplicate-{index}={value}" for index, value in enumerate(components)),
+        "--url-context=https://example.invalid/execute",
+        "synthetic-runner:latest",
+    ]
+    original_args = list(raw_args)
+
+    redacted = sandbox_module._redact_docker_argv(raw_args)
+    rendered = repr(redacted)
+
+    assert endpoint not in rendered
+    assert all(component not in rendered for component in components)
+    assert "HELIX_EVALUATOR_ENDPOINT=<redacted>" in rendered
+    assert "--endpoint=<redacted>" in redacted
+    assert all(
+        f"--duplicate-{index}=<redacted>" in redacted
+        for index in range(len(components))
+    )
+    assert "--url-context=https://example.invalid/execute" in redacted
+    assert raw_args == original_args
+
+
+@pytest.mark.parametrize(
+    "form",
+    ["short-separated", "long-separated", "short-joined", "long-joined"],
+)
+@pytest.mark.parametrize(
+    ("endpoint", "components"), _SYNTHETIC_ENDPOINT_COMPONENT_CASES
+)
+@pytest.mark.parametrize("outcome", ["success", "nonzero", "timeout", "called-process"])
+def test_docker_process_component_redaction_covers_every_diagnostic_surface(
+    mocker,
+    endpoint: str,
+    components: tuple[str, ...],
+    form: str,
+    outcome: str,
+):
+    raw_args = [
+        "docker",
+        "run",
+        *_endpoint_env_args(endpoint, form),
+        f"--endpoint={endpoint}",
+        *(f"--duplicate-{index}={value}" for index, value in enumerate(components)),
+        f"--explicit={_SYNTHETIC_PRIOR_SECRET}",
+        "--url-context=https://example.invalid/execute",
+        "synthetic-runner:latest",
+    ]
+    original_args = list(raw_args)
+    captured_subprocess_args: list[list[str]] = []
+    secret_payload = " | ".join((endpoint, *components, _SYNTHETIC_PRIOR_SECRET))
+    stdout = (
+        "synthetic successful functional output"
+        if outcome == "success"
+        else f"synthetic diagnostic stdout: {secret_payload}"
+    )
+    stderr = (
+        "synthetic successful functional stderr"
+        if outcome == "success"
+        else f"synthetic diagnostic stderr: {secret_payload}"
+    )
+
+    def fake_run(args, **kwargs):
+        captured_subprocess_args.append(list(args))
+        if outcome == "timeout":
+            raise subprocess.TimeoutExpired(
+                args, timeout=1, output=stdout, stderr=stderr
+            )
+        if outcome == "called-process":
+            raise subprocess.CalledProcessError(125, args, output=stdout, stderr=stderr)
+        return subprocess.CompletedProcess(
+            args,
+            0 if outcome == "success" else 9,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    sentinels = (endpoint, *components, _SYNTHETIC_PRIOR_SECRET)
+
+    if outcome in {"timeout", "called-process"}:
+        expected_exception = (
+            subprocess.TimeoutExpired
+            if outcome == "timeout"
+            else subprocess.CalledProcessError
+        )
+        with pytest.raises(expected_exception) as captured:
+            _run_docker(
+                raw_args,
+                check=outcome == "called-process",
+                redaction_values=[_SYNTHETIC_PRIOR_SECRET],
+            )
+        exc = captured.value
+        renderings = [
+            str(exc),
+            repr(exc),
+            repr(exc.cmd),
+            repr(exc.args),
+            str(exc.output),
+            str(exc.stderr),
+        ]
+        safe_args = exc.cmd
+    else:
+        result = _run_docker(
+            raw_args,
+            check=False,
+            redaction_values=[_SYNTHETIC_PRIOR_SECRET],
+        )
+        safe_args = result.args
+        if outcome == "success":
+            assert result.stdout == stdout
+            assert result.stderr == stderr
+            renderings = [repr(result.args)]
+        else:
+            renderings = [
+                str(result),
+                repr(result),
+                repr(result.args),
+                str(result.stdout),
+                str(result.stderr),
+            ]
+
+    assert all(
+        sentinel not in rendering for sentinel in sentinels for rendering in renderings
+    )
+    assert "HELIX_EVALUATOR_ENDPOINT=<redacted>" in repr(safe_args)
+    assert "--endpoint=<redacted>" in safe_args
+    assert "--explicit=<redacted>" in safe_args
+    assert all(
+        f"--duplicate-{index}=<redacted>" in safe_args
+        for index in range(len(components))
+    )
+    assert "--url-context=https://example.invalid/execute" in safe_args
+    assert captured_subprocess_args == [original_args]
+    assert raw_args == original_args
+
+
+@pytest.mark.parametrize(
     ("endpoint", "raw_component", "decoded_component", "form"),
     _SYNTHETIC_STRUCTURED_ENDPOINTS,
 )
@@ -709,7 +1013,7 @@ def test_endpoint_redaction_preserves_harmless_url_context(mocker):
 
     result = _run_docker(raw_args, check=False)
 
-    assert result.stdout == ("synthetic.invalid/evaluate failed: opaque=<redacted>")
+    assert result.stdout == ("synthetic.invalid/evaluate failed: <redacted>")
 
 
 @pytest.mark.parametrize("as_bytes", [False, True], ids=["text", "bytes"])

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -27,6 +27,7 @@ from helix.sandbox import (
 
 
 _SYNTHETIC_SECRET = "synthetic-sentinel-secret-for-redaction-tests"
+_NON_HEURISTIC_ENV_KEY = "SYNTHETIC_SETTING"
 
 
 def _is_workspace_chown(args: list[str]) -> bool:
@@ -361,18 +362,26 @@ def test_docker_argv_redaction_preserves_key_for_all_env_forms(env_args):
     assert "SYNTHETIC_API_KEY=<redacted>" in rendered
 
 
-def test_timeout_exception_redacts_docker_env_in_all_renderings(tmp_path: Path, mocker):
+@pytest.mark.parametrize("as_bytes", [False, True], ids=["text", "bytes"])
+def test_timeout_exception_redacts_docker_env_in_all_renderings(
+    tmp_path: Path, mocker, as_bytes: bool
+):
     source = tmp_path / "candidate"
     source.mkdir()
     (source / "main.py").write_text("print('hi')\n")
+    stdout: str | bytes = f"stdout echoed {_SYNTHETIC_SECRET}"
+    stderr: str | bytes = f"stderr echoed {_SYNTHETIC_SECRET}"
+    if as_bytes:
+        stdout = stdout.encode()
+        stderr = stderr.encode()
 
     def fake_run(args, **kwargs):
         if args[:2] == ["docker", "run"] and "--name" in args:
             raise subprocess.TimeoutExpired(
                 args,
                 timeout=1,
-                output=f"stdout echoed {_SYNTHETIC_SECRET}",
-                stderr=f"stderr echoed {_SYNTHETIC_SECRET}",
+                output=stdout,
+                stderr=stderr,
             )
         return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
 
@@ -383,7 +392,7 @@ def test_timeout_exception_redacts_docker_env_in_all_renderings(tmp_path: Path, 
         run_sandboxed_command(
             ["sh", "-c", "true"],
             cwd=source,
-            env={"SYNTHETIC_API_KEY": _SYNTHETIC_SECRET},
+            env={_NON_HEURISTIC_ENV_KEY: _SYNTHETIC_SECRET},
             sandbox=SandboxConfig(enabled=True, timeout_seconds=1),
             scope="evaluator",
             sync_back=False,
@@ -401,7 +410,7 @@ def test_timeout_exception_redacts_docker_env_in_all_renderings(tmp_path: Path, 
         f"worker exception: {type(exc).__name__}: {exc}",
     ]
     assert all(_SYNTHETIC_SECRET not in item for item in renderings)
-    assert "SYNTHETIC_API_KEY=<redacted>" in repr(exc.cmd)
+    assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in repr(exc.cmd)
 
 
 def test_nonzero_result_redacts_docker_argv_and_output_diagnostics(
@@ -427,7 +436,7 @@ def test_nonzero_result_redacts_docker_argv_and_output_diagnostics(
     result = run_sandboxed_command(
         ["sh", "-c", "exit 7"],
         cwd=source,
-        env={"SYNTHETIC_API_KEY": _SYNTHETIC_SECRET},
+        env={_NON_HEURISTIC_ENV_KEY: _SYNTHETIC_SECRET},
         sandbox=SandboxConfig(enabled=True),
         scope="evaluator",
         sync_back=False,
@@ -436,7 +445,7 @@ def test_nonzero_result_redacts_docker_argv_and_output_diagnostics(
 
     renderings = [repr(result), repr(result.args), result.stdout, result.stderr]
     assert all(_SYNTHETIC_SECRET not in item for item in renderings)
-    assert "SYNTHETIC_API_KEY=<redacted>" in repr(result.args)
+    assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in repr(result.args)
     assert result.returncode == 7
 
 
@@ -445,7 +454,7 @@ def test_called_process_exception_redacts_docker_env_and_indirect_context(mocker
         "docker",
         "run",
         "--env",
-        f"SYNTHETIC_API_KEY={_SYNTHETIC_SECRET}",
+        f"{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}",
         "fixture:latest",
     ]
 
@@ -453,8 +462,8 @@ def test_called_process_exception_redacts_docker_env_and_indirect_context(mocker
         raise subprocess.CalledProcessError(
             125,
             args,
-            output=f"stdout echoed {_SYNTHETIC_SECRET}",
-            stderr=f"stderr echoed {_SYNTHETIC_SECRET}",
+            output=f"stdout echoed {_SYNTHETIC_SECRET}".encode(),
+            stderr=f"stderr echoed {_SYNTHETIC_SECRET}".encode(),
         )
 
     mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
@@ -473,7 +482,167 @@ def test_called_process_exception_redacts_docker_env_and_indirect_context(mocker
         f"sidecar setup failed: {exc}",
     ]
     assert all(_SYNTHETIC_SECRET not in item for item in renderings)
-    assert "SYNTHETIC_API_KEY=<redacted>" in repr(exc.cmd)
+    assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in repr(exc.cmd)
+
+
+def test_successful_result_preserves_functional_output_while_redacting_argv(mocker):
+    env_key = "SYNTHETIC_API_KEY"
+    raw_args = [
+        "docker",
+        "run",
+        "-e",
+        f"{env_key}={_SYNTHETIC_SECRET}",
+        "fixture:latest",
+    ]
+    stdout = f"functional output {_SYNTHETIC_SECRET}"
+    mocker.patch(
+        "helix.sandbox.subprocess.run",
+        return_value=subprocess.CompletedProcess(raw_args, 0, stdout=stdout, stderr=""),
+    )
+
+    result = _run_docker(raw_args)
+
+    assert result.stdout == stdout
+    assert _SYNTHETIC_SECRET not in repr(result.args)
+    assert f"{env_key}=<redacted>" in repr(result.args)
+
+
+@pytest.mark.parametrize(
+    "env_args",
+    [
+        ["-e", f"{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}"],
+        ["--env", f"{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}"],
+        [f"-e{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}"],
+        [f"--env={_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}"],
+    ],
+)
+@pytest.mark.parametrize("as_bytes", [False, True], ids=["text", "bytes"])
+def test_nonzero_diagnostic_output_redacts_all_env_forms(
+    mocker, env_args: list[str], as_bytes: bool
+):
+    raw_args = ["docker", "run", *env_args, "fixture:latest"]
+    output: str | bytes = f"{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}"
+    if as_bytes:
+        output = output.encode()
+    mocker.patch(
+        "helix.sandbox.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            raw_args, 9, stdout=output, stderr=output
+        ),
+    )
+
+    result = _run_docker(raw_args, check=False)
+
+    renderings = [repr(result), str(result.stdout), str(result.stderr)]
+    assert all(_SYNTHETIC_SECRET not in item for item in renderings)
+    assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in str(result.stdout)
+
+
+def test_container_running_exit_logs_redact_sidecar_startup_env(mocker):
+    def fake_run(args, **kwargs):
+        if args[:2] == ["docker", "inspect"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="false exited\n", stderr=""
+            )
+        if args[:2] == ["docker", "logs"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout=f"{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    sidecar = EvaluatorSidecarConfig(
+        image="synthetic-sidecar:latest",
+        command="python -m synthetic_server",
+        endpoint="http://helix-evaluator:8080/evaluate",
+    )
+
+    with pytest.raises(RuntimeError) as captured:
+        with start_evaluator_sidecar(
+            sidecar,
+            fixed_env={_NON_HEURISTIC_ENV_KEY: _SYNTHETIC_SECRET},
+        ):
+            pass
+
+    rendered = str(captured.value)
+    assert _SYNTHETIC_SECRET not in rendered
+    assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in rendered
+
+
+def test_sidecar_service_exit_logs_redact_sidecar_startup_env(mocker):
+    def fake_run(args, **kwargs):
+        if args[:2] == ["docker", "inspect"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="false exited\n", stderr=""
+            )
+        if args[:2] == ["docker", "logs"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout="",
+                stderr=f"{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}\n",
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._wait_for_container_running")
+    sidecar = EvaluatorSidecarConfig(
+        image="synthetic-sidecar:latest",
+        command="python -m synthetic_server",
+        endpoint="http://helix-evaluator:8080/evaluate",
+    )
+
+    with pytest.raises(RuntimeError) as captured:
+        with start_evaluator_sidecar(
+            sidecar,
+            fixed_env={_NON_HEURISTIC_ENV_KEY: _SYNTHETIC_SECRET},
+        ):
+            pass
+
+    rendered = str(captured.value)
+    assert _SYNTHETIC_SECRET not in rendered
+    assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in rendered
+
+
+def test_sidecar_healthcheck_failure_redacts_sidecar_startup_env(mocker):
+    def fake_run(args, **kwargs):
+        if args[:2] == ["docker", "inspect"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="true running\n", stderr=""
+            )
+        if any(item.startswith("HELIX_EVALUATOR_ENDPOINT=") for item in args):
+            return subprocess.CompletedProcess(
+                args,
+                8,
+                stdout=f"{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._wait_for_container_running")
+    mocker.patch("helix.sandbox.time.monotonic", side_effect=[0.0, 0.0, 2.0])
+    mocker.patch("helix.sandbox.time.sleep")
+    sidecar = EvaluatorSidecarConfig(
+        image="synthetic-sidecar:latest",
+        command="python -m synthetic_server",
+        endpoint="http://helix-evaluator:8080/evaluate",
+        startup_timeout_seconds=1,
+    )
+
+    with pytest.raises(TimeoutError) as captured:
+        with start_evaluator_sidecar(
+            sidecar,
+            fixed_env={_NON_HEURISTIC_ENV_KEY: _SYNTHETIC_SECRET},
+        ):
+            pass
+
+    rendered = str(captured.value)
+    assert _SYNTHETIC_SECRET not in rendered
+    assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in rendered
 
 
 def test_sidecar_runtime_nested_same_runtime_restores_outer():
@@ -531,7 +700,7 @@ def test_sidecar_healthcheck_uses_runner_image_and_endpoint():
 def test_start_evaluator_sidecar_injects_fixed_env(mocker):
     calls: list[list[str]] = []
 
-    def fake_run_docker(args, *, check=True):
+    def fake_run_docker(args, **kwargs):
         calls.append(args)
         if args[:2] == ["docker", "inspect"]:
             return subprocess.CompletedProcess(

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -45,6 +45,19 @@ def _endpoint_env_args(endpoint: str, form: str) -> list[str]:
     raise AssertionError(f"unexpected synthetic env form: {form}")
 
 
+def _ordinary_env_args(value: str, form: str) -> list[str]:
+    assignment = f"{_NON_HEURISTIC_ENV_KEY}={value}"
+    if form == "short-separated":
+        return ["-e", assignment]
+    if form == "long-separated":
+        return ["--env", assignment]
+    if form == "short-joined":
+        return [f"-e{assignment}"]
+    if form == "long-joined":
+        return [f"--env={assignment}"]
+    raise AssertionError(f"unexpected synthetic env form: {form}")
+
+
 _SYNTHETIC_ENDPOINTS = [
     f"https://{_SYNTHETIC_ENDPOINT_FRAGMENT}@synthetic.invalid/evaluate",
     (
@@ -578,19 +591,209 @@ def test_endpoint_component_redaction_values_cover_structured_fields(
     assert not {"https", "example.invalid", "/execute"} & values
 
 
-def test_short_query_key_redaction_does_not_corrupt_harmless_url_context():
+@pytest.mark.parametrize("secret", ["x", "abc"])
+@pytest.mark.parametrize("as_bytes", [False, True], ids=["text", "bytes"])
+def test_direct_diagnostic_redaction_substring_scrubs_short_literal_secrets(
+    secret: str, as_bytes: bool
+):
+    diagnostic: str | bytes = f"prefix{secret}suffix"
+    if as_bytes:
+        diagnostic = diagnostic.encode()
+
+    rendered = sandbox_module._redact_diagnostic_output(diagnostic, [secret])
+
+    assert diagnostic not in rendered
+    assert (b"<redacted>" if as_bytes else "<redacted>") in rendered
+
+
+@pytest.mark.parametrize("as_bytes", [False, True], ids=["text", "bytes"])
+def test_short_query_key_redaction_does_not_corrupt_harmless_url_context(
+    as_bytes: bool,
+):
     endpoint = "https://example.invalid/execute?x=synthetic-short-key-value-sentinel"
     values = sandbox_module._endpoint_component_redaction_values(endpoint)
-    diagnostic = "https://example.invalid/execute failed for query key x"
+    diagnostic: str | bytes = (
+        "https://example.invalid/execute prefixxsuffix failed for query key x"
+    )
+    expected: str | bytes = (
+        "https://example.invalid/execute prefixxsuffix failed for query key <redacted>"
+    )
+    if as_bytes:
+        diagnostic = diagnostic.encode()
+        expected = expected.encode()
 
     rendered = sandbox_module._redact_diagnostic_output(
-        diagnostic, tuple(sorted(values, key=len, reverse=True))
+        diagnostic,
+        (),
+        boundary_secrets=tuple(sorted(values, key=len, reverse=True)),
     )
 
     assert "x" in values
-    assert rendered == (
-        "https://example.invalid/execute failed for query key <redacted>"
+    assert rendered == expected
+
+
+@pytest.mark.parametrize("secret", ["x", "abc"])
+@pytest.mark.parametrize(
+    "form",
+    ["short-separated", "long-separated", "short-joined", "long-joined"],
+)
+def test_docker_argv_substring_scrubs_short_ordinary_env_values(secret: str, form: str):
+    raw_args = [
+        "docker",
+        "run",
+        *_ordinary_env_args(secret, form),
+        f"--embedded=prefix{secret}suffix",
+        "fixture:latest",
+    ]
+
+    redacted = sandbox_module._redact_docker_argv(raw_args)
+    embedded_arg = next(arg for arg in redacted if arg.startswith("--embedded="))
+
+    assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in repr(redacted)
+    assert f"prefix{secret}suffix" not in embedded_arg
+    assert "<redacted>" in embedded_arg
+
+
+@pytest.mark.parametrize("secret", ["x", "abc"])
+def test_docker_argv_substring_scrubs_short_explicit_redaction_values(secret: str):
+    raw_args = [
+        "docker",
+        "logs",
+        "fixture",
+        f"--embedded=prefix{secret}suffix",
+    ]
+
+    redacted = sandbox_module._redact_docker_argv(raw_args, redaction_values=[secret])
+    embedded_arg = next(arg for arg in redacted if arg.startswith("--embedded="))
+
+    assert f"prefix{secret}suffix" not in embedded_arg
+    assert "<redacted>" in embedded_arg
+
+
+@pytest.mark.parametrize("secret_source", ["env", "explicit"])
+@pytest.mark.parametrize("secret", ["x", "abc"])
+def test_literal_secret_provenance_overrides_short_endpoint_component_boundaries(
+    secret_source: str, secret: str
+):
+    endpoint = (
+        f"https://example.invalid/execute?{secret}=synthetic-short-key-value-sentinel"
     )
+    raw_args = [
+        "docker",
+        "run",
+        *_endpoint_env_args(endpoint, "short-separated"),
+        f"--embedded=prefix{secret}suffix",
+        "fixture:latest",
+    ]
+    explicit_values: list[str] = []
+    if secret_source == "env":
+        raw_args[2:2] = _ordinary_env_args(secret, "long-joined")
+    else:
+        explicit_values.append(secret)
+
+    redacted = sandbox_module._redact_docker_argv(
+        raw_args, redaction_values=explicit_values
+    )
+    embedded_arg = next(arg for arg in redacted if arg.startswith("--embedded="))
+
+    assert f"prefix{secret}suffix" not in embedded_arg
+    assert "<redacted>" in embedded_arg
+
+
+@pytest.mark.parametrize(
+    "secret_source",
+    [
+        "short-separated",
+        "long-separated",
+        "short-joined",
+        "long-joined",
+        "explicit",
+    ],
+)
+@pytest.mark.parametrize("secret", ["x", "abc"])
+@pytest.mark.parametrize("as_bytes", [False, True], ids=["text", "bytes"])
+@pytest.mark.parametrize("outcome", ["success", "nonzero", "timeout", "called-process"])
+def test_short_literal_secrets_are_substring_scrubbed_from_every_process_surface(
+    mocker,
+    secret_source: str,
+    secret: str,
+    as_bytes: bool,
+    outcome: str,
+):
+    embedded = f"prefix{secret}suffix"
+    explicit_values: list[str] = []
+    env_args: list[str] = []
+    if secret_source == "explicit":
+        explicit_values.append(secret)
+    else:
+        env_args.extend(_ordinary_env_args(secret, secret_source))
+    raw_args = [
+        "docker",
+        "run",
+        *env_args,
+        f"--embedded={embedded}",
+        "fixture:latest",
+    ]
+    stdout: str | bytes = f"stdout {embedded}"
+    stderr: str | bytes = f"stderr {embedded}"
+    if as_bytes:
+        stdout = stdout.encode()
+        stderr = stderr.encode()
+
+    def fake_run(args, **kwargs):
+        if outcome == "timeout":
+            raise subprocess.TimeoutExpired(
+                args, timeout=1, output=stdout, stderr=stderr
+            )
+        if outcome == "called-process":
+            raise subprocess.CalledProcessError(125, args, output=stdout, stderr=stderr)
+        return subprocess.CompletedProcess(
+            args,
+            0 if outcome == "success" else 9,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+
+    if outcome in {"timeout", "called-process"}:
+        expected_exception = (
+            subprocess.TimeoutExpired
+            if outcome == "timeout"
+            else subprocess.CalledProcessError
+        )
+        with pytest.raises(expected_exception) as captured:
+            _run_docker(
+                raw_args,
+                check=outcome == "called-process",
+                redaction_values=explicit_values,
+                diagnostic_output=True,
+            )
+        safe_args = captured.value.cmd
+        actual_stdout = captured.value.output
+        actual_stderr = captured.value.stderr
+    else:
+        result = _run_docker(
+            raw_args,
+            check=False,
+            redaction_values=explicit_values,
+            diagnostic_output=True,
+        )
+        safe_args = result.args
+        actual_stdout = result.stdout
+        actual_stderr = result.stderr
+
+    embedded_arg = next(arg for arg in safe_args if arg.startswith("--embedded="))
+    assert embedded not in embedded_arg
+    assert "<redacted>" in embedded_arg
+    raw_embedded: str | bytes = embedded.encode() if as_bytes else embedded
+    replacement: str | bytes = b"<redacted>" if as_bytes else "<redacted>"
+    assert raw_embedded not in actual_stdout
+    assert raw_embedded not in actual_stderr
+    assert replacement in actual_stdout
+    assert replacement in actual_stderr
+    if secret_source != "explicit":
+        assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in repr(safe_args)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -9,10 +9,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import helix.sandbox as sandbox_module
 from helix.config import EvaluatorSidecarConfig, SandboxConfig
 from helix.sandbox import (
     EvaluatorSidecarRuntime,
     _healthcheck_docker_args,
+    _run_docker,
     current_evaluator_sidecar_runtime,
     evaluator_sidecar_runtime,
     resolve_sandbox_image,
@@ -22,6 +24,9 @@ from helix.sandbox import (
     sandbox_auth_volume_name,
     start_evaluator_sidecar,
 )
+
+
+_SYNTHETIC_SECRET = "synthetic-sentinel-secret-for-redaction-tests"
 
 
 def _is_workspace_chown(args: list[str]) -> bool:
@@ -336,6 +341,141 @@ def test_sandbox_exception_forces_container_and_workspace_cleanup(
     assert cleanup_names == [container_name]
     assert workspace is not None
     assert not workspace.parent.exists()
+
+
+@pytest.mark.parametrize(
+    "env_args",
+    [
+        ["-e", f"SYNTHETIC_API_KEY={_SYNTHETIC_SECRET}"],
+        ["--env", f"SYNTHETIC_API_KEY={_SYNTHETIC_SECRET}"],
+        [f"-eSYNTHETIC_API_KEY={_SYNTHETIC_SECRET}"],
+        [f"--env=SYNTHETIC_API_KEY={_SYNTHETIC_SECRET}"],
+    ],
+)
+def test_docker_argv_redaction_preserves_key_for_all_env_forms(env_args):
+    rendered = repr(
+        sandbox_module._redact_docker_argv(
+            ["docker", "run", *env_args, "fixture:latest"]
+        )
+    )
+
+    assert _SYNTHETIC_SECRET not in rendered
+    assert "SYNTHETIC_API_KEY=<redacted>" in rendered
+
+
+def test_timeout_exception_redacts_docker_env_in_all_renderings(tmp_path: Path, mocker):
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "main.py").write_text("print('hi')\n")
+
+    def fake_run(args, **kwargs):
+        if args[:2] == ["docker", "run"] and "--name" in args:
+            raise subprocess.TimeoutExpired(
+                args,
+                timeout=1,
+                output=f"stdout echoed {_SYNTHETIC_SECRET}",
+                stderr=f"stderr echoed {_SYNTHETIC_SECRET}",
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+
+    with pytest.raises(subprocess.TimeoutExpired) as captured:
+        run_sandboxed_command(
+            ["sh", "-c", "true"],
+            cwd=source,
+            env={"SYNTHETIC_API_KEY": _SYNTHETIC_SECRET},
+            sandbox=SandboxConfig(enabled=True, timeout_seconds=1),
+            scope="evaluator",
+            sync_back=False,
+            image="helix-test:latest",
+        )
+
+    exc = captured.value
+    renderings = [
+        str(exc),
+        repr(exc),
+        repr(exc.cmd),
+        repr(exc.args),
+        str(exc.output),
+        str(exc.stderr),
+        f"worker exception: {type(exc).__name__}: {exc}",
+    ]
+    assert all(_SYNTHETIC_SECRET not in item for item in renderings)
+    assert "SYNTHETIC_API_KEY=<redacted>" in repr(exc.cmd)
+
+
+def test_nonzero_result_redacts_docker_argv_and_output_diagnostics(
+    tmp_path: Path, mocker
+):
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "main.py").write_text("print('hi')\n")
+
+    def fake_run(args, **kwargs):
+        if args[:2] == ["docker", "run"] and "--name" in args:
+            return subprocess.CompletedProcess(
+                args,
+                7,
+                stdout=f"stdout echoed {_SYNTHETIC_SECRET}",
+                stderr=f"stderr echoed {_SYNTHETIC_SECRET}",
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+
+    result = run_sandboxed_command(
+        ["sh", "-c", "exit 7"],
+        cwd=source,
+        env={"SYNTHETIC_API_KEY": _SYNTHETIC_SECRET},
+        sandbox=SandboxConfig(enabled=True),
+        scope="evaluator",
+        sync_back=False,
+        image="helix-test:latest",
+    )
+
+    renderings = [repr(result), repr(result.args), result.stdout, result.stderr]
+    assert all(_SYNTHETIC_SECRET not in item for item in renderings)
+    assert "SYNTHETIC_API_KEY=<redacted>" in repr(result.args)
+    assert result.returncode == 7
+
+
+def test_called_process_exception_redacts_docker_env_and_indirect_context(mocker):
+    raw_args = [
+        "docker",
+        "run",
+        "--env",
+        f"SYNTHETIC_API_KEY={_SYNTHETIC_SECRET}",
+        "fixture:latest",
+    ]
+
+    def fake_run(args, **kwargs):
+        raise subprocess.CalledProcessError(
+            125,
+            args,
+            output=f"stdout echoed {_SYNTHETIC_SECRET}",
+            stderr=f"stderr echoed {_SYNTHETIC_SECRET}",
+        )
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError) as captured:
+        _run_docker(raw_args)
+
+    exc = captured.value
+    renderings = [
+        str(exc),
+        repr(exc),
+        repr(exc.cmd),
+        repr(exc.args),
+        str(exc.output),
+        str(exc.stderr),
+        f"sidecar setup failed: {exc}",
+    ]
+    assert all(_SYNTHETIC_SECRET not in item for item in renderings)
+    assert "SYNTHETIC_API_KEY=<redacted>" in repr(exc.cmd)
 
 
 def test_sidecar_runtime_nested_same_runtime_restores_outer():

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -50,9 +50,7 @@ def _is_workspace_chown_only(args: list[str]) -> bool:
 
 
 def _is_workspace_permission_relax(args: list[str]) -> bool:
-    return args[:2] == ["docker", "run"] and any(
-        "chmod a+rwX" in item for item in args
-    )
+    return args[:2] == ["docker", "run"] and any("chmod a+rwX" in item for item in args)
 
 
 def test_resolve_sandbox_image_defaults_from_backend():
@@ -867,9 +865,7 @@ def test_agent_sync_skips_relax_when_host_owner_available(tmp_path: Path, mocker
     assert [call for call in calls if _is_workspace_chown_only(call)]
 
 
-def test_safe_rmtree_uses_relax_helper_when_host_owner_missing(
-    tmp_path: Path, mocker
-):
+def test_safe_rmtree_uses_relax_helper_when_host_owner_missing(tmp_path: Path, mocker):
     """``_safe_rmtree`` must invoke the relax helper (not chown) when the host
     owner is unavailable, then retry the rmtree."""
     from helix.sandbox import _safe_rmtree

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -607,7 +607,7 @@ def test_sidecar_service_exit_logs_redact_sidecar_startup_env(mocker):
     assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in rendered
 
 
-def test_sidecar_healthcheck_failure_redacts_sidecar_startup_env(mocker):
+def test_sidecar_healthcheck_timeout_redacts_endpoint_and_startup_env(mocker):
     def fake_run(args, **kwargs):
         if args[:2] == ["docker", "inspect"]:
             return subprocess.CompletedProcess(
@@ -626,10 +626,11 @@ def test_sidecar_healthcheck_failure_redacts_sidecar_startup_env(mocker):
     mocker.patch("helix.sandbox._wait_for_container_running")
     mocker.patch("helix.sandbox.time.monotonic", side_effect=[0.0, 0.0, 2.0])
     mocker.patch("helix.sandbox.time.sleep")
+    endpoint = f"https://synthetic.invalid/evaluate?sentinel={_SYNTHETIC_SECRET}"
     sidecar = EvaluatorSidecarConfig(
         image="synthetic-sidecar:latest",
         command="python -m synthetic_server",
-        endpoint="http://helix-evaluator:8080/evaluate",
+        endpoint=endpoint,
         startup_timeout_seconds=1,
     )
 
@@ -641,7 +642,12 @@ def test_sidecar_healthcheck_failure_redacts_sidecar_startup_env(mocker):
             pass
 
     rendered = str(captured.value)
+    assert endpoint not in rendered
     assert _SYNTHETIC_SECRET not in rendered
+    assert rendered.splitlines()[0] == (
+        "Evaluator sidecar endpoint did not become reachable within 1s: "
+        "HELIX_EVALUATOR_ENDPOINT=<redacted>"
+    )
     assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in rendered
 
 

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -28,6 +28,7 @@ from helix.sandbox import (
 
 _SYNTHETIC_SECRET = "synthetic-sentinel-secret-for-redaction-tests"
 _SYNTHETIC_ENDPOINT_FRAGMENT = "synthetic-endpoint-fragment-for-redaction-tests"
+_SYNTHETIC_PRIOR_SECRET = "synthetic-prior-invocation-redaction-value"
 _NON_HEURISTIC_ENV_KEY = "SYNTHETIC_SETTING"
 
 
@@ -53,6 +54,57 @@ _SYNTHETIC_ENDPOINTS = [
     (f"https://synthetic.invalid/evaluate?opaque={_SYNTHETIC_ENDPOINT_FRAGMENT}"),
     f"https://synthetic.invalid/evaluate#{_SYNTHETIC_ENDPOINT_FRAGMENT}",
 ]
+
+
+_SYNTHETIC_STRUCTURED_ENDPOINTS = [
+    pytest.param(
+        "https://synthetic-user%2Bdecoded@synthetic.invalid/evaluate",
+        "synthetic-user%2Bdecoded",
+        "synthetic-user+decoded",
+        "short-separated",
+        id="username",
+    ),
+    pytest.param(
+        "https://synthetic-user:synthetic-password%2Fdecoded@"
+        "synthetic.invalid/evaluate",
+        "synthetic-password%2Fdecoded",
+        "synthetic-password/decoded",
+        "long-separated",
+        id="password",
+    ),
+    pytest.param(
+        "https://synthetic.invalid/evaluate?opaque=synthetic-query%3Fdecoded",
+        "synthetic-query%3Fdecoded",
+        "synthetic-query?decoded",
+        "short-joined",
+        id="query-value",
+    ),
+    pytest.param(
+        "https://synthetic.invalid/evaluate#synthetic-fragment%23decoded",
+        "synthetic-fragment%23decoded",
+        "synthetic-fragment#decoded",
+        "long-joined",
+        id="fragment",
+    ),
+]
+
+
+def _endpoint_duplicated_argv(
+    endpoint: str,
+    raw_component: str,
+    decoded_component: str,
+    form: str,
+) -> list[str]:
+    return [
+        "docker",
+        "run",
+        *_endpoint_env_args(endpoint, form),
+        f"--endpoint={endpoint}",
+        f"--raw-component={raw_component}",
+        f"--decoded-component={decoded_component}",
+        "synthetic-runner:latest",
+        f"--healthcheck=probe {raw_component} {decoded_component}",
+    ]
 
 
 def _is_workspace_chown(args: list[str]) -> bool:
@@ -385,6 +437,156 @@ def test_docker_argv_redaction_preserves_key_for_all_env_forms(env_args):
 
     assert _SYNTHETIC_SECRET not in rendered
     assert "SYNTHETIC_API_KEY=<redacted>" in rendered
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "raw_component", "decoded_component", "form"),
+    _SYNTHETIC_STRUCTURED_ENDPOINTS,
+)
+def test_docker_argv_redacts_endpoint_and_components_duplicated_in_other_tokens(
+    endpoint: str,
+    raw_component: str,
+    decoded_component: str,
+    form: str,
+):
+    raw_args = _endpoint_duplicated_argv(
+        endpoint, raw_component, decoded_component, form
+    )
+
+    rendered = repr(sandbox_module._redact_docker_argv(raw_args))
+
+    for sentinel in (endpoint, raw_component, decoded_component):
+        assert sentinel not in rendered
+    assert "HELIX_EVALUATOR_ENDPOINT=<redacted>" in rendered
+    assert "--endpoint=<redacted>" in rendered
+    assert "--raw-component=<redacted>" in rendered
+    assert "--decoded-component=<redacted>" in rendered
+    assert "--healthcheck=probe <redacted> <redacted>" in rendered
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "raw_component", "decoded_component", "form"),
+    _SYNTHETIC_STRUCTURED_ENDPOINTS,
+)
+@pytest.mark.parametrize("outcome", ["success", "nonzero", "timeout", "called-process"])
+def test_docker_process_redacts_duplicated_endpoint_values_from_diagnostics(
+    mocker,
+    endpoint: str,
+    raw_component: str,
+    decoded_component: str,
+    form: str,
+    outcome: str,
+):
+    raw_args = _endpoint_duplicated_argv(
+        endpoint, raw_component, decoded_component, form
+    )
+    raw_args.append(f"--prior-token={_SYNTHETIC_PRIOR_SECRET}")
+    original_args = list(raw_args)
+    captured_subprocess_args: list[list[str]] = []
+    stdout = (
+        f"functional stdout: {endpoint} {decoded_component} {_SYNTHETIC_PRIOR_SECRET}"
+    )
+    stderr = f"functional stderr: {raw_component}"
+
+    def fake_run(args, **kwargs):
+        captured_subprocess_args.append(list(args))
+        if outcome == "timeout":
+            raise subprocess.TimeoutExpired(
+                args, timeout=1, output=stdout, stderr=stderr
+            )
+        if outcome == "called-process":
+            raise subprocess.CalledProcessError(125, args, output=stdout, stderr=stderr)
+        return subprocess.CompletedProcess(
+            args,
+            0 if outcome == "success" else 9,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    sentinels = (
+        endpoint,
+        raw_component,
+        decoded_component,
+        _SYNTHETIC_PRIOR_SECRET,
+    )
+
+    if outcome in {"timeout", "called-process"}:
+        expected_exception = (
+            subprocess.TimeoutExpired
+            if outcome == "timeout"
+            else subprocess.CalledProcessError
+        )
+        with pytest.raises(expected_exception) as captured:
+            _run_docker(
+                raw_args,
+                check=outcome == "called-process",
+                redaction_values=[_SYNTHETIC_PRIOR_SECRET],
+            )
+        exc = captured.value
+        renderings = [
+            str(exc),
+            repr(exc),
+            repr(exc.cmd),
+            repr(exc.args),
+            str(exc.output),
+            str(exc.stderr),
+            f"subprocess diagnostic: {type(exc).__name__}: {exc}",
+        ]
+        assert all(
+            sentinel not in rendering
+            for sentinel in sentinels
+            for rendering in renderings
+        )
+        safe_args = repr(exc.cmd)
+    else:
+        result = _run_docker(
+            raw_args,
+            check=False,
+            redaction_values=[_SYNTHETIC_PRIOR_SECRET],
+        )
+        safe_args = repr(result.args)
+        assert all(sentinel not in safe_args for sentinel in sentinels)
+        if outcome == "success":
+            assert result.stdout == stdout
+            assert result.stderr == stderr
+        else:
+            renderings = [repr(result), str(result.stdout), str(result.stderr)]
+            assert all(
+                sentinel not in rendering
+                for sentinel in sentinels
+                for rendering in renderings
+            )
+
+    assert "HELIX_EVALUATOR_ENDPOINT=<redacted>" in safe_args
+    assert "--endpoint=<redacted>" in safe_args
+    assert "--raw-component=<redacted>" in safe_args
+    assert "--decoded-component=<redacted>" in safe_args
+    assert "--prior-token=<redacted>" in safe_args
+    assert captured_subprocess_args == [original_args]
+    assert raw_args == original_args
+
+
+def test_explicit_prior_invocation_redaction_values_are_scrubbed_from_argv():
+    raw_args = [
+        "docker",
+        "logs",
+        "synthetic-container",
+        f"--token={_SYNTHETIC_PRIOR_SECRET}",
+        f"--healthcheck=probe {_SYNTHETIC_PRIOR_SECRET}",
+    ]
+    original_args = list(raw_args)
+
+    rendered = repr(
+        sandbox_module._redact_docker_argv(
+            raw_args, redaction_values=[_SYNTHETIC_PRIOR_SECRET]
+        )
+    )
+
+    assert _SYNTHETIC_PRIOR_SECRET not in rendered
+    assert "--token=<redacted>" in rendered
+    assert "--healthcheck=probe <redacted>" in rendered
+    assert raw_args == original_args
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -27,7 +27,32 @@ from helix.sandbox import (
 
 
 _SYNTHETIC_SECRET = "synthetic-sentinel-secret-for-redaction-tests"
+_SYNTHETIC_ENDPOINT_FRAGMENT = "synthetic-endpoint-fragment-for-redaction-tests"
 _NON_HEURISTIC_ENV_KEY = "SYNTHETIC_SETTING"
+
+
+def _endpoint_env_args(endpoint: str, form: str) -> list[str]:
+    assignment = f"HELIX_EVALUATOR_ENDPOINT={endpoint}"
+    if form == "short-separated":
+        return ["-e", assignment]
+    if form == "long-separated":
+        return ["--env", assignment]
+    if form == "short-joined":
+        return [f"-e{assignment}"]
+    if form == "long-joined":
+        return [f"--env={assignment}"]
+    raise AssertionError(f"unexpected synthetic env form: {form}")
+
+
+_SYNTHETIC_ENDPOINTS = [
+    f"https://{_SYNTHETIC_ENDPOINT_FRAGMENT}@synthetic.invalid/evaluate",
+    (
+        "https://synthetic-user:"
+        f"{_SYNTHETIC_ENDPOINT_FRAGMENT}@synthetic.invalid/evaluate"
+    ),
+    (f"https://synthetic.invalid/evaluate?opaque={_SYNTHETIC_ENDPOINT_FRAGMENT}"),
+    f"https://synthetic.invalid/evaluate#{_SYNTHETIC_ENDPOINT_FRAGMENT}",
+]
 
 
 def _is_workspace_chown(args: list[str]) -> bool:
@@ -362,6 +387,129 @@ def test_docker_argv_redaction_preserves_key_for_all_env_forms(env_args):
     assert "SYNTHETIC_API_KEY=<redacted>" in rendered
 
 
+@pytest.mark.parametrize(
+    "form",
+    ["short-separated", "long-separated", "short-joined", "long-joined"],
+)
+@pytest.mark.parametrize(
+    "endpoint",
+    _SYNTHETIC_ENDPOINTS,
+    ids=["username", "password", "query-value", "fragment"],
+)
+@pytest.mark.parametrize("failure", ["timeout", "called-process"])
+def test_endpoint_fragment_redacted_from_subprocess_exception(
+    mocker, form: str, endpoint: str, failure: str
+):
+    raw_args = [
+        "docker",
+        "run",
+        *_endpoint_env_args(endpoint, form),
+        "synthetic-runner:latest",
+    ]
+
+    def fake_run(args, **kwargs):
+        if failure == "timeout":
+            raise subprocess.TimeoutExpired(
+                args,
+                timeout=1,
+                output=f"stdout: {_SYNTHETIC_ENDPOINT_FRAGMENT}",
+                stderr=f"stderr: {_SYNTHETIC_ENDPOINT_FRAGMENT}",
+            )
+        raise subprocess.CalledProcessError(
+            125,
+            args,
+            output=f"stdout: {_SYNTHETIC_ENDPOINT_FRAGMENT}",
+            stderr=f"stderr: {_SYNTHETIC_ENDPOINT_FRAGMENT}",
+        )
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    expected_exception = (
+        subprocess.TimeoutExpired
+        if failure == "timeout"
+        else subprocess.CalledProcessError
+    )
+
+    with pytest.raises(expected_exception) as captured:
+        _run_docker(raw_args)
+
+    exc = captured.value
+    renderings = [
+        str(exc),
+        repr(exc),
+        repr(exc.cmd),
+        repr(exc.args),
+        str(exc.output),
+        str(exc.stderr),
+        f"healthcheck exception: {type(exc).__name__}: {exc}",
+    ]
+    assert all(_SYNTHETIC_ENDPOINT_FRAGMENT not in item for item in renderings)
+    assert "HELIX_EVALUATOR_ENDPOINT=<redacted>" in repr(exc.cmd)
+
+
+@pytest.mark.parametrize(
+    "form",
+    ["short-separated", "long-separated", "short-joined", "long-joined"],
+)
+@pytest.mark.parametrize(
+    "endpoint",
+    _SYNTHETIC_ENDPOINTS,
+    ids=["username", "password", "query-value", "fragment"],
+)
+def test_endpoint_fragment_redacted_from_nonzero_diagnostic(
+    mocker, form: str, endpoint: str
+):
+    raw_args = [
+        "docker",
+        "run",
+        *_endpoint_env_args(endpoint, form),
+        "synthetic-runner:latest",
+    ]
+    mocker.patch(
+        "helix.sandbox.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            raw_args,
+            9,
+            stdout=f"stdout: {_SYNTHETIC_ENDPOINT_FRAGMENT}",
+            stderr=f"stderr: {_SYNTHETIC_ENDPOINT_FRAGMENT}",
+        ),
+    )
+
+    result = _run_docker(raw_args, check=False)
+
+    renderings = [repr(result), str(result.stdout), str(result.stderr)]
+    assert all(_SYNTHETIC_ENDPOINT_FRAGMENT not in item for item in renderings)
+    assert "HELIX_EVALUATOR_ENDPOINT=<redacted>" in repr(result.args)
+
+
+def test_endpoint_redaction_preserves_harmless_url_context(mocker):
+    endpoint = (
+        f"https://synthetic.invalid/evaluate?opaque={_SYNTHETIC_ENDPOINT_FRAGMENT}"
+    )
+    raw_args = [
+        "docker",
+        "run",
+        "-e",
+        f"HELIX_EVALUATOR_ENDPOINT={endpoint}",
+        "synthetic-runner:latest",
+    ]
+    mocker.patch(
+        "helix.sandbox.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            raw_args,
+            9,
+            stdout=(
+                "synthetic.invalid/evaluate failed: opaque="
+                f"{_SYNTHETIC_ENDPOINT_FRAGMENT}"
+            ),
+            stderr="",
+        ),
+    )
+
+    result = _run_docker(raw_args, check=False)
+
+    assert result.stdout == ("synthetic.invalid/evaluate failed: opaque=<redacted>")
+
+
 @pytest.mark.parametrize("as_bytes", [False, True], ids=["text", "bytes"])
 def test_timeout_exception_redacts_docker_env_in_all_renderings(
     tmp_path: Path, mocker, as_bytes: bool
@@ -607,6 +755,42 @@ def test_sidecar_service_exit_logs_redact_sidecar_startup_env(mocker):
     assert f"{_NON_HEURISTIC_ENV_KEY}=<redacted>" in rendered
 
 
+@pytest.mark.parametrize("failure_phase", ["container-start", "service-wait"])
+def test_sidecar_logs_redact_endpoint_fragment(mocker, failure_phase: str):
+    def fake_run(args, **kwargs):
+        if args[:2] == ["docker", "inspect"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="false exited\n", stderr=""
+            )
+        if args[:2] == ["docker", "logs"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout=f"sidecar detail: {_SYNTHETIC_ENDPOINT_FRAGMENT}\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    if failure_phase == "service-wait":
+        mocker.patch("helix.sandbox._wait_for_container_running")
+    sidecar = EvaluatorSidecarConfig(
+        image="synthetic-sidecar:latest",
+        command="python -m synthetic_server",
+        endpoint=(
+            f"https://synthetic.invalid/evaluate?opaque={_SYNTHETIC_ENDPOINT_FRAGMENT}"
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as captured:
+        with start_evaluator_sidecar(sidecar):
+            pass
+
+    rendered = str(captured.value)
+    assert _SYNTHETIC_ENDPOINT_FRAGMENT not in rendered
+    assert "stdout:\nsidecar detail: <redacted>" in rendered
+
+
 def test_sidecar_healthcheck_timeout_redacts_endpoint_and_startup_env(mocker):
     def fake_run(args, **kwargs):
         if args[:2] == ["docker", "inspect"]:
@@ -617,7 +801,10 @@ def test_sidecar_healthcheck_timeout_redacts_endpoint_and_startup_env(mocker):
             return subprocess.CompletedProcess(
                 args,
                 8,
-                stdout=f"{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}\n",
+                stdout=(
+                    f"healthcheck detail: {_SYNTHETIC_ENDPOINT_FRAGMENT}\n"
+                    f"{_NON_HEURISTIC_ENV_KEY}={_SYNTHETIC_SECRET}\n"
+                ),
                 stderr="",
             )
         return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
@@ -626,7 +813,9 @@ def test_sidecar_healthcheck_timeout_redacts_endpoint_and_startup_env(mocker):
     mocker.patch("helix.sandbox._wait_for_container_running")
     mocker.patch("helix.sandbox.time.monotonic", side_effect=[0.0, 0.0, 2.0])
     mocker.patch("helix.sandbox.time.sleep")
-    endpoint = f"https://synthetic.invalid/evaluate?sentinel={_SYNTHETIC_SECRET}"
+    endpoint = (
+        f"https://synthetic.invalid/evaluate?opaque={_SYNTHETIC_ENDPOINT_FRAGMENT}"
+    )
     sidecar = EvaluatorSidecarConfig(
         image="synthetic-sidecar:latest",
         command="python -m synthetic_server",
@@ -643,6 +832,7 @@ def test_sidecar_healthcheck_timeout_redacts_endpoint_and_startup_env(mocker):
 
     rendered = str(captured.value)
     assert endpoint not in rendered
+    assert _SYNTHETIC_ENDPOINT_FRAGMENT not in rendered
     assert _SYNTHETIC_SECRET not in rendered
     assert rendered.splitlines()[0] == (
         "Evaluator sidecar endpoint did not become reachable within 1s: "

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -385,7 +385,9 @@ def test_resume_preserves_cache_and_discovery_across_saves(tmp_path: Path) -> No
     loaded_state.generation = 2
     loaded_state.mutation_counter = 2
     loaded_state.frontier.append("g2-s2")
-    loaded_state.num_metric_calls_by_discovery["g2-s2"] = loaded_state.budget.evaluations
+    loaded_state.num_metric_calls_by_discovery["g2-s2"] = (
+        loaded_state.budget.evaluations
+    )
     fresh_cache.put({"prompt.md": "v2"}, "task_b", output="o2", score=0.9)
     save_state(loaded_state, tmp_path)
     save_eval_cache(fresh_cache._cache, tmp_path)
@@ -447,7 +449,9 @@ def test_state_json_keys_when_val_stage_disabled(tmp_path: Path) -> None:
     )
 
 
-def test_legacy_state_load_followed_by_save_writes_versioned_payload(tmp_path: Path) -> None:
+def test_legacy_state_load_followed_by_save_writes_versioned_payload(
+    tmp_path: Path,
+) -> None:
     """Loading a legacy v0 state.json and re-saving must promote it to the
     current schema_version with new-field defaults present.
 

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -561,6 +561,47 @@ def test_task_accounted_marker_is_idempotent_without_charging_budget(
         )
 
 
+def test_failed_task_charge_roundtrips_without_double_charge_on_resume(
+    tmp_path: Path,
+) -> None:
+    state = EvolutionState(
+        generation=4,
+        frontier=["g0-s0"],
+        instance_scores={},
+        budget=BudgetState(evaluations=5),
+        config_hash="h",
+    )
+    batch = checkpoint_batch_before_dispatch(state, tmp_path, _make_batch())
+    state.budget.evaluations += 2
+    checkpoint_batch_task(
+        state,
+        tmp_path,
+        batch_id=batch.batch_id,
+        task_index=0,
+        status="failed",
+        cleanup="missing",
+        budget_charge=BudgetState(evaluations=2),
+        budget_accounted=True,
+    )
+
+    resumed = load_state(tmp_path)
+    assert resumed is not None
+    replayed = checkpoint_batch_task(
+        resumed,
+        tmp_path,
+        batch_id=batch.batch_id,
+        task_index=0,
+        status="failed",
+        cleanup="missing",
+        budget_charge=BudgetState(evaluations=2),
+        budget_accounted=True,
+    )
+
+    assert resumed.budget.evaluations == 7
+    assert replayed.budget_charge.evaluations == 2
+    assert replayed.budget_accounted
+
+
 def test_pre_dispatch_rejects_candidate_id_collision(tmp_path: Path) -> None:
     state = EvolutionState(
         generation=4,

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -601,6 +601,8 @@ def test_post_apply_checkpoint_requires_and_persists_every_terminal_slot(
         task_index=0,
         status="applied",
         selection="selected",
+        budget_charge=BudgetState(evaluations=0),
+        budget_accounted=True,
         applied=True,
     )
     for task_index, status, cleanup in (
@@ -615,6 +617,8 @@ def test_post_apply_checkpoint_requires_and_persists_every_terminal_slot(
             task_index=task_index,
             status=status,  # type: ignore[arg-type]
             cleanup=cleanup,  # type: ignore[arg-type]
+            budget_charge=BudgetState(evaluations=0),
+            budget_accounted=True,
         )
 
     saver_calls: list[EvolutionState] = []
@@ -634,6 +638,37 @@ def test_post_apply_checkpoint_requires_and_persists_every_terminal_slot(
     assert completed.budget_after_apply == 19
     assert completed.all_tasks_terminal()
     assert saver_calls == [state]
+
+
+def test_post_apply_checkpoint_rejects_task_budget_drift(tmp_path: Path) -> None:
+    state = EvolutionState(
+        generation=4,
+        frontier=["g0-s0"],
+        instance_scores={},
+        budget=BudgetState(evaluations=5),
+        config_hash="h",
+    )
+    batch = checkpoint_batch_before_dispatch(
+        state,
+        tmp_path,
+        _make_batch(),
+        max_in_flight_evaluations=8,
+    )
+    state.budget.evaluations = 7
+    for task_index in range(4):
+        checkpoint_batch_task(
+            state,
+            tmp_path,
+            batch_id=batch.batch_id,
+            task_index=task_index,
+            status="failed",
+            cleanup="missing",
+            budget_charge=BudgetState(evaluations=0),
+            budget_accounted=True,
+        )
+
+    with pytest.raises(ValueError, match="global budget advanced by 2"):
+        checkpoint_batch_after_apply(state, tmp_path, batch_id=batch.batch_id)
 
 
 def test_scheduler_checkpoint_roundtrips_rng_and_sampler_position(

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -20,6 +20,7 @@ Covers the additions called out in /tmp/audit_audit-rng-state-persist.md
 from __future__ import annotations
 
 import json
+import random
 from pathlib import Path
 
 import pytest
@@ -29,7 +30,15 @@ from helix.state import (
     SCHEMA_VERSION,
     BudgetState,
     EvolutionState,
+    ProposalBatchRecord,
+    ProposalTaskRecord,
+    build_scheduler_checkpoint,
+    checkpoint_batch_after_apply,
+    checkpoint_batch_before_dispatch,
+    checkpoint_batch_task,
+    checkpoint_scheduler_state,
     clear_eval_cache,
+    decode_rng_state,
     load_eval_cache,
     load_state,
     save_eval_cache,
@@ -42,8 +51,64 @@ from helix.state import (
 # ---------------------------------------------------------------------------
 
 
+def _make_batch(*, batch_id: str = "g4-b0") -> ProposalBatchRecord:
+    tasks = [
+        ProposalTaskRecord(
+            batch_id=batch_id,
+            p=2,
+            n=2,
+            task_index=index,
+            parent_group=index // 2,
+            mutation_index=index % 2,
+            parent_id="g0-s0" if index < 2 else "g1-s1",
+            child_id=f"g4-s{index + 10}",
+        )
+        for index in range(4)
+    ]
+    return ProposalBatchRecord(
+        batch_id=batch_id,
+        generation=4,
+        p=2,
+        n=2,
+        tasks=tasks,
+    )
+
+
 def _make_full_state() -> EvolutionState:
     """Build an EvolutionState with every field populated."""
+    batch = _make_batch()
+    terminal_values = [
+        ("applied", "selected", "not_required", True, 0.2),
+        ("rejected", "not_selected", "removed", False, -0.1),
+        ("skipped", "not_applicable", "missing", False, None),
+        ("failed", "not_applicable", "removed", False, None),
+    ]
+    for task, (status, selection, cleanup, applied, delta) in zip(
+        batch.tasks, terminal_values, strict=True
+    ):
+        task.status = status  # type: ignore[assignment]
+        task.selection = selection  # type: ignore[assignment]
+        task.cleanup = cleanup  # type: ignore[assignment]
+        task.applied = applied
+        task.score_delta = delta
+        task.budget_charge = BudgetState(evaluations=2)
+        task.budget_accounted = True
+    batch.phase = "complete"
+    batch.budget_before_dispatch = 34
+    batch.max_evaluations = 40
+    batch.max_in_flight_evaluations = 8
+    batch.maximum_overshoot = 2
+    batch.budget_after_apply = 42
+    rng = random.Random(123)
+    scheduler_state = build_scheduler_checkpoint(
+        frontier_rng_state=rng.getstate(),
+        sampler_rng_state=rng.getstate(),
+        sampler_epoch=2,
+        sampler_shuffled_ids=["task_b", "task_a"],
+        sampler_last_trainset_size=2,
+        sampler_id_frequencies={"task_a": 1, "task_b": 1},
+        sampler_fallback={"epoch": -1, "shuffled_ids": []},
+    )
     return EvolutionState(
         generation=4,
         frontier=["g0-s0", "g1-s1", "g2-m1"],
@@ -74,6 +139,8 @@ def _make_full_state() -> EvolutionState:
             "g2-m1": 28,
         },
         active_frontier={"task_a": ["g2-m1"], "task_b": ["g2-m1"]},
+        proposal_batches=[batch],
+        scheduler_state=scheduler_state,
     )
 
 
@@ -92,6 +159,8 @@ def test_state_roundtrip_preserves_all_fields(tmp_path: Path) -> None:
     # Sanity-check that the new fields specifically survived.
     assert loaded.num_metric_calls_by_discovery == state.num_metric_calls_by_discovery
     assert loaded.active_frontier == state.active_frontier
+    assert loaded.proposal_batches == state.proposal_batches
+    assert loaded.scheduler_state == state.scheduler_state
     assert loaded.schema_version == SCHEMA_VERSION
 
 
@@ -148,6 +217,8 @@ def test_load_legacy_state_populates_defaults(tmp_path: Path) -> None:
     assert loaded is not None
     # The new fields default — empty dict for discovery, current schema_version.
     assert loaded.num_metric_calls_by_discovery == {}
+    assert loaded.proposal_batches == []
+    assert loaded.scheduler_state == {}
     assert loaded.schema_version == SCHEMA_VERSION
     # Pre-existing fields still load correctly.
     assert loaded.generation == 1
@@ -367,6 +438,8 @@ def test_state_json_keys_when_val_stage_disabled(tmp_path: Path) -> None:
         "active_frontier",
         "frontier_type",
         "resume_semantics",
+        "proposal_batches",
+        "scheduler_state",
     }
     assert set(raw.keys()) == expected_keys, (
         f"state.json keys diverged from schema_version={SCHEMA_VERSION} "
@@ -390,6 +463,219 @@ def test_legacy_state_load_followed_by_save_writes_versioned_payload(tmp_path: P
     raw = json.loads((tmp_path / ".helix" / "state.json").read_text())
     assert raw["schema_version"] == SCHEMA_VERSION
     assert raw["num_metric_calls_by_discovery"] == {}
+    assert raw["proposal_batches"] == []
+    assert raw["scheduler_state"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Parallel-proposal checkpoint ledger
+# ---------------------------------------------------------------------------
+
+
+def test_pre_dispatch_checkpoint_uses_injected_saver(tmp_path: Path) -> None:
+    state = EvolutionState(
+        generation=4,
+        frontier=["g0-s0", "g1-s1"],
+        instance_scores={},
+        budget=BudgetState(evaluations=7),
+        config_hash="h",
+    )
+    calls: list[EvolutionState] = []
+
+    def cache_aware_saver(value: EvolutionState) -> None:
+        calls.append(value)
+        save_state(value, tmp_path)
+
+    batch = checkpoint_batch_before_dispatch(
+        state,
+        tmp_path,
+        _make_batch(),
+        max_evaluations=10,
+        max_in_flight_evaluations=8,
+        saver=cache_aware_saver,
+    )
+
+    assert calls == [state]
+    assert batch.phase == "dispatched"
+    assert batch.maximum_overshoot == 5
+    loaded = load_state(tmp_path)
+    assert loaded is not None
+    assert loaded.proposal_batches == [batch]
+
+
+def test_task_accounted_marker_is_idempotent_without_charging_budget(
+    tmp_path: Path,
+) -> None:
+    state = EvolutionState(
+        generation=4,
+        frontier=["g0-s0", "g1-s1"],
+        instance_scores={},
+        budget=BudgetState(evaluations=11),
+        config_hash="h",
+    )
+    batch = checkpoint_batch_before_dispatch(state, tmp_path, _make_batch())
+    saver_calls = 0
+
+    def saver(value: EvolutionState) -> None:
+        nonlocal saver_calls
+        saver_calls += 1
+        save_state(value, tmp_path)
+
+    charge = BudgetState(evaluations=3, input_tokens=20, cost_usd=0.1)
+    first = checkpoint_batch_task(
+        state,
+        tmp_path,
+        batch_id=batch.batch_id,
+        task_index=0,
+        status="evaluated",
+        budget_charge=charge,
+        budget_accounted=True,
+        saver=saver,
+    )
+    second = checkpoint_batch_task(
+        state,
+        tmp_path,
+        batch_id=batch.batch_id,
+        task_index=0,
+        status="evaluated",
+        budget_charge=charge,
+        budget_accounted=True,
+        saver=saver,
+    )
+
+    assert first is second
+    assert second.budget_accounted is True
+    assert second.budget_charge == charge
+    assert state.budget.evaluations == 11
+    assert saver_calls == 2
+
+    with pytest.raises(ValueError, match="different budget delta"):
+        checkpoint_batch_task(
+            state,
+            tmp_path,
+            batch_id=batch.batch_id,
+            task_index=0,
+            budget_charge=BudgetState(evaluations=4),
+            budget_accounted=True,
+            saver=saver,
+        )
+
+
+def test_pre_dispatch_rejects_candidate_id_collision(tmp_path: Path) -> None:
+    state = EvolutionState(
+        generation=4,
+        frontier=["g4-s10"],
+        instance_scores={},
+        budget=BudgetState(),
+        config_hash="h",
+    )
+    with pytest.raises(ValueError, match="already reserved"):
+        checkpoint_batch_before_dispatch(state, tmp_path, _make_batch())
+
+
+def test_post_apply_checkpoint_requires_and_persists_every_terminal_slot(
+    tmp_path: Path,
+) -> None:
+    state = EvolutionState(
+        generation=4,
+        frontier=["g0-s0", "g1-s1"],
+        instance_scores={},
+        budget=BudgetState(evaluations=19),
+        config_hash="h",
+    )
+    batch = checkpoint_batch_before_dispatch(state, tmp_path, _make_batch())
+    with pytest.raises(ValueError, match="nonterminal slots: 0, 1, 2, 3"):
+        checkpoint_batch_after_apply(state, tmp_path, batch_id=batch.batch_id)
+
+    checkpoint_batch_task(
+        state,
+        tmp_path,
+        batch_id=batch.batch_id,
+        task_index=0,
+        status="evaluated",
+    )
+    checkpoint_batch_task(
+        state,
+        tmp_path,
+        batch_id=batch.batch_id,
+        task_index=0,
+        status="applied",
+        selection="selected",
+        applied=True,
+    )
+    for task_index, status, cleanup in (
+        (1, "rejected", "removed"),
+        (2, "skipped", "missing"),
+        (3, "failed", "removed"),
+    ):
+        checkpoint_batch_task(
+            state,
+            tmp_path,
+            batch_id=batch.batch_id,
+            task_index=task_index,
+            status=status,  # type: ignore[arg-type]
+            cleanup=cleanup,  # type: ignore[arg-type]
+        )
+
+    saver_calls: list[EvolutionState] = []
+
+    def saver(value: EvolutionState) -> None:
+        saver_calls.append(value)
+        save_state(value, tmp_path)
+
+    completed = checkpoint_batch_after_apply(
+        state,
+        tmp_path,
+        batch_id=batch.batch_id,
+        saver=saver,
+    )
+
+    assert completed.phase == "complete"
+    assert completed.budget_after_apply == 19
+    assert completed.all_tasks_terminal()
+    assert saver_calls == [state]
+
+
+def test_scheduler_checkpoint_roundtrips_rng_and_sampler_position(
+    tmp_path: Path,
+) -> None:
+    rng = random.Random(99)
+    rng.choice(["a", "b", "c"])
+    checkpoint = build_scheduler_checkpoint(
+        frontier_rng_state=rng.getstate(),
+        sampler_rng_state=rng.getstate(),
+        sampler_epoch=3,
+        sampler_shuffled_ids=["c", "a", "b", "a"],
+        sampler_last_trainset_size=3,
+        sampler_id_frequencies={"a": 2, "b": 1, "c": 1},
+        sampler_fallback={"epoch": 1, "last_trainset_size": 3},
+    )
+    expected_draws = [rng.random() for _ in range(4)]
+    state = EvolutionState(
+        generation=2,
+        frontier=["g0-s0"],
+        instance_scores={},
+        budget=BudgetState(),
+        config_hash="h",
+    )
+    saver_calls: list[EvolutionState] = []
+
+    def saver(value: EvolutionState) -> None:
+        saver_calls.append(value)
+        save_state(value, tmp_path)
+
+    checkpoint_scheduler_state(state, tmp_path, checkpoint, saver=saver)
+    loaded = load_state(tmp_path)
+    assert loaded is not None
+    assert saver_calls == [state]
+    assert loaded.scheduler_state["sampler"]["epoch"] == 3
+    assert loaded.scheduler_state["sampler"]["shuffled_ids"] == ["c", "a", "b", "a"]
+
+    restored_rng = random.Random()
+    restored_rng.setstate(
+        decode_rng_state(loaded.scheduler_state["frontier_rng_state"])
+    )
+    assert [restored_rng.random() for _ in range(4)] == expected_draws
 
 
 def test_clear_eval_cache_removes_stale_pickle(tmp_path: Path) -> None:

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -66,7 +66,9 @@ def _make_repo(path: Path) -> None:
 
 
 class TestCreateSeedWorktree:
-    def test_creates_worktree_from_non_git_dir(self, tmp_path: Path, monkeypatch) -> None:
+    def test_creates_worktree_from_non_git_dir(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         """create_seed_worktree should initialise a repo when none exists."""
         monkeypatch.setenv("GIT_AUTHOR_NAME", "HELIX Test")
         monkeypatch.setenv("GIT_AUTHOR_EMAIL", "helix@test.local")
@@ -92,7 +94,9 @@ class TestCreateSeedWorktree:
         assert wt_path.exists()
         assert wt_path.is_dir()
 
-    def test_creates_worktree_from_existing_repo(self, tmp_path: Path, monkeypatch) -> None:
+    def test_creates_worktree_from_existing_repo(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         """create_seed_worktree should work on an existing git repo."""
         monkeypatch.setenv("GIT_AUTHOR_NAME", "HELIX Test")
         monkeypatch.setenv("GIT_AUTHOR_EMAIL", "helix@test.local")
@@ -108,7 +112,9 @@ class TestCreateSeedWorktree:
         assert (base_dir / "g0-s0").is_dir()
         assert candidate.worktree_path == str(base_dir / "g0-s0")
 
-    def test_seed_worktree_contains_source_files(self, tmp_path: Path, monkeypatch) -> None:
+    def test_seed_worktree_contains_source_files(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         monkeypatch.setenv("GIT_AUTHOR_NAME", "HELIX Test")
         monkeypatch.setenv("GIT_AUTHOR_EMAIL", "helix@test.local")
         monkeypatch.setenv("GIT_COMMITTER_NAME", "HELIX Test")
@@ -152,7 +158,9 @@ class TestCreateSeedWorktree:
 
         repo_head = _run(["git", "rev-parse", "HEAD"], repo_root).stdout.strip()
         seed_head = _run(["git", "rev-parse", "HEAD"], wt_path).stdout.strip()
-        assert seed_head != repo_head, "Dirty snapshot should be committed in the seed worktree"
+        assert seed_head != repo_head, (
+            "Dirty snapshot should be committed in the seed worktree"
+        )
 
         child = clone_candidate(seed, "g1-s0", base_dir)
         child_path = Path(child.worktree_path)
@@ -190,7 +198,9 @@ class TestCloneCandidate:
         assert wt_path.exists()
         assert wt_path.is_dir()
 
-    def test_clone_worktree_contains_parent_files(self, tmp_path: Path, monkeypatch) -> None:
+    def test_clone_worktree_contains_parent_files(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         _, base_dir, seed = self._seed(tmp_path, monkeypatch)
         child = clone_candidate(seed, "g1-s1", base_dir)
         assert (Path(child.worktree_path) / "README.md").exists()
@@ -214,9 +224,7 @@ class TestCloneCandidate:
                 )
             )
 
-        registered = _run(
-            ["git", "worktree", "list", "--porcelain"], repo_root
-        ).stdout
+        registered = _run(["git", "worktree", "list", "--porcelain"], repo_root).stdout
         assert all(str(base_dir / child_id) in registered for child_id in child_ids)
         assert all((base_dir / child_id).is_dir() for child_id in child_ids)
 
@@ -229,7 +237,9 @@ class TestCloneCandidate:
         branches_after = _run(
             ["git", "branch", "--list", "helix/g1-s*"], repo_root
         ).stdout
-        assert all(str(base_dir / child_id) not in registered_after for child_id in child_ids)
+        assert all(
+            str(base_dir / child_id) not in registered_after for child_id in child_ids
+        )
         assert all(not (base_dir / child_id).exists() for child_id in child_ids)
         assert branches_after.strip() == ""
 
@@ -363,7 +373,9 @@ class TestRemoveWorktree:
 
 
 class TestGetDiff:
-    def test_diff_is_empty_for_identical_candidates(self, tmp_path: Path, monkeypatch) -> None:
+    def test_diff_is_empty_for_identical_candidates(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         monkeypatch.setenv("GIT_AUTHOR_NAME", "HELIX Test")
         monkeypatch.setenv("GIT_AUTHOR_EMAIL", "helix@test.local")
         monkeypatch.setenv("GIT_COMMITTER_NAME", "HELIX Test")
@@ -467,7 +479,9 @@ class TestEnsureGitRepoIdentity:
 
         assert log == "HELIX <helix@noreply>"
 
-    def test_no_global_git_config_still_succeeds(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_global_git_config_still_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """_ensure_git_repo must succeed even when HOME has no .gitconfig at all
         (e.g. pristine CI environments)."""
         fake_home = tmp_path / "home_no_config"
@@ -539,7 +553,9 @@ class TestEnsureGitRepoIdentity:
 
 
 class TestSnapshotCandidateIdentity:
-    def test_snapshot_commit_author_is_helix(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_snapshot_commit_author_is_helix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """snapshot_candidate must author commits as HELIX <helix@noreply>."""
         monkeypatch.setenv("GIT_AUTHOR_NAME", "HELIX Test")
         monkeypatch.setenv("GIT_AUTHOR_EMAIL", "helix@test.local")

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -7,6 +7,7 @@ environments where no global git config exists.
 
 from __future__ import annotations
 
+import concurrent.futures
 import os
 import subprocess
 from pathlib import Path
@@ -198,6 +199,39 @@ class TestCloneCandidate:
         _, base_dir, seed = self._seed(tmp_path, monkeypatch)
         child = clone_candidate(seed, "g1-s2", base_dir)
         assert child.worktree_path == str(base_dir / "g1-s2")
+
+    def test_concurrent_clone_and_remove_leave_git_metadata_clean(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        repo_root, base_dir, seed = self._seed(tmp_path, monkeypatch)
+        child_ids = [f"g1-s{index}" for index in range(8)]
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            children = list(
+                pool.map(
+                    lambda child_id: clone_candidate(seed, child_id, base_dir),
+                    child_ids,
+                )
+            )
+
+        registered = _run(
+            ["git", "worktree", "list", "--porcelain"], repo_root
+        ).stdout
+        assert all(str(base_dir / child_id) in registered for child_id in child_ids)
+        assert all((base_dir / child_id).is_dir() for child_id in child_ids)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(remove_worktree, children))
+
+        registered_after = _run(
+            ["git", "worktree", "list", "--porcelain"], repo_root
+        ).stdout
+        branches_after = _run(
+            ["git", "branch", "--list", "helix/g1-s*"], repo_root
+        ).stdout
+        assert all(str(base_dir / child_id) not in registered_after for child_id in child_ids)
+        assert all(not (base_dir / child_id).exists() for child_id in child_ids)
+        assert branches_after.strip() == ""
 
 
 class TestSnapshotCandidate:


### PR DESCRIPTION
## Summary

This change adds durable P×N proposal scheduling to HELIX. It can explore mutations from multiple parents concurrently, evaluate them in isolated worktrees and Docker containers, and apply results deterministically even when execution finishes out of order.

When `mutations_per_parent` is omitted, the existing parallel setting retains its K×1 behavior.

## Inspiration and scope

The distinction between parallel parents (`P`) and mutations per parent (`N`) was inspired by GEPA's recent work on parallel proposals:

- [GEPA PR #314](https://github.com/gepa-ai/gepa/pull/314)
- [GEPA PR #330](https://github.com/gepa-ai/gepa/pull/330)
- [Parallel proposals: scaling the proposal axis](https://jialin-blog.gepa-docs-staging.pages.dev/blog/2026/06/30/parallel-proposals/)

## HELIX adaptation

- Schedule proposals in parent-major P×N batches with stable reserved task and candidate IDs.
- Bound mutation and evaluation concurrency while preserving deterministic selection and apply order.
- Give every candidate an isolated Git worktree and, when sandboxing is enabled, an isolated Docker container.
- Refresh protected evaluators per candidate and reject evaluator tampering.
- Persist batch and task journals so interrupted runs can reconcile completed work, charges, cache entries, and cleanup without duplicating proposals.
- Coordinate overlapping minibatch evaluations through singleflight cache entries.
- Redact environment and endpoint-derived secrets from Docker diagnostic surfaces, including argv copies, results, timeouts, exceptions, sidecar logs, and healthchecks, without changing the command that is actually executed.
- Document the configuration and migration behavior and provide opt-in real-Docker CI coverage.

## Reliability work

Adversarial review drove additional fixes around padded-minibatch weighting, atomic scheduler and batch-plan persistence, failed-cleanup resume barriers, mutation and evaluation usage accounting, fatal sibling-result draining, crash recovery, cache overlap, and Docker diagnostic redaction.

The resulting behavior is intentionally stricter than simply launching more workers: the durable ledger and deterministic apply phase define what happens across failures and resumes.

## Validation

- 1,460 unit tests passed.
- 815 corrected-path tests passed.
- 501 sandbox and security tests passed.
- 352 targeted redaction tests passed.
- 3 real-Docker integration tests passed.
- Strict mypy passed across 30 source files.
- All 28 changed Python files pass format checks.
- Ruff reports no branch-introduced findings; one unchanged F401 is inherited from `main`.
- `git diff --check` passed.
- A disposable public HELIX run with sandboxing enabled completed P=1, N=2 with two distinct proposal IDs, worktrees, and containers; a protected evaluator; durable task and budget records; two byte-identical resumes; and cleanup through `helix clean`.
- A fresh independent full-diff review returned ACCEPT with zero actionable findings.

## Residual risk

- This is a large change spanning 36 files and 41 commits.
- Real-Docker CI is opt-in through `workflow_dispatch` rather than a required pull-request check.
- The genuine backend run used the locally available Claude backend; every supported mutation backend was not exercised end to end.
