### PR TITLE
ci: automate pinned mutation runner image publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --all-extras
       - run: uv run pytest tests/unit/ -q
-      - run: uv run mypy --strict src/helix/
+      # tools/ is in scope deliberately: until it was, nothing type-checked the
+      # runner-image tool, which is how twenty lines of duplicated dead code in
+      # its main() reached this branch unnoticed.
+      - run: uv run mypy --strict src/helix/ tools/
 
   # Lint the workflows themselves. actionlint checks workflow structure,
   # expression types, and the shell inside every `run:`; zizmor checks the

--- a/.github/workflows/publish-runners.yml
+++ b/.github/workflows/publish-runners.yml
@@ -1,307 +1,602 @@
-name: Publish Runner Images
+name: Refresh Runner Images
+
+# Nightly is the CHECK cadence, not the release cadence.  The workflow asks
+# every upstream what its latest release is; a backend is rebuilt only when
+# that version is not in the registry yet.  A quiet night is a clean no-op.
+#
+# Recipe changes (editing a Dockerfile, bumping the Debian snapshot or a uv
+# wheel) are not upstream releases, so they ship with a manual `force: true`
+# dispatch rather than a push trigger.
 
 on:
-  push:
-    tags:
-      - "v*"
+  schedule:
+    - cron: "17 07 * * *"
   workflow_dispatch:
+    inputs:
+      operation:
+        description: Refresh upstream CLIs or roll one convenience tag back
+        required: true
+        default: refresh
+        type: choice
+        options:
+          - refresh
+          - rollback
+      backend:
+        description: Backend to force-rebuild or roll back
+        required: false
+        type: choice
+        options:
+          - claude
+          - codex
+          - cursor
+          - gemini
+          - opencode
+      digest:
+        description: Existing multi-arch sha256 digest to roll back to
+        required: false
+        type: string
+      force:
+        description: Rebuild even when the upstream version is unchanged
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  # Refresh and rollback are serialized independently so an incident response
+  # is never queued behind a long in-flight nightly build.
+  group: runner-image-${{ github.event.inputs.operation || 'refresh' }}-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/ke7/helix-evo-runner
+  CATALOG: docker/runner-versions.json
+  LOCKFILE: docker/package-lock.json
+  RETENTION_DAYS: 90
+  # gh expects [host/]owner/repo/path, not an https:// URL.
+  ATTESTATION_SIGNER_WORKFLOW: KE7/helix/.github/workflows/publish-runners.yml
+  ATTESTATION_SOURCE_REF: refs/heads/main
 
 jobs:
-  # ── 1. Build base image, one job per arch, push by digest ─────────────────
-  build-base:
-    name: Build base image (${{ matrix.platform }})
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+  guard:
+    name: Authorize protected release context
+    if: >-
+      ${{
+        github.repository == 'KE7/helix' &&
+        github.event.repository.default_branch == 'main' &&
+        github.ref == 'refs/heads/main' &&
+        (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+    steps:
+      - name: Confirm the protected repository and default branch
+        env:
+          EXPECTED_REPOSITORY: KE7/helix
+          EXPECTED_REF: refs/heads/main
+          ACTUAL_REPOSITORY: ${{ github.repository }}
+          ACTUAL_REF: ${{ github.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ACTUAL_REPOSITORY" == "$EXPECTED_REPOSITORY" ]]
+          [[ "$ACTUAL_REF" == "$EXPECTED_REF" ]]
+
+  resolve:
+    name: Resolve upstream releases and decide what changed
+    needs: guard
+    if: >-
+      ${{
+        needs.guard.result == 'success' &&
+        (github.event_name != 'workflow_dispatch' || inputs.operation == 'refresh')
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      base_tag: ${{ steps.plan.outputs.base_tag }}
+      base_build: ${{ steps.plan.outputs.base_build }}
+      builds: ${{ steps.plan.outputs.builds }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Validate the checked-in source pins
+        run: >-
+          python tools/runner_images.py validate
+          --catalog "$CATALOG"
+          --lockfile "$LOCKFILE"
 
-      - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      # Every npm pin is already in git, so this reaches the network only
+      # for Cursor, which belongs to no package ecosystem.
+      - name: Resolve the pinned inputs
+        run: >-
+          python tools/runner_images.py discover
+          --catalog "$CATALOG"
+          --lockfile "$LOCKFILE"
+          --cursor-checksums
+          --output /tmp/resolved.json
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push base by digest
+      - name: Build only what the registry does not already have
+        id: plan
+        env:
+          FORCE: ${{ inputs.force == true }}
+          FORCE_BACKEND: ${{ inputs.backend }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Absence must be distinguishable from failure.  Only a definitive
+          # "this tag does not exist" counts as absent; an auth, network,
+          # rate-limit, or 5xx failure aborts rather than being mistaken for
+          # "nothing published yet" and silently republishing over a good tag.
+          tag_exists() {
+            local reference="$1" stderr="" status=0
+            stderr="$(docker buildx imagetools inspect "$reference" \
+              --format '{{json .Manifest}}' 2>&1 >/dev/null)" || status=$?
+            if [[ "$status" -eq 0 ]]; then
+              return 0
+            fi
+            if grep -qiE 'not found|manifest unknown|no such manifest|404' \
+              <<< "$stderr"; then
+              return 1
+            fi
+            printf 'registry inspection failed for %s: %s\n' \
+              "$reference" "$stderr" >&2
+            exit 1
+          }
+
+          base_tag="$(python tools/runner_images.py base-tag --catalog "$CATALOG")"
+          if [[ "$FORCE" == "true" ]] \
+            || ! tag_exists "${IMAGE_PREFIX}-base:${base_tag}"; then
+            base_build=true
+          else
+            base_build=false
+          fi
+
+          printf '{}\n' > /tmp/published.json
+          for backend in claude codex cursor gemini opencode; do
+            version="$(jq -r --arg b "$backend" '.backends[$b].version' \
+              /tmp/resolved.json)"
+            if tag_exists "${IMAGE_PREFIX}-${backend}:${version}"; then
+              present=true
+            else
+              present=false
+            fi
+            jq --arg b "$backend" --argjson p "$present" '.[$b] = $p' \
+              /tmp/published.json > /tmp/published.next.json
+            mv /tmp/published.next.json /tmp/published.json
+          done
+
+          # A forced dispatch naming one backend forces only that backend.
+          force_args=()
+          if [[ "$FORCE" == "true" ]]; then
+            force_args=(--force --run-id "$GITHUB_RUN_ID")
+            if [[ -n "$FORCE_BACKEND" ]]; then
+              jq --arg b "$FORCE_BACKEND" \
+                'with_entries(if .key == $b then . else .value = true end)' \
+                /tmp/published.json > /tmp/published.next.json
+              mv /tmp/published.next.json /tmp/published.json
+            fi
+          fi
+          python tools/runner_images.py plan \
+            --resolved /tmp/resolved.json \
+            --published /tmp/published.json \
+            --output /tmp/builds.json \
+            "${force_args[@]+"${force_args[@]}"}"
+
+          {
+            echo "base_tag=${base_tag}"
+            echo "base_build=${base_build}"
+            echo "builds=$(jq -c . /tmp/builds.json)"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### Runner image plan"
+            echo
+            echo "Base \`${base_tag}\` build: \`${base_build}\`"
+            echo
+            jq -r 'if length == 0
+                   then "No upstream CLI released since the last run."
+                   else "| Backend | Version | Tag |", "| --- | --- | --- |",
+                        (.[] | "| \(.name) | \(.version) | `\(.tag)` |")
+                   end' /tmp/builds.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain the resolved manifest and plan
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runner-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            /tmp/resolved.json
+            /tmp/published.json
+            /tmp/builds.json
+          if-no-files-found: error
+          retention-days: ${{ fromJSON(env.RETENTION_DAYS) }}
+
+  base:
+    name: Publish the base runtime
+    needs: [guard, resolve]
+    if: ${{ needs.resolve.outputs.base_build == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      # QEMU/binfmt is what lets one job build and smoke both architectures.
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Materialize exact base arguments
+        id: args
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo 'value<<HELIX_ARGS'
+            echo "NODE_BASE=$(jq -r '.base.node_image' "$CATALOG")"
+            echo "DEBIAN_SNAPSHOT=$(jq -r '.base.debian_snapshot' "$CATALOG")"
+            echo "UV_VERSION=$(jq -r '.base.uv_version' "$CATALOG")"
+            echo "UV_AMD64_WHEEL=$(jq -r '.base.uv_wheels.amd64.url' "$CATALOG")"
+            echo "UV_AMD64_SHA256=$(jq -r '.base.uv_wheels.amd64.sha256' "$CATALOG")"
+            echo "UV_ARM64_WHEEL=$(jq -r '.base.uv_wheels.arm64.url' "$CATALOG")"
+            echo "UV_ARM64_SHA256=$(jq -r '.base.uv_wheels.arm64.sha256' "$CATALOG")"
+            echo HELIX_ARGS
+          } >> "$GITHUB_OUTPUT"
+
+      # Pushed by digest with no tag: nothing in the registry names this image
+      # until it has passed the smoke on both architectures.
+      - name: Build both architectures by digest
         id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: docker/base.Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
+          build-args: ${{ steps.args.outputs.value }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}-base,push-by-digest=true,name-canonical=true,push=true
+          provenance: mode=max
+          sbom: true
 
-      - name: Export digest
+      - name: Smoke both architectures before any tag exists
         env:
-          DIGEST: ${{ steps.build.outputs.digest }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+        shell: bash
         run: |
-          mkdir -p /tmp/digests
-          touch "/tmp/digests/${DIGEST#sha256:}"
+          set -euo pipefail
+          [[ "$BUILD_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          image="${IMAGE_PREFIX}-base@${BUILD_DIGEST}"
+          docker buildx imagetools inspect "$image" \
+            --format '{{json .Manifest}}' > /tmp/manifest.json
+          python tools/runner_images.py verify-platforms --input /tmp/manifest.json
+          smoke="$(jq -r '.base.smoke_command' "$CATALOG")"
+          for platform in linux/amd64 linux/arm64; do
+            docker run --rm --platform "$platform" --network none --read-only \
+              --tmpfs /tmp "$image" sh -lc "$smoke"
+          done
 
-      - name: Upload digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - name: Attach signed GitHub build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
-          name: digests-base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+          subject-name: ${{ env.IMAGE_PREFIX }}-base
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
-  # ── 2. Merge both arch digests into a single multi-arch manifest ──────────
-  merge-base:
-    name: Merge base image manifests
-    runs-on: ubuntu-latest
-    needs: build-base
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          path: /tmp/digests
-          pattern: digests-base-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: ${{ env.IMAGE_PREFIX }}-base
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-
-      - name: Create and push merged manifest list
-        working-directory: /tmp/digests
+      - name: Publish the base tags after attestation succeeds
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          BASE_TAG: ${{ needs.resolve.outputs.base_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          # Both substitutions below are deliberately unquoted: each expands to
-          # a *list* of separate arguments (`-t a -t b`, then one image
-          # reference per digest file), which is exactly the word splitting
-          # SC2046 warns about. Quoting either one would collapse it into a
-          # single malformed argument.
-          # shellcheck disable=SC2046
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE_PREFIX }}-base@sha256:%s ' *)
+          set -euo pipefail
+          [[ "$BUILD_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          image="${IMAGE_PREFIX}-base"
+          gh attestation verify "oci://${image}@${BUILD_DIGEST}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$ATTESTATION_SIGNER_WORKFLOW" \
+            --source-ref "$ATTESTATION_SOURCE_REF" \
+            --source-digest "$GITHUB_SHA" \
+            --deny-self-hosted-runners
+          docker buildx imagetools create -t "${image}:${BASE_TAG}" \
+            "${image}@${BUILD_DIGEST}"
+          docker buildx imagetools create -t "${image}:latest" \
+            "${image}@${BUILD_DIGEST}"
+          actual="$(docker buildx imagetools inspect "${image}:${BASE_TAG}" \
+            --format '{{json .Manifest}}' | jq -r '.digest')"
+          [[ "$actual" == "$BUILD_DIGEST" ]]
 
-  # ── 3. Build each backend (5 images × 2 arches = 10 jobs), push by digest ─
-  build-backends:
-    name: Build ${{ matrix.image.name }} (${{ matrix.platform }})
-    needs: merge-base
-    permissions:
-      contents: read
-      packages: write
+  backend:
+    name: Publish ${{ matrix.name }} ${{ matrix.version }}
+    needs: [guard, resolve, base]
+    # One job per changed backend, and that job builds BOTH architectures. The
+    # Dockerfiles only curl, verify, and untar prebuilt binaries -- nothing
+    # compiles -- so emulation costs seconds and there is no per-architecture
+    # digest to hand between jobs at all.
+    if: >-
+      ${{
+        always() &&
+        needs.resolve.result == 'success' &&
+        (needs.base.result == 'success' || needs.base.result == 'skipped') &&
+        needs.resolve.outputs.builds != '[]'
+      }}
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - name: claude
-            dockerfile: docker/claude.Dockerfile
-          - name: codex
-            dockerfile: docker/codex.Dockerfile
-          - name: cursor
-            dockerfile: docker/cursor.Dockerfile
-          - name: gemini
-            dockerfile: docker/gemini.Dockerfile
-          - name: opencode
-            dockerfile: docker/opencode.Dockerfile
-        platform:
-          - linux/amd64
-          - linux/arm64
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+        include: ${{ fromJSON(needs.resolve.outputs.builds) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: runner-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/plan
 
-      - name: Choose base tag
-        id: base-tag
+      - name: Materialize exact build arguments
+        id: args
+        env:
+          BACKEND: ${{ matrix.name }}
+          BASE_TAG: ${{ needs.resolve.outputs.base_tag }}
         shell: bash
         run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
-            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=latest" >> "$GITHUB_OUTPUT"
-          fi
+          set -euo pipefail
+          [[ "$BACKEND" =~ ^(claude|codex|cursor|gemini|opencode)$ ]]
+          # Pin the base by digest, resolved from its recipe-bound tag.
+          base_digest="$(docker buildx imagetools inspect \
+            "${IMAGE_PREFIX}-base:${BASE_TAG}" \
+            --format '{{json .Manifest}}' | jq -r '.digest')"
+          [[ "$base_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          {
+            echo 'value<<HELIX_ARGS'
+            python tools/runner_images.py build-args \
+              --resolved /tmp/plan/resolved.json \
+              --backend "$BACKEND" \
+              --base-image "${IMAGE_PREFIX}-base@${base_digest}"
+            echo HELIX_ARGS
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push backend by digest
+      - name: Build both architectures by digest
         id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
-          file: ${{ matrix.image.dockerfile }}
-          platforms: ${{ matrix.platform }}
-          build-args: |
-            BASE_IMAGE=${{ env.IMAGE_PREFIX }}-base:${{ steps.base-tag.outputs.value }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          build-args: ${{ steps.args.outputs.value }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}-${{ matrix.name }},push-by-digest=true,name-canonical=true,push=true
+          provenance: mode=max
+          sbom: true
 
-      - name: Export digest
+      - name: Smoke both architectures before any tag exists
         env:
-          DIGEST: ${{ steps.build.outputs.digest }}
+          BACKEND: ${{ matrix.name }}
+          VERSION: ${{ matrix.version }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+        shell: bash
         run: |
-          mkdir -p /tmp/digests
-          touch "/tmp/digests/${DIGEST#sha256:}"
+          set -euo pipefail
+          [[ "$BACKEND" =~ ^(claude|codex|cursor|gemini|opencode)$ ]]
+          [[ "$BUILD_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          image="${IMAGE_PREFIX}-${BACKEND}@${BUILD_DIGEST}"
+          docker buildx imagetools inspect "$image" \
+            --format '{{json .Manifest}}' > /tmp/manifest.json
+          python tools/runner_images.py verify-platforms --input /tmp/manifest.json
+          smoke="$(jq -r --arg b "$BACKEND" '.backends[$b].smoke_command' \
+            /tmp/plan/resolved.json)"
+          # Anchor the version assertion. A bare substring match would let a
+          # CLI reporting 1.10 satisfy a claim about 1.1. Escape ERE
+          # metacharacters first: Cursor versions contain both `.` and `-`.
+          # shellcheck disable=SC2016  # the single quotes are deliberate: the
+          # bracket expression contains literal `$( )` characters, not a shell
+          # expansion, and must reach sed unmodified.
+          escaped="$(printf '%s' "$VERSION" | sed 's/[][\\.*^$(){}?+|]/\\&/g')"
+          for platform in linux/amd64 linux/arm64; do
+            output="$(docker run --rm --platform "$platform" \
+              --network none --read-only \
+              --tmpfs /tmp:rw,nosuid,nodev \
+              --tmpfs /home/node:rw,nosuid,nodev,uid=1000,gid=1000 \
+              --user 1000:1000 "$image" sh -lc "$smoke")"
+            if ! grep -Eq "(^|[^0-9A-Za-z.])v?${escaped}"'([^0-9A-Za-z.]|$)' \
+              <<< "$output"; then
+              echo "${platform}: smoke output does not report ${VERSION}:" >&2
+              printf '%s\n' "$output" >&2
+              exit 1
+            fi
+            if [[ "$BACKEND" == codex ]]; then
+              docker run --rm --platform "$platform" \
+                --network none --read-only \
+                --tmpfs /tmp:rw,nosuid,nodev \
+                --tmpfs /home/node:rw,nosuid,nodev,uid=1000,gid=1000 \
+                --user 1000:1000 "$image" \
+                codex debug models --bundled > /tmp/codex-models.json
+              python tools/runner_images.py verify-codex-catalog \
+                --input /tmp/codex-models.json
+            fi
+          done
 
-      - name: Upload digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - name: Attach signed GitHub build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
-          name: digests-${{ matrix.image.name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+          subject-name: ${{ env.IMAGE_PREFIX }}-${{ matrix.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
-  # ── 4. Merge each backend's 2 arch digests into a multi-arch manifest ─────
-  merge-backends:
-    name: Merge ${{ matrix.image.name }} image manifests
-    needs: build-backends
+      - name: Publish the version and latest tags after attestation
+        env:
+          BACKEND: ${{ matrix.name }}
+          IMAGE_TAG: ${{ matrix.tag }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$BACKEND" =~ ^(claude|codex|cursor|gemini|opencode)$ ]]
+          [[ "$BUILD_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          image="${IMAGE_PREFIX}-${BACKEND}"
+          gh attestation verify "oci://${image}@${BUILD_DIGEST}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$ATTESTATION_SIGNER_WORKFLOW" \
+            --source-ref "$ATTESTATION_SOURCE_REF" \
+            --source-digest "$GITHUB_SHA" \
+            --deny-self-hosted-runners
+          docker buildx imagetools create -t "${image}:${IMAGE_TAG}" \
+            "${image}@${BUILD_DIGEST}"
+          docker buildx imagetools create -t "${image}:latest" \
+            "${image}@${BUILD_DIGEST}"
+          for tag in "$IMAGE_TAG" latest; do
+            actual="$(docker buildx imagetools inspect "${image}:${tag}" \
+              --format '{{json .Manifest}}' | jq -r '.digest')"
+            [[ "$actual" == "$BUILD_DIGEST" ]]
+          done
+
+  rollback:
+    name: Roll a convenience tag back to a verified digest
+    needs: guard
+    if: >-
+      ${{
+        needs.guard.result == 'success' &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.operation == 'rollback'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - name: claude
-          - name: codex
-          - name: cursor
-          - name: gemini
-          - name: opencode
+      attestations: read
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          path: /tmp/digests
-          pattern: digests-${{ matrix.image.name }}-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+          persist-credentials: false
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: ${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-
-      - name: Create and push merged manifest list
-        working-directory: /tmp/digests
-        run: |
-          # Both substitutions below are deliberately unquoted: each expands to
-          # a *list* of separate arguments (`-t a -t b`, then one image
-          # reference per digest file), which is exactly the word splitting
-          # SC2046 warns about. Quoting either one would collapse it into a
-          # single malformed argument.
-          # shellcheck disable=SC2046
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }}@sha256:%s ' *)
-
-  # ── 5. Smoke-test every published image on the native amd64 runner ────────
-  verify:
-    name: Verify published runner images
-    runs-on: ubuntu-latest
-    needs: merge-backends
-    permissions:
-      packages: read
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - name: base
-            command: "python --version && uv --version && git --version"
-          - name: claude
-            command: "claude --version"
-          - name: codex
-            command: "codex --version"
-          - name: cursor
-            command: "cursor agent --version"
-          - name: gemini
-            command: "gemini --version"
-          - name: opencode
-            command: "opencode --version"
-
-    steps:
-      - name: Choose tag
-        id: tag
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
-            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=latest" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull and verify
-        shell: bash
+      # Immutable version tags and every prior digest are never deleted, so a
+      # rollback is a retag against something the registry already holds. No
+      # ledger, no compensating transaction, no signal handling.
+      - name: Verify the target then move latest
         env:
-          IMAGE_NAME: ${{ matrix.image.name }}
-          IMAGE_TAG: ${{ steps.tag.outputs.value }}
-          SMOKE_COMMAND: ${{ matrix.image.command }}
+          BACKEND: ${{ inputs.backend }}
+          TARGET_DIGEST: ${{ inputs.digest }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          image="${IMAGE_PREFIX}-${IMAGE_NAME}:${IMAGE_TAG}"
-          docker pull "$image"
-          docker run --rm "$image" sh -lc "$SMOKE_COMMAND"
+          set -euo pipefail
+          [[ "$BACKEND" =~ ^(claude|codex|cursor|gemini|opencode)$ ]]
+          [[ "$TARGET_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          image="${IMAGE_PREFIX}-${BACKEND}"
+          docker buildx imagetools inspect "${image}@${TARGET_DIGEST}" \
+            --format '{{json .Manifest}}' > /tmp/manifest.json
+          python tools/runner_images.py verify-platforms --input /tmp/manifest.json
+          gh attestation verify "oci://${image}@${TARGET_DIGEST}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$ATTESTATION_SIGNER_WORKFLOW" \
+            --source-ref "$ATTESTATION_SOURCE_REF" \
+            --deny-self-hosted-runners
+          smoke="$(jq -r --arg b "$BACKEND" '.backends[$b].smoke_command' "$CATALOG")"
+          for platform in linux/amd64 linux/arm64; do
+            docker run --rm --platform "$platform" --network none --read-only \
+              --tmpfs /tmp:rw,nosuid,nodev \
+              --tmpfs /home/node:rw,nosuid,nodev,uid=1000,gid=1000 \
+              --user 1000:1000 "${image}@${TARGET_DIGEST}" sh -lc "$smoke"
+          done
+          docker buildx imagetools create -t "${image}:latest" \
+            "${image}@${TARGET_DIGEST}"
+          actual="$(docker buildx imagetools inspect "${image}:latest" \
+            --format '{{json .Manifest}}' | jq -r '.digest')"
+          [[ "$actual" == "$TARGET_DIGEST" ]]
+
+  notify:
+    name: Notify maintainers on failure or cancellation
+    # `failure()` is false for a cancelled run, so without `cancelled()` an
+    # interrupted publish would never notify anyone.
+    if: >-
+      ${{
+        always() &&
+        needs.guard.result == 'success' &&
+        (failure() || cancelled())
+      }}
+    needs: [guard, resolve, base, backend, rollback]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          # `cancelled()` is only callable in a job/step `if:`, so classify the
+          # run from the upstream job results instead.
+          JOB_RESULTS: ${{ toJSON(needs) }}
+        with:
+          script: |
+            const results = Object.values(JSON.parse(process.env.JOB_RESULTS));
+            const cancelled = results.some(job => job.result === "cancelled");
+            // A dedicated label lets the dedupe query filter server-side and
+            // paginate, instead of only seeing the first 100 open issues and
+            // filing a fresh duplicate every night after that.
+            const label = "runner-image-refresh";
+            const title = cancelled
+              ? "Automated runner image refresh was cancelled"
+              : "Automated runner image refresh failed";
+            const body = [
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `Event: ${context.eventName}`,
+              `Outcome: ${cancelled ? "cancelled" : "failed"}`,
+              "",
+              "No tag is published until the image passes the smoke on both architectures,",
+              "so a failed or cancelled run leaves the previously published tags untouched."
+            ].join("\n");
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo, state: "open", labels: label, per_page: 100
+            });
+            const issue = open.find(item => item.title === title && !item.pull_request);
+            if (issue) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number, body
+              });
+            } else {
+              await github.rest.issues.create({
+                ...context.repo, title, body, labels: [label]
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -488,6 +488,11 @@ shared base first with
 build the backend image you need, for example
 `docker build -t helix-runner-codex:latest -f docker/codex.Dockerfile .`, and
 set `[sandbox].image` to that local tag.
+Those images are rebuilt when an upstream CLI releases, not on a calendar: a
+nightly job checks each upstream and publishes only versions the registry does
+not already have. The exact source pins, the multi-architecture publication
+sequence, provenance, and the rollback procedure are documented in
+[`docs/runner-images.md`](docs/runner-images.md).
 
 Evaluator sidecar images are benchmark-specific and are not published by HELIX.
 Use `ghcr.io/ke7/helix-evo-runner-base` or `docker/base.Dockerfile` as a base

--- a/docker/package-lock.json
+++ b/docker/package-lock.json
@@ -1,0 +1,557 @@
+{
+  "name": "helix-runner-pins",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "helix-runner-pins",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-code": "2.1.218",
+        "@lydell/node-pty": "1.1.0",
+        "@openai/codex": "0.145.0",
+        "opencode-ai": "1.18.5"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.218.tgz",
+      "integrity": "sha512-BHV951ruIa6QXaZFDF1wRhwxAOkAiafB2AOWG6wGRUJ4apaJ9mlzp1BFLAhGfG0SknwAyqBenqeT6nit6at4uQ==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.218",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.218",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.218",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.218",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.218",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.218",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.218",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.218"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.218.tgz",
+      "integrity": "sha512-DPy7AUyFxUVMrSA6U+zlWKJwhnHlaNyx25vqJte148lbFqlRmo8axk+gKWZ9C7obCVUk3kyT9pHPkRhYyG8yAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.218.tgz",
+      "integrity": "sha512-bd6z2nWzQlD6WBqYcD6YIYT82plUgm9dl1fW1guZkY2EK94ZRCfb0gZOARbwpDln3rpUVD2j7B6CCG8wO/9IVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.218.tgz",
+      "integrity": "sha512-CcbVQCzXd9EnlktCEPrkElhdBZuqIWhkeinRGxUuZa6aal4h6J+8Dbo+OnfchBEzd1mahRDQK8BckGBAYozv2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.218.tgz",
+      "integrity": "sha512-LYNLmyGf5xpwOh/2iIua7UXyklsm0CzpLbUmFz6pmgUKIeDXK5OV86KpQ42JoUSPBzwti4u9XCWLm7ogr5QliQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.218.tgz",
+      "integrity": "sha512-e132kA4dVipkVIWK66jpCncbJvLqvug2nD3zXEAdmaivuXNWvfQbMaXl6C0T2SusEimAoDirZz57MqKIGVVVcA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.218.tgz",
+      "integrity": "sha512-9+pwWg+UCY5YyXPx29/k3bGvd4JK/CzPsL11uvkjdEar5n2ekdZjaYbGCGpHE6q/pVuHTeA6sLPsrD9f8u4Gqg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.218.tgz",
+      "integrity": "sha512-pihfgWnUuNdJxUUO2gVD/rR53Ua+0bkRpDDd7xt0dTEz/e1QP5D0mZMVo1t7eViNW6G3kpFJzqwRg2noJf0Byw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.218.tgz",
+      "integrity": "sha512-yGtIK2Ko3ewdck++2Qw+iF6XjlnMKHNKfwK2tIk+H+KQpVH+I7kV9HzUUcrIMLv2D62j63RjwyUqMuHBYd5JfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@lydell/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-VDD8LtlMTOrPKWMXUAcB9+LTktzuunqrMwkYR1DMRBkS6LQrCt+0/Ws1o2rMml/n3guePpS7cxhHF7Nm5K4iMw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@lydell/node-pty-darwin-arm64": "1.1.0",
+        "@lydell/node-pty-darwin-x64": "1.1.0",
+        "@lydell/node-pty-linux-arm64": "1.1.0",
+        "@lydell/node-pty-linux-x64": "1.1.0",
+        "@lydell/node-pty-win32-arm64": "1.1.0",
+        "@lydell/node-pty-win32-x64": "1.1.0"
+      }
+    },
+    "node_modules/@lydell/node-pty-darwin-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-7kFD+owAA61qmhJCtoMbqj3Uvff3YHDiU+4on5F2vQdcMI3MuwGi7dM6MkFG/yuzpw8LF2xULpL71tOPUfxs0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-darwin-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-XZdvqj5FjAMjH8bdp0YfaZjur5DrCIDD1VYiE9EkkYVMDQqRUPHYV3U8BVEQVT9hYfjmpr7dNaELF2KyISWSNA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.1.0.tgz",
+      "integrity": "sha512-yyDBmalCfHpLiQMT2zyLcqL2Fay4Xy7rIs8GH4dqKLnEviMvPGOK7LADVkKAsbsyXBSISL3Lt1m1MtxhPH6ckg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.1.0.tgz",
+      "integrity": "sha512-NcNqRTD14QT+vXcEuqSSvmWY+0+WUBn2uRE8EN0zKtDpIEr9d+YiFj16Uqds6QfcLCHfZmC+Ls7YzwTaqDnanA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.1.0.tgz",
+      "integrity": "sha512-JOMbCou+0fA7d/m97faIIfIU0jOv8sn2OR7tI45u3AmldKoKoLP8zHY6SAvDDnI3fccO1R2HeR1doVjpS7HM0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.1.0.tgz",
+      "integrity": "sha512-3N56BZ+WDFnUMYRtsrr7Ky2mhWGl9xXcyqR6cexfuCqcz9RNWL+KoXRv/nZylY5dYaXkft4JaR1uVu+roiZDAw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0.tgz",
+      "integrity": "sha512-/PSPSFujjjmiyVFvG2yu/grOFhsWdokTH8t2KGWhXSo/M5n/dIDsnbsnO82/7bLtIoDuzQf7ATBUMWqPWQINlQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.145.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.145.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.145.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.145.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.145.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.145.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-darwin-arm64.tgz",
+      "integrity": "sha512-h6aQ0UxnaP8mIM/9/qPAH9MNkRliJo88toq1T36IxNM2L5JSU0TFamu+MZn7YkFgDsrp0RfiI+97Tm8AVVxqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-darwin-x64.tgz",
+      "integrity": "sha512-FCYzVKCa9VoLtg9gVyzKpqylonfgZrfcWZN6HsXAZPeuo8CukdMqdgTUOhDn2V6h3MbqS0z6VqQVKUllN/yKhA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-linux-arm64.tgz",
+      "integrity": "sha512-8OLcPXaAol/FOrRoDxWhIiHIFa73KRsM41EKocjRZOwiT4TcelzJWn3dHyiuSb7teWF25rrslvSPyvhULYRRCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-linux-x64.tgz",
+      "integrity": "sha512-u8w8LLv3DvsfrDCoswLIemZ0SoNEXyi511WsfFsSiYUazk9qMsB/NtU8N9vhAfN7mZAxLFoMex4v66JjHuZWwA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-win32-arm64.tgz",
+      "integrity": "sha512-sub61rjEFevi1i3Zx7nAd4JM5XxoNFqMqFc5LfTo2xSI8ixHjFvEYDFDXwXOftT04n3Ht1Wh271ioUZpDiEjEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.145.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-win32-x64.tgz",
+      "integrity": "sha512-u0h9lk094CaXRSqE34SBW2dRaQTPa6fASXqehczWH9QdsU62mBsiAgAdp6tCG4i+YzPmmhjD8FdXNnYGNmwuMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/opencode-ai": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.18.5.tgz",
+      "integrity": "sha512-Q0jlX4ihn7veMeYsLX3c4PYFAKIURU3GIpXt1FnhNxNn3v8+RpIZ8z9umG5D0r8g8Smp9fZLGjgLe/9mJ4NyYw==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "opencode": "bin/opencode.exe"
+      },
+      "optionalDependencies": {
+        "opencode-darwin-arm64": "1.18.5",
+        "opencode-darwin-x64": "1.18.5",
+        "opencode-darwin-x64-baseline": "1.18.5",
+        "opencode-linux-arm64": "1.18.5",
+        "opencode-linux-arm64-musl": "1.18.5",
+        "opencode-linux-x64": "1.18.5",
+        "opencode-linux-x64-baseline": "1.18.5",
+        "opencode-linux-x64-baseline-musl": "1.18.5",
+        "opencode-linux-x64-musl": "1.18.5",
+        "opencode-windows-arm64": "1.18.5",
+        "opencode-windows-x64": "1.18.5",
+        "opencode-windows-x64-baseline": "1.18.5"
+      }
+    },
+    "node_modules/opencode-darwin-arm64": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.5.tgz",
+      "integrity": "sha512-an4t+aOHTREf1f1Z8mNIyEoy1iJL+434BuB+2UKFuAarMUaV37SWkPiS4oW8nvJjXyb8LC0AFSeVA8AeBy44cg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.18.5.tgz",
+      "integrity": "sha512-mAXaO4qje89avIEclKeUHmuj0DJG4PBYljtGuMJaJtnQVNns/BzfZb4bR8IYfVXTv0QwYk2Sudju/mGN5vpNNA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64-baseline": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.5.tgz",
+      "integrity": "sha512-7coC1U01D3YoKiJFT/qop7zO6bGwJ+5NgkxV/SZvRbgfXFbaXpG4c38q/YOk6QcC3aJ11/3R7qgUFkfkyHFUPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-linux-arm64": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.18.5.tgz",
+      "integrity": "sha512-cnv2IAi/TpitYJUq44TC0Ci5zVCi9Qspx/7P2pDNcp5IH9f6U58t9oi9WpHyVtkFthAQc2CdSIByb3HuduscAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-arm64-musl": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.5.tgz",
+      "integrity": "sha512-GsX09fuzCUfRpDnZ/cS4Z0N4B6yk+Yckr1kXB2Z0sN2hajxqypOpwUkzaS/MkGgbRHP3vR2fFZQj0FSORHvy8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.18.5.tgz",
+      "integrity": "sha512-aa/Y6xznaGtE0kA2sZKdddY7iNBw/yrXWH0mA6fGs4GgrYc9jcXS+UXLwLZLWZwLLYBOFYoAoyeWiJoEZ0ba6w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.5.tgz",
+      "integrity": "sha512-4eXOJCG/8KmPUlFe2vJTT7u24GOF8VMLPHlNjqrwu31CxlT+csEk287lI0ayPX3J0R1pbG71HLcJLqsokR+wvw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline-musl": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.5.tgz",
+      "integrity": "sha512-2DdvOrg5kE2kaGdeFF/ifV9QfVFmzQM8eOthDTvDDdMm4fCWF1tmVpBdpcLO5tzZmVpO3M0aT6+TiF8/nKmq+A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-musl": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.18.5.tgz",
+      "integrity": "sha512-RrXkgR9SWRO9nP+kopCga/Cry2LrkPC+GaM0UIMUMaso/p3OJDSRinwFdSSNCf+J8JlI6vzjb1+eUyRApSWjtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-windows-arm64": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.18.5.tgz",
+      "integrity": "sha512-9424cw1gPH+aLCN06NfRFk0j+KbYizguReEo8Ftsg4HHK09qAFtFwjc9rcakkWCSoF+an4U5fDOG1jfcf9jYcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.18.5.tgz",
+      "integrity": "sha512-b1cbKqn4RMWVH+I6utY0Qtgf/fXwu/asaa4sgrTOV//yrhxL42NKITD+nAzscgzHHzX1kzDkl8I2OBtW/KXWJg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64-baseline": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.5.tgz",
+      "integrity": "sha512-KC9vzFEnwIXMaARLftiLqjtmVig6u7u+nzwya2UXr+b7DJj3LkSzSkv3jFD9AIGNox2saOr47Gt9VMeCtr6O6w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    }
+  }
+}

--- a/docker/package.json
+++ b/docker/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "helix-runner-pins",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pin store for the mutation-runner images. Never installed: package-lock.json is generated with `npm install --package-lock-only --ignore-scripts`, and docker/*.Dockerfile hand-extract the verified tarballs it names. See docs/runner-images.md.",
+  "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.218",
+    "@lydell/node-pty": "1.1.0",
+    "@openai/codex": "0.145.0",
+    "opencode-ai": "1.18.5"
+  }
+}

--- a/docker/runner-versions.json
+++ b/docker/runner-versions.json
@@ -1,0 +1,59 @@
+{
+  "backends": {
+    "claude": {
+      "dockerfile": "docker/claude.Dockerfile",
+      "smoke_command": "claude --version"
+    },
+    "codex": {
+      "dockerfile": "docker/codex.Dockerfile",
+      "smoke_command": "codex --version"
+    },
+    "cursor": {
+      "dockerfile": "docker/cursor.Dockerfile",
+      "installer": "https://cursor.com/install",
+      "platforms": {
+        "amd64": {
+          "sha256": "6e9f17247ffeb5f8f7e2246b4bcd6bb26cb2d5a9f9a4b0012c9a80d868ed25b4",
+          "tarball": "https://downloads.cursor.com/lab/2026.07.20-8cc9c0b/linux/x64/agent-cli-package.tar.gz"
+        },
+        "arm64": {
+          "sha256": "2986152b283c70a666b015035b2e99a96d13afd2660a587b8639417cfdd147fb",
+          "tarball": "https://downloads.cursor.com/lab/2026.07.20-8cc9c0b/linux/arm64/agent-cli-package.tar.gz"
+        }
+      },
+      "smoke_command": "cursor-agent --version && cursor agent --version",
+      "version": "2026.07.20-8cc9c0b"
+    },
+    "gemini": {
+      "dockerfile": "docker/gemini.Dockerfile",
+      "package": "@google/gemini-cli",
+      "sha512": "ffa16f7ef95cb0e26d9f7340813a79fdc6bdc52ea799ab78a2d43e3445684fa968be62363798c7c6d06a1ad8cb528f9cbc17c682d4765a69023f1c691e3afad5",
+      "smoke_command": "gemini --version",
+      "tarball": "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-0.52.0.tgz",
+      "version": "0.52.0"
+    },
+    "opencode": {
+      "dockerfile": "docker/opencode.Dockerfile",
+      "smoke_command": "opencode --version"
+    }
+  },
+  "base": {
+    "debian_snapshot": "20260720T000000Z",
+    "dockerfile": "docker/base.Dockerfile",
+    "node_image": "node:22-bookworm-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3",
+    "smoke_command": "python --version && uv --version && git --version && rg --version",
+    "uv_version": "0.11.7",
+    "uv_wheels": {
+      "amd64": {
+        "sha256": "4e4d5e31bea86e1b6e0f5a0f95e14e80018e6f6c0129256d2915a4b3d793644d",
+        "url": "https://files.pythonhosted.org/packages/83/eb/4e1557daf6693cb446ed28185664ad6682fd98c6dbac9e433cbc35df450a/uv-0.11.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+      },
+      "arm64": {
+        "sha256": "5985a15a92bd9a170fc1947abb1fbc3e9828c5a430ad85b5bed8356c20b67a71",
+        "url": "https://files.pythonhosted.org/packages/f2/7f/fbed29775b0612f4f5679d3226268f1a347161abc1727b4080fb41d9f46f/uv-0.11.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl"
+      }
+    }
+  },
+  "registry_prefix": "ghcr.io/ke7/helix-evo-runner",
+  "schema_version": 2
+}

--- a/docs/runner-images.md
+++ b/docs/runner-images.md
@@ -1,0 +1,245 @@
+# Mutation-agent runner supply chain
+
+HELIX runs each mutation agent inside a per-backend container image. This
+document covers how those images are built, what is pinned, and how to change
+or roll back what they run.
+
+## What is pinned, and why
+
+This is the point of the whole pipeline. No image ever runs
+`npm install -g <cli>@latest` or `curl https://cursor.com/install | bash`.
+Every byte that lands in an image is fetched from an expected host over HTTPS
+and verified against a recorded checksum before it is unpacked. Those pins live
+in two files, split by who owns the format:
+
+| Layer | Pin | Where |
+| --- | --- | --- |
+| Base OS | `node:22-bookworm-slim` by `sha256:` digest | `docker/base.Dockerfile` |
+| Base packages | Debian snapshot `20260720T000000Z` — a frozen apt archive | `docker/runner-versions.json` |
+| `uv` | version-pinned wheel URL + SHA-256, per architecture | `docker/runner-versions.json` |
+| claude / codex / opencode CLIs | tarball URL + sha512 integrity, plus each native subpackage | `docker/package-lock.json` |
+| Gemini CLI | bundled parent tarball URL + SHA-512 | `docker/runner-versions.json` |
+| `@lydell/node-pty` (Gemini's native dep) | tarball URL + sha512, per architecture | `docker/package-lock.json` |
+| Cursor CLI | archive URL + SHA-256, per architecture | `docker/runner-versions.json` |
+
+### Why a lockfile
+
+`package-lock.json` already stores, for every platform-native binary, exactly
+what a pin catalog would store by hand: the resolved URL, the sha512 integrity,
+and the `cpu`/`os`/`libc` constraints — including transitive optional
+dependencies. Maintaining a second copy of that by hand was the single largest
+source of code in this pipeline.
+
+It is generated with `npm install --package-lock-only --ignore-scripts`, which
+resolves without installing. **This is a pin store, not an install step.** The
+Dockerfiles still hand-extract three verified tarballs each. `npm ci` is
+deliberately not used: it would pull 655 packages for Gemini alone, where the
+image today holds one bundled `bundle/gemini.js` plus node-pty, and it would
+introduce install-script execution the build has never had.
+
+Gemini's own tarball stays a hand-maintained pin because its unbundled
+dependency tree is 655 packages and would make the lockfile 8,459 lines, even
+though its published tarball ships self-contained. Cursor stays hand-maintained
+because it belongs to no package ecosystem at all: its version lives inside a
+shell script, and its archives must be downloaded and hashed directly.
+
+Renovate maintains the lockfile natively, so a version bump and its integrity
+hash arrive in the same PR. Against the previous bespoke catalog it could only
+have bumped version strings and left the digests stale.
+
+### What the tool enforces
+
+`tools/runner_images.py validate` checks both files: npm downloads only from
+`registry.npmjs.org`, Cursor archives only from `downloads.cursor.com`, HTTPS
+only, digests of the correct length, and — importantly — that every artifact an
+image extracts is named in `LOCKFILE_ARTIFACTS` and really is a `linux` binary
+for the expected CPU and a glibc one.
+
+That allowlist is what stops a build from extracting a package nobody reviewed.
+npm records whatever optional dependencies upstream declared; the tool records
+what a human approved. A new native optional dependency appearing upstream
+cannot enter an image without a line changing in the tool. It is named per
+package rather than queried by `cpu`/`os`/`libc`, because those fields do not
+identify a unique artifact — claude publishes `linux-x64` and `linux-x64-musl`,
+opencode publishes `linux-x64` and `linux-x64-baseline`.
+
+The residual catalog rejects a version or digest for a lockfile-owned backend,
+so the two files cannot drift into disagreeing about the same fact.
+
+Cursor's installer is downloaded but never executed. It is parsed for its
+single embedded release version and the official archive URLs, which are then
+fetched and checksummed directly. Because those archives are version-addressed
+and immutable, an unchanged version reuses the reviewed checksum in the catalog
+instead of re-downloading hundreds of megabytes every night; any drift in the
+version or the URL falls back to a full re-download and re-hash.
+
+The base bootstraps apt over `http://snapshot.debian.org` because the slim base
+has no CA certificates yet — `ca-certificates` is installed *by* that same apt
+run. APT still verifies Debian's signed release metadata, and the residual risk
+of being served an older signed snapshot is bounded by the pinned timestamp.
+Every later download uses HTTPS plus a recorded content digest.
+
+## When images get rebuilt
+
+**Nightly is the check cadence, not the release cadence.** The scheduled run
+asks each upstream for its latest release and compares it against the registry:
+
+```
+resolved_version = discover upstream latest        (npm dist-tags / cursor installer)
+if <image>:<resolved_version> already exists  ->  skip
+else                                          ->  build and publish
+```
+
+If nothing shipped upstream, the run is a clean no-op. A backend is rebuilt
+because Codex released 0.146.0, not because a day passed.
+
+Tags published per backend:
+
+- `ghcr.io/ke7/helix-evo-runner-<backend>:<upstream-version>` — e.g. `codex:0.145.0`
+- `ghcr.io/ke7/helix-evo-runner-<backend>:latest` — moved on a successful publish
+
+and for the shared runtime:
+
+- `ghcr.io/ke7/helix-evo-runner-base:node22-uv<uv>-snapshot<date>-r<6hex>`
+- `ghcr.io/ke7/helix-evo-runner-base:latest`
+
+The base tag's six-hex suffix covers the whole base recipe — `base.Dockerfile`
+itself plus the node digest, snapshot, uv version, and wheel digests. Without
+it, editing `base.Dockerfile` would leave the tag unchanged, the "already
+published?" check would answer *yes*, and every backend would silently build
+`FROM` a stale base.
+
+## Publication sequence
+
+`.github/workflows/publish-runners.yml` is six jobs:
+
+1. **`guard`** — accept only `KE7/helix` on its `main` default branch, from a
+   schedule or a manual dispatch. Pull requests and forks cannot publish.
+2. **`resolve`** — discover upstream versions, ask the registry what already
+   exists, emit the build matrix. Absence is decided by `imagetools inspect`,
+   where *only* a definitive "no such tag" counts as absent; an auth, network,
+   rate-limit, or server error aborts rather than being mistaken for "nothing
+   published yet".
+3. **`base`** — build and publish the base runtime, only when its recipe tag is
+   absent (or `force` is set).
+4. **`backend`** — one job per changed backend. Each builds **both**
+   architectures in a single `--platform linux/amd64,linux/arm64` invocation
+   under QEMU. This is cheap because the Dockerfiles only download, verify, and
+   untar prebuilt binaries — nothing compiles.
+5. **`rollback`** — manual dispatch only.
+6. **`notify`** — file or update one labelled issue on failure *or*
+   cancellation.
+
+Jobs 3 and 4 both follow the same order, and the order is the point:
+
+```
+build and push BY DIGEST (no tag exists yet)
+  -> assert the index really has linux/amd64 and linux/arm64
+  -> smoke each architecture: --network none, --read-only, private tmpfs HOME,
+     uid/gid 1000, no credential mount, and an anchored version assertion
+  -> for Codex, also parse `codex debug models --bundled` and require the exact
+     slug gpt-5.6-luna with reasoning levels low, medium, high, xhigh, max
+  -> attach BuildKit SBOM + provenance and an OIDC-signed GitHub attestation
+  -> verify that attestation
+  -> only now create the :<version> and :latest tags, then read them back
+```
+
+**No tag ever names an image that has not passed both smokes.** A failed or
+cancelled run leaves every previously published tag exactly where it was.
+
+Because absence is decided by a tag's existence rather than by verifying its
+attestation, the discovery path trusts that only this workflow can write to
+these repositories — it holds the only `packages: write` grant. Attestation is
+still generated and verified on every publish and every rollback.
+
+The per-backend matrix uses `fail-fast: false`, so one backend failing does not
+block the others; each backend publishes independently.
+
+## Changing a recipe
+
+Editing a Dockerfile, bumping the Debian snapshot, or moving a uv wheel is not
+an upstream release, so the nightly check will not notice it. Ship it with a
+manual dispatch:
+
+```
+workflow_dispatch(operation: refresh, force: true)                   # everything
+workflow_dispatch(operation: refresh, force: true, backend: codex)   # one backend
+```
+
+A base recipe change is picked up automatically, because the base tag is bound
+to the recipe.
+
+If the upstream version has already been published, a forced rebuild does
+**not** overwrite that tag. It publishes `<version>-r<run_id>` and moves
+`latest` there, so `codex:0.145.0` always means the bytes it meant on the day
+it was first published. This matters because a version tag may already be
+pinned in someone's `sandbox.image` config.
+
+## Rolling back
+
+Immutable version tags and every prior digest are never deleted, so a rollback
+is a retag against something the registry already holds:
+
+```
+workflow_dispatch(operation: rollback, backend: codex, digest: sha256:...)
+```
+
+The job validates the backend against the five literals and the digest against
+`^sha256:[0-9a-f]{64}$`, asserts both platforms are present, verifies the
+target's GitHub attestation, runs the smoke on both architectures, moves
+`latest`, and reads it back. No ledger, no compensating transaction, no signal
+handling — there is nothing to compensate, because nothing is destroyed.
+
+Rollback has its own concurrency group, so an incident is never queued behind
+an in-flight nightly build.
+
+## Local proof
+
+Build the base first, then a backend against it:
+
+```sh
+docker build --file docker/base.Dockerfile --tag helix-runner-base:proof .
+
+docker build \
+  --build-arg BASE_IMAGE=helix-runner-base:proof \
+  --file docker/codex.Dockerfile \
+  --tag helix-runner-codex:proof .
+
+docker run --rm --network none --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev \
+  --tmpfs /home/node:rw,nosuid,nodev,uid=1000,gid=1000 \
+  --user 1000:1000 \
+  helix-runner-codex:proof codex debug models --bundled > /tmp/codex-models.json
+
+python tools/runner_images.py verify-codex-catalog --input /tmp/codex-models.json
+```
+
+To regenerate the npm pins after editing `docker/package.json` (Renovate
+normally does this for you):
+
+```sh
+cd docker && npm install --package-lock-only --ignore-scripts
+python tools/runner_images.py validate --catalog docker/runner-versions.json
+```
+
+Use a task-specific tag; do not reuse `latest`. This proves the Dockerfiles and
+source pins on your native architecture only — the published multi-arch index
+digest and its attestations are the real release identity.
+
+## Tests
+
+`tests/unit/test_runner_images.py` covers all of this offline — no test
+reaches the network. It validates the catalog and the lockfile, resolves every
+backend, checks that the build arguments cover exactly the ARGs each Dockerfile
+declares (in both directions) and that their digests are the lockfile's own
+integrity fields, exercises the change-detection policy, the forced-rebuild tag
+rule, and the base-tag recipe binding, and invokes all seven CLI subcommands
+through `main()`.
+
+Two workflow properties are asserted here because no linter knows them: that no
+tag is created before the image passes both smokes, and that the registry
+absence check is fail-closed. Everything else about the workflow — YAML
+validity, expression types, shell correctness, template injection, unpinned
+actions, credential persistence, permission scope — is checked by **actionlint**
+and **zizmor**, which run as a blocking `lint-workflows` job in CI. Those
+replaced roughly 130 lines of hand-rolled source-text grep tests.

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,30 @@
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["!pypa/gh-action-pypi-publish"],
       "pinDigests": true
+    },
+    {
+      "description": "Runner CLI pins. The npm manager rewrites docker/package-lock.json in npm's own format, so the resolved URL and the sha512 integrity move together with the version. That is the whole reason the pins live in a lockfile: Renovate cannot recompute a digest sitting next to a version in a bespoke JSON file, so a hand-rolled catalog would get version-only PRs with stale hashes.",
+      "matchFileNames": ["docker/package.json"],
+      "rangeStrategy": "pin",
+      "separateMinorPatch": true,
+      "commitMessageTopic": "runner CLI {{depName}}",
+      "addLabels": ["runner-images"],
+      "groupName": null
+    },
+    {
+      "description": "Codex must keep shipping gpt-5.6-luna with an xhigh reasoning level; tools/runner_images.py fails closed below 0.145.0, and the backend job asserts the model catalog after the image is built.",
+      "matchPackageNames": ["@openai/codex"],
+      "addLabels": ["needs-codex-model-check"]
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "uv is copied into the base image from a digest-pinned wheel pair, so its version is tracked here rather than by a package manager.",
+      "customType": "regex",
+      "managerFilePatterns": ["/^docker/runner-versions\\.json$/"],
+      "matchStrings": ["\"uv_version\":\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "uv",
+      "datasourceTemplate": "pypi"
     }
   ],
   "vulnerabilityAlerts": {

--- a/tests/unit/test_runner_images.py
+++ b/tests/unit/test_runner_images.py
@@ -1,0 +1,709 @@
+"""Offline release-safety tests for mutation-agent runner images.
+
+Every CLI subcommand is exercised through ``main()``. The previous suite was
+851 lines and left 21% of the tool unexecuted, with four of seven subcommands
+never invoked at all -- which is how twenty lines of duplicated dead code
+reached the branch. Source-text greps over the workflow are gone: actionlint
+and zizmor run in CI and cover that ground properly. What survives here either
+calls the tool and asserts an outcome, or encodes a property no linter knows.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from helix.config import AgentConfig
+from helix.mutator import _build_backend_args
+from tools.runner_images import (
+    BACKENDS,
+    LOCKFILE_ARTIFACTS,
+    PLATFORMS,
+    RunnerPlanError,
+    _fetch,
+    _fetch_sha256,
+    base_tag,
+    build_arguments,
+    change_plan,
+    discover,
+    main as runner_images_main,
+    parse_cursor_installer,
+    resolve_cursor_checksums,
+    validate_catalog,
+    validate_lockfile,
+    verify_codex_catalog,
+    verify_platforms,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+CATALOG_PATH = ROOT / "docker" / "runner-versions.json"
+LOCKFILE_PATH = ROOT / "docker" / "package-lock.json"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "publish-runners.yml"
+BASE_IMAGE = "ghcr.io/ke7/helix-evo-runner-base@sha256:" + "a" * 64
+
+
+def _catalog() -> dict:
+    return json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+
+
+def _lock() -> dict:
+    return json.loads(LOCKFILE_PATH.read_text(encoding="utf-8"))
+
+
+CURSOR_INSTALLER = (
+    b"#!/bin/sh\nVERSION=2026.07.20-8cc9c0b\n"
+    b"https://downloads.cursor.com/lab/2026.07.20-8cc9c0b/linux/x64/a.tgz\n"
+)
+
+
+def _resolved() -> dict:
+    """Resolve every backend with no network access at all.
+
+    Everything but Cursor is already pinned in git, so only Cursor's installer
+    needs a fixture. Its archive digests come from the reviewed catalog pins,
+    which is exactly what `--cursor-checksums` reuses in production when the
+    version has not moved.
+    """
+    import tools.runner_images as module
+
+    original = module._fetch
+    module._fetch = lambda *args, **kwargs: CURSOR_INSTALLER  # type: ignore[assignment]
+    try:
+        resolved = discover(_catalog(), _lock(), cursor_checksums=False)
+    finally:
+        module._fetch = original  # type: ignore[assignment]
+
+    recorded = _catalog()["backends"]["cursor"]["platforms"]
+    for platform in PLATFORMS:
+        resolved["backends"]["cursor"]["platforms"][platform]["sha256"] = recorded[
+            platform
+        ]["sha256"]
+    return resolved
+
+
+# --------------------------------------------------------------------------
+# The checked-in pins
+# --------------------------------------------------------------------------
+
+
+def test_checked_in_catalog_and_lockfile_are_complete_and_content_pinned() -> None:
+    validate_catalog(_catalog())
+    validate_lockfile(_lock())
+
+
+def test_lockfile_covers_every_artifact_an_image_extracts() -> None:
+    """Each allowlisted package resolves to an on-platform linux/glibc binary."""
+    packages = _lock()["packages"]
+    for backend, group in LOCKFILE_ARTIFACTS.items():
+        for slot, package in group.items():
+            node = packages[f"node_modules/{package}"]
+            assert node["resolved"].startswith("https://registry.npmjs.org/")
+            assert node["integrity"].startswith("sha512-")
+            if slot in PLATFORMS:
+                assert node["cpu"] == [{"amd64": "x64", "arm64": "arm64"}[slot]]
+                assert node["os"] == ["linux"], (backend, slot)
+                # A musl build would not run on the Debian base.
+                assert node.get("libc") in (None, ["glibc"]), (backend, slot)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda c: c["backends"]["claude"].update(version="9.9.9"), "lockfile"),
+        (
+            lambda c: c["backends"]["cursor"].update(installer="https://evil.invalid"),
+            "installer",
+        ),
+        (
+            lambda c: c["backends"]["gemini"].update(
+                tarball="https://evil.invalid/x.tgz"
+            ),
+            "untrusted",
+        ),
+        (lambda c: c["backends"]["gemini"].update(sha512="beef"), "sha512"),
+        (
+            lambda c: c["backends"]["codex"].update(
+                dockerfile="docker/evil.Dockerfile"
+            ),
+            "dockerfile",
+        ),
+        (
+            lambda c: c["backends"]["codex"].update(smoke_command="codex; rm -rf /"),
+            "smoke command",
+        ),
+        (lambda c: c["base"].update(node_image="node:22"), "digest-pinned"),
+        (lambda c: c["base"]["uv_wheels"]["amd64"].update(sha256="nope"), "sha256"),
+        (lambda c: c["backends"].pop("gemini"), "exactly the five backends"),
+    ],
+)
+def test_catalog_fails_closed_on_untrusted_or_unmeasured_input(mutate, match) -> None:
+    catalog = _catalog()
+    mutate(catalog)
+    with pytest.raises(RunnerPlanError, match=match):
+        validate_catalog(catalog)
+
+
+@pytest.mark.parametrize(
+    ("package", "field", "value", "match"),
+    [
+        ("@anthropic-ai/claude-code-linux-x64", "cpu", ["arm64"], "cpu"),
+        ("@anthropic-ai/claude-code-linux-x64", "os", ["darwin"], "os"),
+        ("@anthropic-ai/claude-code-linux-x64", "libc", ["musl"], "libc"),
+        ("opencode-linux-arm64", "integrity", "sha256-abc", "integrity"),
+        ("opencode-linux-arm64", "resolved", "https://evil.invalid/x.tgz", "untrusted"),
+        ("@openai/codex", "version", "0.144.9", "0.145.0"),
+    ],
+)
+def test_lockfile_fails_closed_on_off_platform_or_unmeasured_artifacts(
+    package: str, field: str, value: object, match: str
+) -> None:
+    lock = _lock()
+    lock["packages"][f"node_modules/{package}"][field] = value
+    with pytest.raises(RunnerPlanError, match=match):
+        validate_lockfile(lock)
+
+
+def test_lockfile_fails_closed_when_an_allowlisted_artifact_disappears() -> None:
+    """A removed optional dependency must stop the build, not shrink the image."""
+    lock = _lock()
+    del lock["packages"]["node_modules/@lydell/node-pty-linux-arm64"]
+    with pytest.raises(RunnerPlanError, match="not in the lockfile"):
+        validate_lockfile(lock)
+
+
+# --------------------------------------------------------------------------
+# Resolution and build arguments
+# --------------------------------------------------------------------------
+
+
+def test_discover_resolves_every_backend_from_pins_already_in_git() -> None:
+    resolved = _resolved()
+    assert sorted(resolved["backends"]) == sorted(BACKENDS)
+    claude = resolved["backends"]["claude"]
+    assert claude["version"] == "2.1.218"
+    assert len(claude["sha512"]) == 128
+    # Codex's platform binaries are aliases carrying their own version string.
+    codex = resolved["backends"]["codex"]
+    assert codex["platforms"]["amd64"]["package_version"] == "0.145.0-linux-x64"
+    # Gemini takes its own tarball from the catalog and node-pty from the lock.
+    gemini = resolved["backends"]["gemini"]
+    assert "gemini-cli" in gemini["tarball"]
+    assert "node-pty" in gemini["artifacts"]["shared"][0]["tarball"]
+
+
+def test_build_arguments_cover_every_arg_each_dockerfile_declares() -> None:
+    """Every ARG a Dockerfile reads must be supplied, and nothing else.
+
+    The expectation is derived from the Dockerfiles rather than restated, so
+    this survives a refactor and still catches the real bug: a key the tool
+    stops emitting silently builds from a stale ARG default instead of failing.
+    """
+    resolved = _resolved()
+    for name in BACKENDS:
+        arguments = dict(
+            entry.split("=", 1)
+            for entry in build_arguments(resolved["backends"][name], BASE_IMAGE)
+        )
+        dockerfile = (ROOT / "docker" / f"{name}.Dockerfile").read_text()
+        declared = set(re.findall(r"^ARG ([A-Z0-9_]+)", dockerfile, re.M))
+        declared -= {"TARGETARCH"}  # supplied by buildx, not by us
+        assert not declared - set(arguments), f"{name}: unsupplied build args"
+        # ...and nothing else. buildx accepts a surplus argument silently, so
+        # only this direction catches the tool drifting from the recipe.
+        assert not set(arguments) - declared - {"BASE_IMAGE"}, f"{name}: surplus args"
+        assert arguments["CLI_VERSION"] == resolved["backends"][name]["version"]
+
+
+def test_dockerfile_arg_defaults_match_the_pins_the_tool_resolves() -> None:
+    """Every pinned ARG default equals the pin resolved from the lockfile.
+
+    The defaults exist so ``docker build`` works off a plain checkout with no
+    tooling. That makes them a second copy of every pin, and a second copy is
+    only safe if it cannot drift, so this asserts the recipes and the pin store
+    agree. A lockfile bump that does not also update the recipe fails here,
+    rather than leaving a default that silently builds last release's tarball
+    for anyone building locally.
+    """
+    resolved = _resolved()
+    for name in BACKENDS:
+        arguments = dict(
+            entry.split("=", 1)
+            for entry in build_arguments(resolved["backends"][name], BASE_IMAGE)
+        )
+        dockerfile = (ROOT / "docker" / f"{name}.Dockerfile").read_text()
+        # Enumerated from the recipe, never from a hand-written list: an ARG
+        # added later is covered the moment it is declared, so the guarantee
+        # cannot narrow silently as pins are added.
+        declared = [
+            arg
+            for arg in re.findall(r"^ARG ([A-Z0-9_]+)", dockerfile, re.M)
+            # TARGETARCH is supplied by buildx; BASE_IMAGE's default is a local
+            # convenience tag rather than a content pin.
+            if arg not in {"TARGETARCH", "BASE_IMAGE"}
+        ]
+        assert declared, f"{name}: no pinned ARGs found in the recipe"
+        defaults = dict(re.findall(r"^ARG ([A-Z0-9_]+)=(.*)$", dockerfile, re.M))
+        for arg in declared:
+            assert arg in defaults, (
+                f"{name}.Dockerfile: ARG {arg} has no default, so a plain "
+                f"`docker build` would build it empty"
+            )
+            assert defaults[arg] == arguments[arg], (
+                f"{name}.Dockerfile: ARG {arg} default has drifted from the "
+                f"resolved pin\n"
+                f"  recipe default: {defaults[arg]}\n"
+                f"  resolved pin:   {arguments[arg]}"
+            )
+
+
+def test_base_dockerfile_arg_defaults_match_the_catalog() -> None:
+    """The base recipe's defaults are the same pins the workflow passes it."""
+    base = _catalog()["base"]
+    defaults = dict(
+        re.findall(
+            r"^ARG ([A-Z0-9_]+)=(.*)$",
+            (ROOT / "docker" / "base.Dockerfile").read_text(),
+            re.M,
+        )
+    )
+    expected = {
+        "NODE_BASE": base["node_image"],
+        "DEBIAN_SNAPSHOT": base["debian_snapshot"],
+        "UV_VERSION": base["uv_version"],
+    } | {
+        f"UV_{platform.upper()}_{field}": base["uv_wheels"][platform][key]
+        for platform in PLATFORMS
+        for field, key in (("WHEEL", "url"), ("SHA256", "sha256"))
+    }
+    # Equality both ways: a new pinned ARG that this test does not know about
+    # is a failure, not a silent gap.
+    assert defaults == expected, (
+        "docker/base.Dockerfile defaults have drifted from the catalog\n"
+        f"  only in recipe:  {sorted(defaults.items() - expected.items())}\n"
+        f"  only in catalog: {sorted(expected.items() - defaults.items())}"
+    )
+
+
+def test_build_arguments_digests_match_the_lockfile_byte_for_byte() -> None:
+    """The build args are the lockfile's own integrity fields, hex-decoded."""
+    resolved = _resolved()
+    packages = _lock()["packages"]
+    for name, group in LOCKFILE_ARTIFACTS.items():
+        arguments = dict(
+            entry.split("=", 1)
+            for entry in build_arguments(resolved["backends"][name], BASE_IMAGE)
+        )
+        for slot, package in group.items():
+            integrity = packages[f"node_modules/{package}"]["integrity"]
+            expected = base64.b64decode(integrity.removeprefix("sha512-")).hex()
+            key = {"cli": "CLI_SHA512", "shared": "CLI_SHARED_SHA512"}.get(
+                slot, f"CLI_{slot.upper()}_SHA512"
+            )
+            assert arguments[key] == expected, f"{name}/{slot}"
+
+
+@pytest.mark.parametrize(
+    "base_image",
+    [
+        "ghcr.io/ke7/helix-evo-runner-base:latest",
+        "ghcr.io/ke7/helix-evo-runner-base",
+        "docker.io/library/node@sha256:" + "a" * 64,
+    ],
+)
+def test_build_arguments_reject_a_floating_base(base_image: str) -> None:
+    with pytest.raises(RunnerPlanError, match="digest-pinned"):
+        build_arguments(_resolved()["backends"]["codex"], base_image)
+
+
+def test_build_arguments_reject_an_injected_control_byte() -> None:
+    resolved = _resolved()
+    item = copy.deepcopy(resolved["backends"]["codex"])
+    item["tarball"] = "https://registry.npmjs.org/a.tgz\nCLI_SHA512=bad"
+    with pytest.raises(RunnerPlanError, match="control byte"):
+        build_arguments(item, BASE_IMAGE)
+
+
+# --------------------------------------------------------------------------
+# Cursor: the one backend in no package ecosystem
+# --------------------------------------------------------------------------
+
+
+def test_cursor_installer_requires_one_unambiguous_version() -> None:
+    installer = b"""
+    VERSION=2026.07.20-8cc9c0b
+    DOWNLOAD=https://downloads.cursor.com/lab/2026.07.20-8cc9c0b/linux/x64/a.tgz
+    """
+    resolved = parse_cursor_installer(installer)
+    assert resolved["version"] == "2026.07.20-8cc9c0b"
+    assert len(resolved["installer_sha256"]) == 64
+    with pytest.raises(RunnerPlanError, match="exactly one"):
+        parse_cursor_installer(installer + b"\nVERSION=2026.07.21-deadbee\n")
+
+
+def test_cursor_archives_are_rehashed_only_when_their_identity_moves() -> None:
+    cursor = _catalog()["backends"]["cursor"]
+    tarballs = {p: cursor["platforms"][p]["tarball"] for p in PLATFORMS}
+    hashed: list[str] = []
+
+    def fetch(url: str) -> str:
+        hashed.append(url)
+        return "e" * 64
+
+    # Unchanged version and URLs: reuse the reviewed digests, download nothing.
+    assert resolve_cursor_checksums(
+        tarballs, cursor["version"], cursor, fetch_sha256=fetch
+    ) == {p: cursor["platforms"][p]["sha256"] for p in PLATFORMS}
+    assert hashed == []
+
+    # Same version but a URL the catalog never recorded still re-hashes.
+    tampered = dict(tarballs)
+    tampered["arm64"] = "https://downloads.cursor.com/lab/x/linux/arm64/other.tgz"
+    resolved = resolve_cursor_checksums(
+        tampered, cursor["version"], cursor, fetch_sha256=fetch
+    )
+    assert hashed == [tampered["arm64"]]
+    assert resolved["amd64"] == cursor["platforms"]["amd64"]["sha256"]
+
+
+def test_cursor_smoke_covers_both_entry_points_the_mutator_uses() -> None:
+    """The mutator runs `cursor agent`; auth paths run `cursor-agent`.
+
+    `docker/cursor.Dockerfile` installs `cursor-agent` and writes a `cursor`
+    shim beside it. Deleting the shim would break every Cursor mutation inside
+    the sandbox, so the smoke command has to exercise both spellings. The
+    expectation is read out of the mutator's own argv rather than grepped out
+    of its source text.
+    """
+    argv = _build_backend_args("/workspace", AgentConfig(backend="cursor"), "prompt.md")
+    assert argv[:2] == ["cursor", "agent"]
+
+    dockerfile = (ROOT / "docker" / "cursor.Dockerfile").read_text()
+    assert "/usr/local/bin/cursor-agent" in dockerfile
+    assert "> /usr/local/bin/cursor" in dockerfile
+
+    smoke = _catalog()["backends"]["cursor"]["smoke_command"]
+    assert smoke == "cursor-agent --version && cursor agent --version"
+
+
+# --------------------------------------------------------------------------
+# Network behaviour
+# --------------------------------------------------------------------------
+
+
+def test_upstream_fetches_retry_and_rehash_the_whole_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stream that dies halfway must never contribute partial bytes."""
+    payload = b"cursor-archive-bytes"
+    attempts: list[int] = []
+
+    class _Stream:
+        def __init__(self, chunks: list[bytes]) -> None:
+            self.chunks = chunks
+
+        def __enter__(self) -> "_Stream":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self, _size: int = -1) -> bytes:
+            return self.chunks.pop(0) if self.chunks else b""
+
+    def urlopen(request: object, timeout: float = 0.0) -> _Stream:
+        attempts.append(len(attempts))
+        if len(attempts) == 1:
+            raise urllib.error.URLError("connection reset")
+        return _Stream([payload[:5], payload[5:]])
+
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+    delays: list[float] = []
+    assert (
+        _fetch_sha256("https://downloads.cursor.com/a.tgz", sleep=delays.append)
+        == hashlib.sha256(payload).hexdigest()
+    )
+    assert delays == [1.0]
+
+    attempts.clear()
+    delays = []
+
+    def always_fails(request: object, timeout: float = 0.0) -> _Stream:
+        attempts.append(len(attempts))
+        raise urllib.error.URLError("connection reset")
+
+    monkeypatch.setattr(urllib.request, "urlopen", always_fails)
+    with pytest.raises(urllib.error.URLError):
+        _fetch("https://registry.npmjs.org/x", sleep=delays.append)
+    assert len(attempts) == 3
+    assert delays == [1.0, 2.0]
+
+
+# --------------------------------------------------------------------------
+# Planning and post-build assertions
+# --------------------------------------------------------------------------
+
+
+def test_plan_builds_only_versions_the_registry_does_not_have() -> None:
+    resolved = _resolved()
+    published = {name: True for name in BACKENDS}
+    assert change_plan(resolved, published) == []
+
+    published["codex"] = False
+    builds = change_plan(resolved, published)
+    assert [b["name"] for b in builds] == ["codex"]
+    assert builds[0]["tag"] == resolved["backends"]["codex"]["version"]
+
+
+def test_forced_rebuild_never_overwrites_a_published_version_tag() -> None:
+    resolved = _resolved()
+    published = {name: True for name in BACKENDS}
+    builds = change_plan(resolved, published, force=True, run_id="42")
+    assert all(b["tag"] == f"{b['version']}-r42" for b in builds)
+    # A forced rebuild of a published version needs a run id to tag with.
+    with pytest.raises(RunnerPlanError, match="run id"):
+        change_plan(resolved, published, force=True)
+
+
+def test_plan_rejects_an_unsafe_upstream_version() -> None:
+    resolved = _resolved()
+    resolved["backends"]["codex"]["version"] = "0.145.0 --build-arg=x"
+    with pytest.raises(RunnerPlanError, match="unsafe image version"):
+        change_plan(resolved, {})
+
+
+def test_base_tag_binds_the_whole_base_recipe(tmp_path: Path) -> None:
+    """Editing the Dockerfile or any pin must change the tag."""
+    base = _catalog()["base"]
+    dockerfile = tmp_path / "base.Dockerfile"
+    dockerfile.write_text("FROM node:22\n")
+    original = base_tag(base, dockerfile)
+
+    dockerfile.write_text("FROM node:22\nRUN echo drift\n")
+    assert base_tag(base, dockerfile) != original
+    dockerfile.write_text("FROM node:22\n")
+    assert base_tag(base, dockerfile) == original
+
+    for field, value in (
+        ("node_image", base["node_image"].replace("6c74", "6c75")),
+        ("debian_snapshot", "20260721T000000Z"),
+        ("uv_version", "0.11.8"),
+    ):
+        drifted = dict(base)
+        drifted[field] = value
+        assert base_tag(drifted, dockerfile) != original
+
+
+def test_codex_catalog_requires_luna_with_xhigh_second_highest() -> None:
+    def payload(efforts: list[str]) -> dict:
+        return {
+            "models": [
+                {
+                    "slug": "gpt-5.6-luna",
+                    "supported_reasoning_levels": [{"effort": e} for e in efforts],
+                }
+            ]
+        }
+
+    verify_codex_catalog(payload(["low", "medium", "high", "xhigh", "max"]))
+    with pytest.raises(RunnerPlanError, match="reasoning order"):
+        verify_codex_catalog(payload(["low", "medium", "high", "max"]))
+    with pytest.raises(RunnerPlanError, match="gpt-5.6-luna"):
+        verify_codex_catalog({"models": []})
+
+
+def test_manifest_parity_requires_exact_linux_amd64_and_arm64() -> None:
+    def manifest(platforms: list[tuple[str, str]]) -> dict:
+        return {
+            "manifests": [
+                {"platform": {"os": os, "architecture": arch}} for os, arch in platforms
+            ]
+        }
+
+    verify_platforms(manifest([("linux", "amd64"), ("linux", "arm64")]))
+    # Attestation entries carry os "unknown" and must be ignored, not counted.
+    verify_platforms(
+        manifest([("linux", "amd64"), ("linux", "arm64"), ("unknown", "unknown")])
+    )
+    with pytest.raises(RunnerPlanError, match="parity"):
+        verify_platforms(manifest([("linux", "amd64")]))
+
+
+# --------------------------------------------------------------------------
+# The CLI itself -- every subcommand, through main()
+# --------------------------------------------------------------------------
+
+
+def test_every_cli_subcommand_runs_and_reports_its_exit_status(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The gap that let twenty lines of dead code into main() unnoticed."""
+    resolved_path = tmp_path / "resolved.json"
+    resolved_path.write_text(json.dumps(_resolved()))
+    published = tmp_path / "published.json"
+    published.write_text(json.dumps({name: False for name in BACKENDS}))
+
+    assert runner_images_main(["validate", "--catalog", str(CATALOG_PATH)]) == 0
+
+    assert (
+        runner_images_main(
+            [
+                "plan",
+                "--resolved",
+                str(resolved_path),
+                "--published",
+                str(published),
+                "--output",
+                str(tmp_path / "builds.json"),
+            ]
+        )
+        == 0
+    )
+    builds = json.loads((tmp_path / "builds.json").read_text())
+    assert [b["name"] for b in builds] == list(BACKENDS)
+
+    assert runner_images_main(["base-tag", "--catalog", str(CATALOG_PATH)]) == 0
+    assert capsys.readouterr().out.strip().startswith("node22-uv")
+
+    assert (
+        runner_images_main(
+            [
+                "build-args",
+                "--resolved",
+                str(resolved_path),
+                "--backend",
+                "gemini",
+                "--base-image",
+                BASE_IMAGE,
+            ]
+        )
+        == 0
+    )
+    assert "CLI_SHARED_TARBALL=" in capsys.readouterr().out
+
+    catalog_input = tmp_path / "models.json"
+    catalog_input.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "slug": "gpt-5.6-luna",
+                        "supported_reasoning_levels": [
+                            {"effort": e}
+                            for e in ("low", "medium", "high", "xhigh", "max")
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    assert (
+        runner_images_main(["verify-codex-catalog", "--input", str(catalog_input)]) == 0
+    )
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "manifests": [
+                    {"platform": {"os": "linux", "architecture": "amd64"}},
+                    {"platform": {"os": "linux", "architecture": "arm64"}},
+                ]
+            }
+        )
+    )
+    assert runner_images_main(["verify-platforms", "--input", str(manifest)]) == 0
+
+
+def test_discover_subcommand_writes_a_resolved_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`discover` is what the workflow depends on to produce a file on disk."""
+    installer = (
+        b"VERSION=2026.07.20-8cc9c0b\n"
+        b"https://downloads.cursor.com/lab/2026.07.20-8cc9c0b/linux/x64/a.tgz\n"
+    )
+    monkeypatch.setattr("tools.runner_images._fetch", lambda *a, **k: installer)
+    output = tmp_path / "resolved.json"
+    assert (
+        runner_images_main(
+            ["discover", "--catalog", str(CATALOG_PATH), "--output", str(output)]
+        )
+        == 0
+    )
+    resolved = json.loads(output.read_text())
+    assert sorted(resolved["backends"]) == sorted(BACKENDS)
+    assert resolved["backends"]["cursor"]["version"] == "2026.07.20-8cc9c0b"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ['["not", "an", "object"]', '{"schema_version": 2, "backends": null}', "{}"],
+)
+def test_malformed_input_exits_cleanly_instead_of_tracebacking(
+    tmp_path: Path, payload: str
+) -> None:
+    broken = tmp_path / "catalog.json"
+    broken.write_text(payload)
+    assert runner_images_main(["validate", "--catalog", str(broken)]) == 2
+
+
+# --------------------------------------------------------------------------
+# The one workflow property no linter knows
+# --------------------------------------------------------------------------
+
+
+def test_no_tag_is_created_before_the_image_passes_both_smokes() -> None:
+    """A tag must never name an image that has not been validated."""
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    for job in ("base", "backend"):
+        start = text.index(f"\n  {job}:\n")
+        end = min(
+            (
+                p
+                for p in (
+                    text.find(c, start + 1)
+                    for c in ("\n  backend:\n", "\n  rollback:\n", "\n  notify:\n")
+                )
+                if p != -1
+            ),
+            default=len(text),
+        )
+        segment = text[start:end]
+        build_at = segment.index("push-by-digest=true")
+        smoke_at = segment.index("Smoke both architectures before any tag exists")
+        attest_at = segment.index("actions/attest-build-provenance@")
+        tag_at = segment.index("docker buildx imagetools create -t")
+        assert build_at < smoke_at < attest_at < tag_at, job
+        assert "for platform in linux/amd64 linux/arm64" in segment, job
+        assert "verify-platforms" in segment, job
+
+
+def test_registry_absence_check_is_fail_closed() -> None:
+    """Only a definitive "no such tag" is absence; everything else aborts."""
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    helper = text[text.index("tag_exists() {") : text.index('base_tag="$(')]
+    assert "grep -qiE 'not found|manifest unknown|no such manifest|404'" in text
+    assert "registry inspection failed for" in text
+    assert helper.count("exit 1") == 1
+    assert "return 1" in helper
+
+
+def test_publish_workflow_cannot_publish_from_a_pull_request() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    trigger_block = text.split("env:", 1)[0]
+    assert "pull_request:" not in trigger_block
+    assert "github.repository == 'KE7/helix'" in text
+    assert "github.ref == 'refs/heads/main'" in text
+    assert (
+        "ATTESTATION_SIGNER_WORKFLOW: KE7/helix/.github/workflows/publish-runners.yml"
+    ) in text
+    assert '--signer-workflow "$ATTESTATION_SIGNER_WORKFLOW"' in text
+    assert "--deny-self-hosted-runners" in text

--- a/tools/runner_images.py
+++ b/tools/runner_images.py
@@ -1,0 +1,817 @@
+#!/usr/bin/env python3
+"""Resolve and validate content-addressed HELIX mutation-runner inputs.
+
+Network discovery and pure planning are deliberately separate.  Unit tests use
+captured registry/installer fixtures; only the protected release workflow calls
+``discover`` against upstream services or checks registry tags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, TypeVar
+
+
+BACKENDS = ("claude", "codex", "cursor", "gemini", "opencode")
+PLATFORMS = ("amd64", "arm64")
+# The exact lockfile entry each image extracts, per backend and platform.
+#
+# This stays a checked-in decision rather than a query over the lockfile's
+# cpu/os/libc fields, because those fields do not identify a unique artifact:
+# claude publishes linux-x64 (libc glibc) *and* linux-x64-musl for the same
+# cpu/os, and opencode publishes linux-x64 (AVX2) *and* linux-x64-baseline with
+# identical cpu/os/libc. Naming the package is also what preserves the property
+# that a build extracts exactly the artifacts someone reviewed and nothing
+# else: a new optional dependency appearing upstream cannot enter an image
+# without a line changing here.
+#
+# ``cli`` is the wrapper package; ``shared`` is architecture-independent.
+# Gemini has no ``cli`` entry -- its own tarball is a residual catalog pin,
+# because its 655-package unbundled dependency tree would make the lockfile
+# 8,459 lines even though the published tarball ships a self-contained bundle.
+LOCKFILE_ARTIFACTS: dict[str, dict[str, str]] = {
+    "claude": {
+        "cli": "@anthropic-ai/claude-code",
+        "amd64": "@anthropic-ai/claude-code-linux-x64",
+        "arm64": "@anthropic-ai/claude-code-linux-arm64",
+    },
+    "codex": {
+        "cli": "@openai/codex",
+        # npm aliases of @openai/codex itself, not separate packages:
+        # `npm:@openai/codex@<version>-linux-x64`.
+        "amd64": "@openai/codex-linux-x64",
+        "arm64": "@openai/codex-linux-arm64",
+    },
+    "gemini": {
+        "shared": "@lydell/node-pty",
+        "amd64": "@lydell/node-pty-linux-x64",
+        "arm64": "@lydell/node-pty-linux-arm64",
+    },
+    "opencode": {
+        "cli": "opencode-ai",
+        # Baseline runs on every x86-64 CPU; see docker/opencode.Dockerfile for
+        # why the AVX2 build and its runtime /proc/cpuinfo branch were dropped.
+        "amd64": "opencode-linux-x64-baseline",
+        "arm64": "opencode-linux-arm64",
+    },
+}
+LOCKFILE_CPU = {"amd64": "x64", "arm64": "arm64"}
+# Backends whose own tarball stays a hand-maintained catalog pin.
+RESIDUAL_PARENTS = frozenset(
+    name for name, group in LOCKFILE_ARTIFACTS.items() if "cli" not in group
+)
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+SHA512_RE = re.compile(r"^[0-9a-f]{128}$")
+VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z._+-]*$")
+# ``smoke_command`` reaches ``sh -lc`` inside the build container.  The catalog
+# is an in-repo trust boundary, so this is defense in depth rather than an
+# exploitable path, but the charset deliberately excludes ``;``, backticks,
+# ``$``, ``(``, ``)``, ``<``, ``>``, backslash, and newlines.
+SMOKE_COMMAND_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z _.=/&|'\"-]{0,255}$")
+TAG_RE = re.compile(r"^[0-9A-Za-z_][0-9A-Za-z_.-]{0,127}$")
+CURSOR_VERSION_RE = re.compile(r"2026\.[0-9]{2}\.[0-9]{2}-[0-9a-f]+")
+# HELIX needs a Codex that ships gpt-5.6-luna with an xhigh reasoning level.
+CODEX_MINIMUM_VERSION = (0, 145, 0)
+
+DEFAULT_LOCKFILE = (
+    Path(__file__).resolve().parent.parent / "docker" / "package-lock.json"
+)
+
+T = TypeVar("T")
+Sleep = Callable[[float], None]
+NETWORK_RETRY_ATTEMPTS = 3
+RETRYABLE_HTTP_STATUS = frozenset({429, 500, 502, 503, 504})
+
+
+class RunnerPlanError(ValueError):
+    """A release input is ambiguous, malformed, or violates promotion policy."""
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise RunnerPlanError(f"{path}: expected a JSON object")
+    return value
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _require_url(value: object, host: str) -> str:
+    if not isinstance(value, str):
+        raise RunnerPlanError("expected URL string")
+    if not value or any(ord(character) <= 0x20 for character in value):
+        raise RunnerPlanError(f"URL contains whitespace or controls: {value!r}")
+    parsed = urllib.parse.urlparse(value)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise RunnerPlanError(f"untrusted upstream URL: {value!r}") from exc
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != host
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in {None, 443}
+        or not parsed.path.startswith("/")
+        or parsed.fragment
+    ):
+        raise RunnerPlanError(f"untrusted upstream URL: {value!r}")
+    return value
+
+
+def _semver_tuple(value: str) -> tuple[int, int, int]:
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", value)
+    if not match:
+        raise RunnerPlanError(f"expected stable semantic version, got {value!r}")
+    return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+def _require_source(
+    source: object,
+    host: str,
+    digest: re.Pattern[str],
+    digest_field: str,
+    context: str,
+) -> None:
+    """Require a download to be an HTTPS URL on ``host`` plus a content digest."""
+    if not isinstance(source, dict):
+        raise RunnerPlanError(f"{context}: expected an object")
+    _require_url(source.get("tarball") or source.get("url"), host)
+    if not digest.fullmatch(str(source.get(digest_field, ""))):
+        raise RunnerPlanError(f"{context}: invalid {digest_field}")
+
+
+def _require_version(value: object, context: str) -> str:
+    if not isinstance(value, str) or not VERSION_RE.fullmatch(value):
+        raise RunnerPlanError(f"{context}: invalid version")
+    return value
+
+
+def _require_smoke_command(value: object, context: str) -> str:
+    if not isinstance(value, str) or not SMOKE_COMMAND_RE.fullmatch(value):
+        raise RunnerPlanError(f"{context}: smoke command is missing or unsafe")
+    return value
+
+
+def base_tag(base: Mapping[str, Any], dockerfile: Path) -> str:
+    """Derive the base image tag from the whole base recipe.
+
+    The readable part names what a human cares about.  The six-hex suffix binds
+    every input that can change the built bytes -- the Dockerfile itself plus
+    each pinned catalog value -- so editing ``docker/base.Dockerfile`` or
+    bumping the node digest cannot silently reuse an already-published, stale
+    base.  Without it, "does this tag exist?" would answer *yes* for a recipe
+    that no longer matches the checkout, and every backend would build FROM a
+    stale base with nothing reporting a problem.
+    """
+    material = json.dumps(
+        {
+            "dockerfile": hashlib.sha256(dockerfile.read_bytes()).hexdigest(),
+            "node_image": base["node_image"],
+            "debian_snapshot": base["debian_snapshot"],
+            "uv_version": base["uv_version"],
+            "uv_wheels": base["uv_wheels"],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    fingerprint = hashlib.sha256(material.encode("utf-8")).hexdigest()[:6]
+    snapshot = str(base["debian_snapshot"])[:8]
+    tag = f"node22-uv{base['uv_version']}-snapshot{snapshot}-r{fingerprint}"
+    if not TAG_RE.fullmatch(tag):
+        raise RunnerPlanError(f"derived base image tag is unsafe: {tag!r}")
+    return tag
+
+
+def validate_catalog(catalog: dict[str, Any]) -> None:
+    """Check the checked-in source pins a build actually depends on.
+
+    Scope is deliberately narrow: every value a Dockerfile consumes must be
+    present, come from the expected host over HTTPS, and carry a digest of the
+    right shape.  Anything a build does not read is not validated here.
+    """
+    if catalog.get("schema_version") != 2:
+        raise RunnerPlanError("unsupported runner catalog schema")
+    if catalog.get("registry_prefix") != "ghcr.io/ke7/helix-evo-runner":
+        raise RunnerPlanError("unexpected runner registry prefix")
+    backends = catalog.get("backends")
+    if not isinstance(backends, dict) or tuple(sorted(backends)) != tuple(
+        sorted(BACKENDS)
+    ):
+        raise RunnerPlanError("runner catalog must contain exactly the five backends")
+
+    base = catalog.get("base")
+    if not isinstance(base, dict):
+        raise RunnerPlanError("missing base configuration")
+    if not re.fullmatch(
+        r"node:[^@\s]+@sha256:[0-9a-f]{64}", str(base.get("node_image", ""))
+    ):
+        raise RunnerPlanError("base node image must be digest-pinned")
+    if base.get("dockerfile") != "docker/base.Dockerfile":
+        raise RunnerPlanError("unexpected base dockerfile")
+    if not isinstance(base.get("uv_version"), str):
+        raise RunnerPlanError("base uv version is required")
+    if not re.fullmatch(r"\d{8}T\d{6}Z", str(base.get("debian_snapshot", ""))):
+        raise RunnerPlanError("base Debian snapshot timestamp is invalid")
+    uv_wheels = base.get("uv_wheels")
+    if not isinstance(uv_wheels, dict) or tuple(sorted(uv_wheels)) != PLATFORMS:
+        raise RunnerPlanError("base requires exact amd64/arm64 uv wheels")
+    for platform in PLATFORMS:
+        _require_source(
+            uv_wheels[platform],
+            "files.pythonhosted.org",
+            SHA256_RE,
+            "sha256",
+            f"base uv/{platform}",
+        )
+    _require_smoke_command(base.get("smoke_command"), "base")
+
+    for name in BACKENDS:
+        item = backends[name]
+        if not isinstance(item, dict):
+            raise RunnerPlanError(f"{name}: expected a backend object")
+        _require_smoke_command(item.get("smoke_command"), name)
+        if item.get("dockerfile") != f"docker/{name}.Dockerfile":
+            raise RunnerPlanError(f"{name}: unexpected dockerfile")
+
+        if name == "cursor":
+            # Cursor belongs to no package ecosystem: its version lives inside
+            # a shell script and its archives must be hashed by hand.
+            if item.get("installer") != "https://cursor.com/install":
+                raise RunnerPlanError("cursor: unexpected installer")
+            _require_version(item.get("version"), name)
+            platforms = item.get("platforms")
+            if not isinstance(platforms, dict) or tuple(sorted(platforms)) != PLATFORMS:
+                raise RunnerPlanError("cursor: exact amd64/arm64 inputs required")
+            for platform in PLATFORMS:
+                _require_source(
+                    platforms[platform],
+                    "downloads.cursor.com",
+                    SHA256_RE,
+                    "sha256",
+                    f"cursor/{platform}",
+                )
+        elif name in RESIDUAL_PARENTS:
+            # Gemini's own tarball is pinned here rather than in the lockfile;
+            # only its node-pty artifacts come from the lockfile.
+            _require_version(item.get("version"), name)
+            if item.get("package") != "@google/gemini-cli":
+                raise RunnerPlanError(f"{name}: unexpected npm package")
+            _require_source(item, "registry.npmjs.org", SHA512_RE, "sha512", name)
+        elif set(item) - {"dockerfile", "smoke_command"}:
+            # Everything else is owned by docker/package-lock.json. A stray
+            # version or digest here would be a second source of truth that
+            # nothing keeps in step with the lockfile.
+            raise RunnerPlanError(
+                f"{name}: version and digests belong to the lockfile, "
+                f"not the catalog: {sorted(set(item) - {'dockerfile', 'smoke_command'})}"
+            )
+
+
+def validate_lockfile(lock: Mapping[str, Any]) -> None:
+    """Check every artifact an image extracts is present and on-platform.
+
+    npm records whatever the upstream optional-dependency closure happened to
+    contain.  ``LOCKFILE_ARTIFACTS`` records what a human reviewed.  This is
+    where the two must agree, and it is what stops a new native optional
+    dependency from entering an image just because upstream declared one.
+    """
+    if lock.get("lockfileVersion") != 3:
+        raise RunnerPlanError("unsupported npm lockfile version")
+    packages = lock.get("packages")
+    if not isinstance(packages, dict):
+        raise RunnerPlanError("lockfile has no packages map")
+
+    for name, group in sorted(LOCKFILE_ARTIFACTS.items()):
+        for slot, package in sorted(group.items()):
+            node = packages.get(f"node_modules/{package}")
+            if not isinstance(node, dict):
+                raise RunnerPlanError(
+                    f"{name}/{slot}: {package} is not in the lockfile"
+                )
+            context = f"{name}/{slot}"
+            _require_url(node.get("resolved"), "registry.npmjs.org")
+            _lockfile_sha512(node, context)
+            if slot in PLATFORMS:
+                if node.get("cpu") != [LOCKFILE_CPU[slot]]:
+                    raise RunnerPlanError(f"{context}: wrong cpu {node.get('cpu')!r}")
+                if node.get("os") != ["linux"]:
+                    raise RunnerPlanError(f"{context}: wrong os {node.get('os')!r}")
+                # The base image is Debian, so a musl build would not run.
+                if node.get("libc") not in (None, ["glibc"]):
+                    raise RunnerPlanError(f"{context}: wrong libc {node.get('libc')!r}")
+
+    codex = packages.get("node_modules/@openai/codex")
+    if not isinstance(codex, dict):
+        raise RunnerPlanError("codex is not in the lockfile")
+    # HELIX requires a Codex that ships gpt-5.6-luna with an xhigh level.
+    if _semver_tuple(str(codex.get("version"))) < CODEX_MINIMUM_VERSION:
+        raise RunnerPlanError("codex must remain at least 0.145.0")
+
+
+def _lockfile_sha512(node: Mapping[str, Any], context: str) -> str:
+    """Return the hex sha512 behind a lockfile ``integrity`` field."""
+    integrity = node.get("integrity")
+    if not isinstance(integrity, str) or not integrity.startswith("sha512-"):
+        raise RunnerPlanError(f"{context}: missing sha512 integrity")
+    try:
+        digest = base64.b64decode(
+            integrity.removeprefix("sha512-"), validate=True
+        ).hex()
+    except ValueError as exc:
+        raise RunnerPlanError(f"{context}: malformed sha512 integrity") from exc
+    if not SHA512_RE.fullmatch(digest):
+        raise RunnerPlanError(f"{context}: malformed sha512 digest")
+    return digest
+
+
+def _lockfile_source(
+    lock: Mapping[str, Any], package: str, context: str
+) -> dict[str, str]:
+    """Return the ``{package, version, tarball, sha512}`` a Dockerfile needs."""
+    node = lock["packages"][f"node_modules/{package}"]
+    return {
+        "package": package,
+        # Aliased entries carry the aliased package's own version.
+        "version": str(node["version"]),
+        "tarball": _require_url(node["resolved"], "registry.npmjs.org"),
+        "sha512": _lockfile_sha512(node, context),
+    }
+
+
+def parse_cursor_installer(payload: bytes) -> dict[str, str]:
+    text = payload.decode("utf-8")
+    versions = sorted(set(CURSOR_VERSION_RE.findall(text)))
+    if len(versions) != 1:
+        raise RunnerPlanError(
+            f"cursor installer must name exactly one version; found {versions!r}"
+        )
+    version = versions[0]
+    return {
+        "version": version,
+        "installer_sha256": hashlib.sha256(payload).hexdigest(),
+        "amd64_tarball": (
+            f"https://downloads.cursor.com/lab/{version}/linux/x64/"
+            "agent-cli-package.tar.gz"
+        ),
+        "arm64_tarball": (
+            f"https://downloads.cursor.com/lab/{version}/linux/arm64/"
+            "agent-cli-package.tar.gz"
+        ),
+    }
+
+
+def _is_retryable(exc: OSError) -> bool:
+    """Report whether an idempotent GET may be safely repeated.
+
+    Only transient conditions qualify.  These reads resolve upstream npm
+    metadata and Cursor archives, where a 404 means the package or release
+    genuinely is not there and 401/403 mean the request is malformed or
+    blocked; retrying either would turn a decisive answer into a slower,
+    noisier one without ever changing it.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code in RETRYABLE_HTTP_STATUS
+    return isinstance(exc, (urllib.error.URLError, TimeoutError))
+
+
+def _retry_get(
+    operation: Callable[[], T],
+    *,
+    description: str,
+    attempts: int = NETWORK_RETRY_ATTEMPTS,
+    sleep: Sleep = time.sleep,
+) -> T:
+    """Run one idempotent GET with bounded exponential backoff.
+
+    ``sleep`` is injected so unit tests observe the backoff schedule without
+    spending wall-clock time.  A non-retryable error, and the final attempt's
+    error, propagate unchanged so every existing fail-closed handler still
+    sees the original exception.
+    """
+    if attempts < 1:
+        raise RunnerPlanError(f"{description}: retry budget must be positive")
+    for attempt in range(1, attempts + 1):
+        try:
+            return operation()
+        except OSError as exc:
+            if attempt == attempts or not _is_retryable(exc):
+                raise
+            sleep(float(2 ** (attempt - 1)))
+    raise RunnerPlanError(  # pragma: no cover - loop always returns or raises
+        f"{description}: exhausted {attempts} attempts"
+    )
+
+
+def _fetch(url: str, timeout: float = 30.0, *, sleep: Sleep = time.sleep) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "helix-runner-version-audit/1"},
+    )
+
+    def read() -> bytes:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload: bytes = response.read()
+        return payload
+
+    return _retry_get(read, description=f"fetch {url}", sleep=sleep)
+
+
+def _fetch_sha256(
+    url: str, timeout: float = 180.0, *, sleep: Sleep = time.sleep
+) -> str:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "helix-runner-version-audit/1"},
+    )
+
+    def read() -> str:
+        # The digest is rebuilt per attempt: a stream that died halfway must
+        # never contribute its partial bytes to the recorded checksum.
+        digest = hashlib.sha256()
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            while chunk := response.read(1024 * 1024):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    return _retry_get(read, description=f"hash {url}", sleep=sleep)
+
+
+def resolve_cursor_checksums(
+    tarballs: Mapping[str, str],
+    version: str,
+    catalog_item: Mapping[str, Any],
+    *,
+    fetch_sha256: Callable[[str], str] = _fetch_sha256,
+) -> dict[str, str]:
+    """Return the SHA-256 of each discovered Cursor platform archive.
+
+    Cursor's release archives are addressed by version and are
+    content-immutable, so streaming both multi-hundred-megabyte tarballs
+    through a hash every single day proves nothing new once the version has
+    not moved.  A reviewed catalog digest is reused only when the discovered
+    version *and* the derived URL both still match it; any drift at all falls
+    back to a full re-download and re-hash.
+    """
+    recorded = catalog_item.get("platforms")
+    checksums: dict[str, str] = {}
+    for platform in PLATFORMS:
+        tarball = tarballs[platform]
+        cached = recorded.get(platform) if isinstance(recorded, dict) else None
+        if (
+            version == catalog_item.get("version")
+            and isinstance(cached, dict)
+            and cached.get("tarball") == tarball
+            and SHA256_RE.fullmatch(str(cached.get("sha256", "")))
+        ):
+            checksums[platform] = str(cached["sha256"])
+        else:
+            checksums[platform] = fetch_sha256(tarball)
+    return checksums
+
+
+def discover(
+    catalog: dict[str, Any], lock: dict[str, Any], *, cursor_checksums: bool
+) -> dict[str, Any]:
+    """Resolve every pinned input into the flat map the workflow builds from.
+
+    Everything except Cursor is already pinned in git -- npm packages by
+    ``docker/package-lock.json``, Gemini's bundled tarball and the base runtime
+    by the catalog -- so this reaches the network only for Cursor, whose
+    version lives inside a shell script at ``https://cursor.com/install``.
+    """
+    validate_catalog(catalog)
+    validate_lockfile(lock)
+    resolved: dict[str, Any] = {
+        "schema_version": 1,
+        "base": catalog["base"],
+        "backends": {},
+    }
+    for name in BACKENDS:
+        item = catalog["backends"][name]
+        common = {
+            "kind": "codex"
+            if name == "codex"
+            else "cursor"
+            if name == "cursor"
+            else "npm",
+            "dockerfile": item["dockerfile"],
+            "smoke_command": item["smoke_command"],
+        }
+        if name == "cursor":
+            resolved["backends"][name] = _resolve_cursor(item, common, cursor_checksums)
+            continue
+
+        group = LOCKFILE_ARTIFACTS[name]
+        if name in RESIDUAL_PARENTS:
+            parent = {
+                "package": item["package"],
+                "version": item["version"],
+                "tarball": item["tarball"],
+                "sha512": item["sha512"],
+            }
+        else:
+            parent = _lockfile_source(lock, group["cli"], f"{name}/cli")
+        entry: dict[str, Any] = {**parent, **common}
+
+        if name == "codex":
+            # Codex's platform binaries are aliases of @openai/codex itself,
+            # so each one's lockfile version is `<version>-linux-<arch>`.
+            entry["platforms"] = {
+                platform: {
+                    "package_version": (
+                        source := _lockfile_source(
+                            lock, group[platform], f"{name}/{platform}"
+                        )
+                    )["version"],
+                    "tarball": source["tarball"],
+                    "sha512": source["sha512"],
+                }
+                for platform in PLATFORMS
+            }
+        else:
+            entry["artifacts"] = {
+                slot: [_lockfile_source(lock, group[slot], f"{name}/{slot}")]
+                for slot in ("shared", "amd64", "arm64")
+                if slot in group
+            }
+        resolved["backends"][name] = entry
+    return resolved
+
+
+def _resolve_cursor(
+    item: Mapping[str, Any], common: Mapping[str, str], cursor_checksums: bool
+) -> dict[str, Any]:
+    cursor: dict[str, Any] = dict(
+        parse_cursor_installer(_fetch(str(item["installer"])))
+    )
+    tarballs = {
+        platform: str(cursor.pop(f"{platform}_tarball")) for platform in PLATFORMS
+    }
+    cursor.update(
+        {
+            **common,
+            "installer": item["installer"],
+            "platforms": {
+                platform: {"tarball": tarballs[platform]} for platform in PLATFORMS
+            },
+        }
+    )
+    if cursor_checksums:
+        checksums = resolve_cursor_checksums(tarballs, str(cursor["version"]), item)
+        for platform in PLATFORMS:
+            cursor["platforms"][platform]["sha256"] = checksums[platform]
+    return cursor
+
+
+def build_arguments(item: Mapping[str, Any], base_image: str) -> list[str]:
+    """Return the exact ``KEY=VALUE`` build arguments for one backend.
+
+    This lived as a fifty-line ``jq`` case statement inside the workflow, where
+    it could not be tested and where a value containing a newline would have
+    injected an extra build argument into the heredoc. Every value is checked
+    here instead.
+    """
+    if not re.fullmatch(
+        r"ghcr\.io/[a-z0-9][a-z0-9._/-]*@sha256:[0-9a-f]{64}", base_image
+    ):
+        raise RunnerPlanError(f"base image must be digest-pinned: {base_image!r}")
+    kind = item.get("kind")
+    arguments = {
+        "BASE_IMAGE": base_image,
+        "CLI_VERSION": str(item["version"]),
+    }
+    if kind in {"npm", "codex"}:
+        arguments["CLI_TARBALL"] = str(item["tarball"])
+        arguments["CLI_SHA512"] = str(item["sha512"])
+    if kind == "npm":
+        artifacts = item["artifacts"]
+        # Only Gemini declares a shared (architecture-independent) artifact, so
+        # only Gemini's Dockerfile declares the matching ARGs. Emitting the pair
+        # for claude/opencode would pass buildx two arguments their recipes
+        # never read.
+        if "shared" in artifacts:
+            shared = artifacts["shared"][0]
+            arguments["CLI_SHARED_TARBALL"] = str(shared["tarball"])
+            arguments["CLI_SHARED_SHA512"] = str(shared["sha512"])
+        for platform in PLATFORMS:
+            entries = artifacts[platform]
+            upper = platform.upper()
+            arguments[f"CLI_{upper}_TARBALL"] = str(entries[0]["tarball"])
+            arguments[f"CLI_{upper}_SHA512"] = str(entries[0]["sha512"])
+    elif kind in {"codex", "cursor"}:
+        digest_field = "sha512" if kind == "codex" else "sha256"
+        for platform in PLATFORMS:
+            source = item["platforms"][platform]
+            upper = platform.upper()
+            arguments[f"CLI_{upper}_TARBALL"] = str(source["tarball"])
+            arguments[f"CLI_{upper}_{digest_field.upper()}"] = str(source[digest_field])
+    else:
+        raise RunnerPlanError(f"unknown backend kind {kind!r}")
+
+    for key, value in arguments.items():
+        if any(ord(character) < 0x20 for character in value):
+            raise RunnerPlanError(f"{key}: build argument contains a control byte")
+    return [f"{key}={value}" for key, value in arguments.items()]
+
+
+def change_plan(
+    resolved: Mapping[str, Any],
+    published: Mapping[str, Any],
+    *,
+    force: bool = False,
+    run_id: str = "",
+) -> list[dict[str, str]]:
+    """Decide which backends to build, and under which tag.
+
+    The whole policy: an upstream release that is not in the registry yet gets
+    built; anything already published is skipped.  Nightly is therefore the
+    *check* cadence and an upstream release is the *publish* trigger, so a
+    quiet night is a clean no-op.
+
+    ``force`` rebuilds regardless -- the escape hatch for a recipe change that
+    upstream did not trigger.  When the version tag already exists, a forced
+    rebuild publishes ``<version>-r<run_id>`` instead of overwriting it: a tag
+    someone has pinned must never silently change meaning.
+    """
+    builds: list[dict[str, str]] = []
+    for name in BACKENDS:
+        item = resolved["backends"][name]
+        version = str(item["version"])
+        if not VERSION_RE.fullmatch(version) or len(version) > 80:
+            raise RunnerPlanError(f"{name}: unsafe image version {version!r}")
+        exists = bool(published.get(name, False))
+        if exists and not force:
+            continue
+        tag = version
+        if exists:
+            if not re.fullmatch(r"[0-9]+", run_id):
+                raise RunnerPlanError(
+                    f"{name}: forcing a rebuild of a published version needs "
+                    "a numeric run id for the replacement tag"
+                )
+            tag = f"{version}-r{run_id}"
+        if not TAG_RE.fullmatch(tag):
+            raise RunnerPlanError(f"{name}: derived image tag is unsafe: {tag!r}")
+        builds.append(
+            {
+                "name": name,
+                "dockerfile": str(item["dockerfile"]),
+                "version": version,
+                "tag": tag,
+            }
+        )
+    return builds
+
+
+def verify_codex_catalog(payload: dict[str, Any]) -> None:
+    models = payload.get("models")
+    if not isinstance(models, list):
+        raise RunnerPlanError("codex model catalog has no models array")
+    matches = [model for model in models if model.get("slug") == "gpt-5.6-luna"]
+    if len(matches) != 1:
+        raise RunnerPlanError("expected exactly one gpt-5.6-luna catalog entry")
+    levels = matches[0].get("supported_reasoning_levels")
+    if not isinstance(levels, list):
+        raise RunnerPlanError("Luna catalog entry has no reasoning levels")
+    efforts = [entry.get("effort") for entry in levels]
+    expected = ["low", "medium", "high", "xhigh", "max"]
+    # The equality above already pins xhigh as the second-highest effort, which
+    # is the property HELIX actually depends on.
+    if efforts != expected:
+        raise RunnerPlanError(
+            f"unexpected Luna reasoning order: {efforts!r}; expected {expected!r}"
+        )
+
+
+def verify_platforms(payload: dict[str, Any]) -> None:
+    manifests = payload.get("manifests")
+    if not isinstance(manifests, list):
+        raise RunnerPlanError("manifest list has no manifests")
+    platforms: list[dict[str, Any]] = []
+    for manifest in manifests:
+        if not isinstance(manifest, dict):
+            raise RunnerPlanError("manifest list entry is not an object")
+        platform = manifest.get("platform", {})
+        if not isinstance(platform, dict):
+            raise RunnerPlanError("manifest platform is not an object")
+        platforms.append(platform)
+    runtime_platforms = sorted(
+        (platform.get("os"), platform.get("architecture"))
+        for platform in platforms
+        if platform.get("os") != "unknown"
+    )
+    if runtime_platforms != [("linux", "amd64"), ("linux", "arm64")]:
+        raise RunnerPlanError(
+            f"expected exact linux/amd64+linux/arm64 parity, got {runtime_platforms!r}"
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--catalog", type=Path, required=True)
+    validate.add_argument("--lockfile", type=Path, default=DEFAULT_LOCKFILE)
+    discovery = subparsers.add_parser("discover")
+    discovery.add_argument("--catalog", type=Path, required=True)
+    discovery.add_argument("--lockfile", type=Path, default=DEFAULT_LOCKFILE)
+    discovery.add_argument("--output", type=Path, required=True)
+    discovery.add_argument("--cursor-checksums", action="store_true")
+    plan = subparsers.add_parser("plan")
+    plan.add_argument("--resolved", type=Path, required=True)
+    plan.add_argument("--published", type=Path, required=True)
+    plan.add_argument("--output", type=Path, required=True)
+    plan.add_argument("--force", action="store_true")
+    plan.add_argument("--run-id", default="")
+    base = subparsers.add_parser("base-tag")
+    base.add_argument("--catalog", type=Path, required=True)
+    args_command = subparsers.add_parser("build-args")
+    args_command.add_argument("--resolved", type=Path, required=True)
+    args_command.add_argument("--backend", choices=BACKENDS, required=True)
+    args_command.add_argument("--base-image", required=True)
+    catalog = subparsers.add_parser("verify-codex-catalog")
+    catalog.add_argument("--input", type=Path, required=True)
+    platforms = subparsers.add_parser("verify-platforms")
+    platforms.add_argument("--input", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "validate":
+            validate_catalog(load_json(args.catalog))
+            validate_lockfile(load_json(args.lockfile))
+        elif args.command == "discover":
+            write_json(
+                args.output,
+                discover(
+                    load_json(args.catalog),
+                    load_json(args.lockfile),
+                    cursor_checksums=args.cursor_checksums,
+                ),
+            )
+        elif args.command == "plan":
+            write_json(
+                args.output,
+                change_plan(
+                    load_json(args.resolved),
+                    load_json(args.published),
+                    force=args.force,
+                    run_id=args.run_id,
+                ),
+            )
+        elif args.command == "build-args":
+            resolved = load_json(args.resolved)
+            for argument in build_arguments(
+                resolved["backends"][args.backend], args.base_image
+            ):
+                print(argument)
+        elif args.command == "base-tag":
+            catalog = load_json(args.catalog)
+            validate_catalog(catalog)
+            # ``validate_catalog`` has already pinned ``base.dockerfile`` to the
+            # literal ``docker/base.Dockerfile``, so the path is a constant
+            # relative to the repository root and needs no traversal guard.
+            root = args.catalog.resolve().parent.parent
+            print(base_tag(catalog["base"], root / str(catalog["base"]["dockerfile"])))
+        elif args.command == "verify-codex-catalog":
+            verify_codex_catalog(load_json(args.input))
+        elif args.command == "verify-platforms":
+            verify_platforms(load_json(args.input))
+        else:  # pragma: no cover - argparse enforces the command set
+            raise AssertionError(args.command)
+    except (
+        OSError,
+        json.JSONDecodeError,
+        RunnerPlanError,
+        # A catalog that is well-formed JSON but structurally wrong (a list
+        # where an object belongs, a null where a string belongs) must still
+        # exit 2 with the standard message rather than a raw traceback.
+        AttributeError,
+        TypeError,
+    ) as exc:
+        print(f"runner image gate failed: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Rebased onto a stack of three independently-mergeable PRs. **The backup of the previous tip (`10f8c5f`) is `backup/runner-refresh-pre-split-10f8c5f`, pushed.**

**This PR: 10 files, +2,951 / −225.**

```
git diff --shortstat origin/stack/runner-images-base...origin/agent/helix-runner-refresh
```

Its base is `stack/runner-images-base` (= `main` + #53 + #54 + #56) so the diff shows only this PR's own work. Retarget to `main` once those three land.

## What was extracted

| PR | Purpose | LOC (`git diff --shortstat origin/main...<branch>`) |
|---|---|---|
| #53 | Lint the workflows, fix all 23 findings | +105 / −30 |
| #54 | Pin every runner image input to a verified artifact | +202 / −12 |
| #56 | Let Renovate maintain dependencies and action digests | +29 |
| **#43** | Automate pinned runner image publication | **+2,951 / −225** |

#53, #54 and #56 are each based directly on `main` and can merge in any order.

## Honest accounting

`#43` went from **+3,167 → +2,951** insertions and 18 → 10 files. That is only **−6.8%**.

**The whole stack is bigger than the original PR, not smaller**: `git diff --shortstat origin/main...origin/agent/helix-runner-refresh` gives **18 files, +3,249 / −229**, against the original's 18 files, +3,167 / −227. It grew by 82 insertions. Those 82 lines bought two build-breaking bug fixes, two drift tests, a lint gate that found 23 real findings on `main` alone, a fix for CI silently skipping stacked PRs, and Renovate config.

Splitting alone cannot make this PR small, because 2,777 of its 2,951 lines are five files that are mutually dead without each other: the tool (817), its tests (639), the lockfile (557), the workflow (519), and the docs (245). A lockfile nothing reads, a tool nothing calls, and a workflow with no tool are each individually inert, so splitting them further would produce PRs that are smaller but not independently valuable or revertable. **The remaining size is a real cost of the feature, not packaging.** See the review notes at the end for what could still go.

## Why the pins still have ARG defaults

The Dockerfiles keep an `ARG` default for every pin, so `docker build -f docker/codex.Dockerfile .` works off a plain checkout. That is a second copy of every pin.

The hazard was never "the defaults exist" — it was **"a missing pin can silently fall back to a stale default and produce an unpinned image that looks fine."** Deleting the defaults solves that by removing the fallback; asserting them by test solves it by removing the *divergence*, which is the actual hazard. The test version is strictly better on two counts:

1. drift becomes a CI failure with a named cause, instead of a silent stale build;
2. `docker build` keeps working for a human debugging an image by hand.

Deletion was tried and reverted: it would have traded a silent-staleness bug for a "you cannot build this image without first running a tool that refuses to emit args for a local base" bug — worse, because it breaks the debugging path people reach for when something is already wrong. It also *cost* ~30 lines rather than saving any, since `ARG X=value` → `ARG X` is a modification and the fail-closed guards add lines.

Two tests now carry that guarantee, so they were built to hold it:

- they enumerate pins **from the recipe**, never from a hand-written list, so an `ARG` added later is covered the moment it is declared and the guarantee cannot narrow silently;
- failures name the drifting `ARG` and print both values;
- **verified by mutation**: all **42** pinned `ARG` defaults across the six recipes were perturbed one at a time — every one was caught — as was deleting a default outright (12/12).

```
opencode.Dockerfile: ARG CLI_ARM64_SHA512 default has drifted from the resolved pin
  recipe default: 999bf62008bf4e98ad60952ae384c2d028b9cd50a2f50b29c7fecfda90cd729e...
  resolved pin:   727bf62008bf4e98ad60952ae384c2d028b9cd50a2f50b29c7fecfda90cd729e...
```

## Preserved deliberately

- the **"no tag before both smokes"** ordering — push by digest → verify platforms → smoke each arch → attest → tag — unchanged;
- per-backend `fail-fast: false` isolation;
- fail-closed registry absence (only a definitive "no such tag" counts as absent);
- Gemini **not** lockfiled (655-package tree → 8,459-line lock) and Cursor's shell-installer path;
- the Codex `gpt-5.6-luna` / `xhigh` assertion and the opencode `1.18.5` pin.

## One real cut

`build_arguments` had a branch emitting empty strings for absent artifacts. `_lockfile_source` either returns a one-element list or raises, so it could never run. Removed (817 lines, was 824).

## Verification

- `uv run pytest tests/unit -q` → **912 passed**
- `uv run mypy --strict src/helix/ tools/` → clean (30 files)
- `actionlint` → clean, run with **shellcheck 0.11.0 on PATH** (without it, every SC rule is silently skipped)
- `zizmor 1.16.3 --persona=regular` → clean
- `renovate-config-validator` → valid

**No image was built or smoke-tested. There is no Docker daemon on the workstation this was prepared on.** Every claim about image *contents* rests on reading the recipes, not on running them.

## Notes for review

- `build_arguments` rejects any base image that is not `ghcr.io/…@sha256:…`, so it refuses to emit args for `helix-runner-base:proof`. That is correct for CI and hostile to a human; a documented local-build escape hatch is worth considering.
- Neither of the two Dockerfile line-continuation bugs fixed in #54 could ever have built. Nothing in CI builds images on a pull request, so a Dockerfile linter (hadolint) would be the highest-value follow-up gate.
- `docker/runner-versions.json` (59) still overlaps the lockfile and the recipes; collapsing the residual catalog is the next real reduction available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
