### PR TITLE
fix(worktree): serialise git common-metadata transactions

### DIFF
--- a/src/helix/worktree.py
+++ b/src/helix/worktree.py
@@ -9,10 +9,23 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 
 from helix.exceptions import GitError, HelixError, print_helix_error
 from helix.population import Candidate
+
+
+# ``git worktree add`` reads every entry under ``.git/worktrees/`` while it
+# registers a new one, and ``git worktree remove`` deletes those entries.  Run
+# concurrently against one common repository they race: an ``add`` that reads a
+# sibling entry a concurrent ``remove`` is deleting aborts with
+# ``fatal: failed to read .git/worktrees/<other>/commondir``.  Branch deletion
+# and ``prune`` touch the same shared metadata.  Candidate worktrees are created
+# and removed from HELIX's mutation/evaluation worker pools, so serialise every
+# common-metadata transaction in this process.  Re-entrant because a single
+# transaction issues several git calls.
+_worktree_metadata_lock = threading.RLock()
 
 
 # ---------------------------------------------------------------------------
@@ -393,26 +406,27 @@ def create_empty_seed_worktree(repo_root: Path, base_dir: Path) -> Candidate:
             env={**os.environ, **helix_git_env()},
         )
 
-    # Prune stale worktree registrations before creating new ones.
-    subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
-
     seed_id = "g0-s0"
     worktree_path = base_dir / seed_id
     base_dir.mkdir(parents=True, exist_ok=True)
 
-    try:
-        _run(
-            ["git", "worktree", "add", str(worktree_path), "--detach", "HEAD"],
-            cwd=repo_root,
-            operation=f"create empty seed worktree at {worktree_path}",
-        )
-    except GitError as exc:
-        exc.suggestion = (
-            f"Could not create empty seed worktree at {worktree_path}. "
-            f"Try: git worktree prune && rm -rf {worktree_path}, then retry."
-        )
-        print_helix_error(exc)
-        raise
+    # Prune stale worktree registrations before creating new ones; prune and add
+    # are one common-metadata transaction (see ``_worktree_metadata_lock``).
+    with _worktree_metadata_lock:
+        subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
+        try:
+            _run(
+                ["git", "worktree", "add", str(worktree_path), "--detach", "HEAD"],
+                cwd=repo_root,
+                operation=f"create empty seed worktree at {worktree_path}",
+            )
+        except GitError as exc:
+            exc.suggestion = (
+                f"Could not create empty seed worktree at {worktree_path}. "
+                f"Try: git worktree prune && rm -rf {worktree_path}, then retry."
+            )
+            print_helix_error(exc)
+            raise
 
     return Candidate(
         id=seed_id,
@@ -452,28 +466,29 @@ def create_seed_worktree(repo_root: Path, base_dir: Path) -> Candidate:
     # Fix 6: Abort early if stale helix/* branches exist from a previous run.
     _check_no_stale_helix_branches(repo_root)
 
-    # Prune stale worktree registrations before creating new ones
-    subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
-
     seed_id = "g0-s0"
     worktree_path = base_dir / seed_id
     base_dir.mkdir(parents=True, exist_ok=True)
 
-    try:
-        _run(
-            ["git", "worktree", "add", str(worktree_path), "--detach", "HEAD"],
-            cwd=repo_root,
-            operation=f"create seed worktree at {worktree_path}",
-        )
-    except GitError as exc:
-        exc.suggestion = (
-            f"Could not create seed worktree at {worktree_path}. "
-            f"Try: git worktree prune && rm -rf {worktree_path}, then retry. "
-            f"If the path already exists as a worktree, also try: "
-            f"git worktree remove --force {worktree_path}"
-        )
-        print_helix_error(exc)
-        raise
+    # Prune stale worktree registrations before creating new ones; prune and add
+    # are one common-metadata transaction (see ``_worktree_metadata_lock``).
+    with _worktree_metadata_lock:
+        subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
+        try:
+            _run(
+                ["git", "worktree", "add", str(worktree_path), "--detach", "HEAD"],
+                cwd=repo_root,
+                operation=f"create seed worktree at {worktree_path}",
+            )
+        except GitError as exc:
+            exc.suggestion = (
+                f"Could not create seed worktree at {worktree_path}. "
+                f"Try: git worktree prune && rm -rf {worktree_path}, then retry. "
+                f"If the path already exists as a worktree, also try: "
+                f"git worktree remove --force {worktree_path}"
+            )
+            print_helix_error(exc)
+            raise
 
     candidate = Candidate(
         id=seed_id,
@@ -537,32 +552,34 @@ def clone_candidate(parent: Candidate, new_id: str, base_dir: Path) -> Candidate
     )
     commit_sha = head_result.stdout.strip()
 
-    # Prune stale worktree registrations (safe — only removes metadata for missing paths)
-    subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
-
-    try:
-        _run(
-            [
-                "git", "worktree", "add",
-                str(new_worktree_path),
-                "-b", new_branch,
-                commit_sha,
-            ],
-            cwd=repo_root,
-            operation=f"clone candidate {parent.id} -> {new_id}",
-        )
-    except GitError as exc:
-        exc.suggestion = (
-            f"Could not create worktree for {new_id} (branch {new_branch}). "
-            f"If a stale branch exists, try: git branch -D {new_branch} && "
-            f"git worktree prune. "
-            f"If the worktree path already exists, try: "
-            f"git worktree remove --force {new_worktree_path} && "
-            f"git worktree prune. "
-            f"Then retry the evolution."
-        )
-        print_helix_error(exc)
-        raise
+    # Prune stale worktree registrations (safe — only removes metadata for
+    # missing paths); prune and add are one common-metadata transaction (see
+    # ``_worktree_metadata_lock``).
+    with _worktree_metadata_lock:
+        subprocess.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
+        try:
+            _run(
+                [
+                    "git", "worktree", "add",
+                    str(new_worktree_path),
+                    "-b", new_branch,
+                    commit_sha,
+                ],
+                cwd=repo_root,
+                operation=f"clone candidate {parent.id} -> {new_id}",
+            )
+        except GitError as exc:
+            exc.suggestion = (
+                f"Could not create worktree for {new_id} (branch {new_branch}). "
+                f"If a stale branch exists, try: git branch -D {new_branch} && "
+                f"git worktree prune. "
+                f"If the worktree path already exists, try: "
+                f"git worktree remove --force {new_worktree_path} && "
+                f"git worktree prune. "
+                f"Then retry the evolution."
+            )
+            print_helix_error(exc)
+            raise
 
     # Parse generation from new_id (format: g<gen>-s<slot>)
     try:
@@ -659,20 +676,23 @@ def remove_worktree(candidate: Candidate) -> None:
     else:
         repo_root = wt
 
-    _run(
-        ["git", "worktree", "remove", "--force", str(wt)],
-        cwd=repo_root,
-        operation=f"remove worktree {candidate.id}",
-    )
+    # Removing the worktree entry and deleting its branch are one
+    # common-metadata transaction (see ``_worktree_metadata_lock``).
+    with _worktree_metadata_lock:
+        _run(
+            ["git", "worktree", "remove", "--force", str(wt)],
+            cwd=repo_root,
+            operation=f"remove worktree {candidate.id}",
+        )
 
-    # Delete the tracking branch; ignore errors (branch may not exist)
-    branch = f"helix/{candidate.id}"
-    _run(
-        ["git", "branch", "-D", branch],
-        cwd=repo_root,
-        check=False,
-        operation=f"delete branch {branch}",
-    )
+        # Delete the tracking branch; ignore errors (branch may not exist)
+        branch = f"helix/{candidate.id}"
+        _run(
+            ["git", "branch", "-D", branch],
+            cwd=repo_root,
+            check=False,
+            operation=f"delete branch {branch}",
+        )
 
 
 def get_diff(candidate_a: Candidate, candidate_b: Candidate) -> str:

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from helix.population import Candidate
 from helix.worktree import (
     _ensure_git_repo,
     clone_candidate,
@@ -530,3 +531,86 @@ class TestSnapshotCandidateIdentity:
             check=True,
         ).stdout.strip()
         assert log == "HELIX <helix@noreply>"
+
+
+class TestConcurrentWorktreeMetadata:
+    """``git worktree`` common-metadata operations must not interleave.
+
+    ``git worktree add`` walks every entry under ``.git/worktrees/`` while it
+    registers a new one, and ``git worktree remove`` deletes those entries.
+    Run concurrently they race, and ``add`` aborts with
+    ``fatal: failed to read .git/worktrees/<other>/commondir``.
+    """
+
+    @staticmethod
+    def _is_metadata_command(args: object) -> bool:
+        if not isinstance(args, list) or len(args) < 2 or args[0] != "git":
+            return False
+        return args[1] == "worktree" or (args[1] == "branch" and "-D" in args)
+
+    def test_metadata_commands_never_run_concurrently(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        import threading
+        import time
+
+        from helix import worktree as worktree_module
+
+        repo_root = tmp_path / "project"
+        _make_repo(repo_root)
+        base_dir = tmp_path / "worktrees"
+        base_dir.mkdir()
+
+        parent = Candidate(
+            id="g0-s0",
+            worktree_path=str(repo_root),
+            branch_name="main",
+            generation=0,
+            parent_id=None,
+            parent_ids=[],
+            operation="seed",
+        )
+
+        probe = threading.Lock()
+        active = 0
+        max_active = 0
+        real_run = worktree_module.subprocess.run
+
+        def instrumented_run(args, *a, **kw):  # type: ignore[no-untyped-def]
+            nonlocal active, max_active
+            if not self._is_metadata_command(args):
+                return real_run(args, *a, **kw)
+            with probe:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                # Widen the window so an unserialised implementation is
+                # observed deterministically rather than probabilistically.
+                time.sleep(0.02)
+                return real_run(args, *a, **kw)
+            finally:
+                with probe:
+                    active -= 1
+
+        monkeypatch.setattr(worktree_module.subprocess, "run", instrumented_run)
+
+        errors: list[BaseException] = []
+
+        def churn(index: int) -> None:
+            try:
+                child = clone_candidate(parent, f"g1-s{index}", base_dir)
+                remove_worktree(child)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=churn, args=(i,)) for i in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert not errors, f"concurrent worktree churn failed: {errors!r}"
+        assert max_active == 1, (
+            "git worktree common-metadata commands ran concurrently "
+            f"(peak={max_active}); they must be serialised"
+        )


### PR DESCRIPTION
## The bug

`git worktree add` walks every entry under `.git/worktrees/` while registering a new one, and `git worktree remove` deletes those entries. Run concurrently against one common repository they race:

```
fatal: failed to read .git/worktrees/g25-s2/commondir
```

That is an `add` for one candidate dying because a *different* candidate's admin entry was unlinked mid-scan. `git worktree prune` and `git branch -D` touch the same shared metadata.

HELIX creates and removes candidate worktrees from its mutation and evaluation worker pools, so this is reachable in any run where `evolution.max_workers` and `num_parallel_proposals` put more than one candidate in flight. The failure surfaces as a `GitError` that drops a proposal slot for the generation.

## Reproduction

Against `main`, 16 concurrent clone+remove workers over 40 rounds:

| | failures / 640 ops |
|---|---|
| `main` | **5 (~0.8%)** |
| this branch | **0** |

At 8 workers it did not reproduce, which is why this has gone unnoticed — it needs enough concurrency for an `add` scan to overlap a `remove`.

## The fix

Guard prune+add and remove+branch-delete with a process-wide re-entrant lock, so each common-metadata transaction is atomic within the process. Re-entrant because a single transaction issues several git calls.

Nothing else changes: the large line count in `worktree.py` is indentation from wrapping existing blocks in `with`. `git diff -w` shows only the lock, the four `with` statements, and comments.

## Test

`TestConcurrentWorktreeMetadata` instruments `subprocess.run` and asserts no two git worktree/branch commands are ever in flight at once. It reports peak concurrency **4 without the fix** and **1 with it**, so it fails on `main` and passes here — no reliance on winning a race.

## Validation

- `pytest tests/unit/` — 868 passed
- `mypy --strict src/helix/worktree.py` — clean
- 640-operation concurrency stress: 0 failures (5 on `main`)
