### PR TITLE
fix(mutator): clean up failed mutations and isolate sandboxed opencode

### DIFF
--- a/src/helix/exceptions.py
+++ b/src/helix/exceptions.py
@@ -114,10 +114,10 @@ class RateLimitError(HelixError):
     logging the failure and returning ``None`` for that proposal slot rather
     than crashing the entire run.
 
-    Detected heuristically from non-zero exit codes or JSON error fields that
-    contain keywords such as "rate limit", "overloaded", "529", "usage limit",
-    or "extra usage".  After retries are exhausted the error bubbles up to the
-    evolution loop, which logs it and continues with a smaller proposal set.
+    Classified first from structured backend status fields, with a narrowly
+    scoped text fallback only when no structured signal is available. After
+    retries are exhausted the error bubbles up to the evolution loop, which
+    logs it and continues with a smaller proposal set.
     """
 
 

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -345,6 +345,23 @@ def run_evaluator(
             error_ctx,
         )
 
+    # Docker reserves exit 125 for failures before the container command
+    # starts (daemon, image, or invocation errors).  A structured-result
+    # parser cannot add useful information here and would otherwise hide the
+    # actual Docker diagnostic behind "no HELIX_RESULT= line".
+    if returncode == 125:
+        raise EvaluatorError(
+            "Evaluator Docker invocation failed before the evaluator started.",
+            operation="run_evaluator",
+            phase="docker invocation",
+            command=evaluator.command,
+            cwd=str(candidate.worktree_path),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
+            suggestion="Check the Docker diagnostic in stderr above.",
+        )
+
     # Collect ASI
     asi = _collect_asi(
         stdout,

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -719,6 +719,42 @@ def _write_mutation_prompt_artifact(worktree_path: str, prompt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# OpenCode credential files, which sit beside the session database inside the
+# opencode data directory.  These must survive per-candidate XDG_DATA_HOME
+# isolation; the database deliberately must not.
+OPENCODE_CREDENTIAL_FILES = ("auth.json", "account.json")
+
+
+def opencode_source_data_dir() -> Path:
+    """Return the user's real opencode data directory."""
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return base / "opencode"
+
+
+def _link_opencode_credentials(target_dir: Path) -> None:
+    """Make the user's opencode credentials visible inside *target_dir*.
+
+    Symlinks rather than copies, so no credential bytes are written into the
+    candidate worktree.  Missing credentials are not an error here: opencode
+    may be authenticated by environment variable instead, and a genuine auth
+    failure surfaces from the CLI with a far better message than anything this
+    helper could invent.
+    """
+    source_dir = opencode_source_data_dir()
+    for name in OPENCODE_CREDENTIAL_FILES:
+        source = source_dir / name
+        destination = target_dir / name
+        if not source.exists() or destination.exists():
+            continue
+        try:
+            destination.symlink_to(source)
+        except OSError:
+            # Filesystems without symlink support (or a race with a sibling
+            # worker) must not abort the mutation.
+            continue
+
+
 def _add_backend_auth_env(env: dict[str, str], backend: str) -> None:
     """Pass official headless auth env vars without requiring TOML config."""
     for key in BACKEND_AUTH_ENV.get(backend, ()):
@@ -769,9 +805,7 @@ def _build_backend_args(
             # is valid TOML basic-string syntax for all printable ASCII — safe
             # for any realistic effort value.  See ``codex exec --help`` for
             # the full ``-c`` interface.
-            args.extend(
-                ["-c", f"model_reasoning_effort={json.dumps(config.effort)}"]
-            )
+            args.extend(["-c", f"model_reasoning_effort={json.dumps(config.effort)}"])
         args.append(_prompt_file_instruction(prompt_artifact_name))
         return args
 
@@ -1602,11 +1636,24 @@ def invoke_claude_code(
         # same opencode.db and hit the identical WAL contention, one layer down.
         # Redirect to the per-candidate ``/workspace`` mount instead; direct
         # subprocesses use the equivalent directory in their real worktree.
+        #
+        # Redirecting XDG_DATA_HOME also moves opencode's *credential* files,
+        # which live in the same directory as the database.  An isolated state
+        # dir therefore starts unauthenticated, and the CLI then fails with an
+        # opaque provider-side error rather than an auth error.  Link the
+        # credentials back in so only the database is per-candidate.
         if sandbox is not None and sandbox.enabled:
             backend_env["XDG_DATA_HOME"] = "/workspace/.helix_opencode_state"
+            # NOTE: the container path is not linked here.  Its credentials live
+            # in the auth volume at ``/home/node/.local/share/opencode`` and are
+            # only reachable from inside the container, so the equivalent link
+            # has to be made there.  This is untested: it needs a running Docker
+            # daemon, which was unavailable when this was written.
         else:
             opencode_state_dir = Path(worktree_path) / ".helix_opencode_state"
-            opencode_state_dir.mkdir(parents=True, exist_ok=True)
+            opencode_data_dir = opencode_state_dir / "opencode"
+            opencode_data_dir.mkdir(parents=True, exist_ok=True)
+            _link_opencode_credentials(opencode_data_dir)
             backend_env["XDG_DATA_HOME"] = str(opencode_state_dir)
     if sandbox is not None and sandbox.enabled:
         sandbox_image = resolve_sandbox_image(sandbox, backend)

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shlex
 import subprocess
+import threading
 from pathlib import Path
 from typing import Any, Callable
 
@@ -577,32 +579,36 @@ def build_mutation_prompt(
 # Rate-limit detection
 # ---------------------------------------------------------------------------
 
-_RATE_LIMIT_KEYWORDS = [
-    "rate limit",
-    "rate-limit",
-    "ratelimit",
-    "overloaded",
-    "529",
-    "usage limit",
-    "extra usage",
-    "quota",
+_RATE_LIMIT_PATTERNS = (
+    re.compile(r"\brate(?:[ -]?limit)\b", re.IGNORECASE),
+    re.compile(r"\boverloaded\b", re.IGNORECASE),
+    re.compile(r"\b529\b"),
+    re.compile(r"\busage limit\b", re.IGNORECASE),
+    re.compile(r"\bextra usage\b", re.IGNORECASE),
+    # A bare ``quota`` appears in unrelated configuration errors (for example,
+    # "quota field missing").  Require language that actually says the quota
+    # has been consumed before classifying it as a retryable rate limit.
+    re.compile(
+        r"\bquota(?:\s+has)?(?:\s+been)?\s+"
+        r"(?:exceeded|exhausted|reached|depleted|limit(?:ed)?)\b",
+        re.IGNORECASE,
+    ),
     # 429 is the canonical rate-limit status and several CLIs report only the
     # numeric code, with no prose an operator could match on.
-    "429",
-    "too many requests",
-]
+    re.compile(r"\b429\b"),
+    re.compile(r"\btoo many requests\b", re.IGNORECASE),
+)
 
 
 def _looks_like_rate_limit(text: str) -> bool:
     """Return True if *text* contains a rate-limit / overload signal.
 
-    Detection stays keyword-based and additive: an unrecognised backend error
-    must fall through to the generic unknown-failure path with its own message
+    Detection stays deliberately narrow: an unrecognised backend error must
+    fall through to the generic unknown-failure path with its own message
     preserved, rather than being reported as a quota problem the operator
     cannot act on.
     """
-    lower = text.lower()
-    return any(kw in lower for kw in _RATE_LIMIT_KEYWORDS)
+    return any(pattern.search(text) for pattern in _RATE_LIMIT_PATTERNS)
 
 
 # ---------------------------------------------------------------------------
@@ -744,6 +750,7 @@ OPENCODE_PERMISSION_FLAGS = ("--auto", "--dangerously-skip-permissions")
 OPENCODE_PERMISSION_FLAG_FALLBACK = "--auto"
 
 _opencode_permission_flag_cache: str | None = None
+_opencode_permission_flag_lock = threading.Lock()
 
 
 def opencode_permission_flag(*, refresh: bool = False) -> str:
@@ -758,33 +765,43 @@ def opencode_permission_flag(*, refresh: bool = False) -> str:
     if _opencode_permission_flag_cache is not None and not refresh:
         return _opencode_permission_flag_cache
 
-    help_text = ""
-    try:
-        completed = subprocess.run(
-            ["opencode", "run", "--help"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        help_text = f"{completed.stdout}\n{completed.stderr}"
-    except (OSError, subprocess.SubprocessError):
+    # Proposal workers are threads.  Check again while holding the lock so
+    # simultaneous first mutations share one capability probe instead of each
+    # starting its own subprocess.
+    with _opencode_permission_flag_lock:
+        if _opencode_permission_flag_cache is not None and not refresh:
+            return _opencode_permission_flag_cache
+
         help_text = ""
-
-    chosen = OPENCODE_PERMISSION_FLAG_FALLBACK
-    for flag in OPENCODE_PERMISSION_FLAGS:
-        if flag in help_text:
-            chosen = flag
-            break
-    else:
-        if help_text:
-            logger.warning(
-                "opencode run --help advertised no known permission flag; "
-                "falling back to %s",
-                chosen,
+        try:
+            completed = subprocess.run(
+                ["opencode", "run", "--help"],
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
+            help_text = f"{completed.stdout}\n{completed.stderr}"
+        except (OSError, subprocess.SubprocessError):
+            help_text = ""
 
-    _opencode_permission_flag_cache = chosen
-    return chosen
+        chosen = OPENCODE_PERMISSION_FLAG_FALLBACK
+        for flag in OPENCODE_PERMISSION_FLAGS:
+            # Avoid accepting lookalikes such as ``--auto-continue`` as the
+            # permission flag.  Help output need only advertise the exact CLI
+            # option, not merely contain the flag's spelling as a substring.
+            if re.search(rf"(?<![\w-]){re.escape(flag)}(?![\w-])", help_text):
+                chosen = flag
+                break
+        else:
+            if help_text:
+                logger.warning(
+                    "opencode run --help advertised no known permission flag; "
+                    "falling back to %s",
+                    chosen,
+                )
+
+        _opencode_permission_flag_cache = chosen
+        return chosen
 
 
 # OpenCode credential files, which sit beside the session database inside the

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -580,9 +580,22 @@ def build_mutation_prompt(
 # ---------------------------------------------------------------------------
 
 _RATE_LIMIT_PATTERNS = (
-    re.compile(r"\brate(?:[ -]?limit)\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:exceeded|hit|reached|exhausted)\s+(?:your\s+)?"
+        r"(?:a\s+)?rate(?:[ -]?limit)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\brate(?:[ -]?limit)\s+(?:has\s+been\s+)?"
+        r"(?:exceeded|hit|reached|exhausted)\b",
+        re.IGNORECASE,
+    ),
     re.compile(r"\boverloaded\b", re.IGNORECASE),
-    re.compile(r"\b529\b"),
+    # 529 means overloaded only in an HTTP status context.  A bare number can
+    # occur inside a session id (for example, a UUID) and must not discard a
+    # completed mutation.
+    re.compile(r"\bHTTP\s+529\b", re.IGNORECASE),
+    re.compile(r"(?<![\w-])529(?![\w-])\s+(?:server\s+)?overloaded\b", re.IGNORECASE),
     re.compile(r"\busage limit\b", re.IGNORECASE),
     re.compile(r"\bextra usage\b", re.IGNORECASE),
     # A bare ``quota`` appears in unrelated configuration errors (for example,
@@ -593,11 +606,12 @@ _RATE_LIMIT_PATTERNS = (
         r"(?:exceeded|exhausted|reached|depleted|limit(?:ed)?)\b",
         re.IGNORECASE,
     ),
-    # 429 is the canonical rate-limit status and several CLIs report only the
-    # numeric code, with no prose an operator could match on.
-    re.compile(r"\b429\b"),
+    # 429 is canonical, but require it to be its own status token rather than
+    # a hyphen-delimited fragment of an identifier.
+    re.compile(r"(?<![\w-])429(?![\w-])"),
     re.compile(r"\btoo many requests\b", re.IGNORECASE),
 )
+_CONFIGURATION_ERROR_PATTERN = re.compile(r"\b(?:configuration|config) error\b", re.IGNORECASE)
 
 
 def _looks_like_rate_limit(text: str) -> bool:
@@ -608,7 +622,34 @@ def _looks_like_rate_limit(text: str) -> bool:
     preserved, rather than being reported as a quota problem the operator
     cannot act on.
     """
+    # Do not turn invalid local configuration into retryable operator advice.
+    # Structured status fields, when present, are handled by the caller first.
+    if _CONFIGURATION_ERROR_PATTERN.search(text):
+        return False
     return any(pattern.search(text) for pattern in _RATE_LIMIT_PATTERNS)
+
+
+def _api_error_status(parsed: dict[str, Any]) -> int | None:
+    """Return a backend envelope's API status when it is an integer."""
+    value = parsed.get("api_error_status")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _has_structured_failure_signal(parsed: dict[str, Any]) -> bool:
+    """Whether *parsed* contains an unambiguous backend failure field."""
+    return isinstance(parsed.get("subtype"), str) or _api_error_status(parsed) is not None
+
+
+def _backend_error_text(parsed: dict[str, Any]) -> str:
+    """Return the backend's designated error message, if available."""
+    value = parsed.get("error")
+    return value if isinstance(value, str) else ""
 
 
 # ---------------------------------------------------------------------------
@@ -1795,8 +1836,25 @@ def invoke_claude_code(
             )
             usage = _normalise_usage_stats(parsed)
             if backend == "claude":
+                if _api_error_status(parsed) == 429:
+                    raise RateLimitError(
+                        f"{backend_name} hit a rate/usage limit (HTTP 429)",
+                        operation=f"{backend_name} invocation",
+                        phase="structured backend result",
+                        command=cmd_str,
+                        cwd=str(worktree_path),
+                        stdout=result.stdout,
+                        stderr=result.stderr,
+                        exit_code=result.returncode,
+                        suggestion=(
+                            f"{backend_name} reported a rate limit. "
+                            "Retry after backoff or check your API quota."
+                        ),
+                    )
                 error_text = str(parsed.get("error", ""))
-                if _looks_like_rate_limit(error_text):
+                if not _has_structured_failure_signal(parsed) and _looks_like_rate_limit(
+                    error_text
+                ):
                     logger.error(
                         "Rate limit detected in JSON response: %s", error_text[:200]
                     )
@@ -1816,31 +1874,9 @@ def invoke_claude_code(
                     )
             return parsed, usage
 
-        rate_limit_source = result.stderr or result.stdout
-        if _looks_like_rate_limit(rate_limit_source):
-            logger.error(
-                "Rate limit detected in subprocess exit for %s (code %d): %s",
-                backend_name,
-                result.returncode,
-                rate_limit_source[:200],
-            )
-            raise RateLimitError(
-                f"{backend_name} hit a rate/usage limit (exit code {result.returncode})",
-                operation=f"{backend_name} invocation",
-                phase="subprocess exit",
-                command=cmd_str,
-                cwd=str(worktree_path),
-                stdout=result.stdout,
-                stderr=result.stderr,
-                exit_code=result.returncode,
-                suggestion=(
-                    f"{backend_name} reported a rate limit. "
-                    "Retry after backoff or check your quota."
-                ),
-            )
-
-        # Claude's max-turns exhaustion is intentionally treated as partial
-        # success because the subprocess may have already produced useful edits.
+        # Claude writes a structured result envelope even for many non-zero
+        # exits.  Classify that envelope before inspecting raw output: a UUID
+        # or transcript fragment must never pre-empt a real max-turns result.
         if backend == "claude":
             try:
                 parsed = _parse_backend_output(
@@ -1856,15 +1892,87 @@ def invoke_claude_code(
                         parsed.get("num_turns", "?"),
                     )
                     return parsed, usage
+
+                if _api_error_status(parsed) == 429:
+                    raise RateLimitError(
+                        f"{backend_name} hit a rate/usage limit (HTTP 429)",
+                        operation=f"{backend_name} invocation",
+                        phase="structured backend result",
+                        command=cmd_str,
+                        cwd=str(worktree_path),
+                        stdout=result.stdout,
+                        stderr=result.stderr,
+                        exit_code=result.returncode,
+                        suggestion=(
+                            f"{backend_name} reported a rate limit. "
+                            "Retry after backoff or check your quota."
+                        ),
+                    )
+
+                # The error field is a bounded fallback only when the envelope
+                # supplies no classifying field.  Do not search session ids or
+                # unrelated JSON fields in a valid structured result.
+                if not _has_structured_failure_signal(parsed) and _looks_like_rate_limit(
+                    _backend_error_text(parsed)
+                ):
+                    raise RateLimitError(
+                        f"{backend_name} hit a rate/usage limit (exit code {result.returncode})",
+                        operation=f"{backend_name} invocation",
+                        phase="structured backend result fallback",
+                        command=cmd_str,
+                        cwd=str(worktree_path),
+                        stdout=result.stdout,
+                        stderr=result.stderr,
+                        exit_code=result.returncode,
+                        suggestion=(
+                            f"{backend_name} reported a rate limit. "
+                            "Retry after backoff or check your quota."
+                        ),
+                    )
+            except RateLimitError:
+                raise
             except MutationError:
                 parsed = None
 
-        parsed = _parse_backend_output(
-            backend,
-            result,
-            cmd_str=cmd_str,
-            worktree_path=worktree_path,
+        # No structured signal was available.  Search both streams so an HTTP
+        # status on stdout is not hidden by an unrelated stderr warning.  This
+        # is deliberately last-resort and retains both streams on the error.
+        rate_limit_source = "\n".join(
+            stream for stream in (result.stdout, result.stderr) if stream
         )
+        use_raw_rate_limit_fallback = parsed is None or (
+            not _has_structured_failure_signal(parsed)
+            and not _backend_error_text(parsed)
+        )
+        if use_raw_rate_limit_fallback and _looks_like_rate_limit(rate_limit_source):
+            logger.error(
+                "Rate limit detected in subprocess exit for %s (code %d): %s",
+                backend_name,
+                result.returncode,
+                rate_limit_source[:200],
+            )
+            raise RateLimitError(
+                f"{backend_name} hit a rate/usage limit (exit code {result.returncode})",
+                operation=f"{backend_name} invocation",
+                phase="subprocess exit fallback",
+                command=cmd_str,
+                cwd=str(worktree_path),
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.returncode,
+                suggestion=(
+                    f"{backend_name} reported a rate limit. "
+                    "Retry after backoff or check your quota."
+                ),
+            )
+
+        if parsed is None:
+            parsed = _parse_backend_output(
+                backend,
+                result,
+                cmd_str=cmd_str,
+                worktree_path=worktree_path,
+            )
         usage = _normalise_usage_stats(parsed)
 
         raise MutationError(

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -811,7 +811,11 @@ def _build_backend_args(
             "run",
             "--format",
             "json",
-            "--dangerously-skip-permissions",
+            # OpenCode 1.18+ uses --auto for non-interactive permission
+            # approval.  The prior --dangerously-skip-permissions flag is
+            # not accepted by the currently supported CLI, which exits
+            # before doing any work.
+            "--auto",
         ]
         if config.model:
             args.extend(["--model", config.model])

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from helix.backends import BACKEND_AUTH_ENV, backend_display_name
-from helix.display import UsageStats
+from helix.display import UsageStats, print_warning
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, SandboxConfig
 from helix.exceptions import (
@@ -1573,7 +1573,7 @@ def invoke_claude_code(
     _add_backend_auth_env(backend_env, backend)
     if backend == "gemini":
         backend_env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"
-    if backend == "opencode" and (sandbox is None or not sandbox.enabled):
+    if backend == "opencode":
         # Per-candidate SQLite isolation for concurrent opencode subprocesses.
         #
         # OpenCode stores its session database at:
@@ -1587,16 +1587,23 @@ def invoke_claude_code(
         #   "Failed to run the query 'PRAGMA journal_mode = WAL'"
         # (observed in PR #34 E2E re-verify: g1-s1 lost to this error while g1-s2 succeeded).
         #
-        # Fix: set XDG_DATA_HOME to a per-candidate directory.  OpenCode respects
-        # XDG_DATA_HOME and will create an isolated database at:
-        #   <worktree>/.helix_opencode_state/opencode/opencode.db
-        # Each parallel worker gets its own fresh database; no contention.
+        # Fix: point XDG_DATA_HOME at storage owned by this candidate.  OpenCode
+        # respects XDG_DATA_HOME and creates its database below ``opencode/``.
         #
-        # The sandbox branch is excluded: container isolation already provides
-        # per-candidate filesystem separation, so XDG_DATA_HOME would be redundant.
-        opencode_state_dir = Path(worktree_path) / ".helix_opencode_state"
-        opencode_state_dir.mkdir(parents=True, exist_ok=True)
-        backend_env["XDG_DATA_HOME"] = str(opencode_state_dir)
+        # This applies to sandboxed runs too.  Containers do NOT isolate the
+        # backend's home directory: ``sandbox._docker_args`` mounts the single
+        # named auth volume ``helix-auth-<backend>`` at ``/home/node:rw`` and sets
+        # ``HOME=/home/node``, so every concurrent candidate container shares one
+        # writable ``~/.local/share``.  Without XDG_DATA_HOME they all open the
+        # same opencode.db and hit the identical WAL contention, one layer down.
+        # Redirect to the per-candidate ``/workspace`` mount instead; direct
+        # subprocesses use the equivalent directory in their real worktree.
+        if sandbox is not None and sandbox.enabled:
+            backend_env["XDG_DATA_HOME"] = "/workspace/.helix_opencode_state"
+        else:
+            opencode_state_dir = Path(worktree_path) / ".helix_opencode_state"
+            opencode_state_dir.mkdir(parents=True, exist_ok=True)
+            backend_env["XDG_DATA_HOME"] = str(opencode_state_dir)
     if sandbox is not None and sandbox.enabled:
         sandbox_image = resolve_sandbox_image(sandbox, backend)
         result = run_sandboxed_command(
@@ -1728,6 +1735,26 @@ def invoke_claude_code(
 # ---------------------------------------------------------------------------
 
 
+def _remove_failed_mutation_worktree(
+    child: Candidate,
+    new_id: str,
+    cause: BaseException,
+) -> None:
+    """Drop a failed mutation's worktree, surfacing any cleanup failure.
+
+    Swallowing the cleanup error would make a leaked worktree indistinguishable
+    from one that was never created, and would leave a stale ``helix/<id>``
+    branch behind that the next run's stale-branch guard aborts on.
+    """
+    try:
+        remove_worktree(child)
+    except Exception as cleanup_exc:
+        print_warning(
+            f"Could not remove failed mutation worktree {new_id} after "
+            f"{type(cause).__name__}: {cleanup_exc}"
+        )
+
+
 def mutate(
     parent: Candidate,
     eval_result: EvalResult,
@@ -1762,28 +1789,35 @@ def mutate(
     Candidate | None
         The new candidate on success, or ``None`` if mutation failed.
     """
+    # ``clone_candidate`` has already created a live worktree and branch, so
+    # every subsequent step runs under the cleanup handlers below.  Worktree
+    # preparation and prompt-artifact writing touch the filesystem and can fail
+    # on their own; before this was guarded, any failure between the clone and
+    # the backend call leaked the worktree and its ``helix/<id>`` branch.
     child = clone_candidate(parent, new_id, base_dir)
-    child.operation = "mutate"
-    if prepare_worktree is not None:
-        prepare_worktree(child)
-
-    prompt = build_mutation_prompt(
-        config.objective,
-        eval_result,
-        background,
-        config.agent.max_turns,
-    )
-
-    # Persist the rendered prompt to the worktree for post-hoc inspection:
-    # what did the mutator actually see on this generation?  Sits next to
-    # ``helix_batch.json`` in the worktree root.  The leading dot and the
-    # per-worktree ``.gitignore`` entry (see ``_ignore_helix_artifacts``)
-    # keep it out of the candidate git tree — otherwise it'd leak into
-    # every subsequent mutation's diff and the mutator would see its own
-    # prior prompt file as part of the codebase.
-    prompt_artifact_name = _write_mutation_prompt_artifact(child.worktree_path, prompt)
-
     try:
+        child.operation = "mutate"
+        if prepare_worktree is not None:
+            prepare_worktree(child)
+
+        prompt = build_mutation_prompt(
+            config.objective,
+            eval_result,
+            background,
+            config.agent.max_turns,
+        )
+
+        # Persist the rendered prompt to the worktree for post-hoc inspection:
+        # what did the mutator actually see on this generation?  Sits next to
+        # ``helix_batch.json`` in the worktree root.  The leading dot and the
+        # per-worktree ``.gitignore`` entry (see ``_ignore_helix_artifacts``)
+        # keep it out of the candidate git tree — otherwise it'd leak into
+        # every subsequent mutation's diff and the mutator would see its own
+        # prior prompt file as part of the codebase.
+        prompt_artifact_name = _write_mutation_prompt_artifact(
+            child.worktree_path, prompt
+        )
+
         _, usage = invoke_claude_code(
             child.worktree_path,
             prompt,
@@ -1797,19 +1831,16 @@ def mutate(
     except MutationError as exc:
         exc.operation = f"mutate {new_id} (parent: {parent.id})"
         print_helix_error(exc)
-        try:
-            remove_worktree(child)
-        except Exception:
-            pass
+        _remove_failed_mutation_worktree(child, new_id, exc)
         return None
-    except RateLimitError:
-        # Rate limit — clean up orphaned worktree, then re-raise so the parallel
-        # futures handler in evolution.py can log it and continue with a smaller
-        # proposal set.
-        try:
-            remove_worktree(child)
-        except Exception:
-            pass
+    except Exception as exc:
+        # Rate limits and any other failure (git, filesystem, evaluator-manifest
+        # refresh, an unexpected backend error) propagate to the caller so it can
+        # decide whether the run continues — but never leave this worktree
+        # orphaned first.  Previously only RateLimitError was cleaned up, so an
+        # unexpected exception leaked the worktree and left a stale
+        # ``helix/<id>`` branch that trips the next run's stale-branch guard.
+        _remove_failed_mutation_worktree(child, new_id, exc)
         raise
 
     # NOTE: snapshot_candidate() is intentionally NOT called here.

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -579,15 +579,28 @@ def build_mutation_prompt(
 
 _RATE_LIMIT_KEYWORDS = [
     "rate limit",
+    "rate-limit",
+    "ratelimit",
     "overloaded",
     "529",
     "usage limit",
     "extra usage",
+    "quota",
+    # 429 is the canonical rate-limit status and several CLIs report only the
+    # numeric code, with no prose an operator could match on.
+    "429",
+    "too many requests",
 ]
 
 
 def _looks_like_rate_limit(text: str) -> bool:
-    """Return True if *text* contains a rate-limit / overload keyword."""
+    """Return True if *text* contains a rate-limit / overload signal.
+
+    Detection stays keyword-based and additive: an unrecognised backend error
+    must fall through to the generic unknown-failure path with its own message
+    preserved, rather than being reported as a quota problem the operator
+    cannot act on.
+    """
     lower = text.lower()
     return any(kw in lower for kw in _RATE_LIMIT_KEYWORDS)
 
@@ -719,6 +732,61 @@ def _write_mutation_prompt_artifact(worktree_path: str, prompt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Non-interactive permission flags accepted by opencode, newest first.
+# 1.18+ renamed --dangerously-skip-permissions to --auto; passing the wrong one
+# makes the CLI exit before doing any work, so the supported flag is probed
+# from `opencode run --help` rather than assumed from a version string.
+OPENCODE_PERMISSION_FLAGS = ("--auto", "--dangerously-skip-permissions")
+
+# Used when the probe cannot run at all (opencode not installed yet, --help
+# failed).  Dispatch then fails with the CLI's own error, which is clearer
+# than anything a guess here would produce.
+OPENCODE_PERMISSION_FLAG_FALLBACK = "--auto"
+
+_opencode_permission_flag_cache: str | None = None
+
+
+def opencode_permission_flag(*, refresh: bool = False) -> str:
+    """Return the non-interactive permission flag this opencode build accepts.
+
+    Probes ``opencode run --help`` once per process and caches the answer, so
+    a P×N batch does not pay for a probe per mutation.  Both the pre-1.18 and
+    1.18+ spellings are supported; whichever the installed CLI advertises is
+    the one that gets passed.
+    """
+    global _opencode_permission_flag_cache
+    if _opencode_permission_flag_cache is not None and not refresh:
+        return _opencode_permission_flag_cache
+
+    help_text = ""
+    try:
+        completed = subprocess.run(
+            ["opencode", "run", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        help_text = f"{completed.stdout}\n{completed.stderr}"
+    except (OSError, subprocess.SubprocessError):
+        help_text = ""
+
+    chosen = OPENCODE_PERMISSION_FLAG_FALLBACK
+    for flag in OPENCODE_PERMISSION_FLAGS:
+        if flag in help_text:
+            chosen = flag
+            break
+    else:
+        if help_text:
+            logger.warning(
+                "opencode run --help advertised no known permission flag; "
+                "falling back to %s",
+                chosen,
+            )
+
+    _opencode_permission_flag_cache = chosen
+    return chosen
+
+
 # OpenCode credential files, which sit beside the session database inside the
 # opencode data directory.  These must survive per-candidate XDG_DATA_HOME
 # isolation; the database deliberately must not.
@@ -845,11 +913,7 @@ def _build_backend_args(
             "run",
             "--format",
             "json",
-            # OpenCode 1.18+ uses --auto for non-interactive permission
-            # approval.  The prior --dangerously-skip-permissions flag is
-            # not accepted by the currently supported CLI, which exits
-            # before doing any work.
-            "--auto",
+            opencode_permission_flag(),
         ]
         if config.model:
             args.extend(["--model", config.model])
@@ -911,6 +975,23 @@ def _parse_json_object_output(
     return parsed
 
 
+def _try_parse_single_json_object(stdout: str) -> dict[str, Any] | None:
+    """Return *stdout* parsed as one JSON object, or None if it is not one.
+
+    Only a multi-line document is worth this attempt: a single-line object is
+    already handled by the per-line path, and treating every one-line stream
+    as a candidate here would mask genuine JSONL parsing.
+    """
+    text = stdout.strip()
+    if not text or "\n" not in text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def _parse_jsonl_output(
     stdout: str,
     *,
@@ -921,6 +1002,16 @@ def _parse_jsonl_output(
     exit_code: int,
     strict: bool,
 ) -> dict[str, Any]:
+    # Backwards compatibility: opencode 1.18+ emits one JSON object per line,
+    # but older builds emitted a single pretty-printed object spanning several
+    # lines.  That document parses as a whole and not per line, so try it
+    # before treating the stream as broken.  This is additive only: a stream
+    # that is neither valid JSONL nor a valid JSON object still fails loudly
+    # below.
+    single_object = _try_parse_single_json_object(stdout)
+    if single_object is not None:
+        return {"events": [single_object], "unparsable_lines": []}
+
     events: list[dict[str, Any]] = []
     unparsable: list[str] = []
     for raw_line in stdout.splitlines():

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -199,8 +199,19 @@ def test_backend_usage_parsing_charges_llm_budget(
     # Guard against future refactors that bypass ``_build_backend_args`` or
     # leave ``_MUTATOR_OVERRIDE`` set globally — the test must observe the
     # real backend dispatch, not a short-circuited override.
-    assert mock_run.call_count == 1
-    invoked_args = mock_run.call_args.args[0]
+    #
+    # Capability probes (e.g. opencode's ``run --help`` permission-flag probe)
+    # also go through ``subprocess.run``, so count dispatches rather than all
+    # calls; there must still be exactly one actual backend invocation.
+    dispatches = [
+        call.args[0]
+        for call in mock_run.call_args_list
+        if call.args
+        and call.args[0][0] == _BACKEND_EXECUTABLE[backend]
+        and "--help" not in call.args[0]
+    ]
+    assert len(dispatches) == 1
+    invoked_args = dispatches[0]
     assert invoked_args[0] == _BACKEND_EXECUTABLE[backend]
 
     budget.charge_llm_usage(

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import sys
 from unittest.mock import MagicMock
 
+import pytest
 
 from helix.population import Candidate, EvalResult
 from helix.config import HelixConfig, EvaluatorConfig
+from helix.exceptions import EvaluatorError
 from helix.executor import run_evaluator
 
 
@@ -93,6 +95,22 @@ class TestRunEvaluatorSuccess:
         result = run_evaluator(candidate, config)
 
         assert result.scores["success"] == 0.0
+
+    def test_docker_exit_125_surfaces_docker_diagnostic(self, tmp_path, mocker):
+        mocker.patch(
+            "helix.executor.subprocess.run",
+            return_value=MagicMock(
+                stdout="", stderr="docker: Error response from daemon: image unavailable", returncode=125
+            ),
+        )
+        candidate = make_candidate(str(tmp_path))
+        config = make_config(score_parser="helix_result")
+
+        with pytest.raises(EvaluatorError) as exc_info:
+            run_evaluator(candidate, config)
+        assert exc_info.value.phase == "docker invocation"
+        assert "image unavailable" in exc_info.value.stderr
+        assert "HELIX_RESULT" not in str(exc_info.value)
 
     def test_stdout_included_in_asi(self, mocker):
         mock_run = mocker.patch("helix.executor.subprocess.run")

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1897,6 +1897,46 @@ class TestOpenCodeSubprocessIsolation:
         # The database itself is still per-candidate, which is the whole point.
         assert not (isolated / "opencode.db").exists()
 
+    def test_opencode_credential_state_is_ignored_not_copied(
+        self, tmp_path: Path, mocker, monkeypatch
+    ):
+        """Credential symlinks cannot enter a candidate's committed diff."""
+        source = tmp_path / "real-xdg" / "opencode"
+        source.mkdir(parents=True)
+        secret = "credential-bytes-must-not-be-copied"
+        auth_source = source / "auth.json"
+        auth_source.write_text(secret)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "real-xdg"))
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=worktree, check=True)
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"result","sessionID":"ses_abc"}\n',
+            stderr="",
+            returncode=0,
+        )
+
+        invoke_claude_code(
+            str(worktree), "fix the bug", AgentConfig(backend="opencode")
+        )
+
+        auth_link = worktree / ".helix_opencode_state" / "opencode" / "auth.json"
+        assert auth_link.is_symlink()
+        assert auth_link.readlink() == auth_source
+        assert auth_link.lstat().st_size != len(secret)
+        assert ".helix_opencode_state/" in (worktree / ".gitignore").read_text()
+        # Check Git's actual ignore engine rather than only the .gitignore
+        # text: a candidate can never add the link (and its credential target)
+        # to a committed diff.
+        mocker.stop(mock_run)
+        ignored = subprocess.run(
+            ["git", "check-ignore", "-q", ".helix_opencode_state/opencode/auth.json"],
+            cwd=worktree,
+        )
+        assert ignored.returncode == 0
+
     def test_opencode_credential_linking_tolerates_missing_source(
         self, tmp_path: Path, mocker, monkeypatch
     ):
@@ -2024,6 +2064,7 @@ class TestOpenCodeSandboxedIsolation:
         self, tmp_path: Path, mocker
     ):
         run_sandboxed = mocker.patch("helix.mutator.run_sandboxed_command")
+        mocker.patch("helix.mutator.opencode_permission_flag", return_value="--auto")
         run_sandboxed.return_value = MagicMock(
             stdout='{"type":"result","sessionID":"ses_abc"}\n',
             stderr="",

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -90,7 +90,7 @@ class TestBuildMutationPrompt:
         er = make_eval_result(
             asi={
                 "stdout": (
-                    "HELIX_RESULT=[[1.0, {\"task_completed\": true}]]\n"
+                    'HELIX_RESULT=[[1.0, {"task_completed": true}]]\n'
                     "human fallback line\n"
                 ),
                 "stderr": "",
@@ -1499,7 +1499,8 @@ class TestCountCodexStdoutToolEvents:
 
         stdout = tmp_path / "stdout.jsonl"
         stdout.write_text(
-            json.dumps({"type": "thread.started", "thread_id": "abc"}) + "\n"
+            json.dumps({"type": "thread.started", "thread_id": "abc"})
+            + "\n"
             + json.dumps(
                 {
                     "type": "item.completed",
@@ -1537,8 +1538,10 @@ class TestCountCodexStdoutToolEvents:
 
         stdout = tmp_path / "stdout.jsonl"
         stdout.write_text(
-            json.dumps({"type": "thread.started"}) + "\n"
-            + json.dumps({"type": "turn.completed"}) + "\n"
+            json.dumps({"type": "thread.started"})
+            + "\n"
+            + json.dumps({"type": "turn.completed"})
+            + "\n"
         )
 
         count, names = _count_codex_stdout_tool_events(stdout)
@@ -1558,9 +1561,7 @@ class TestCountCodexStdoutToolEvents:
 class TestCountCursorStdoutToolEvents:
     """Tests for ``_count_cursor_stdout_tool_events``."""
 
-    def test_counts_only_started_events_not_completed(
-        self, tmp_path: Path
-    ) -> None:
+    def test_counts_only_started_events_not_completed(self, tmp_path: Path) -> None:
         from helix.mutator import _count_cursor_stdout_tool_events
 
         stdout = tmp_path / "stdout.jsonl"
@@ -1715,9 +1716,7 @@ class TestCountTranscriptToolEventsDispatcher:
         assert count == 0
         assert names == []
 
-    def test_missing_file_returns_zero_for_known_backend(
-        self, tmp_path: Path
-    ) -> None:
+    def test_missing_file_returns_zero_for_known_backend(self, tmp_path: Path) -> None:
         from helix.mutator import _count_transcript_tool_events
 
         count, names = _count_transcript_tool_events(
@@ -1753,9 +1752,7 @@ class TestCountTranscriptToolEventsDispatcher:
         from helix.mutator import _count_transcript_tool_events
 
         stdout = tmp_path / "stdout.jsonl"
-        stdout.write_text(
-            json.dumps({"type": "tool_use", "tool_name": "grep"}) + "\n"
-        )
+        stdout.write_text(json.dumps({"type": "tool_use", "tool_name": "grep"}) + "\n")
 
         count, names = _count_transcript_tool_events(stdout, "gemini")
 
@@ -1776,7 +1773,9 @@ class TestTranscriptToolPatchesUsageInArtifact:
         )
 
         # Set up a fake transcript with 3 tool_use events
-        transcript_root = tmp_path / "claude-home" / ".claude" / "projects" / "-workspace"
+        transcript_root = (
+            tmp_path / "claude-home" / ".claude" / "projects" / "-workspace"
+        )
         transcript_root.mkdir(parents=True)
         (transcript_root / "sess_tool.jsonl").write_text(
             json.dumps(
@@ -1860,6 +1859,71 @@ class TestOpenCodeSubprocessIsolation:
             f"XDG_DATA_HOME={xdg!r} should be under the candidate worktree {tmp_path}"
         )
 
+    def test_opencode_credentials_survive_isolation(
+        self, tmp_path: Path, mocker, monkeypatch
+    ):
+        """Isolating XDG_DATA_HOME must not hide opencode's credentials.
+
+        The credential files live in the same directory as the session
+        database, so a bare redirect leaves the CLI unauthenticated and every
+        mutation fails with an opaque provider error.
+        """
+        source = tmp_path / "real-xdg" / "opencode"
+        source.mkdir(parents=True)
+        (source / "auth.json").write_text('{"openrouter": {"type": "api"}}')
+        (source / "account.json").write_text("{}")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "real-xdg"))
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"result","sessionID":"ses_abc"}\n',
+            stderr="",
+            returncode=0,
+        )
+
+        invoke_claude_code(
+            str(worktree), "fix the bug", AgentConfig(backend="opencode")
+        )
+
+        isolated = Path(mock_run.call_args[1]["env"]["XDG_DATA_HOME"]) / "opencode"
+        auth = isolated / "auth.json"
+        assert auth.exists(), "credentials must be reachable from the isolated dir"
+        assert json.loads(auth.read_text())["openrouter"]["type"] == "api"
+        # Linked, not copied: no credential bytes are written into the worktree.
+        assert auth.is_symlink()
+        # The database itself is still per-candidate, which is the whole point.
+        assert not (isolated / "opencode.db").exists()
+
+    def test_opencode_credential_linking_tolerates_missing_source(
+        self, tmp_path: Path, mocker, monkeypatch
+    ):
+        """A machine with no stored credentials must still dispatch.
+
+        opencode may be authenticated by environment variable instead, and a
+        real auth failure reports itself far better than a guess here would.
+        """
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "empty-xdg"))
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"result","sessionID":"ses_abc"}\n',
+            stderr="",
+            returncode=0,
+        )
+
+        invoke_claude_code(
+            str(worktree), "fix the bug", AgentConfig(backend="opencode")
+        )
+
+        isolated = Path(mock_run.call_args[1]["env"]["XDG_DATA_HOME"]) / "opencode"
+        assert isolated.is_dir()
+        assert not (isolated / "auth.json").exists()
+
     def test_opencode_subprocess_isolation_unique_per_candidate(
         self, tmp_path: Path, mocker
     ):
@@ -1897,13 +1961,16 @@ class TestOpenCodeSubprocessIsolation:
         )
 
         invoke_claude_code(
-            str(tmp_path), "prompt", AgentConfig(backend="opencode"),
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend="opencode"),
             passthrough_env=["PATH", "HOME"],
         )
 
         env = mock_run.call_args[1]["env"]
         # PATH and HOME are passed through from the parent process environment
         import os
+
         if "PATH" in os.environ:
             assert "PATH" in env, "PATH must survive the env scrub for opencode"
         if "HOME" in os.environ:
@@ -1919,9 +1986,7 @@ class TestOpenCodeSubprocessIsolation:
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
 
         for backend in ("claude", "codex", "cursor", "gemini"):
-            invoke_claude_code(
-                str(tmp_path), "prompt", AgentConfig(backend=backend)
-            )
+            invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend=backend))
             env = mock_run.call_args[1]["env"]
             assert "XDG_DATA_HOME" not in env, (
                 f"XDG_DATA_HOME must not be injected for {backend} backend"
@@ -1936,9 +2001,7 @@ class TestOpenCodeSubprocessIsolation:
             returncode=0,
         )
 
-        invoke_claude_code(
-            str(tmp_path), "prompt", AgentConfig(backend="opencode")
-        )
+        invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="opencode"))
 
         gitignore_path = tmp_path / ".gitignore"
         assert gitignore_path.exists(), ".gitignore must be created in the worktree"

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1045,7 +1045,7 @@ class TestInvokeClaudeCode:
             (
                 "opencode",
                 ["opencode", "run"],
-                ["--format", "json", "--dangerously-skip-permissions"],
+                ["--format", "json", "--auto"],
             ),
         ],
     )

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -1944,4 +1945,141 @@ class TestOpenCodeSubprocessIsolation:
         gitignore_text = gitignore_path.read_text()
         assert ".helix_opencode_state/" in gitignore_text, (
             ".helix_opencode_state/ must be gitignored to keep it out of candidate history"
+        )
+
+
+class TestOpenCodeSandboxedIsolation:
+    """Sandboxed opencode runs need XDG_DATA_HOME too.
+
+    Containers do not isolate the backend home directory: ``_docker_args``
+    mounts the single named auth volume ``helix-auth-<backend>`` at
+    ``/home/node:rw`` and sets ``HOME=/home/node``, so every concurrent
+    candidate container shares one writable ``~/.local/share``.
+    """
+
+    def test_sandboxed_opencode_gets_workspace_scoped_xdg_data_home(
+        self, tmp_path: Path, mocker
+    ):
+        run_sandboxed = mocker.patch("helix.mutator.run_sandboxed_command")
+        run_sandboxed.return_value = MagicMock(
+            stdout='{"type":"result","sessionID":"ses_abc"}\n',
+            stderr="",
+            returncode=0,
+        )
+
+        invoke_claude_code(
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend="opencode"),
+            sandbox=SandboxConfig(enabled=True),
+        )
+
+        env = run_sandboxed.call_args[1]["env"]
+        assert env.get("XDG_DATA_HOME") == "/workspace/.helix_opencode_state", (
+            "sandboxed opencode must get a candidate-scoped XDG_DATA_HOME; the "
+            "auth volume mounted at /home/node is shared across containers"
+        )
+
+
+class TestMutateWorktreeCleanup:
+    """``mutate`` must never leave a live worktree behind on failure.
+
+    ``clone_candidate`` creates a worktree and a ``helix/<id>`` branch before
+    anything can fail.  A leaked pair survives the run and trips the next
+    run's stale-branch guard.
+    """
+
+    @staticmethod
+    def _seed(tmp_path: Path) -> tuple[Candidate, Path]:
+        repo = tmp_path / "repo"
+        base = tmp_path / "worktrees"
+        repo.mkdir()
+        base.mkdir()
+        for args in (
+            ["git", "init", "-q", "-b", "main"],
+            ["git", "config", "user.email", "helix@test.local"],
+            ["git", "config", "user.name", "HELIX Test"],
+        ):
+            subprocess.run(args, cwd=repo, check=True, capture_output=True)
+        (repo / "f.txt").write_text("seed\n")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-qm", "seed"], cwd=repo, check=True, capture_output=True
+        )
+        parent = Candidate(
+            id="g0-s0",
+            worktree_path=str(repo),
+            branch_name="main",
+            generation=0,
+            parent_id=None,
+            parent_ids=[],
+            operation="seed",
+        )
+        return parent, base
+
+    @staticmethod
+    def _config() -> HelixConfig:
+        return HelixConfig(objective="obj", evaluator={"command": "true"})
+
+    @staticmethod
+    def _eval_result() -> EvalResult:
+        return EvalResult(
+            candidate_id="g0-s0", scores={}, asi={}, instance_scores={}
+        )
+
+    def test_unexpected_backend_error_removes_worktree_and_branch(
+        self, tmp_path: Path, mocker
+    ):
+        parent, base = self._seed(tmp_path)
+        mocker.patch(
+            "helix.mutator.invoke_claude_code",
+            side_effect=RuntimeError("backend crashed"),
+        )
+
+        with pytest.raises(RuntimeError):
+            mutate(
+                parent=parent,
+                eval_result=self._eval_result(),
+                new_id="g1-s1",
+                config=self._config(),
+                base_dir=base,
+                background=None,
+            )
+
+        assert not (base / "g1-s1").exists(), (
+            "mutate() leaked a worktree after an exception that is neither "
+            "MutationError nor RateLimitError"
+        )
+        branches = subprocess.run(
+            ["git", "branch", "--list", "helix/g1-s1"],
+            cwd=parent.worktree_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        assert branches.strip() == "", "mutate() leaked the helix/g1-s1 branch"
+
+    def test_prepare_worktree_failure_removes_worktree(
+        self, tmp_path: Path, mocker
+    ):
+        """Failures between the clone and the backend call must clean up too."""
+        parent, base = self._seed(tmp_path)
+        mocker.patch("helix.mutator.invoke_claude_code")
+
+        def explode(_candidate):
+            raise OSError("evaluator manifest refresh failed")
+
+        with pytest.raises(OSError):
+            mutate(
+                parent=parent,
+                eval_result=self._eval_result(),
+                new_id="g1-s2",
+                config=self._config(),
+                base_dir=base,
+                background=None,
+                prepare_worktree=explode,
+            )
+
+        assert not (base / "g1-s2").exists(), (
+            "mutate() leaked a worktree when prepare_worktree raised"
         )

--- a/tests/unit/test_opencode_compat.py
+++ b/tests/unit/test_opencode_compat.py
@@ -1,0 +1,161 @@
+"""Backwards-compatibility tests for the opencode backend.
+
+The opencode CLI changed its non-interactive permission flag and its
+structured-output shape between releases. HELIX must work against both the
+older and the newer builds rather than pinning either one.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+import helix.mutator as mutator
+from helix.exceptions import MutationError
+
+
+@pytest.fixture(autouse=True)
+def _clear_flag_cache():
+    mutator._opencode_permission_flag_cache = None
+    yield
+    mutator._opencode_permission_flag_cache = None
+
+
+def _help(text: str):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=text, stderr="")
+
+
+class TestPermissionFlagProbe:
+    def test_new_cli_gets_auto(self, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_help("  --auto  auto-approve permissions (dangerous!)"),
+        )
+        assert mutator.opencode_permission_flag() == "--auto"
+
+    def test_old_cli_keeps_legacy_flag(self, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_help("  --dangerously-skip-permissions  skip prompts"),
+        )
+        assert mutator.opencode_permission_flag() == "--dangerously-skip-permissions"
+
+    def test_probe_is_cached_across_calls(self, mocker):
+        run = mocker.patch("helix.mutator.subprocess.run", return_value=_help("--auto"))
+        for _ in range(5):
+            mutator.opencode_permission_flag()
+        assert run.call_count == 1, "a P×N batch must not re-probe per mutation"
+
+    def test_probe_failure_falls_back(self, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run", side_effect=FileNotFoundError("opencode")
+        )
+        assert (
+            mutator.opencode_permission_flag()
+            == mutator.OPENCODE_PERMISSION_FLAG_FALLBACK
+        )
+
+    def test_built_args_use_probed_flag(self, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_help("  --dangerously-skip-permissions  skip prompts"),
+        )
+        from helix.config import AgentConfig
+
+        args = mutator._build_backend_args(
+            "/tmp/wt", AgentConfig(backend="opencode"), "prompt.md"
+        )
+        assert "--dangerously-skip-permissions" in args
+        assert "--auto" not in args
+
+
+class TestOpenCodeOutputParsing:
+    def _parse(self, stdout: str, *, strict: bool = True):
+        return mutator._parse_jsonl_output(
+            stdout,
+            backend="opencode",
+            cmd_str="opencode run",
+            worktree_path="/tmp/wt",
+            stderr="",
+            exit_code=0,
+            strict=strict,
+        )
+
+    def test_jsonl_stream(self):
+        stdout = (
+            '{"type":"step_start"}\n'
+            '{"type":"tool_use","part":{"tool":"edit"}}\n'
+            '{"type":"step_finish"}\n'
+        )
+        result = self._parse(stdout)
+        assert [e["type"] for e in result["events"]] == [
+            "step_start",
+            "tool_use",
+            "step_finish",
+        ]
+        assert result["unparsable_lines"] == []
+
+    def test_blank_lines_are_skipped(self):
+        result = self._parse('\n{"type":"a"}\n\n\n{"type":"b"}\n\n')
+        assert len(result["events"]) == 2
+
+    def test_single_line_object_still_parses(self):
+        result = self._parse('{"type":"result","sessionID":"ses_1"}\n')
+        assert result["events"] == [{"type": "result", "sessionID": "ses_1"}]
+
+    def test_pretty_printed_single_object_is_accepted(self):
+        """Older builds emitted one indented object spanning many lines."""
+        stdout = json.dumps({"type": "result", "sessionID": "ses_1"}, indent=2)
+        assert "\n" in stdout
+        result = self._parse(stdout)
+        assert result["events"] == [{"type": "result", "sessionID": "ses_1"}]
+        assert result["unparsable_lines"] == []
+
+    def test_empty_stdout_is_not_an_error(self):
+        result = self._parse("")
+        assert result["events"] == []
+        assert result["unparsable_lines"] == []
+
+    def test_unparseable_stream_still_fails_loudly(self):
+        with pytest.raises(MutationError):
+            self._parse('{"type":"a"}\nthis is not json at all\n')
+
+    def test_non_strict_records_unparsable_instead_of_raising(self):
+        result = self._parse('{"type":"a"}\nnot json\n', strict=False)
+        assert len(result["events"]) == 1
+        assert result["unparsable_lines"] == ["not json"]
+
+
+class TestRateLimitClassification:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "HTTP 429 Too Many Requests",
+            "429",
+            "You have exceeded your rate limit",
+            "server overloaded",
+            "usage limit reached",
+            "quota exceeded for this model",
+        ],
+    )
+    def test_real_rate_limit_signals_are_detected(self, text):
+        assert mutator._looks_like_rate_limit(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "UnknownError: Unexpected server error. Check server logs for details.",
+            "ENOENT: no such file or directory",
+            "model not found",
+            "",
+        ],
+    )
+    def test_unrelated_errors_are_not_called_rate_limits(self, text):
+        """An unclassified failure must not be reported as a quota problem.
+
+        Sending an operator to a quota dashboard for a non-quota failure is
+        strictly worse than saying the error is unrecognised.
+        """
+        assert mutator._looks_like_rate_limit(text) is False

--- a/tests/unit/test_opencode_compat.py
+++ b/tests/unit/test_opencode_compat.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 import subprocess
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -47,6 +49,33 @@ class TestPermissionFlagProbe:
         for _ in range(5):
             mutator.opencode_permission_flag()
         assert run.call_count == 1, "a P×N batch must not re-probe per mutation"
+
+    def test_probe_is_cached_across_parallel_workers(self, mocker):
+        """Concurrent first mutations still pay for exactly one probe."""
+        probe_started = threading.Event()
+        release_probe = threading.Event()
+
+        def delayed_help(*_args, **_kwargs):
+            probe_started.set()
+            assert release_probe.wait(timeout=2)
+            return _help("--auto")
+
+        run = mocker.patch("helix.mutator.subprocess.run", side_effect=delayed_help)
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(mutator.opencode_permission_flag)
+            assert probe_started.wait(timeout=2)
+            second = executor.submit(mutator.opencode_permission_flag)
+            release_probe.set()
+            assert first.result(timeout=2) == "--auto"
+            assert second.result(timeout=2) == "--auto"
+        assert run.call_count == 1
+
+    def test_lookalike_flag_does_not_mask_legacy_flag(self, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_help("--auto-continue\n--dangerously-skip-permissions"),
+        )
+        assert mutator.opencode_permission_flag() == "--dangerously-skip-permissions"
 
     def test_probe_failure_falls_back(self, mocker):
         mocker.patch(
@@ -149,6 +178,8 @@ class TestRateLimitClassification:
             "UnknownError: Unexpected server error. Check server logs for details.",
             "ENOENT: no such file or directory",
             "model not found",
+            "Configuration error: quota field is missing",
+            "The quota identifier is invalid",
             "",
         ],
     )
@@ -159,3 +190,44 @@ class TestRateLimitClassification:
         strictly worse than saying the error is unrecognised.
         """
         assert mutator._looks_like_rate_limit(text) is False
+
+    def test_http_429_raises_rate_limit_error(self, tmp_path, mocker):
+        run = mocker.patch(
+            "helix.mutator.subprocess.run",
+            side_effect=[
+                _help("--auto"),
+                subprocess.CompletedProcess(
+                    args=[],
+                    returncode=1,
+                    stdout="",
+                    stderr="HTTP 429 Too Many Requests",
+                ),
+            ],
+        )
+        from helix.config import AgentConfig
+
+        with pytest.raises(mutator.RateLimitError):
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="opencode")
+            )
+        assert run.call_count == 2
+
+    def test_quota_configuration_error_is_not_a_rate_limit(self, tmp_path, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            side_effect=[
+                _help("--auto"),
+                subprocess.CompletedProcess(
+                    args=[],
+                    returncode=1,
+                    stdout="",
+                    stderr="Configuration error: quota field is missing",
+                ),
+            ],
+        )
+        from helix.config import AgentConfig
+
+        with pytest.raises(MutationError):
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="opencode")
+            )

--- a/tests/unit/test_opencode_compat.py
+++ b/tests/unit/test_opencode_compat.py
@@ -15,7 +15,9 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 import helix.mutator as mutator
-from helix.exceptions import MutationError
+from helix.config import HelixConfig
+from helix.exceptions import MutationError, RateLimitError
+from helix.population import Candidate, EvalResult
 
 
 @pytest.fixture(autouse=True)
@@ -179,7 +181,9 @@ class TestRateLimitClassification:
             "ENOENT: no such file or directory",
             "model not found",
             "Configuration error: quota field is missing",
+            "Configuration error: rate limit must be a positive integer",
             "The quota identifier is invalid",
+            "b883f164-a429-4646-91a6-5a606e5292a9",
             "",
         ],
     )
@@ -211,6 +215,150 @@ class TestRateLimitClassification:
                 str(tmp_path), "prompt", AgentConfig(backend="opencode")
             )
         assert run.call_count == 2
+
+    def test_structured_api_status_429_is_rate_limit_with_stderr_present(
+        self, tmp_path, mocker
+    ):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout=json.dumps(
+                    {"api_error_status": 429, "error": "request rejected"}
+                ),
+                stderr="unrelated warning emitted on stderr",
+            ),
+        )
+        from helix.config import AgentConfig
+
+        with pytest.raises(RateLimitError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="claude")
+            )
+        assert exc_info.value.exit_code == 1
+        assert exc_info.value.phase == "structured backend result"
+        assert exc_info.value.stdout
+        assert exc_info.value.stderr == "unrelated warning emitted on stderr"
+
+    def test_stdout_429_is_checked_when_stderr_is_non_empty(self, tmp_path, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            side_effect=[
+                _help("--auto"),
+                subprocess.CompletedProcess(
+                    args=[],
+                    returncode=1,
+                    stdout="HTTP 429 Too Many Requests",
+                    stderr="non-empty unrelated warning",
+                ),
+            ],
+        )
+        from helix.config import AgentConfig
+
+        with pytest.raises(RateLimitError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="opencode")
+            )
+        assert exc_info.value.stdout == "HTTP 429 Too Many Requests"
+        assert exc_info.value.stderr == "non-empty unrelated warning"
+
+    def test_max_turns_session_id_collision_remains_partial_success(
+        self, tmp_path, mocker
+    ):
+        payload = {
+            "subtype": "error_max_turns",
+            "session_id": "b883f164-a429-4646-91a6-5a606e5292a9",
+            "num_turns": 60,
+            "error": "Reached maximum number of turns (60)",
+        }
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=1, stdout=json.dumps(payload), stderr=""
+            ),
+        )
+        from helix.config import AgentConfig
+
+        parsed, usage = mutator.invoke_claude_code(
+            str(tmp_path), "prompt", AgentConfig(backend="claude")
+        )
+        assert parsed["subtype"] == "error_max_turns"
+        assert usage.num_turns == 60
+
+    def test_max_turns_collision_returns_candidate_to_evolution_gate(
+        self, tmp_path, mocker
+    ):
+        """A partial result must leave the child available for normal gating."""
+        parent = Candidate(
+            id="g0-s0",
+            worktree_path=str(tmp_path),
+            branch_name="main",
+            generation=0,
+            parent_id=None,
+            parent_ids=[],
+            operation="seed",
+        )
+        child_path = tmp_path / "g1-s1"
+        child_path.mkdir()
+        child = Candidate(
+            id="g1-s1",
+            worktree_path=str(child_path),
+            branch_name="helix/g1-s1",
+            generation=1,
+            parent_id="g0-s0",
+            parent_ids=["g0-s0"],
+            operation="mutate",
+        )
+        payload = {
+            "subtype": "error_max_turns",
+            "session_id": "b883f164-a429-4646-91a6-5a606e5292a9",
+            "num_turns": 60,
+        }
+        mocker.patch("helix.mutator.clone_candidate", return_value=child)
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=1, stdout=json.dumps(payload), stderr=""
+            ),
+        )
+        config = HelixConfig(
+            objective="objective",
+            evaluator={"command": "true"},
+            agent={"backend": "claude"},
+        )
+
+        returned = mutator.mutate(
+            parent=parent,
+            eval_result=EvalResult(candidate_id="g0-s0", scores={}, asi={}, instance_scores={}),
+            new_id="g1-s1",
+            config=config,
+            base_dir=tmp_path,
+        )
+
+        assert returned is child, "partial max-turns work must reach the evolution gate"
+
+    def test_unknown_failure_preserves_underlying_message(self, tmp_path, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            side_effect=[
+                _help("--auto"),
+                subprocess.CompletedProcess(
+                    args=[],
+                    returncode=1,
+                    stdout="",
+                    stderr="backend exploded while preparing request",
+                ),
+            ],
+        )
+        from helix.config import AgentConfig
+
+        with pytest.raises(MutationError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="opencode")
+            )
+        assert not isinstance(exc_info.value, RateLimitError)
+        assert exc_info.value.stderr == "backend exploded while preparing request"
 
     def test_quota_configuration_error_is_not_a_rate_limit(self, tmp_path, mocker):
         mocker.patch(


### PR DESCRIPTION
## Scope

Hardens OpenCode mutation execution and ensures a failed mutation cleans up its candidate worktree and branch. It also reports Docker exit 125 as a Docker-invocation failure rather than attempting to parse it as evaluator output.

The credential fix and the `XDG_DATA_HOME` redirect ship together deliberately. The redirect prevents parallel workers contending on one `opencode.db`, but it also moves OpenCode's credential files — so shipping the redirect alone would leave the sandboxed path unauthenticated.

## Fixes

1. **Permission-flag compatibility.** Recent OpenCode releases advertise `--auto`; older releases advertise `--dangerously-skip-permissions`. HELIX probes `opencode run --help`, selects the exact advertised option, and caches it once per process. The cache is lock-protected, so a P×N batch makes one probe even when its first workers start together.

2. **Credential isolation for direct subprocesses.** Per-candidate `XDG_DATA_HOME` prevents P>1 workers sharing `opencode.db`, but it also hides `auth.json` and `account.json`. The direct path symlinks those two files into the candidate state directory: credentials remain reachable, no credential bytes are copied into a worktree, and the database remains per-candidate. The state directory is ignored by Git.

3. **Failure classification.** Structured backend fields are consulted before any text heuristic. `error_max_turns` is handled ahead of the rate-limit check, so a proposal that exhausted its turns is gated as a partial success rather than discarded. Rate-limit detection requires an HTTP status context: a session identifier containing the digits `529` no longer reads as an overload response, and a configuration error mentioning a quota field is not retryable.

4. **Output compatibility.** JSONL parsing is preserved and an older pretty-printed single JSON object is additionally accepted. Malformed structured output still fails loudly.

5. **Failed-mutation cleanup.** Remove the candidate worktree and branch when setup or backend invocation fails, including on unexpected exceptions.

6. **Docker pre-start failures.** Treat Docker exit 125 as an invocation failure and retain Docker's own diagnostic, instead of surfacing it as a missing-`HELIX_RESULT` parse error several frames from the cause.

## Tests

- both permission-flag spellings, exact-option matching, fallback, and cross-thread cache behaviour
- JSONL and pretty-printed single-object structured output
- credentials reachable under isolated XDG state as symlinks, with Git confirming the link is ignored and no credential bytes are copied
- 429 routes to `RateLimitError`; a `529` inside a session identifier and quota-configuration errors do not
- `error_max_turns` preserves the candidate for gating
- sandboxed XDG state remains candidate-scoped

## Validation

- `uv run pytest tests/unit -q` — **909 passed**
- `uv run mypy --strict src/helix/` — **clean**

## Limitation

Container-side credential linking remains unimplemented and unverified. Inside the container, credentials are reachable only through the shared auth volume, so the equivalent link must be made and exercised there.
