### PR TITLE
fix(eval-cache): reject miscounted evaluator batches before writing

### DIFF
--- a/src/helix/eval_cache.py
+++ b/src/helix/eval_cache.py
@@ -99,6 +99,13 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         objective_scores_list: list[dict[str, float]] | None = None,
         side_info_list: list[dict[str, Any]] | None = None,
     ) -> None:
+        # Validate every positional list BEFORE taking the lock and mutating
+        # the cache.  A mismatched batch must be rejected whole: writing the
+        # prefix and then raising leaves the cache holding entries from a
+        # batch the caller believes it never stored.
+        _validate_batch_cardinality(
+            example_ids, outputs, scores, objective_scores_list, side_info_list
+        )
         h = _candidate_hash(candidate)
         with self._lock:
             for i, eid in enumerate(example_ids):
@@ -157,6 +164,12 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
         if uncached_ids:
             batch = fetcher(uncached_ids)
             outputs, scores, obj_scores, side_infos = evaluator(batch, candidate)
+            # Validate before the projection loop below: an evaluator that
+            # returns the wrong number of results would otherwise raise a bare
+            # IndexError partway through, or silently drop trailing results.
+            _validate_batch_cardinality(
+                uncached_ids, outputs, scores, obj_scores, side_infos
+            )
             for idx, eid in enumerate(uncached_ids):
                 outputs_by_id[eid] = outputs[idx]
                 scores_by_id[eid] = scores[idx]
@@ -177,3 +190,33 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
                 side_infos,
             )
         return outputs_by_id, scores_by_id, objective_by_id, side_info_by_id, len(uncached_ids)
+
+
+def _validate_batch_cardinality(
+    example_ids: list[DataId],
+    outputs: list[RolloutOutput],
+    scores: list[float],
+    objective_scores_list: list[dict[str, float]] | None,
+    side_info_list: list[dict[str, Any]] | None,
+) -> None:
+    """Reject a batch whose evaluator results do not match its example ids.
+
+    Every list here is positional to ``example_ids``.  A short list used to
+    surface as a bare ``IndexError`` partway through a write (leaving the cache
+    holding a prefix of a rejected batch); a long one was silently truncated,
+    discarding results the evaluator actually produced.  Both are evaluator
+    contract violations and are reported as such, before any mutation.
+    """
+    expected = len(example_ids)
+    lengths = {"outputs": len(outputs), "scores": len(scores)}
+    if objective_scores_list is not None:
+        lengths["objective_scores"] = len(objective_scores_list)
+    if side_info_list is not None:
+        lengths["side_info"] = len(side_info_list)
+    mismatched = {name: size for name, size in lengths.items() if size != expected}
+    if mismatched:
+        rendered = ", ".join(f"{name}={size}" for name, size in mismatched.items())
+        raise ValueError(
+            "Evaluator batch cardinality mismatch: expected "
+            f"{expected} result(s) for {expected} example id(s); {rendered}."
+        )

--- a/tests/unit/test_eval_cache.py
+++ b/tests/unit/test_eval_cache.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 
+import pytest
+
 from helix.eval_cache import EvaluationCache, _candidate_hash
 
 
@@ -179,3 +181,88 @@ def test_cache_isolation_by_candidate() -> None:
     cached, uncached = cache.get_batch(b, [1])
     assert cached == {}
     assert uncached == [1]
+
+
+class TestBatchCardinalityGuard:
+    """Evaluator results are positional to ``example_ids``.
+
+    A short result list used to raise a bare ``IndexError`` partway through
+    the write, leaving the cache holding a prefix of a batch the caller
+    believes was rejected; a long one was silently truncated.
+    """
+
+    def test_short_batch_is_rejected_without_mutating_the_cache(self) -> None:
+        cache: EvaluationCache[str, str] = EvaluationCache()
+
+        with pytest.raises(ValueError, match="cardinality mismatch"):
+            cache.put_batch(
+                {"prog": "x"}, ["a", "b", "c"], ["oa", "ob", "oc"], [1.0, 2.0]
+            )
+
+        assert cache._cache == {}, (
+            "a rejected batch must not leave partial entries in the cache"
+        )
+
+    def test_long_batch_is_rejected_rather_than_truncated(self) -> None:
+        cache: EvaluationCache[str, str] = EvaluationCache()
+
+        with pytest.raises(ValueError, match="cardinality mismatch"):
+            cache.put_batch({"prog": "x"}, ["a"], ["oa", "ob"], [1.0, 99.0])
+
+        assert cache._cache == {}
+
+    def test_mismatched_side_channel_lists_are_rejected(self) -> None:
+        cache: EvaluationCache[str, str] = EvaluationCache()
+
+        with pytest.raises(ValueError, match="objective_scores=1"):
+            cache.put_batch(
+                {"prog": "x"},
+                ["a", "b"],
+                ["oa", "ob"],
+                [1.0, 2.0],
+                [{"m": 1.0}],
+            )
+
+        with pytest.raises(ValueError, match="side_info=3"):
+            cache.put_batch(
+                {"prog": "x"},
+                ["a", "b"],
+                ["oa", "ob"],
+                [1.0, 2.0],
+                None,
+                [{"i": 1}, {"i": 2}, {"i": 3}],
+            )
+
+        assert cache._cache == {}
+
+    def test_evaluate_with_cache_full_reports_the_contract_violation(self) -> None:
+        """The failure is named, not a bare IndexError from a projection loop."""
+        cache: EvaluationCache[str, str] = EvaluationCache()
+
+        def short_evaluator(batch, candidate):  # type: ignore[no-untyped-def]
+            return ["only-one"], [1.0], None, None
+
+        with pytest.raises(ValueError, match="cardinality mismatch"):
+            cache.evaluate_with_cache_full(
+                {"prog": "x"},
+                ["a", "b", "c"],
+                lambda ids: list(ids),
+                short_evaluator,
+            )
+
+        assert cache._cache == {}
+
+    def test_well_formed_batches_still_round_trip(self) -> None:
+        cache: EvaluationCache[str, str] = EvaluationCache()
+        cache.put_batch(
+            {"prog": "x"},
+            ["a", "b"],
+            ["oa", "ob"],
+            [1.0, 2.0],
+            [{"m": 1.0}, {"m": 2.0}],
+            [{"i": 1}, {"i": 2}],
+        )
+        cached, uncached = cache.get_batch({"prog": "x"}, ["a", "b"])
+        assert uncached == []
+        assert cached["a"].score == 1.0
+        assert cached["b"].side_info == {"i": 2}


### PR DESCRIPTION
## The bug

`outputs`, `scores`, `objective_scores_list` and `side_info_list` are all positional to `example_ids`, but nothing verified they line up. Two failure modes, both reproduced against `main`:

**Too few results — partial write, then crash.** `put_batch` indexes `outputs[i]` / `scores[i]` *inside* the lock. With 3 ids and 2 scores it writes 2 entries and then raises `IndexError`:

```
[BUG HIT] put_batch short return -> partial cache write then IndexError
      raised=IndexError; entries_written_before_raise=2 (expected 0 on a rejected batch)
```

The cache is left holding a prefix of a batch the caller believes was rejected. Those entries are indistinguishable from good ones and are served as hits on every later lookup — for the rest of the run and, once persisted, across resumes.

**Too many results — silent truncation.**

```
[BUG HIT] put_batch long return -> silently truncated, no error
      entries=1; extra evaluator result for 'b' dropped silently
```

`evaluate_with_cache_full` touches the same lists in its projection loop *before* `put_batch` is reached, so it surfaced first as an equally opaque `IndexError` with no indication that the evaluator was at fault.

## The fix

Validate every positional list up front — before the lock, before any mutation — and raise a named error identifying which list is wrong:

```
Evaluator batch cardinality mismatch: expected 3 result(s) for 3 example id(s); scores=2.
```

Called from both `put_batch` and `evaluate_with_cache_full` (the latter needs its own call because its projection loop runs first).

## Tests

`TestBatchCardinalityGuard` — 4 of the 5 fail on `main`, all pass here:

- short batch rejected with the cache left empty
- long batch rejected rather than truncated
- mismatched `objective_scores` / `side_info` rejected
- `evaluate_with_cache_full` reports the contract violation rather than `IndexError`
- well-formed batches still round-trip (regression guard — passes on `main` too)

## Validation

- `pytest tests/unit/` — 872 passed
- `mypy --strict src/helix/eval_cache.py` — clean
- `ruff check src/helix/eval_cache.py` — clean
