### PR TITLE
feat(evolution): P×N proposals [1/2: pipeline extraction]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,11 +87,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   layout, minus `tests/`).  Wheel contents unchanged.
 
 ### Added
-- Multi-axis Pareto frontier (GEPA `FrontierType` parity,
-  `src/gepa/core/state.py:22-23`).  New
+- Multi-axis Pareto frontier (GEPA's `FrontierType` type alias in
+  `core/state.py`).  New
   `evolution.frontier_type: Literal["instance", "objective", "hybrid",
   "cartesian"]` with default `"hybrid"` — matches GEPA's own
-  `optimize_anything` default (`src/gepa/optimize_anything.py:476`).
+  Optimize Anything engine default (`EngineConfig.frontier_type` in
+  `gepa_launcher.py`).
   `ParetoFrontier` now tracks per-objective-name and per-`(val_id,
   objective_name)` best sets alongside the existing per-example-id
   tracking, and `get_non_dominated()` / `select_parent()` dispatch on
@@ -100,12 +101,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EvalResult.per_example_side_info: list[dict[str, Any]] | None` —
   per-example diagnostic dicts from the new `helix_result` contract,
   positional to `instance_scores` by `helix_batch.json` id order.
-  GEPA analogue: `EvaluationBatch.trajectories`
-  (`src/gepa/core/adapter.py:25`).
+  GEPA analogue: `EvaluationBatch.trajectories` in `core/adapter.py`.
 - `EvalResult.objective_scores: list[dict[str, float]] | None` —
   per-example objective-axis harvest from `side_info["scores"]`.  GEPA
-  analogue: `EvaluationBatch.objective_scores`
-  (`src/gepa/core/adapter.py:26`).  Feeds `frontier_type ∈ {"objective",
+  analogue: `EvaluationBatch.objective_scores` in `core/adapter.py`.
+  Feeds `frontier_type ∈ {"objective",
   "hybrid", "cartesian"}`; harmless on the `"instance"` path.
 - `DatasetConfig.train_size` / `val_size` — cardinality-only fields that drive
   the minibatch sampler when the evaluator owns the dataset (Architecture A
@@ -141,8 +141,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   modes.  The `"instance"` path keeps its existing fallback semantics.
 - **BREAKING**: `evolution.cache_evaluation` now defaults to `False`
   (previously `True`).  Matches GEPA Optimize Anything's conservative
-  cache_evaluation default
-  (`src/gepa/optimize_anything.py:476`).  When the cache *is* enabled,
+  `cache_evaluation` default on `EngineConfig` in `gepa_launcher.py`.
+  When the cache *is* enabled,
   entries are now keyed by candidate **content** (the worktree's
   `HEAD^{tree}` SHA, with a clean-state guard) rather than HELIX's
   lineage `candidate.id`, so equivalent candidates can reuse results
@@ -154,7 +154,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   payload — one `[score, side_info]` pair per id in `helix_batch.json`.
   HELIX zips it into `instance_scores` and stores `side_info_i` on
   `EvalResult.per_example_side_info` for the reflection prompt.  GEPA
-  `optimize_anything` parity (`src/gepa/optimize_anything.py:387-438`).
+  Optimize Anything parity — evaluators return per-example
+  `(score, side_info)` results, as `OptimizeAnythingAdapter` expects.
   The previous scalar-plus-id-keyed-dict contract is removed — it
   silently failed the minibatch gate whenever the evaluator keyed its
   dict by aggregate metric names (`task__metric`) instead of per-example
@@ -193,7 +194,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2026-04-10
 
 ### Added
-- GEPA (Gradual Enhancement with Progressive Adaptation) parity support for evolution strategies
+- GEPA (Genetic-Pareto) parity support for evolution strategies
 - Seedless evolution mode allowing evolution without explicit random seeds
 - Automatic retry logic for API rate-limit handling
 - Rich progress bar for evolution tracking and visualization

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ of it: each selected parent is reused across its `N` consecutive slots, where
 `N` = `evolution.mutations_per_parent` is the number of reflective mutations
 proposed per selected parent. Each slot draws its own minibatch, so siblings are gated on
 different examples rather than selecting whichever sibling got an easy batch.
-Thus `k = P*N` is the number of proposal slots (logical proposals) per
+Thus `P*N` is the number of proposal slots (logical proposals) per
 iteration. For an admitted proposal batch, let `C` be the number
 of proposal contexts
 actually built (`C <= P*N`). Context construction checks the budget before
@@ -484,7 +484,7 @@ U = 2 * sum(|m_i| for i in 1..C) + s * (V_stage + V_full)
 
 `U` is not bounded by `P*N`: they have different units. `P*N` counts proposal
 slots, while `U` counts example-evaluation units. For the sharper comparison,
-the tempting closed form `2*k*m + s*(V_stage + V_full)`, where `m` is a common
+the tempting closed form `2*(P*N)*m + s*(V_stage + V_full)`, where `m` is a common
 minibatch size, is looser than summing admitted slots: budget exhaustion can make
 `C < P*N`, and a slot's minibatch can be short. Since
 `maximum_overshoot = max(0, evaluations_before + U - max_evaluations)`, inflating
@@ -542,8 +542,8 @@ batched or parallel full-validation call in HELIX today. The `max_workers`
 knob therefore names different layers in the two systems: HELIX's
 `evolution.max_workers` bounds the proposal pool described above, while
 upstream's `EngineConfig.max_workers` bounds the adapter's evaluation pool
-that backs full validation. When `k > evolution.max_workers`, HELIX queues
-excess proposal work. The logical width `k` therefore does not guarantee that
+that backs full validation. When `P*N > evolution.max_workers`, HELIX queues
+excess proposal work. The logical width `P*N` therefore does not guarantee that
 every evaluation runs at once; worker-pool capacity and the sequential apply
 phase still bound HELIX's wall-clock parallelism.
 
@@ -557,8 +557,8 @@ provides the underlying scaling model. In HELIX, the practical knobs are
 interactions to reason about a workload. In the GEPA comparison below, `V` is
 the validation-set size and `W` is the worker count:
 
-- `k = P*N` proposal slots are submitted to one bounded pool. The pool uses
-  `max_workers = min(len(contexts), evolution.max_workers)`, so when `k` is
+- `P*N` proposal slots are submitted to one bounded pool. The pool uses
+  `max_workers = min(len(contexts), evolution.max_workers)`, so when `P*N` is
   larger than `evolution.max_workers`, excess proposal work queues instead of
   adding proposal-stage parallelism.
 - HELIX's proposal executor has no explicit round barrier: it submits all
@@ -573,12 +573,13 @@ the validation-set size and `W` is the worker count:
   `adapter.batch_evaluate` call, so its validation cost is bounded by
   `EngineConfig.max_workers` rather than by `j` sequential passes.
 - The batch bound charges `2 * sum(|m_i|)` for the parent and child training
-  minibatches. With `k` admitted contexts sharing minibatch size `m`, that is
-  approximately `2*k*m`; increasing `k` therefore increases `U` and the
+  minibatches. With `C` admitted contexts sharing minibatch size `m`, that is
+  approximately `2*C*m`; increasing `P*N` therefore increases `U` and the
   permitted `max(0, U - 1)` overshoot roughly linearly against the fixed
   `evolution.max_evaluations` cap.
-- The blog's analytical `k*V <= W` model assumes a parallel full-validation
-  stage: up to `k` accepted candidates are each evaluated on all `V` validation
+- The blog's analytical `k*V <= W` model — where `k` is the blog's own symbol
+  for accepted candidates, not HELIX's `P*N` — assumes a parallel
+  full-validation stage: up to `k` accepted candidates are each evaluated on all `V` validation
   examples in parallel across `W` workers. That describes upstream's standard
   path: the engine batches accepted candidates into one `adapter.batch_evaluate`
   call, and the standard `OptimizeAnythingAdapter` fans every

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This is why a full solver module or a shrinkwrap of an ML kernel behave qualitat
 | 🔧 | **Tool access during mutation** | The configured backend can read, grep, run tests, inspect the codebase, and use the web mid-mutation |
 | ✅ | **Self-verification** | Mutations verify themselves by running commands before committing |
 | 📊 | **Pareto frontier** | Instance-level Pareto selection across test cases — no single metric bottleneck |
-| ⚡ | **Parallel evaluation** | Worktrees are isolated → parallel proposals via `ThreadPoolExecutor` (GEPA parity, bounded by `evolution.max_workers`) |
+| ⚡ | **Parallel evaluation** | Worktrees are isolated → parallel proposals via `ThreadPoolExecutor` (proposal concurrency bounded by `evolution.max_workers`) |
 | 🔀 | **Merge / crossover** | Combine two frontier candidates that excel on different instances |
 | 💾 | **State persistence & resume** | Crash-safe generation-granular resume with `helix resume` |
 | 🚦 | **Gated mutations** | Train-set gating rejects regressions before Pareto evaluation |
@@ -391,7 +391,7 @@ merge_val_overlap_floor = 5      # minimum val-set overlap for merge candidates
 merge_subsample_size = 5         # stratified val subsample size for merge acceptance (GEPA parity)
 max_workers = 8                  # thread-pool cap for parent-eval + mutation pools
                                  # (default: os.cpu_count(), or 32 if that returns None)
-num_parallel_proposals = 1       # parallel mutations per generation; "auto" resolves to max_workers // minibatch_size
+num_parallel_proposals = 1       # parallel mutations per generation
 minibatch_size = 3               # train-set minibatch size for reflective mutation
 cache_evaluation = true          # reuse per-instance evaluator results
 acceptance_criterion = "strict_improvement"
@@ -431,7 +431,7 @@ Resume is generation-granular. If a run is interrupted, HELIX preserves the
 last completed generation and reconciles incomplete children: it avoids
 corruption, duplicate budget charges, duplicate frontier entries, and orphaned
 worktrees, but discards the interrupted generation's in-flight mutations.
-It does not resume a partially completed P×N batch slot-by-slot. The random
+It does not resume a partially completed proposal batch slot-by-slot. The random
 number generator is seeded again for each invocation, so a resumed search need
 not take the same path as an uninterrupted run.
 
@@ -443,12 +443,153 @@ interruption point only; it does not cover the apply phase or a partially
 written state file.
 
 Evaluation caps are dispatch boundaries rather than cancellation points. For
-an admitted evaluation phase with `U` uncached units, HELIX records and checks
-the in-flight bound; the maximum permitted overshoot is `max(0, U - 1)`. A
-cache-cold P×N minibatch phase has `U <= P*N*minibatch_size`; cache hits and
-failed mutations reduce the observed use. The enclosing proposal batch uses a
-conservative aggregate of its admitted parent, child, and possible validation
-phases before checking the final observed charge.
+an admitted evaluation phase, `U` is the bound on uncached evaluation units
+that the phase may still consume (`max_in_flight_evaluations`); HELIX records
+and checks the in-flight bound, and the maximum permitted overshoot is
+`max(0, U - 1)`.
+
+For this bound, `P` = `evolution.num_parallel_proposals` is the number of parents
+sampled per iteration from HELIX's frequency-weighted Pareto list; HELIX samples
+them with replacement, so the same parent can occupy multiple `P` slots in one
+iteration. Upstream GEPA implements this same parent-major, with-replacement
+design directly as `PxNSampling(p, n)`: it samples `p` parents with replacement,
+then loops `n` times per parent to build that parent's mutation tasks, drawing a
+fresh minibatch for each task (upstream also ships `SameParentSampling`,
+`IndependentSampling`, and a single-parent/single-mutation default strategy).
+HELIX's `P*N` layout is parity with upstream's `PxNSampling`, not an extension
+of it: each selected parent is reused across its `N` consecutive slots, where
+`N` = `evolution.mutations_per_parent` is the number of reflective mutations
+proposed per selected parent. Each slot draws its own minibatch, so siblings are gated on
+different examples rather than selecting whichever sibling got an easy batch.
+Thus `k = P*N` is the number of proposal slots (logical proposals) per
+iteration. For an admitted proposal batch, let `C` be the number
+of proposal contexts
+actually built (`C <= P*N`). Context construction checks the budget before
+each slot in the nested `P`-by-`N` loop, so budget exhaustion can stop it early
+and make `C < P*N`. As a consequence of that replacement policy, the frontier
+does not cap `C` by its number of distinct parents. For context `i`, let `m_i` be
+that slot's sampled minibatch of training example ids; in no-example mode,
+there is no minibatch, so use `|m_i| = 1` by convention and the slot
+contributes `2`. Let `s` be the
+selected capacity: at most `1` (`min(1, C)`) for
+`proposal_selection = "best_improvement"`, `min(proposal_top_k, C)` for
+`"top_k"`, and `C` for `"all_improvements"`. Finally, let
+`V_stage = len(stage_val_example_ids)`
+and let `V_full = len(full_val_example_ids)`, or `1` when there is no
+full-validation set. The exact conservative bound computed by HELIX is:
+
+```
+U = 2 * sum(|m_i| for i in 1..C) + s * (V_stage + V_full)
+```
+
+`U` is not bounded by `P*N`: they have different units. `P*N` counts proposal
+slots, while `U` counts example-evaluation units. For the sharper comparison,
+the tempting closed form `2*k*m + s*(V_stage + V_full)`, where `m` is a common
+minibatch size, is looser than summing admitted slots: budget exhaustion can make
+`C < P*N`, and a slot's minibatch can be short. Since
+`maximum_overshoot = max(0, evaluations_before + U - max_evaluations)`, inflating
+`U` directly inflates the overshoot tolerated by the guard. `enforce_batch_budget_guard`
+raises when actual in-flight evaluations exceed `max_in_flight_evaluations` and
+again when actual overshoot exceeds `maximum_overshoot`, so substituting `P*N`
+would break runs rather than merely record a rough estimate. Computing `U` from
+admitted work keeps both assertions strict. In short, `P` and `N` are configured
+widths; `U` is what was actually admitted at this dispatch boundary. Cache hits,
+failed mutations, short final minibatches, and `best_improvement` narrowing `s`
+to `1` all pull real consumption below a `P*N`-derived estimate, while the guard
+exists to catch accounting regressions.
+
+For example, with `P=2`, `N=2` (`k=4`), minibatch size `10`, `V_stage=20`,
+`V_full=100`, and the default `all_improvements` selection (`s=C=4`):
+
+```
+U = 2*(4*10) + 4*(20+100) = 80 + 480 = 560   versus   P*N = 4
+```
+
+The ratio is not fixed: minibatch size, validation-set sizes, and selection mode
+all change it, and none appears in `P*N`. A bound of `4` against `560` real units
+would therefore fire the in-flight guard immediately.
+
+When every example-bearing context has the same minibatch size `m`, where `m` is
+the common value of `|m_i|`, the first term is `2*C*m`. The factor `2` covers
+the worker's parent and child training
+minibatch evaluations; in no-example mode each context contributes two
+single-evaluation units. These are example-evaluation units, not proposals:
+`evaluation_budget_units` charges `0` for a cached result, one unit per uncached
+example in a minibatch, and `1` for a no-example evaluation. This is why
+`U` depends on the admitted contexts, sampled example counts, and validation
+sizes rather than only on `P` and `N`. Cache hits and failed mutations reduce
+observed use below the bound.
+
+HELIX and upstream GEPA get their proposal-stage and validation-stage
+concurrency from different places. HELIX threads its `P*N` proposal slots
+through a single pool bounded by `evolution.max_workers`, because each HELIX
+proposal worker synchronously runs the evaluator subprocess — that pool is
+HELIX's only proposal-stage concurrency mechanism. Upstream GEPA has no
+equivalent engine-managed proposal-worker pool: its reflective-mutation
+throughput comes from one batched call at the reflection edge (`reflect_many`,
+backed by `LM.batch_complete(..., max_workers=10)`) rather than from engine
+threads. For the candidates that clear acceptance, upstream batches all of them
+into a single `_evaluate_programs_on_valset` call and, for adapters that
+implement `batch_evaluate` (the standard `OptimizeAnythingAdapter` does), fans
+every `(candidate, example)` pair across one `ThreadPoolExecutor` — so
+upstream's standard full-validation path is itself parallel. (An adapter
+without `batch_evaluate` falls back to sequential evaluation, and
+`write_agent_state=True` forces serial evaluation.) Only the acceptance
+decision and pool mutation that follow (`_add_evaluated_program`) run
+sequentially in upstream, by design. HELIX, by contrast, validates each
+accepted candidate sequentially, one at a time in sampled order — there is no
+batched or parallel full-validation call in HELIX today. The `max_workers`
+knob therefore names different layers in the two systems: HELIX's
+`evolution.max_workers` bounds the proposal pool described above, while
+upstream's `EngineConfig.max_workers` bounds the adapter's evaluation pool
+that backs full validation. When `k > evolution.max_workers`, HELIX queues
+excess proposal work. The logical width `k` therefore does not guarantee that
+every evaluation runs at once; worker-pool capacity and the sequential apply
+phase still bound HELIX's wall-clock parallelism.
+
+### Choosing P versus N
+
+The [GEPA parallel proposals analysis](https://gepa-ai.github.io/gepa/blog/2026/07/30/parallel-proposals/)
+provides the underlying scaling model. In HELIX, the practical knobs are
+`evolution.num_parallel_proposals` (`P`), `evolution.mutations_per_parent`
+(`N`), `evolution.max_workers` (the proposal-pool cap), and
+`evolution.max_evaluations` (the evaluation-budget cap). Use their code-defined
+interactions to reason about a workload. In the GEPA comparison below, `V` is
+the validation-set size and `W` is the worker count:
+
+- `k = P*N` proposal slots are submitted to one bounded pool. The pool uses
+  `max_workers = min(len(contexts), evolution.max_workers)`, so when `k` is
+  larger than `evolution.max_workers`, excess proposal work queues instead of
+  adding proposal-stage parallelism.
+- HELIX's proposal executor has no explicit round barrier: it submits all
+  admitted contexts and workers take queued tasks as they finish. For
+  similar-duration proposal workers, a full HELIX batch therefore behaves
+  roughly like `ceil(k / max_workers)` proposal waves, followed by `j`
+  sequential acceptance/full-validation passes, where `j` is the number of
+  candidates that clear acceptance. HELIX validates each accepted candidate
+  one at a time, so raising `evolution.max_workers` speeds proposal
+  generation but not the `j`-candidate validation cost. Upstream's standard
+  path differs here: it batches its `j` accepted candidates into one
+  `adapter.batch_evaluate` call, so its validation cost is bounded by
+  `EngineConfig.max_workers` rather than by `j` sequential passes.
+- The batch bound charges `2 * sum(|m_i|)` for the parent and child training
+  minibatches. With `k` admitted contexts sharing minibatch size `m`, that is
+  approximately `2*k*m`; increasing `k` therefore increases `U` and the
+  permitted `max(0, U - 1)` overshoot roughly linearly against the fixed
+  `evolution.max_evaluations` cap.
+- The blog's analytical `k*V <= W` model assumes a parallel full-validation
+  stage: up to `k` accepted candidates are each evaluated on all `V` validation
+  examples in parallel across `W` workers. That describes upstream's standard
+  path: the engine batches accepted candidates into one `adapter.batch_evaluate`
+  call, and the standard `OptimizeAnythingAdapter` fans every
+  `(candidate, example)` pair across a `ThreadPoolExecutor` bounded by
+  `max_workers`. It does not describe HELIX: HELIX validates accepted
+  candidates sequentially, one at a time in sampled order, with no batched or
+  parallel full-validation call. The blog's speedup figures are therefore a
+  genuine upper bound for HELIX specifically, not a property shared by both
+  systems. For HELIX, actual proposal-stage concurrency is capped by
+  `evolution.max_workers`; upstream instead bounds its adapter-side
+  full-validation concurrency with its `EngineConfig.max_workers` setting.
 
 ### Docker Sandboxing
 

--- a/README.md
+++ b/README.md
@@ -577,9 +577,8 @@ the validation-set size and `W` is the worker count:
   approximately `2*C*m`; increasing `P*N` therefore increases `U` and the
   permitted `max(0, U - 1)` overshoot roughly linearly against the fixed
   `evolution.max_evaluations` cap.
-- The blog's analytical `k*V <= W` model — where `k` is the blog's own symbol
-  for accepted candidates, not HELIX's `P*N` — assumes a parallel
-  full-validation stage: up to `k` accepted candidates are each evaluated on all `V` validation
+- The blog's analytical `k*V <= W` model assumes a parallel full-validation
+  stage: up to `k` accepted candidates are each evaluated on all `V` validation
   examples in parallel across `W` workers. That describes upstream's standard
   path: the engine batches accepted candidates into one `adapter.batch_evaluate`
   call, and the standard `OptimizeAnythingAdapter` fans every

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This is why a full solver module or a shrinkwrap of an ML kernel behave qualitat
 | 📊 | **Pareto frontier** | Instance-level Pareto selection across test cases — no single metric bottleneck |
 | ⚡ | **Parallel evaluation** | Worktrees are isolated → parallel proposals via `ThreadPoolExecutor` (GEPA parity, bounded by `evolution.max_workers`) |
 | 🔀 | **Merge / crossover** | Combine two frontier candidates that excel on different instances |
-| 💾 | **State persistence & resume** | Crash-safe — resume from any generation with `helix resume` |
+| 💾 | **State persistence & resume** | Crash-safe generation-granular resume with `helix resume` |
 | 🚦 | **Gated mutations** | Train-set gating rejects regressions before Pareto evaluation |
 | 📋 | **Semantic mutation log** | Full trajectory with root-cause analysis, changes made, and parent lineage |
 
@@ -92,7 +92,7 @@ flowchart TD
     CFG(["📄 helix.toml"]):::host
     LOAD["Load & validate config\n⚠ ValueError if max_gen ≤ 0\nAND max_eval ≤ 0"]:::host
     RES{"resume?"}:::dec
-    REC["Reconcile on resume:\ncleanup partial attempts\n& orphaned worktrees"]:::host
+    REC["Resume from last completed generation:\ncleanup in-flight attempts\n& orphaned worktrees"]:::host
     SEED["Evaluate seed candidate"]:::eval
     FRONT["🏆 Pareto Frontier"]:::host
 
@@ -424,6 +424,31 @@ skip_special_files = true        # skip FIFOs/sockets/devices during workspace s
 [worktree]
 base_dir = ".helix/worktrees"
 ```
+
+### Resume and parallel-batch boundaries
+
+Resume is generation-granular. If a run is interrupted, HELIX preserves the
+last completed generation and reconciles incomplete children: it avoids
+corruption, duplicate budget charges, duplicate frontier entries, and orphaned
+worktrees, but discards the interrupted generation's in-flight mutations.
+It does not resume a partially completed P×N batch slot-by-slot. The random
+number generator is seeded again for each invocation, so a resumed search need
+not take the same path as an uninterrupted run.
+
+This behaviour was exercised in a multi-hour interrupted run: budget remained
+`336`, cost remained `$0.77971`, the five-member frontier and its lineage were
+unchanged, three full-validation results remained available, and the resumed
+generation completed an accepted gate → validate → promote cycle. This is one
+interruption point only; it does not cover the apply phase or a partially
+written state file.
+
+Evaluation caps are dispatch boundaries rather than cancellation points. For
+an admitted evaluation phase with `U` uncached units, HELIX records and checks
+the in-flight bound; the maximum permitted overshoot is `max(0, U - 1)`. A
+cache-cold P×N minibatch phase has `U <= P*N*minibatch_size`; cache hits and
+failed mutations reduce the observed use. The enclosing proposal batch uses a
+conservative aggregate of its admitted parent, child, and possible validation
+phases before checking the final observed charge.
 
 ### Docker Sandboxing
 

--- a/skills/helix/SKILL.md
+++ b/skills/helix/SKILL.md
@@ -248,7 +248,6 @@ Map source concepts to HELIX this way:
 | `EngineConfig(seed=N)` | top-level `rng_seed = N` |
 | `EngineConfig(max_metric_calls=N)` | `[evolution].max_evaluations = N` |
 | `EngineConfig(max_workers=N)` | `[evolution].max_workers = N` |
-| `EngineConfig(num_parallel_proposals=N|"auto")` | `[evolution].num_parallel_proposals = N` or `"auto"` |
 | `ReflectionConfig(reflection_minibatch_size=K)` | `[evolution].minibatch_size = K` |
 | `EngineConfig(cache_evaluation=True)` | `[evolution].cache_evaluation = true` |
 | `EngineConfig(acceptance_criterion=...)` | `[evolution].acceptance_criterion = "..."` |

--- a/skills/helix/references/toml.md
+++ b/skills/helix/references/toml.md
@@ -120,7 +120,7 @@ perfect_score_threshold = 1.0
 max_evaluations = -1
 
 minibatch_size = 3
-num_parallel_proposals = 4  # or "auto"
+num_parallel_proposals = 4
 max_workers = 32
 cache_evaluation = true
 acceptance_criterion = "strict_improvement"

--- a/src/helix/batch_sampler.py
+++ b/src/helix/batch_sampler.py
@@ -1,7 +1,7 @@
 """HELIX minibatch sampler — GEPA parity.
 
 Line-for-line port of
-  gepa.strategies.batch_sampler.EpochShuffledBatchSampler
+  gepa.strategies.batch_sampler.EpochShuffledBatchSampler.
 
 Also provides :class:`StratifiedBatchSampler`, which is a HELIX extension
 over EpochShuffledBatchSampler that guarantees each minibatch of size K

--- a/src/helix/budget.py
+++ b/src/helix/budget.py
@@ -32,10 +32,16 @@ from helix.trace import TRACE, EventType
 class BatchBudgetGuard:
     """The explicit budget contract for one admitted proposal batch.
 
-    ``max_in_flight_evaluations`` is the conservative number of uncached
-    evaluation units that the batch can still consume after it has crossed a
-    dispatch boundary. It is deliberately a unit bound, not a worker count:
-    one evaluator invocation can account for several minibatch examples.
+    A batch uses ``P = evolution.num_parallel_proposals`` parents sampled with
+    replacement and ``N = evolution.mutations_per_parent`` reflective
+    mutations per selected parent, yielding up to ``P*N`` proposal slots.
+
+    Let ``U = max_in_flight_evaluations`` be the conservative number of
+    uncached evaluation units that the batch can still consume after it has
+    crossed a dispatch boundary. It is deliberately a unit bound, not a
+    worker count: one evaluator invocation can account for several minibatch
+    examples.
+
     """
 
     evaluations_before: int
@@ -127,9 +133,9 @@ def evaluation_budget_units(
 ) -> int:
     """Return evaluation budget units for an evaluation attempt.
 
-    Cached results charge 0 units; minibatch evals with N uncached
-    examples charge N (clamped at 0); single-task / no-example paths
-    charge 1 (one evaluator invocation).
+    Cached results charge 0 units; minibatch evals charge one unit per
+    uncached example (clamped at 0); single-task / no-example paths charge 1
+    (one evaluator invocation).
     """
     if was_cached:
         return 0

--- a/src/helix/budget.py
+++ b/src/helix/budget.py
@@ -20,11 +20,94 @@ introduce a ``threading.Lock`` here first; otherwise concurrent
 from __future__ import annotations
 
 import warnings
+from dataclasses import dataclass
 
 from helix.config import HelixConfig
 from helix.display import UsageStats
 from helix.state import EvolutionState
 from helix.trace import TRACE, EventType
+
+
+@dataclass(frozen=True)
+class BatchBudgetGuard:
+    """The explicit budget contract for one admitted proposal batch.
+
+    ``max_in_flight_evaluations`` is the conservative number of uncached
+    evaluation units that the batch can still consume after it has crossed a
+    dispatch boundary. It is deliberately a unit bound, not a worker count:
+    one evaluator invocation can account for several minibatch examples.
+    """
+
+    evaluations_before: int
+    max_evaluations: int
+    max_in_flight_evaluations: int
+    maximum_overshoot: int
+
+
+def begin_batch_budget_guard(
+    state: EvolutionState,
+    *,
+    max_evaluations: int,
+    max_in_flight_evaluations: int,
+) -> BatchBudgetGuard:
+    """Record the admissible in-flight work and overshoot for a batch.
+
+    With a positive cap, a batch starts only below that cap. Once admitted,
+    its in-flight work is allowed to drain. Thus a batch with ``U`` units can
+    overshoot by at most ``max(0, U - 1)`` in the worst case (it starts one
+    unit below the cap). A non-positive cap is unlimited.
+
+    Raises:
+        ValueError: if the caller supplies a negative in-flight unit bound.
+    """
+    if max_in_flight_evaluations < 0:
+        raise ValueError(
+            "Batch in-flight evaluation bound must be non-negative "
+            f"(actual {max_in_flight_evaluations}, permitted >= 0)"
+        )
+
+    evaluations_before = state.budget.evaluations
+    maximum_overshoot = (
+        0
+        if max_evaluations <= 0
+        else max(0, evaluations_before + max_in_flight_evaluations - max_evaluations)
+    )
+    return BatchBudgetGuard(
+        evaluations_before=evaluations_before,
+        max_evaluations=max_evaluations,
+        max_in_flight_evaluations=max_in_flight_evaluations,
+        maximum_overshoot=maximum_overshoot,
+    )
+
+
+def enforce_batch_budget_guard(
+    state: EvolutionState,
+    guard: BatchBudgetGuard,
+    *,
+    actual_in_flight_evaluations: int,
+) -> None:
+    """Reject a batch whose observed work exceeds its declared budget bounds.
+
+    Both failures name the observed and allowed values so an accounting
+    regression cannot silently turn a documented bound into best-effort
+    behaviour.
+    """
+    if actual_in_flight_evaluations > guard.max_in_flight_evaluations:
+        raise ValueError(
+            "Batch in-flight evaluation units exceeded their bound: "
+            f"actual {actual_in_flight_evaluations}, permitted "
+            f"{guard.max_in_flight_evaluations}"
+        )
+
+    if guard.max_evaluations <= 0:
+        return
+
+    actual_overshoot = max(0, state.budget.evaluations - guard.max_evaluations)
+    if actual_overshoot > guard.maximum_overshoot:
+        raise ValueError(
+            "Batch evaluation-budget overshoot exceeded its bound: "
+            f"actual {actual_overshoot}, permitted {guard.maximum_overshoot}"
+        )
 
 
 def budget_exhausted(state: EvolutionState, config: HelixConfig) -> bool:

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -1172,7 +1172,10 @@ def attempts_cmd(
     help="Project root directory (defaults to current working directory).",
 )
 def resume(config_path: str, project_dir: Path | None) -> None:
-    """Resume a previously started evolution run."""
+    """Resume from the last completed generation of an evolution run.
+
+    In-flight proposal batches are reconciled rather than resumed slot-by-slot.
+    """
     # NOTE: ``resume`` deliberately does NOT expose ``--effort`` (or other
     # agent-config overrides). Switching reasoning effort mid-run would
     # mix candidates produced under different sampling regimes, breaking

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -370,8 +370,6 @@ class EvolutionConfig(BaseModel):
             "GEPA parity: ReflectionConfig.reflection_minibatch_size default."
         ),
     )
-    # GEPA parity: ``EngineConfig.max_workers`` in ``gepa_launcher.py``,
-    # default ``os.cpu_count() or 32``.
     max_workers: int = Field(
         default_factory=lambda: os.cpu_count() or 32,
         description=(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -311,17 +311,19 @@ class EvolutionConfig(BaseModel):
     # Number of val ids sampled for merge acceptance. Default 5 matches
     # GEPA (merge.py:262 num_subsample_ids=5). Must be >= 1.
     merge_subsample_size: int = 5
-    # GEPA parity: number of parallel proposals per generation. When > 1,
-    # sample N parents, run N mutations in parallel via ThreadPoolExecutor,
-    # then accept sequentially. See GEPA core/engine.py
-    # _run_parallel_reflective_batch.
-    num_parallel_proposals: int | Literal["auto"] = Field(
+    # HELIX's own P: the number of parents sampled per iteration for
+    # parallel mutation proposals. Upstream expresses the same idea via
+    # its SamplingStrategy classes — see PxNSampling(p, n) in
+    # src/gepa/strategies/proposal_sampling.py ("P parents x N mutations
+    # each = P*N total tasks").
+    num_parallel_proposals: int = Field(
         default=1,
         description=(
-            "Number of concurrent mutation proposals per iteration. "
-            "GEPA parity: EngineConfig.num_parallel_proposals. "
-            "Set to 'auto' to derive from max_workers // minibatch_size, "
-            "matching GEPA's optimize_anything._resolve_num_parallel_proposals."
+            "Number of concurrent mutation proposals per iteration (P). "
+            "Upstream GEPA expresses the same idea through its "
+            "PxNSampling(p, n) sampling strategy. See "
+            "https://gepa-ai.github.io/gepa/blog/2026/07/30/parallel-proposals/ "
+            "for the scaling analysis."
         ),
     )
     mutations_per_parent: int = Field(
@@ -333,7 +335,9 @@ class EvolutionConfig(BaseModel):
             "Each of the P*N tasks draws its own minibatch. Default 1 keeps "
             "the historical one-child-per-parent behaviour. Note that "
             "max_evaluations is checked between slots, so raising P*N raises "
-            "how far a single iteration can overshoot the cap."
+            "how far a single iteration can overshoot the cap. See "
+            "https://gepa-ai.github.io/gepa/blog/2026/07/30/parallel-proposals/ "
+            "for GEPA's scaling analysis."
         ),
     )
     proposal_selection: Literal[
@@ -366,14 +370,13 @@ class EvolutionConfig(BaseModel):
             "GEPA parity: ReflectionConfig.reflection_minibatch_size default."
         ),
     )
+    # GEPA parity: ``EngineConfig.max_workers`` in ``gepa_launcher.py``,
+    # default ``os.cpu_count() or 32``.
     max_workers: int = Field(
         default_factory=lambda: os.cpu_count() or 32,
         description=(
             "Max parallel eval workers — bounds both the parent-eval and "
-            "mutation ThreadPools in the num_parallel_proposals pipeline. "
-            "GEPA parity: EngineConfig.max_workers "
-            "(/tmp/gepa-official/src/gepa/optimize_anything.py:485, "
-            "default os.cpu_count() or 32)."
+            "mutation ThreadPools in the num_parallel_proposals pipeline."
         ),
     )
     cache_evaluation: bool = Field(
@@ -464,35 +467,28 @@ class EvolutionConfig(BaseModel):
             "objective/cartesian selection raises an actionable "
             ":class:`helix.population.MissingObjectiveScoresError`.\n\n"
             "The acceptance gate stays positional on ``scores_list`` "
-            "regardless of ``frontier_type``; only the Pareto retention / "
-            "parent-selection decision is multi-axis."
+            "regardless of ``frontier_type`` (GEPA's acceptance criteria "
+            "in ``strategies/acceptance.py`` compare subsample score lists "
+            "positionally); only the Pareto retention / parent-selection decision is "
+            "multi-axis.  Non-``instance`` paths require ``helix_result`` "
+            'to emit per-example ``side_info["scores"]`` dicts — without '
+            "them the objective / cartesian frontiers raise instead of "
+            "falling back to scalar semantics."
         ),
     )
 
     def model_post_init(self, __context: object) -> None:
-        # ``max_workers`` is validated before the "auto" resolution below
-        # consumes it: ``max(1, 0 // k)`` would silently launder a zero or
-        # negative worker count into a P of 1 instead of rejecting it.
         if self.max_workers < 1:
             raise ValueError(
                 f"evolution.max_workers must be >= 1 (got {self.max_workers})"
             )
-        # GEPA parity: resolve ``num_parallel_proposals="auto"`` to
-        # ``max(1, max_workers // minibatch_size)`` once at construction
-        # time so every downstream consumer sees a plain int.  Mirrors
-        # /tmp/gepa-official/src/gepa/optimize_anything.py:1108-1116.
-        _p_raw = self.num_parallel_proposals
-        if isinstance(_p_raw, str):
-            num_proposals = max(1, self.max_workers // max(1, self.minibatch_size))
-            self.num_parallel_proposals = num_proposals
-        else:
-            num_proposals = _p_raw
         # A zero or negative P was accepted before P×N landed: it produced an
         # empty proposal batch every iteration, so the run burned through
         # max_generations without ever proposing a candidate.
-        if num_proposals < 1:
+        if self.num_parallel_proposals < 1:
             raise ValueError(
-                f"evolution.num_parallel_proposals must be >= 1 (got {num_proposals})"
+                "evolution.num_parallel_proposals must be >= 1 "
+                f"(got {self.num_parallel_proposals})"
             )
         if self.mutations_per_parent < 1:
             raise ValueError(
@@ -502,7 +498,7 @@ class EvolutionConfig(BaseModel):
         # ``proposal_top_k`` is meaningful only for the strategy that reads
         # it; accepting it elsewhere would let a config claim a bound that
         # silently does nothing.
-        _batch_size = num_proposals * self.mutations_per_parent
+        _batch_size = self.num_parallel_proposals * self.mutations_per_parent
         if self.proposal_selection == "top_k":
             if self.proposal_top_k is None:
                 raise ValueError(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -324,6 +324,41 @@ class EvolutionConfig(BaseModel):
             "matching GEPA's optimize_anything._resolve_num_parallel_proposals."
         ),
     )
+    mutations_per_parent: int = Field(
+        default=1,
+        description=(
+            "Number of children proposed per selected parent (N). Combined "
+            "with num_parallel_proposals (P), one iteration proposes P*N "
+            "children: P parents sampled with replacement, N mutations each. "
+            "Each of the P*N tasks draws its own minibatch. Default 1 keeps "
+            "the historical one-child-per-parent behaviour. Note that "
+            "max_evaluations is checked between slots, so raising P*N raises "
+            "how far a single iteration can overshoot the cap."
+        ),
+    )
+    proposal_selection: Literal[
+        "all_improvements", "best_improvement", "top_k"
+    ] = Field(
+        default="all_improvements",
+        description=(
+            "Which of the proposals that clear the acceptance gate are "
+            "promoted to full validation and the frontier. "
+            "'all_improvements' (default): every proposal that improves on "
+            "its parent. 'best_improvement': only the single largest "
+            "improvement. 'top_k': the proposal_top_k largest improvements. "
+            "Ties resolve to the earlier proposal in sampled order, so "
+            "worker completion timing can never change the outcome."
+        ),
+    )
+    proposal_top_k: int | None = Field(
+        default=None,
+        description=(
+            "Number of proposals to promote under proposal_selection='top_k'. "
+            "Required for that strategy and bounded by "
+            "num_parallel_proposals * mutations_per_parent; rejected for the "
+            "other strategies, where it would have no effect."
+        ),
+    )
     minibatch_size: int = Field(
         default=3,
         description=(
@@ -435,13 +470,56 @@ class EvolutionConfig(BaseModel):
     )
 
     def model_post_init(self, __context: object) -> None:
+        # ``max_workers`` is validated before the "auto" resolution below
+        # consumes it: ``max(1, 0 // k)`` would silently launder a zero or
+        # negative worker count into a P of 1 instead of rejecting it.
+        if self.max_workers < 1:
+            raise ValueError(
+                f"evolution.max_workers must be >= 1 (got {self.max_workers})"
+            )
         # GEPA parity: resolve ``num_parallel_proposals="auto"`` to
         # ``max(1, max_workers // minibatch_size)`` once at construction
         # time so every downstream consumer sees a plain int.  Mirrors
         # /tmp/gepa-official/src/gepa/optimize_anything.py:1108-1116.
-        if self.num_parallel_proposals == "auto":
-            self.num_parallel_proposals = max(
-                1, self.max_workers // max(1, self.minibatch_size)
+        _p_raw = self.num_parallel_proposals
+        if isinstance(_p_raw, str):
+            num_proposals = max(1, self.max_workers // max(1, self.minibatch_size))
+            self.num_parallel_proposals = num_proposals
+        else:
+            num_proposals = _p_raw
+        # A zero or negative P was accepted before P×N landed: it produced an
+        # empty proposal batch every iteration, so the run burned through
+        # max_generations without ever proposing a candidate.
+        if num_proposals < 1:
+            raise ValueError(
+                f"evolution.num_parallel_proposals must be >= 1 (got {num_proposals})"
+            )
+        if self.mutations_per_parent < 1:
+            raise ValueError(
+                "evolution.mutations_per_parent must be >= 1 "
+                f"(got {self.mutations_per_parent})"
+            )
+        # ``proposal_top_k`` is meaningful only for the strategy that reads
+        # it; accepting it elsewhere would let a config claim a bound that
+        # silently does nothing.
+        _batch_size = num_proposals * self.mutations_per_parent
+        if self.proposal_selection == "top_k":
+            if self.proposal_top_k is None:
+                raise ValueError(
+                    "evolution.proposal_top_k is required when "
+                    "evolution.proposal_selection='top_k'"
+                )
+            if not 1 <= self.proposal_top_k <= _batch_size:
+                raise ValueError(
+                    "evolution.proposal_top_k must be between 1 and "
+                    "num_parallel_proposals * mutations_per_parent "
+                    f"({_batch_size}) (got {self.proposal_top_k})"
+                )
+        elif self.proposal_top_k is not None:
+            raise ValueError(
+                "evolution.proposal_top_k is only valid when "
+                "evolution.proposal_selection='top_k' (got "
+                f"proposal_selection={self.proposal_selection!r})"
             )
         if self.val_stage_size is not None and self.val_stage_size < 0:
             raise ValueError(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -375,8 +375,11 @@ class EvolutionConfig(BaseModel):
     max_workers: int = Field(
         default_factory=lambda: os.cpu_count() or 32,
         description=(
-            "Max parallel eval workers — bounds both the parent-eval and "
-            "mutation ThreadPools in the num_parallel_proposals pipeline."
+            "Caps how many proposal slots run concurrently; each slot's "
+            "worker does that slot's parent eval and mutation. No effect "
+            "with a single slot (no pool is created). Does not bound full "
+            "validation, which runs sequentially afterward, or "
+            "concurrency inside the evaluator."
         ),
     )
     cache_evaluation: bool = Field(

--- a/src/helix/eval_cache.py
+++ b/src/helix/eval_cache.py
@@ -1,7 +1,7 @@
 """HELIX evaluation cache — GEPA parity.
 
-Line-for-line port of the GEPA cache layer at
-``gepa/core/state.py:27-130``.
+Ports the cache layer GEPA implements as ``_candidate_hash``,
+``CachedEvaluation``, and ``EvaluationCache`` in ``core/state.py``.
 """
 from __future__ import annotations
 
@@ -42,7 +42,7 @@ class EvaluationCache(Generic[RolloutOutput, DataId]):
     _cache: dict[CacheKey, CachedEvaluation[RolloutOutput]] = field(
         default_factory=dict
     )
-    # Thread safety (audit-mutation §C4 / audit-budget-caching §C1): the
+    # Thread safety (mutation audit C4 / budget-caching audit C1): the
     # parent-minibatch eval now runs inside a ThreadPoolExecutor (see
     # evolution.py parent-eval parallel stage), so concurrent readers/writers
     # can race on ``_cache``.  A single lock serialises every access.

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -3036,8 +3036,37 @@ def _run_evolution_impl(
                     mutations_accepted=mutations_accepted,
                 )
 
-            def _discard_gated_child(gated: GatedProposal, *, label: str) -> None:
-                """Undo a gated child that will not be applied after all."""
+            def _discard_gated_child(
+                gated: GatedProposal, *, label: str, reason: str, decision: str
+            ) -> None:
+                """Undo a gated child that will not be applied after all.
+
+                The child cleared its acceptance gate, so the gate already
+                wrote it a lineage entry.  Recording the drop under
+                ``attempts/`` keeps that entry from pointing at nothing — the
+                contract a gate rejection already honours — and keeps a
+                proposal dropped by selection or by dedupe distinguishable
+                from one the criterion rejected when a run is read back.
+                """
+                _discard_parent = gated.proposal.presample_ctx[0]
+                _discard_ids = gated.subsample_ids
+                _save_attempt_result(
+                    base_dir,
+                    gated.gating_result,
+                    status="rejected",
+                    reason=reason,
+                    parent_id=_discard_parent.id,
+                    generation=gen,
+                    stage="train_minibatch" if _discard_ids is not None else "train",
+                    example_ids=list(_discard_ids) if _discard_ids else None,
+                )
+                TRACE.emit(
+                    EventType.ACCEPT_DECISION,
+                    candidate_id=gated.child.id,
+                    decision=decision,
+                    example_ids=list(_discard_ids) if _discard_ids else None,
+                    score=float(sum(gated.judgement.after)),
+                )
                 _safe_remove_worktree(gated.child, label=label)
                 candidates.pop(gated.child.id, None)
 
@@ -3072,7 +3101,12 @@ def _run_evolution_impl(
                         f"Duplicate proposal: {gated.child.id} is byte-identical "
                         f"to {first_claim} -- removing."
                     )
-                    _discard_gated_child(gated, label="duplicate proposal candidate")
+                    _discard_gated_child(
+                        gated,
+                        label="duplicate proposal candidate",
+                        reason="duplicate_child",
+                        decision="reject_duplicate",
+                    )
                     return True
                 _seen_child_keys[key] = gated.child.id
                 return False
@@ -3135,7 +3169,10 @@ def _run_evolution_impl(
                                 f"was not selected -- removing."
                             )
                             _discard_gated_child(
-                                _g, label="unselected proposal candidate"
+                                _g,
+                                label="unselected proposal candidate",
+                                reason="proposal_selection",
+                                decision="reject_selection",
                             )
                     for _g in _selected:
                         if _drop_duplicate_child(_g):

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -464,9 +464,11 @@ def _reconcile_incomplete_attempts_on_resume(
     worktrees_dir: Path,
     lineage_path: Path,
 ) -> bool:
-    """Discard interrupted live attempts so resume retries their visible slot.
+    """Discard interrupted live attempts so resume restarts that generation.
 
-    A completed proposal has either an evaluation artifact, an attempt artifact,
+    Resume is generation-granular, not slot-granular: a partially completed
+    P×N batch is discarded and planned again on the next invocation. A completed
+    proposal has either an evaluation artifact, an attempt artifact,
     or frontier membership.  If a lineage entry still has a worktree but none of
     those completion markers, HELIX likely stopped between candidate creation
     and final result persistence.  Remove only those live incomplete worktrees;
@@ -2539,10 +2541,9 @@ def _run_evolution_impl(
             # therefore overspend the cap by up to P*N parent-minibatch evals
             # plus P*N child-minibatch evals — the batch's work is already
             # dispatched and paid for by the time the apply phase charges it.
-            # This is documented rather than accounted for: pre-dispatch
-            # reservation would have to predict cache hits and skip-perfect
-            # outcomes, and guessing low would idle workers on every
-            # iteration to protect a bound that is already approximate.
+            # The conservative per-batch unit bound below is checked after
+            # the already-admitted work drains. It intentionally does not
+            # reserve speculative cache hits or cancel live workers.
             # =============================================================
 
             # GEPA parity: ``num_parallel_proposals="auto"`` is resolved to an int
@@ -2569,6 +2570,40 @@ def _run_evolution_impl(
                 print_warning("Budget exhausted mid-generation -- stopping.")
                 _save_state(state)
                 break
+
+            # The worker pool, sequential gate, and optional validation stages
+            # are all already admitted before the next budget boundary. Keep a
+            # conservative unit bound for that whole P×N batch, then check the
+            # observed charge before ending the generation. This makes the
+            # documented ``max(0, U - 1)`` overshoot contract executable
+            # without reserving speculative cache hits.
+            _selected_capacity = len(presample_contexts)
+            if config.evolution.proposal_selection == "best_improvement":
+                _selected_capacity = min(1, _selected_capacity)
+            elif config.evolution.proposal_selection == "top_k":
+                assert config.evolution.proposal_top_k is not None
+                _selected_capacity = min(
+                    config.evolution.proposal_top_k, _selected_capacity
+                )
+            _batch_in_flight_units = sum(
+                (
+                    2 * len(_context[2])
+                    if _context[2] is not None
+                    # In no-example mode the worker evaluates the parent and
+                    # the sequential gate evaluates the child, one unit each.
+                    else 2
+                )
+                for _context in presample_contexts
+            )
+            _batch_in_flight_units += _selected_capacity * (
+                len(stage_val_example_ids)
+                + (len(full_val_example_ids) if full_val_example_ids else 1)
+            )
+            _batch_budget_guard = budget_api.begin_batch_budget_guard(
+                state,
+                max_evaluations=config.evolution.max_evaluations,
+                max_in_flight_evaluations=_batch_in_flight_units,
+            )
 
             worker_results = _dispatch_proposals(
                 presample_contexts,
@@ -3197,12 +3232,36 @@ def _run_evolution_impl(
                 and semantic_skip_count
                 and retryable_semantic_skip_count == semantic_skip_count
             ):
+                budget_api.enforce_batch_budget_guard(
+                    state,
+                    _batch_budget_guard,
+                    actual_in_flight_evaluations=(
+                        state.budget.evaluations
+                        - _batch_budget_guard.evaluations_before
+                    ),
+                )
                 _save_state(state)
                 TRACE.emit(EventType.ITER_END, decision=f"{gen}:skip")
                 continue
             # If budget was exhausted during sequential acceptance, break outer loop.
             if _budget_break:
+                budget_api.enforce_batch_budget_guard(
+                    state,
+                    _batch_budget_guard,
+                    actual_in_flight_evaluations=(
+                        state.budget.evaluations
+                        - _batch_budget_guard.evaluations_before
+                    ),
+                )
                 break
+
+            budget_api.enforce_batch_budget_guard(
+                state,
+                _batch_budget_guard,
+                actual_in_flight_evaluations=(
+                    state.budget.evaluations - _batch_budget_guard.evaluations_before
+                ),
+            )
 
             # Render at end of generation using the last result seen.
             # Post-UX upgrade: we update the live display but do NOT

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -58,12 +58,16 @@ from helix.lineage import LineageEntry, find_merge_triplet, load_lineage, record
 from helix.merger import merge, select_eval_subsample_for_merged_program
 from helix.mutator import mutate, build_seed_generation_prompt, generate_seed
 from helix.proposals import (
+    AcceptanceMemo,
     EvaluatedProposal,
+    GatedProposal,
     MutationFailedProposal,
     ProposalContext,
     ProposalResult,
+    ScoreVectors,
     SkippedProposal,
     TamperedProposal,
+    select_proposals,
 )
 from helix.population import (
     Candidate,
@@ -1244,13 +1248,25 @@ def _plan_proposals(
     use_minibatch_gate: bool,
     gen: int,
     n_proposals: int,
+    mutations_per_parent: int = 1,
 ) -> tuple[list[ProposalContext], bool]:
-    """Sample the iteration's proposal slots sequentially.
+    """Sample the iteration's ``P*N`` proposal slots sequentially.
 
     Parent selection, the ``state.i`` bump and minibatch sampling all happen
     here, in order, before any concurrent work starts — so the slots a run
     attempts are a function of the seed and not of completion timing.
     Returns the sampled contexts and whether the budget cut sampling short.
+
+    The loop is parent-major: ``P`` parents are selected with replacement and
+    each gets ``N`` consecutive slots.  A parent is drawn once and reused
+    across its ``N`` slots, which is what makes N a "more tries at this
+    parent" knob rather than a second, differently-shaped P.  Each slot still
+    draws its own minibatch, so siblings are gated on different examples and
+    an accepted sibling is not merely the one that drew the easy batch.
+
+    At ``N == 1`` this walks exactly the same call sequence as the flat loop
+    it replaces: one budget check, one counter advance and one parent draw
+    per slot, in that order.
     """
 
     # ---- Step 1a: Build pre-sample contexts (SEQUENTIAL) ----
@@ -1270,56 +1286,75 @@ def _plan_proposals(
     ] = []
     _budget_break = False
 
+    _slot_idx = 0
+
     for _p_idx in range(n_proposals):
-        if budget_api.budget_exhausted(state, config):
-            _budget_break = True
+        # Drawn lazily, on this parent's first surviving slot, so that the
+        # budget check and counter advance below keep running first — the
+        # order the flat loop had.
+        parent: Candidate | None = None
+        parent_frontier_result: EvalResult | None = None
+
+        for _n_idx in range(mutations_per_parent):
+            if budget_api.budget_exhausted(state, config):
+                _budget_break = True
+                break
+
+            # GEPA parity (engine.py:405-410): the FIRST proposal reuses
+            # the iteration slot already created at the top of the outer
+            # loop (state.i bumped at evolution.py loop head).  For each
+            # ADDITIONAL parallel proposal, GEPA bumps state.i again so
+            # the per-proposal counter advances independently of the
+            # outer loop.  The bump is unconditional (no minibatch gate).
+            # Under P×N the counter advances per *slot*, not per parent:
+            # every slot draws its own minibatch and the sampler keys off
+            # this counter, so sharing it across N siblings would hand
+            # them all the same batch.
+            if _slot_idx > 0:
+                budget_api.advance_proposal_counter(
+                    state, source="parallel_proposal"
+                )
+
+            if parent is None:
+                parent = frontier.select_parent()
+                parent_frontier_result = frontier._results.get(parent.id)
+
+            # --- Minibatch gate pre-sampling (GEPA §5.1) --------------
+            # Sample subsample ids.  ``state.i`` is now advanced at the
+            # top of the run loop (GEPA engine.py:649) — and again per
+            # extra parallel proposal above (engine.py:408) — so the
+            # sampler always sees the right counter.  The parent-on-
+            # minibatch eval is deferred to §1b so that N parent evals
+            # overlap under ``num_parallel_proposals > 1``
+            # (audit-mutation §C4 MODERATE E).
+            subsample_ids: list[str] | None = None
+            if (
+                use_minibatch_gate
+                and train_loader is not None
+                and batch_sampler is not None
+            ):
+                subsample_ids = batch_sampler.next_minibatch_ids(
+                    train_loader, state
+                )
+                TRACE.emit(
+                    EventType.SAMPLE_MINIBATCH,
+                    candidate_id=parent.id,
+                    example_ids=list(subsample_ids),
+                    split="train",
+                )
+
+            # g (gen) and s (mutation_counter) advance together under
+            # n_proposals=1 / mutations_per_parent=1 / merge_disabled
+            # defaults. They diverge when P*N > 1 (multiple s-slots per gen)
+            # or when merge fires (gen advances without incrementing s).
+            new_id = budget_api.next_mutation_id(state, gen)
+            presample_contexts.append(
+                (parent, parent_frontier_result, subsample_ids, new_id)
+            )
+            _slot_idx += 1
+
+        if _budget_break:
             break
-
-        # GEPA parity (engine.py:405-410): the FIRST proposal reuses
-        # the iteration slot already created at the top of the outer
-        # loop (state.i bumped at evolution.py loop head).  For each
-        # ADDITIONAL parallel proposal, GEPA bumps state.i again so
-        # the per-proposal counter advances independently of the
-        # outer loop.  The bump is unconditional (no minibatch gate).
-        if _p_idx > 0:
-            budget_api.advance_proposal_counter(
-                state, source="parallel_proposal"
-            )
-
-        parent = frontier.select_parent()
-        parent_frontier_result = frontier._results.get(parent.id)
-
-        # --- Minibatch gate pre-sampling (GEPA §5.1) --------------
-        # Sample subsample ids.  ``state.i`` is now advanced at the
-        # top of the run loop (GEPA engine.py:649) — and again per
-        # extra parallel proposal above (engine.py:408) — so the
-        # sampler always sees the right counter.  The parent-on-
-        # minibatch eval is deferred to §1b so that N parent evals
-        # overlap under ``num_parallel_proposals > 1``
-        # (audit-mutation §C4 MODERATE E).
-        subsample_ids: list[str] | None = None
-        if (
-            use_minibatch_gate
-            and train_loader is not None
-            and batch_sampler is not None
-        ):
-            subsample_ids = batch_sampler.next_minibatch_ids(
-                train_loader, state
-            )
-            TRACE.emit(
-                EventType.SAMPLE_MINIBATCH,
-                candidate_id=parent.id,
-                example_ids=list(subsample_ids),
-                split="train",
-            )
-
-        # g (gen) and s (mutation_counter) advance together under n_proposals=1
-        # / merge_disabled defaults. They diverge when n_proposals > 1 (multiple
-        # s-slots per gen) or when merge fires (gen advances without incrementing s).
-        new_id = budget_api.next_mutation_id(state, gen)
-        presample_contexts.append(
-            (parent, parent_frontier_result, subsample_ids, new_id)
-        )
 
     return presample_contexts, _budget_break
 
@@ -1723,6 +1758,31 @@ def _run_evolution_impl(
             batch_sampler = EpochShuffledBatchSampler[str](
                 minibatch_size=config.evolution.minibatch_size,
                 rng=rng,
+            )
+
+    # One iteration draws P*N minibatches back to back.  The train set only
+    # holds ``len(trainset) // minibatch_size`` disjoint ones, so past that
+    # the sampler wraps into a new epoch and slots *within a single batch*
+    # start gating on examples an earlier sibling already used.  The run is
+    # still correct — it just stops being a comparison across distinct
+    # evidence, which is the thing that makes selecting among siblings
+    # meaningful.
+    if use_minibatch_gate and train_loader is not None:
+        _p_cfg = config.evolution.num_parallel_proposals
+        _batch_slots = (
+            _p_cfg if isinstance(_p_cfg, int) else 1
+        ) * config.evolution.mutations_per_parent
+        _distinct_minibatches = len(train_loader) // max(
+            1, config.evolution.minibatch_size
+        )
+        if _batch_slots > _distinct_minibatches:
+            print_warning(
+                f"num_parallel_proposals * mutations_per_parent = "
+                f"{_batch_slots} exceeds the {_distinct_minibatches} disjoint "
+                f"minibatches available from {len(train_loader)} train "
+                f"examples at minibatch_size="
+                f"{config.evolution.minibatch_size}; minibatches will repeat "
+                f"within an iteration."
             )
 
     # GEPA-parity per-(candidate_hash, example_id) eval cache.  Kept
@@ -2472,6 +2532,17 @@ def _run_evolution_impl(
             #   3. Process acceptances SEQUENTIALLY
             # When num_parallel_proposals == 1, behaviour is identical to
             # the original single-mutation path.
+            #
+            # BUDGET OVERSHOOT.  ``max_evaluations`` is a stop condition, not
+            # a reservation: it is checked between slots, and a slot that
+            # starts under the cap runs to completion.  One iteration can
+            # therefore overspend the cap by up to P*N parent-minibatch evals
+            # plus P*N child-minibatch evals — the batch's work is already
+            # dispatched and paid for by the time the apply phase charges it.
+            # This is documented rather than accounted for: pre-dispatch
+            # reservation would have to predict cache hits and skip-perfect
+            # outcomes, and guessing low would idle workers on every
+            # iteration to protect a bound that is already approximate.
             # =============================================================
 
             # GEPA parity: ``num_parallel_proposals="auto"`` is resolved to an int
@@ -2491,6 +2562,7 @@ def _run_evolution_impl(
                 use_minibatch_gate=use_minibatch_gate,
                 gen=gen,
                 n_proposals=n_proposals,
+                mutations_per_parent=config.evolution.mutations_per_parent,
             )
 
             if _budget_break and not presample_contexts:
@@ -2519,15 +2591,39 @@ def _run_evolution_impl(
             # Read worker results in pre-sampling order.  Budget mutations, lineage
             # writes, and frontier updates are all sequential here
             # (GEPA apply_proposal_output parity, engine.py:449-452).
+            #
+            # The step is split in two halves.  ``_gate_proposal`` charges the
+            # proposal's budget, records lineage and runs the acceptance gate;
+            # ``_apply_proposal`` runs the val stages and inserts into the
+            # frontier.  ``best_improvement`` and ``top_k`` cannot decide
+            # anything until every proposal in the batch has been gated, so
+            # they need the halves to be separable.  ``all_improvements``
+            # still runs them interleaved per proposal — see the driver below.
 
             _last_eval_result: "EvalResult | None" = None
             _gen_skip_records: "list[dict[str, Any]]" = []
             semantic_skip_count = 0
             retryable_semantic_skip_count = 0
+            _acceptance_memo = AcceptanceMemo(acceptance)
 
-            for _p_idx, wr in enumerate(worker_results):
+            def _gate_proposal(
+                _p_idx: int, wr: "ProposalResult | None"
+            ) -> GatedProposal | None:
+                """Charge, record and gate one proposal slot.
+
+                Returns the gated proposal when it cleared its acceptance
+                gate, or None when the slot produced nothing to promote
+                (empty slot, skip-perfect, mutation failure, tamper, or a
+                gate rejection).  Sets ``_budget_break`` in the enclosing
+                scope when the budget ran out mid-slot; callers must check
+                it before using the return value.
+                """
+                nonlocal _last_eval_result, _budget_break
+                nonlocal semantic_skip_count, retryable_semantic_skip_count
+                nonlocal mutations_attempted
+
                 if wr is None:
-                    continue
+                    return None
 
                 _parent, _parent_frontier_result, _subsample_ids, _new_id = wr.presample_ctx
 
@@ -2545,7 +2641,7 @@ def _run_evolution_impl(
                             source="parent_minibatch",
                         )
                     print_warning(f"Mutation {_new_id} failed -- skipping.")
-                    continue
+                    return None
 
                 if isinstance(wr, SkippedProposal):
                     # Charge parent eval budget (both paths)
@@ -2581,7 +2677,7 @@ def _run_evolution_impl(
                     semantic_skip_count += 1
                     if _subsample_ids is not None:
                         retryable_semantic_skip_count += 1
-                    continue
+                    return None
 
                 if isinstance(wr, TamperedProposal):
                     # Charge parent eval budget
@@ -2605,7 +2701,7 @@ def _run_evolution_impl(
                         f"({', '.join(wr.tampered_paths)}) -- rejecting."
                     )
                     _safe_remove_worktree(wr.child, label="tamper-rejected mutation candidate")
-                    continue
+                    return None
 
                 # wr is EvaluatedProposal at this point (mypy narrows via isinstance exhaustion)
                 child = wr.child
@@ -2635,7 +2731,7 @@ def _run_evolution_impl(
                     print_warning("Budget exhausted mid-generation -- stopping.")
                     _save_state(state)
                     _budget_break = True
-                    break
+                    return None
 
                 # Charge LLM usage
                 if wr.child_usage:
@@ -2692,7 +2788,7 @@ def _run_evolution_impl(
                         print_warning("Budget exhausted mid-generation -- stopping.")
                         _save_state(state)
                         _budget_break = True
-                        break
+                        return None
 
                     # Apply the configured acceptance criterion on the
                     # per-instance score vectors (GEPA §5.1).
@@ -2701,8 +2797,6 @@ def _run_evolution_impl(
                     # parent or child minibatch result is an evaluator bug, not a
                     # benign zero.  Both vectors must cover every id in
                     # ``_subsample_ids`` so the acceptance criterion compares like-for-like.
-                    from types import SimpleNamespace as _SN  # noqa: PLC0415
-
                     assert set(_subsample_ids).issubset(
                         wr.parent_eval_result.instance_scores
                     ), (
@@ -2723,11 +2817,8 @@ def _run_evolution_impl(
                         float(gating_result.instance_scores[str(eid)])
                         for eid in _subsample_ids
                     ]
-                    _proposal = _SN(
-                        subsample_scores_before=_before,
-                        subsample_scores_after=_after,
-                    )
-                    if not acceptance.should_accept(_proposal):
+                    _judgement = _acceptance_memo.judge(_p_idx, _before, _after)
+                    if not _judgement.accepted:
                         _save_attempt_result(
                             base_dir, gating_result,
                             status="rejected", reason="minibatch_gate",
@@ -2747,7 +2838,7 @@ def _run_evolution_impl(
                             child, label="minibatch-gate-rejected candidate"
                         )
                         del candidates[child.id]
-                        continue
+                        return None
                     else:
                         TRACE.emit(
                             EventType.ACCEPT_DECISION, candidate_id=child.id,
@@ -2777,17 +2868,14 @@ def _run_evolution_impl(
                         print_warning("Budget exhausted mid-generation -- stopping.")
                         _save_state(state)
                         _budget_break = True
-                        break
-
-                    from types import SimpleNamespace as _SN  # noqa: PLC0415
+                        return None
 
                     _legacy_before = list(parent_acceptance_result.instance_scores.values())
                     _legacy_after = list(gating_result.instance_scores.values())
-                    _legacy_proposal = _SN(
-                        subsample_scores_before=_legacy_before,
-                        subsample_scores_after=_legacy_after,
+                    _judgement = _acceptance_memo.judge(
+                        _p_idx, _legacy_before, _legacy_after
                     )
-                    if not acceptance.should_accept(_legacy_proposal):
+                    if not _judgement.accepted:
                         parent_sum = sum(_legacy_before)
                         child_sum = sum(_legacy_after)
                         _save_attempt_result(
@@ -2802,7 +2890,28 @@ def _run_evolution_impl(
                         )
                         _safe_remove_worktree(child, label="train-gate-rejected candidate")
                         del candidates[child.id]
-                        continue
+                        return None
+
+                return GatedProposal(
+                    order=_p_idx,
+                    proposal=wr,
+                    judgement=_judgement,
+                    gating_result=gating_result,
+                    subsample_ids=_subsample_ids,
+                )
+
+            def _apply_proposal(gated: GatedProposal) -> None:
+                """Promote one gated proposal to full validation and the frontier.
+
+                Sets ``_budget_break`` in the enclosing scope when the budget
+                ran out mid-slot; callers must check it before continuing.
+                """
+                nonlocal _last_eval_result, _budget_break
+                nonlocal merges_due, last_iter_found_new_program, mutations_accepted
+
+                wr = gated.proposal
+                child = gated.child
+                _parent, _parent_frontier_result, _subsample_ids, _new_id = wr.presample_ctx
 
                 # --- Staged val gate ------------------------------------------
                 # UNCHANGED from previous architecture — runs sequentially after gating.
@@ -2825,9 +2934,7 @@ def _run_evolution_impl(
                         print_warning("Budget exhausted mid-generation -- stopping.")
                         _save_state(state)
                         _budget_break = True
-                        break
-
-                    from types import SimpleNamespace as _SN  # noqa: PLC0415
+                        return
 
                     _stage_before = _scores_for_example_ids(
                         _parent_frontier_result
@@ -2837,11 +2944,14 @@ def _run_evolution_impl(
                         stage_val_example_ids,
                     )
                     _stage_after = _scores_for_example_ids(stage_result, stage_val_example_ids)
-                    _proposal = _SN(
+                    # Not routed through the acceptance memo: this is the val
+                    # stage's own comparison, a different pair of vectors from
+                    # the proposal gate's, and it runs at most once per child.
+                    _stage_proposal = ScoreVectors(
                         subsample_scores_before=_stage_before,
                         subsample_scores_after=_stage_after,
                     )
-                    if not acceptance.should_accept(_proposal):
+                    if not acceptance.should_accept(_stage_proposal):
                         _save_attempt_result(
                             base_dir, stage_result,
                             status="rejected", reason="val_stage",
@@ -2861,7 +2971,7 @@ def _run_evolution_impl(
                         )
                         _safe_remove_worktree(child, label="val-stage-rejected candidate")
                         del candidates[child.id]
-                        continue
+                        return
 
                     TRACE.emit(
                         EventType.ACCEPT_DECISION, candidate_id=child.id,
@@ -2894,7 +3004,7 @@ def _run_evolution_impl(
                     print_warning("Budget exhausted mid-generation -- stopping.")
                     _save_state(state)
                     _budget_break = True
-                    break
+                    return
 
                 # --- Update frontier ------------------------------------------
                 set_phase(HelixPhase.PARETO_UPDATE)
@@ -2925,6 +3035,114 @@ def _run_evolution_impl(
                     mutations_attempted=mutations_attempted,
                     mutations_accepted=mutations_accepted,
                 )
+
+            def _discard_gated_child(gated: GatedProposal, *, label: str) -> None:
+                """Undo a gated child that will not be applied after all."""
+                _safe_remove_worktree(gated.child, label=label)
+                candidates.pop(gated.child.id, None)
+
+            # Content key -> the child id that first claimed it this batch.
+            _seen_child_keys: dict[str, str] = {}
+            # With a single slot per iteration there is no sibling for a child
+            # to be identical to, so the default configuration pays nothing
+            # for the content keys (two git invocations each).
+            _dedupe_batch = len(worker_results) > 1
+
+            def _drop_duplicate_child(gated: GatedProposal) -> bool:
+                """Drop a child byte-identical to one already promoted this batch.
+
+                Two slots can land on the same tree — most easily two of the
+                N siblings of one parent, which start from the same worktree
+                and the same reflection.  Applying both would put two
+                frontier entries on one point, spend a second full validation
+                on a score already known, and weight parent selection toward
+                whatever that point happens to be.
+
+                ``_candidate_content_key`` falls back to the candidate id
+                when it cannot resolve a clean tree, so an unresolvable child
+                is treated as unique: this collapses children it can prove
+                identical and never guesses.
+                """
+                if not _dedupe_batch:
+                    return False
+                key = _candidate_content_key(gated.child)
+                first_claim = _seen_child_keys.get(key)
+                if first_claim is not None:
+                    print_warning(
+                        f"Duplicate proposal: {gated.child.id} is byte-identical "
+                        f"to {first_claim} -- removing."
+                    )
+                    _discard_gated_child(gated, label="duplicate proposal candidate")
+                    return True
+                _seen_child_keys[key] = gated.child.id
+                return False
+
+            # ---- Step 3 driver -------------------------------------------
+            # ``all_improvements`` promotes every proposal that clears the
+            # gate, so it never needs to see the batch as a whole and keeps
+            # gating and applying each proposal before moving to the next —
+            # the exact interleaving, and therefore the exact budget-break
+            # points, this loop had before selection existed.
+            #
+            # The other two strategies rank proposals against each other, so
+            # they must gate the whole batch first and only then apply the
+            # winners.  That reordering is the reason for the split, and it
+            # is confined to the configurations that opted into it.
+            #
+            # If the budget runs out mid-gate the batch is abandoned without
+            # applying anything: proposals already gated keep their worktree
+            # and lineage entry, and resume reconciles them through the same
+            # incomplete-attempt path that already handles a budget break in
+            # the middle of the interleaved loop.
+            _selection = config.evolution.proposal_selection
+            if _selection == "all_improvements":
+                for _p_idx, wr in enumerate(worker_results):
+                    _gated = _gate_proposal(_p_idx, wr)
+                    if _budget_break:
+                        break
+                    if _gated is None:
+                        continue
+                    if _drop_duplicate_child(_gated):
+                        continue
+                    _apply_proposal(_gated)
+                    if _budget_break:
+                        break
+            else:
+                _gated_batch: list[GatedProposal] = []
+                for _p_idx, wr in enumerate(worker_results):
+                    _gated = _gate_proposal(_p_idx, wr)
+                    if _budget_break:
+                        break
+                    if _gated is not None:
+                        _gated_batch.append(_gated)
+
+                if not _budget_break:
+                    _selected = select_proposals(
+                        _gated_batch,
+                        strategy=_selection,
+                        top_k=config.evolution.proposal_top_k,
+                    )
+                    _selected_orders = {g.order for g in _selected}
+                    # Everything gated but not selected is discarded here, in
+                    # sampled order, before any of the winners are applied —
+                    # so the frontier never briefly contains a child that
+                    # selection already ruled out.
+                    for _g in _gated_batch:
+                        if _g.order not in _selected_orders:
+                            print_info(
+                                f"Selection ({_selection}): {_g.child.id} cleared "
+                                f"the gate (improvement {_g.improvement:+.4f}) but "
+                                f"was not selected -- removing."
+                            )
+                            _discard_gated_child(
+                                _g, label="unselected proposal candidate"
+                            )
+                    for _g in _selected:
+                        if _drop_duplicate_child(_g):
+                            continue
+                        _apply_proposal(_g)
+                        if _budget_break:
+                            break
 
             # Write skip records for this generation (GEPA parity — single JSON list)
             if _gen_skip_records:

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -96,19 +96,19 @@ from helix.worktree import (
 )
 from helix.evaluator_manifest import (  # noqa: E402, F401 (re-exported compatibility symbols)
     # 14 moved symbols — re-exported for backward compatibility and internal use
-    _collect_protected_evaluator_paths,
-    _copy_protected_path,
+    _collect_protected_evaluator_paths,  # noqa: F401
+    _copy_protected_path,  # noqa: F401
     _detect_evaluator_tamper,
-    _evaluator_manifest_path,
+    _evaluator_manifest_path,  # noqa: F401
     _extract_script_token,
-    _iter_protected_manifest_files,
+    _iter_protected_manifest_files,  # noqa: F401
     _load_evaluator_integrity_manifest,
     _looks_like_script_file,
     _build_evaluator_integrity_manifest,
     _refresh_and_snapshot_protected_evaluator_files,
     _refresh_protected_evaluator_files,
-    _sha256_file,
-    _to_repo_relative,
+    _sha256_file,  # noqa: F401
+    _to_repo_relative,  # noqa: F401
     _write_evaluator_integrity_manifest,
     # Constants needed by _check_evaluator_script_exists (which stays in this module)
     _NO_SCRIPT_COMMANDS,
@@ -467,7 +467,10 @@ def _reconcile_incomplete_attempts_on_resume(
     """Discard interrupted live attempts so resume restarts that generation.
 
     Resume is generation-granular, not slot-granular: a partially completed
-    P×N batch is discarded and planned again on the next invocation. A completed
+    batch of ``P = evolution.num_parallel_proposals`` parents and
+    ``N = evolution.mutations_per_parent`` reflective mutations per parent,
+    with up to ``P×N`` proposal slots, is discarded and planned again on the next
+    invocation. A completed
     proposal has either an evaluation artifact, an attempt artifact,
     or frontier membership.  If a lineage entry still has a worktree but none of
     those completion markers, HELIX likely stopped between candidate creation
@@ -765,8 +768,9 @@ def _write_helix_batch(worktree_path: str | Path, example_ids: list[str]) -> Non
 
 # Per-worktree lock registry.  Used to serialize ``_write_helix_batch`` +
 # ``run_evaluator`` calls that share the same worktree path.  GEPA calls
-# ``adapter.evaluate`` in-process so has no file-handoff race (see GEPA
-# core/engine.py:381-452); HELIX's Architecture A writes per-batch indices
+# ``adapter.evaluate``/``adapter.batch_evaluate`` in-process (see GEPA's
+# ``_run_reflective_batch`` in ``core/engine.py``) so has no file-handoff
+# race; HELIX's Architecture A writes per-batch indices
 # to ``{worktree}/helix_batch.json`` before subprocess launch, so concurrent
 # parallel parent-evals on the same worktree would clobber each other's
 # batch file.  Different worktrees may evaluate concurrently.
@@ -873,9 +877,10 @@ def _cached_evaluate_batch(
 ) -> tuple[EvalResult, int]:
     """Evaluate ``candidate`` on ``example_ids`` with per-example caching.
 
-    GEPA parity: line-for-line mirror of GEPA's ``cached_evaluate_full``
-    (``gepa/core/state.py:618-633`` → ``EvaluationCache.evaluate_with_cache_full``
-    at ``gepa/core/state.py:94-130``).  Flow:
+    GEPA parity: line-for-line mirror of GEPA's ``cached_evaluate_full`` in
+    ``core/state.py``, which delegates to
+    ``EvaluationCache.evaluate_with_cache_full`` (also ``core/state.py``).
+    Flow:
 
       1. ``cache.get_batch(candidate, example_ids)`` partitions into
          ``(cached, uncached_ids)``.
@@ -890,7 +895,8 @@ def _cached_evaluate_batch(
     subprocess (0 if all were cached) — mirrors GEPA's
     ``len(uncached_ids)`` return value.
     """
-    # Non-cached branch — mirrors GEPA state.py:628-633 verbatim.
+    # Non-cached branch — mirrors GEPA's ``cached_evaluate_full`` verbatim
+    # for the no-cache case.
     if cache is None:
         # Per-worktree lock (see ``_worktree_lock`` docstring): serializes
         # concurrent ``write_helix_batch`` + ``run_evaluator`` on the same
@@ -908,7 +914,8 @@ def _cached_evaluate_batch(
 
     # Cached branch — delegate to the GEPA-parity helper on the cache
     # itself (helix.eval_cache.EvaluationCache.evaluate_with_cache_full,
-    # which is a line-for-line port of GEPA state.py:94-130).
+    # which is a line-for-line port of GEPA's
+    # ``EvaluationCache.evaluate_with_cache_full`` in ``core/state.py``).
     # Cache keys must remain stable across equivalent candidate content, but
     # train/val batches must not alias when they share positional ids like
     # "0", "1", ... .
@@ -939,7 +946,7 @@ def _cached_evaluate_batch(
         # these ids; the positional parser reads the same file to construct
         # the returned instance_scores.
         # Per-worktree lock: see ``_worktree_lock`` — parent-minibatch
-        # parallelism (audit-mutation §C4) requires serialising the
+        # parallelism (mutation audit C4) requires serialising the
         # ``write_helix_batch`` + ``run_evaluator`` pair on a given worktree.
         with _worktree_lock(candidate.worktree_path):
             _refresh_protected_evaluator_files(candidate, config, project_root)
@@ -952,20 +959,22 @@ def _cached_evaluate_batch(
             )
         # HELIX does not track rollout outputs per-example; store ``None``
         # per slot (the cache's ``RolloutOutput`` type parameter is
-        # ``object`` precisely for this reason — see evolution.py:536).
+        # ``object`` precisely for this reason — see the
+        # ``MinibatchEvalCache[object, str]`` annotation on this function's
+        # ``cache`` parameter).
         outputs: list[object] = [None] * len(batch)
-        # GEPA parity (adapter.py:154 — ``len(outputs) == len(scores) ==
-        # len(batch)``): a missing instance id is an evaluator bug, not a
-        # benign zero.  Mirrors the minibatch-acceptance and merge-gate
-        # asserts (evolution.py:1394-1411, :1838-1862).
+        # GEPA parity (``GEPAAdapter.evaluate``'s docstring: ``len(outputs)
+        # == len(scores) == len(batch)``): a missing instance id is an
+        # evaluator bug, not a benign zero.  Mirrors the minibatch-acceptance
+        # and merge-gate ``issubset`` asserts elsewhere in this module.
         missing = set(batch) - set(fresh.instance_scores)
         assert not missing, (
             f"Evaluator did not return scores for requested ids: {sorted(missing)}"
         )
         scores = [float(fresh.instance_scores[eid]) for eid in batch]
         # Thread per-example objective_scores through the cache: GEPA
-        # ``EvaluationBatch.objective_scores`` parity
-        # (``src/gepa/core/adapter.py:26``).  Feeds the multi-axis
+        # ``EvaluationBatch.objective_scores`` parity (``core/adapter.py``
+        # in upstream GEPA).  Feeds the multi-axis
         # Pareto frontier when ``evolution.frontier_type`` is
         # ``"objective"``, ``"hybrid"``, or ``"cartesian"``.  The
         # underlying ``EvaluationCache`` already has a slot for this
@@ -1002,7 +1011,9 @@ def _cached_evaluate_batch(
     )
 
     # Merge hits + fresh into a single EvalResult.  ``scores_by_id``
-    # covers every requested id (GEPA state.py:108-127 guarantees this).
+    # covers every requested id (GEPA's
+    # ``EvaluationCache.evaluate_with_cache_full`` in ``core/state.py``
+    # guarantees this).
     # ``scores`` (aggregate dict) and ``asi`` (metadata) are not carried
     # on cached paths: the minibatch gate and frontier update logic only
     # read ``instance_scores``.
@@ -1252,7 +1263,10 @@ def _plan_proposals(
     n_proposals: int,
     mutations_per_parent: int = 1,
 ) -> tuple[list[ProposalContext], bool]:
-    """Sample the iteration's ``P*N`` proposal slots sequentially.
+    """Sample the iteration's ``P*N`` proposal slots sequentially, where
+    ``P`` is ``n_proposals`` (``evolution.num_parallel_proposals``) and ``N``
+    is ``mutations_per_parent`` (``evolution.mutations_per_parent``), the
+    number of reflective mutations proposed per selected parent.
 
     Parent selection, the ``state.i`` bump and minibatch sampling all happen
     here, in order, before any concurrent work starts — so the slots a run
@@ -1272,15 +1286,18 @@ def _plan_proposals(
     """
 
     # ---- Step 1a: Build pre-sample contexts (SEQUENTIAL) ----
-    # GEPA core/engine.py:381-452 has three stages:
-    #   1. ``prepare_proposal`` — sequential (parent select + minibatch sample)
-    #   2. ``execute_proposal`` — PARALLEL (parent eval + reflect + child eval)
-    #   3. ``apply_proposal_output`` — sequential (budget + cache write)
-    # HELIX §1a mirrors GEPA's prepare_proposal: candidate selection,
-    # ``state.i`` bump, and minibatch sampling live here.  The parent
-    # minibatch EVAL is moved out to §1b (see below) to parallelise it,
-    # matching GEPA reflective_mutation.py:268 (``eval_curr = adapter.evaluate(...)``)
-    # running inside the thread pool submitted at engine.py:422-426.
+    # HELIX splits proposal work into three phases: this function samples
+    # parents and minibatches sequentially (§1a); the parent minibatch EVAL is
+    # then run inside a thread pool in §1b so the P*N slots overlap (each
+    # worker runs its evaluator subprocess synchronously, so the pool is what
+    # gives HELIX its concurrency here); acceptance is applied sequentially
+    # back in the run loop. The P*N sampling shape this builds — P parents
+    # drawn with replacement, each given N consecutive slots, each slot
+    # drawing its own minibatch — matches upstream GEPA's ``PxNSampling``
+    # (src/gepa/strategies/proposal_sampling.py). Upstream reaches its own
+    # proposal concurrency differently: one batched reflection call
+    # (``BatchReflectionLM.reflect_many``) rather than engine-level threads,
+    # with evaluation concurrency living in the adapter.
     #
     # Entries are tuples ``(parent, parent_frontier_result, subsample_ids, new_id)``.
     presample_contexts: list[
@@ -1302,16 +1319,18 @@ def _plan_proposals(
                 _budget_break = True
                 break
 
-            # GEPA parity (engine.py:405-410): the FIRST proposal reuses
-            # the iteration slot already created at the top of the outer
-            # loop (state.i bumped at evolution.py loop head).  For each
-            # ADDITIONAL parallel proposal, GEPA bumps state.i again so
-            # the per-proposal counter advances independently of the
-            # outer loop.  The bump is unconditional (no minibatch gate).
-            # Under P×N the counter advances per *slot*, not per parent:
-            # every slot draws its own minibatch and the sampler keys off
-            # this counter, so sharing it across N siblings would hand
-            # them all the same batch.
+            # HELIX's proposal counter (``state.i``) advances per *slot*, not
+            # once per generation: the FIRST slot reuses the counter value
+            # already bumped at the top of the outer run loop, and each
+            # ADDITIONAL slot below bumps it again here, unconditionally (no
+            # minibatch gate). This is what makes every slot draw its own
+            # minibatch instead of all P*N siblings sharing one batch.
+            # Upstream's ``PxNSampling`` reaches the same per-slot-minibatch
+            # outcome by a different mechanism: it calls
+            # ``next_minibatch_ids`` once per task inside the inner N loop
+            # rather than bumping a shared counter, and upstream sets
+            # ``state.i`` once per proposer call
+            # (reflective_mutation.py), not per proposal task.
             if _slot_idx > 0:
                 budget_api.advance_proposal_counter(
                     state, source="parallel_proposal"
@@ -1321,14 +1340,15 @@ def _plan_proposals(
                 parent = frontier.select_parent()
                 parent_frontier_result = frontier._results.get(parent.id)
 
-            # --- Minibatch gate pre-sampling (GEPA §5.1) --------------
-            # Sample subsample ids.  ``state.i`` is now advanced at the
-            # top of the run loop (GEPA engine.py:649) — and again per
-            # extra parallel proposal above (engine.py:408) — so the
-            # sampler always sees the right counter.  The parent-on-
-            # minibatch eval is deferred to §1b so that N parent evals
-            # overlap under ``num_parallel_proposals > 1``
-            # (audit-mutation §C4 MODERATE E).
+            # --- Minibatch gate pre-sampling -----------------------------
+            # Sample subsample ids.  ``state.i`` was already advanced for
+            # this slot above — once at the top of the run loop for the
+            # first slot, and once more by the per-slot counter advance
+            # just above for every later slot — so the sampler always sees
+            # this slot's own counter value here.  The parent-on-minibatch
+            # eval is deferred to §1b so that parent evaluations for the
+            # sampled slots overlap under ``num_parallel_proposals > 1``
+            # (mutation audit C4, MODERATE E).
             subsample_ids: list[str] | None = None
             if (
                 use_minibatch_gate
@@ -1362,13 +1382,17 @@ def _plan_proposals(
 
 # -- _run_proposal_worker closure (atomic per-proposal worker) --
 # Replaces the old _eval_parent + _do_mutate split closures with a
-# single atomic worker that runs the full GEPA execute_proposal shape:
-#   parent_eval (reflective_mutation.py:268) →
-#   skip-perfect (reflective_mutation.py:308) →
-#   LLM mutate (reflective_mutation.py:369) →
-#   tamper check → child_eval (reflective_mutation.py:420).
-# Budget charging is deferred to the sequential acceptance loop
-# (apply_proposal_output parity).
+# single atomic worker that runs one P*N slot end-to-end inside a
+# ThreadPoolExecutor: parent eval (minibatch path bypasses the cache;
+# no-minibatch path runs a cached train eval) → skip-perfect check →
+# LLM mutation via ``mutate`` → evaluator-tamper check → child
+# minibatch eval (minibatch path only).  Budget charging is deferred
+# to the sequential acceptance loop below.
+#
+# This follows the same sample → evaluate → mutate → evaluate shape as
+# upstream's ``ReflectiveMutationProposer.propose``, though upstream
+# batches these stages across all sampled tasks per iteration instead
+# of running one call per proposal slot.
 def _run_proposal_worker(
     pre_ctx: ProposalContext,
     *,
@@ -1381,7 +1405,8 @@ def _run_proposal_worker(
     use_minibatch_gate: bool,
     gen: int,
 ) -> ProposalResult:
-    """Atomic proposal worker — GEPA execute_proposal shape.
+    """Atomic proposal worker — mirrors the sample/evaluate/mutate/evaluate
+    shape of GEPA's ``ReflectiveMutationProposer.propose``.
 
     Runs inside a ThreadPoolExecutor. All parameters except pre_ctx
     are captured from the enclosing scope (config, project_root,
@@ -1403,7 +1428,10 @@ def _run_proposal_worker(
     _parent_n_uncached: int = 0
     if _sub_ids is not None:
         try:
-            # Bypass minibatch_cache — mirrors GEPA reflective_mutation.py:268
+            # Bypass minibatch_cache — mirrors GEPA's
+            # ``ReflectiveMutationProposer.propose``, which evaluates each
+            # sampled parent fresh via ``self._batch_evaluate`` rather than
+            # through a cache
             _mb, _n = _cached_evaluate_batch(
                 _parent,
                 list(_sub_ids),
@@ -1443,7 +1471,8 @@ def _run_proposal_worker(
     _eval_for_mutate = _parent_eval
 
     # ---- Step W3: Skip-perfect check ----
-    # GEPA parity (reflective_mutation.py:308-327): fires on both
+    # GEPA parity (mirrors the skip-perfect-score gate in
+    # ``ReflectiveMutationProposer.propose``): fires on both
     # minibatch and no-minibatch paths.  _parent_eval is always set
     # at this point (minibatch eval OR train eval above).
     if (
@@ -1619,7 +1648,7 @@ def run_evolution(
     base_dir: Path,
 ) -> HelixResult:
     """Run the HELIX evolutionary loop."""
-    # Mirror GEPA api.py:262-265: at least one stopping condition is required.
+    # Mirror GEPA's ``optimize`` (``api.py``): at least one stopping condition is required.
     # Without this, perfect-skip + always-perfect data + no effective bound =
     # a run that terminates only by the OS.  In HELIX, max_generations (loop
     # bound) and max_evaluations (budget cap, <= 0 disables) are the two
@@ -1728,16 +1757,17 @@ def _run_evolution_impl(
 
     # Batch sampler (GEPA §2) — only wired in when a train loader exists.
     #
-    # GEPA parity (harness-detected): GEPA shares a single ``random.Random``
-    # across ``candidate_selector`` AND ``EpochShuffledBatchSampler``
-    # (gepa/optimize_anything.py:1417 + 1423-1491).  Each
+    # GEPA parity (harness-detected): upstream shares a single
+    # ``random.Random`` across ``candidate_selector`` AND
+    # ``EpochShuffledBatchSampler`` — both are constructed from the same
+    # ``rng`` inside ``gepa.api.optimize``.  Each
     # ``candidate_selector.select()`` consumes one draw from the shared rng
     # *before* the sampler's first shuffle.  Passing a fresh
     # ``random.Random(seed)`` here would leave HELIX's sampler rng
-    # untouched at first shuffle while GEPA's has already advanced — the
-    # result is that minibatches diverge from GEPA starting with the very
-    # first iteration on identical seeds.  Detected by the GEPA
-    # differential testing harness (tests/unit/test_gepa_diff_harness.py).
+    # untouched at first shuffle while upstream's has already advanced —
+    # the result is that minibatches diverge from upstream starting with
+    # the very first iteration on identical seeds.  Detected by
+    # differential testing against upstream on identical seeds.
     batch_sampler: BatchSampler[str] | None = None
     if use_minibatch_gate:
         if config.evolution.batch_sampler == "stratified":
@@ -1793,10 +1823,10 @@ def _run_evolution_impl(
     # Use ``object`` for the output type parameter: HELIX only stores
     # per-(candidate, example) scores here, not rollout outputs.
     #
-    # GEPA parity (audit-rng-state-persist C1): on resume, restore the
+    # GEPA parity (rng-state-persist audit C1): on resume, restore the
     # cache contents from .helix/eval_cache.pkl when caching is enabled.
-    # Mirrors GEPA's behaviour at gepa/core/state.py:683-687
-    # (initialize_gepa_state) — when ``cache_evaluation`` is off we drop any
+    # Mirrors GEPA's ``initialize_gepa_state`` (``core/state.py``)
+    # — when ``cache_evaluation`` is off we drop any
     # persisted cache, when it is on we merge the on-disk dict into the
     # fresh cache instance.  The actual persistence happens via the
     # ``_save_state`` helper defined below, called at every existing
@@ -1851,9 +1881,10 @@ def _run_evolution_impl(
         evaluator_manifest = current_root_manifest
         _write_evaluator_integrity_manifest(base_dir, evaluator_manifest)
 
-    # GEPA parity (audit-rng-state-persist C1): bundle eval-cache persistence
-    # with state.json writes.  GEPA's single ``GEPAState.save`` call pickles
-    # the cache atomically alongside everything else (state.py:306-340); HELIX
+    # GEPA parity (rng-state-persist audit C1): bundle eval-cache persistence
+    # with state.json writes.  GEPA's single ``GEPAState.save`` call
+    # (``core/state.py``) pickles the cache atomically alongside everything
+    # else; HELIX
     # routes the (candidate_id, example_id)-keyed companion pickle through
     # this helper so every save site stays consistent without rewriting them.
     # One-shot guard for the disabled-cache cleanup: ``clear_eval_cache``
@@ -2011,7 +2042,7 @@ def _run_evolution_impl(
         # evaluator scores the seed on the complete val split.
         # GEPA parity: when val_size is set we route through
         # ``_cached_evaluate_batch`` — the per-example cache consumer mirrors
-        # ``cached_evaluate_full`` at gepa/core/state.py:618.  When val_size
+        # GEPA's ``cached_evaluate_full`` in ``core/state.py``.  When val_size
         # is None (single-task/no-example mode, e.g. circle_packing) we
         # cannot key the cache by example id, so we fall back to one evaluator
         # call (counted as one uncached metric call).
@@ -2037,11 +2068,10 @@ def _run_evolution_impl(
         frontier.add(seed, seed_result)
         _sync_frontier_state()
         state.instance_scores[seed.id] = seed_result.instance_scores
-        # GEPA parity (audit-rng-state-persist C/§3): record per-program
+        # GEPA parity (rng-state-persist audit C/§3): record per-program
         # discovery budget at the moment the program enters the frontier.
-        # Mirrors GEPA core/state.py:537 (``num_metric_calls_by_discovery
-        # .append(num_metric_calls_by_discovery_of_new_program)`` inside
-        # ``update_state_with_new_program``).
+        # Mirrors GEPA's ``num_metric_calls_by_discovery.append(...)`` inside
+        # ``update_state_with_new_program`` (``core/state.py``).
         budget_api.record_discovery_budget(state, seed.id)
         _save_state(state)
 
@@ -2087,7 +2117,9 @@ def _run_evolution_impl(
         merges_due = 0
         # GEPA parity (M1): merge only fires when the *previous* iteration
         # found (accepted) a new program.  This prevents consecutive merge-only
-        # generations after a rejected merge.  Mirrors GEPA engine.py:666.
+        # generations after a rejected merge.  Mirrors the
+        # ``last_iter_found_new_program`` gate in GEPA's ``GEPAEngine.run``
+        # (``core/engine.py``).
         last_iter_found_new_program = False
         # Mutation counters for display
         mutations_attempted = 0
@@ -2095,9 +2127,10 @@ def _run_evolution_impl(
 
         gen = start_gen - 1
         while gen < config.evolution.max_generations:
-            # GEPA parity (engine.py:649): increment generation UNCONDITIONALLY
+            # GEPA parity: increment generation UNCONDITIONALLY
             # at the top of the loop body, before any proposal work.  GEPA
-            # advances ``state.i`` at line 649, before any proposal logic.
+            # advances ``state.i`` unconditionally at the top of
+            # ``GEPAEngine.run``'s loop body, before any proposal logic.
             # Moving the increment here eliminates the helix-original rollback
             # construct that caused the NB-2 infinite-retry scenario
             # (always-perfect data + cached parent eval + no budget cap →
@@ -2110,7 +2143,10 @@ def _run_evolution_impl(
             live.update(phase=f"Starting Generation {gen}")
 
             budget_api.set_generation(state, gen)
-            # GEPA parity (engine.py:649): bump ``state.i`` unconditionally at
+            # GEPA parity (mirrors GEPA incrementing its own iteration
+            # counter unconditionally at the top of
+            # ``GEPAEngine.run``'s loop body in ``core/engine.py``): bump
+            # ``state.i`` unconditionally at
             # the top of every iteration so the proposal counter — used by the
             # batch sampler and as a tiebreaker elsewhere — advances regardless
             # of whether we sampled from the frontier or skipped.
@@ -2125,13 +2161,14 @@ def _run_evolution_impl(
             # GEPA parity (Fix 6/7): Merge OR mutate per iteration.
             # Merge fires FIRST at the start of the iteration (deferred from
             # previous acceptance).  If merge fires, skip mutation entirely
-            # (``continue``).  This matches GEPA core/engine.py:664-737.
+            # (``continue``).  This matches the merge-then-mutate structure of
+            # GEPA's ``GEPAEngine.run`` (``core/engine.py``).
             # =============================================================
-            # GEPA parity (M2 fallthrough — audit-init-engine.md B3):
+            # GEPA parity (M2 fallthrough — init-engine audit B3):
             # merge_attempted tracks whether an actual merge eval happened this
-            # iteration.  GEPA engine.py:664-741 only ``continue``s past the
-            # reflective mutation block when a merge is accepted (line 719) or
-            # rejected (line 737) — i.e. after the merged candidate has been
+            # iteration.  GEPA's ``GEPAEngine.run`` only ``continue``s past the
+            # reflective mutation block when a merge is accepted or
+            # rejected — i.e. after the merged candidate has been
             # evaluated.  All earlier fail-fast paths (<2 non-dominated, no
             # triplet, pair already attempted, missing/insufficient val overlap,
             # merge operator failure, evaluator-tamper pre-eval reject) fall
@@ -2158,7 +2195,9 @@ def _run_evolution_impl(
             ):
                 set_phase(HelixPhase.MERGE)
                 # GEPA parity (M1): clear the flag so consecutive merge-only
-                # generations cannot fire (mirrors engine.py:668,740).
+                # generations cannot fire (mirrors the
+                # ``last_iter_found_new_program`` clears in GEPA's
+                # ``GEPAEngine.run``).
                 last_iter_found_new_program = False
 
                 lineage = load_lineage(lineage_path)
@@ -2177,10 +2216,12 @@ def _run_evolution_impl(
                 ]
 
                 # GEPA parity (L3): ``find_merge_triplet`` returns None when
-                # ``len(frontier_ids) < 2`` (lineage.py:145) without consuming
-                # rng, so the "< 2 non-dominated" fail-fast reduces to
-                # ``triplet is None`` — both paths now fall through to
-                # reflective mutation (GEPA engine.py:741-742).
+                # ``len(frontier_ids) < 2`` (in HELIX's ``lineage.py``)
+                # without consuming rng, so the "< 2 non-dominated" fail-fast
+                # reduces to ``triplet is None`` — both paths now fall through
+                # to reflective mutation, mirroring how GEPA's main loop
+                # proceeds to the reflective proposer whenever
+                # ``MergeProposer.propose`` returns ``None``.
                 #
                 # GEPA parity (merge-pairing audit D1):
                 # mirror GEPA ``merge.py:130-131`` — you need two siblings plus
@@ -2315,7 +2356,7 @@ def _run_evolution_impl(
                         if merge_tamper:
                             # Evaluator-tamper reject happens PRE-eval — no
                             # merge was attempted in the GEPA sense
-                            # (audit-init-engine.md B3).  Fall through.
+                            # (init-engine audit B3).  Fall through.
                             print_warning(
                                 f"Merge {merge_id} touched protected evaluator files "
                                 f"({', '.join(merge_tamper)}) -- rejecting."
@@ -2379,8 +2420,9 @@ def _run_evolution_impl(
                             )
                             # GEPA parity (M2/B3): from here on, the merged
                             # candidate is evaluated, so this iteration is
-                            # consumed (GEPA engine.py:719 on accept,
-                            # engine.py:737 on reject).  merge_attempted=True
+                            # consumed (GEPA's ``GEPAEngine.run`` ``continue``s
+                            # on both the merge-accept and merge-reject
+                            # branches).  merge_attempted=True
                             # causes the end-of-branch guard below to
                             # ``continue`` past reflective mutation.
                             merge_attempted = True
@@ -2460,9 +2502,10 @@ def _run_evolution_impl(
                                 # eval on the merged candidate and pass THAT
                                 # result (not the 5-id subsample) to
                                 # ``frontier.add`` / ``state.instance_scores``.
-                                # Mirrors GEPA ``engine.py:688-696`` →
-                                # ``_run_full_eval_and_add`` (engine.py:175-197)
-                                # → ``_evaluate_on_valset`` (engine.py:154-173).
+                                # Mirrors GEPA's merge-accept path, which calls
+                                # ``_run_full_eval_and_add`` (``core/engine.py``),
+                                # itself backed by
+                                # ``_evaluate_programs_on_valset``.
                                 # Without this, the merged entry carries only
                                 # subsample coverage and Pareto dominance /
                                 # ``sum_score`` comparisons skew against the
@@ -2497,10 +2540,12 @@ def _run_evolution_impl(
                                 state.instance_scores[merged.id] = (
                                     full_val_result.instance_scores
                                 )
-                                # GEPA parity (audit-rng-state-persist C/§3):
+                                # GEPA parity (rng-state-persist audit C/§3):
                                 # record per-program discovery budget at the
                                 # moment the merged program enters the
-                                # frontier.  GEPA core/state.py:537.
+                                # frontier.  Mirrors GEPA's
+                                # ``update_state_with_new_program``
+                                # (``core/state.py``).
                                 budget_api.record_discovery_budget(state, merged.id)
                             else:
                                 print_warning(
@@ -2512,7 +2557,8 @@ def _run_evolution_impl(
                                     del candidates[merged.id]
 
                 # GEPA parity (M2/B3): only consume this iteration when a merge
-                # was actually evaluated (engine.py:719,737).  On any fall-through
+                # was actually evaluated (mirrors the accept/reject
+                # ``continue``s in GEPA's ``GEPAEngine.run``).  On any fall-through
                 # (triplet None, pair already attempted, overlap fail, merge op
                 # failure, tamper reject) we drop into reflective mutation below.
                 if merge_attempted:
@@ -2522,23 +2568,33 @@ def _run_evolution_impl(
             elif config.evolution.merge_enabled:
                 # GEPA parity (C1): unconditionally clear flag when merge is enabled
                 # but gate conditions not met (merges_due==0 or last_iter_found=False).
-                # GEPA engine.py:739-740 always clears before reflective mutation.
+                # GEPA's ``GEPAEngine.run`` always clears
+                # ``last_iter_found_new_program`` before reflective mutation.
                 last_iter_found_new_program = False
             # =============================================================
             # Phase 2: Mutation (only when merge did not fire above)
             #
-            # GEPA parity (M6): when num_parallel_proposals > 1, run the
-            # GEPA 3-step parallel pipeline (engine.py:381-452):
-            #   1. Sample N parent contexts sequentially
-            #   2. Execute N mutations in ThreadPoolExecutor
+            # When num_parallel_proposals > 1, HELIX runs its own three-step
+            # proposal pipeline:
+            #   1. Sample P parents and their P*N proposal slots sequentially
+            #      (P = num_parallel_proposals, N = reflective mutations per parent)
+            #   2. Dispatch the P*N proposal workers through a bounded
+            #      ThreadPoolExecutor (each worker runs its evaluator
+            #      subprocess synchronously, so the pool is HELIX's source of
+            #      concurrency here)
             #   3. Process acceptances SEQUENTIALLY
             # When num_parallel_proposals == 1, behaviour is identical to
-            # the original single-mutation path.
+            # the original single-mutation path. The P*N sampling shape
+            # matches upstream GEPA's ``PxNSampling``, but upstream gets its
+            # own proposal concurrency from a batched reflection call and
+            # adapter-side evaluation rather than an engine-level thread pool.
             #
             # BUDGET OVERSHOOT.  ``max_evaluations`` is a stop condition, not
             # a reservation: it is checked between slots, and a slot that
-            # starts under the cap runs to completion.  One iteration can
-            # therefore overspend the cap by up to P*N parent-minibatch evals
+            # starts under the cap runs to completion. Here P is
+            # ``num_parallel_proposals`` and N is ``mutations_per_parent``.
+            # One iteration can therefore overspend the cap by up to P*N
+            # parent-minibatch evals
             # plus P*N child-minibatch evals — the batch's work is already
             # dispatched and paid for by the time the apply phase charges it.
             # The conservative per-batch unit bound below is checked after
@@ -2546,10 +2602,6 @@ def _run_evolution_impl(
             # reserve speculative cache hits or cancel live workers.
             # =============================================================
 
-            # GEPA parity: ``num_parallel_proposals="auto"`` is resolved to an int
-            # in ``EvolutionConfig.model_post_init`` (mirrors GEPA
-            # optimize_anything._resolve_num_parallel_proposals).  The assert both
-            # documents that invariant and narrows the type for mypy --strict.
             _np_raw = config.evolution.num_parallel_proposals
             assert isinstance(_np_raw, int)
             n_proposals = _np_raw
@@ -2574,7 +2626,8 @@ def _run_evolution_impl(
             # The worker pool, sequential gate, and optional validation stages
             # are all already admitted before the next budget boundary. Keep a
             # conservative unit bound for that whole P×N batch, then check the
-            # observed charge before ending the generation. This makes the
+            # observed charge before ending the generation. Here U is that
+            # batch's bound on uncached evaluation units. This makes the
             # documented ``max(0, U - 1)`` overshoot contract executable
             # without reserving speculative cache hits.
             _selected_capacity = len(presample_contexts)
@@ -2622,10 +2675,11 @@ def _run_evolution_impl(
                 gen=gen,
             )
 
-            # ---- Step 3: Sequential acceptance (sampling order, GEPA engine.py:446-452) ----
+            # ---- Step 3: Sequential acceptance (sampling order) ----
             # Read worker results in pre-sampling order.  Budget mutations, lineage
-            # writes, and frontier updates are all sequential here
-            # (GEPA apply_proposal_output parity, engine.py:449-452).
+            # writes, and frontier updates are all sequential here — mirrors
+            # GEPA's ``_run_reflective_batch`` (``core/engine.py``), which
+            # applies its selected candidates to the pool in order.
             #
             # The step is split in two halves.  ``_gate_proposal`` charges the
             # proposal's budget, records lineage and runs the acceptance gate;
@@ -2828,7 +2882,8 @@ def _run_evolution_impl(
                     # Apply the configured acceptance criterion on the
                     # per-instance score vectors (GEPA §5.1).
                     #
-                    # GEPA parity (adapter.py:154): a missing instance id in the
+                    # GEPA parity (``GEPAAdapter.evaluate``'s docstring,
+                    # ``core/adapter.py``): a missing instance id in the
                     # parent or child minibatch result is an evaluator bug, not a
                     # benign zero.  Both vectors must cover every id in
                     # ``_subsample_ids`` so the acceptance criterion compares like-for-like.
@@ -2893,7 +2948,7 @@ def _run_evolution_impl(
                     gating_result.candidate_id = child.id
                     _last_eval_result = gating_result
                     # Single-task/no-example mode still charges on train eval.
-                    # GEPA parity (MODERATE D — audit-mutation.md C3):
+                    # GEPA parity (MODERATE D — mutation audit C3):
                     # same strict-sum acceptance criterion as minibatch path.
                     budget_api.charge_evaluation(
                         state, was_cached=_gating_cached, candidate_id=child.id,
@@ -3047,9 +3102,10 @@ def _run_evolution_impl(
                 frontier.add(child, val_result)
                 _sync_frontier_state()
                 state.instance_scores[child.id] = val_result.instance_scores
-                # GEPA parity (audit-rng-state-persist C/§3): record per-program
+                # GEPA parity (rng-state-persist audit C/§3): record per-program
                 # discovery budget at the moment the child enters the frontier.
-                # GEPA core/state.py:537.
+                # Mirrors GEPA's ``update_state_with_new_program``
+                # (``core/state.py``).
                 budget_api.record_discovery_budget(state, child.id)
                 TRACE.emit(
                     EventType.FRONTIER_UPDATE,
@@ -3115,9 +3171,9 @@ def _run_evolution_impl(
             def _drop_duplicate_child(gated: GatedProposal) -> bool:
                 """Drop a child byte-identical to one already promoted this batch.
 
-                Two slots can land on the same tree — most easily two of the
-                N siblings of one parent, which start from the same worktree
-                and the same reflection.  Applying both would put two
+                Two slots can land on the same tree — most easily multiple
+                siblings of one parent, which start from the same worktree and
+                the same reflection.  Applying both would put two
                 frontier entries on one point, spend a second full validation
                 on a score already known, and weight parent selection toward
                 whatever that point happens to be.
@@ -3221,7 +3277,10 @@ def _run_evolution_impl(
                 _save_skip_record(base_dir, generation=gen, records=_gen_skip_records)
 
             # Check semantic skip: all proposals were perfect on the minibatch.
-            # GEPA parity (engine.py:649, reflective_mutation.py:308-327): gen was
+            # GEPA parity (mirrors GEPA unconditionally incrementing its own
+            # iteration counter in ``core/engine.py`` and the
+            # skip-perfect-score gate in
+            # ``ReflectiveMutationProposer.propose``): gen was
             # already incremented unconditionally at the top of the loop, so on
             # resume the next iteration will be gen+1 — no rollback, no infinite loop.
             if (

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -12,6 +12,8 @@ import subprocess
 import tempfile
 import threading
 import traceback
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -55,6 +57,14 @@ from helix.executor import run_evaluator
 from helix.lineage import LineageEntry, find_merge_triplet, load_lineage, record_entry
 from helix.merger import merge, select_eval_subsample_for_merged_program
 from helix.mutator import mutate, build_seed_generation_prompt, generate_seed
+from helix.proposals import (
+    EvaluatedProposal,
+    MutationFailedProposal,
+    ProposalContext,
+    ProposalResult,
+    SkippedProposal,
+    TamperedProposal,
+)
 from helix.population import (
     Candidate,
     CandidateSummary,
@@ -1224,6 +1234,348 @@ def _build_helix_result(
 # ---------------------------------------------------------------------------
 
 
+def _plan_proposals(
+    *,
+    config: HelixConfig,
+    state: EvolutionState,
+    frontier: ParetoFrontier,
+    batch_sampler: "BatchSampler[str] | None",
+    train_loader: "HelixDataLoader | _RangeDataLoader | None",
+    use_minibatch_gate: bool,
+    gen: int,
+    n_proposals: int,
+) -> tuple[list[ProposalContext], bool]:
+    """Sample the iteration's proposal slots sequentially.
+
+    Parent selection, the ``state.i`` bump and minibatch sampling all happen
+    here, in order, before any concurrent work starts — so the slots a run
+    attempts are a function of the seed and not of completion timing.
+    Returns the sampled contexts and whether the budget cut sampling short.
+    """
+
+    # ---- Step 1a: Build pre-sample contexts (SEQUENTIAL) ----
+    # GEPA core/engine.py:381-452 has three stages:
+    #   1. ``prepare_proposal`` — sequential (parent select + minibatch sample)
+    #   2. ``execute_proposal`` — PARALLEL (parent eval + reflect + child eval)
+    #   3. ``apply_proposal_output`` — sequential (budget + cache write)
+    # HELIX §1a mirrors GEPA's prepare_proposal: candidate selection,
+    # ``state.i`` bump, and minibatch sampling live here.  The parent
+    # minibatch EVAL is moved out to §1b (see below) to parallelise it,
+    # matching GEPA reflective_mutation.py:268 (``eval_curr = adapter.evaluate(...)``)
+    # running inside the thread pool submitted at engine.py:422-426.
+    #
+    # Entries are tuples ``(parent, parent_frontier_result, subsample_ids, new_id)``.
+    presample_contexts: list[
+        tuple[Candidate, EvalResult | None, list[str] | None, str]
+    ] = []
+    _budget_break = False
+
+    for _p_idx in range(n_proposals):
+        if budget_api.budget_exhausted(state, config):
+            _budget_break = True
+            break
+
+        # GEPA parity (engine.py:405-410): the FIRST proposal reuses
+        # the iteration slot already created at the top of the outer
+        # loop (state.i bumped at evolution.py loop head).  For each
+        # ADDITIONAL parallel proposal, GEPA bumps state.i again so
+        # the per-proposal counter advances independently of the
+        # outer loop.  The bump is unconditional (no minibatch gate).
+        if _p_idx > 0:
+            budget_api.advance_proposal_counter(
+                state, source="parallel_proposal"
+            )
+
+        parent = frontier.select_parent()
+        parent_frontier_result = frontier._results.get(parent.id)
+
+        # --- Minibatch gate pre-sampling (GEPA §5.1) --------------
+        # Sample subsample ids.  ``state.i`` is now advanced at the
+        # top of the run loop (GEPA engine.py:649) — and again per
+        # extra parallel proposal above (engine.py:408) — so the
+        # sampler always sees the right counter.  The parent-on-
+        # minibatch eval is deferred to §1b so that N parent evals
+        # overlap under ``num_parallel_proposals > 1``
+        # (audit-mutation §C4 MODERATE E).
+        subsample_ids: list[str] | None = None
+        if (
+            use_minibatch_gate
+            and train_loader is not None
+            and batch_sampler is not None
+        ):
+            subsample_ids = batch_sampler.next_minibatch_ids(
+                train_loader, state
+            )
+            TRACE.emit(
+                EventType.SAMPLE_MINIBATCH,
+                candidate_id=parent.id,
+                example_ids=list(subsample_ids),
+                split="train",
+            )
+
+        # g (gen) and s (mutation_counter) advance together under n_proposals=1
+        # / merge_disabled defaults. They diverge when n_proposals > 1 (multiple
+        # s-slots per gen) or when merge fires (gen advances without incrementing s).
+        new_id = budget_api.next_mutation_id(state, gen)
+        presample_contexts.append(
+            (parent, parent_frontier_result, subsample_ids, new_id)
+        )
+
+    return presample_contexts, _budget_break
+
+# -- _run_proposal_worker closure (atomic per-proposal worker) --
+# Replaces the old _eval_parent + _do_mutate split closures with a
+# single atomic worker that runs the full GEPA execute_proposal shape:
+#   parent_eval (reflective_mutation.py:268) →
+#   skip-perfect (reflective_mutation.py:308) →
+#   LLM mutate (reflective_mutation.py:369) →
+#   tamper check → child_eval (reflective_mutation.py:420).
+# Budget charging is deferred to the sequential acceptance loop
+# (apply_proposal_output parity).
+def _run_proposal_worker(
+    pre_ctx: ProposalContext,
+    *,
+    config: HelixConfig,
+    project_root: Path,
+    worktrees_dir: Path,
+    minibatch_cache: "MinibatchEvalCache[object, str] | None",
+    eval_cache: EvaluationCache | None,
+    evaluator_manifest: dict[str, str],
+    use_minibatch_gate: bool,
+    gen: int,
+) -> ProposalResult:
+    """Atomic proposal worker — GEPA execute_proposal shape.
+
+    Runs inside a ThreadPoolExecutor. All parameters except pre_ctx
+    are captured from the enclosing scope (config, project_root,
+    frontier, minibatch_cache, eval_cache, worktrees_dir,
+    evaluator_manifest, use_minibatch_gate, gen).
+
+    Thread-safety:
+    - Reads frontier (read-only during worker phase) ✓
+    - Reads config, project_root (immutable) ✓
+    - Writes to per-candidate worktree only (no shared mutable state) ✓
+    - Budget mutations DEFERRED to sequential acceptance loop ✓
+    """
+    _parent, _pfr, _sub_ids, _new_id = pre_ctx
+
+    # ---- Step W1: Parent eval ----
+    # Minibatch path: run parent eval fresh (bypass cache, GEPA parity).
+    # No-minibatch path: run train eval (single-task mode, n=1 in practice).
+    _parent_eval: "EvalResult | None" = None
+    _parent_n_uncached: int = 0
+    if _sub_ids is not None:
+        try:
+            # Bypass minibatch_cache — mirrors GEPA reflective_mutation.py:268
+            _mb, _n = _cached_evaluate_batch(
+                _parent,
+                list(_sub_ids),
+                None,  # bypass minibatch_cache
+                config,
+                "train",
+                project_root,
+            )
+            _mb.candidate_id = _parent.id
+            _parent_eval = _mb
+            _parent_n_uncached = _n
+        except Exception as _pe_exc:
+            print_warning(
+                f"Parent eval for proposal {_new_id} "
+                f"(parent: {_parent.id}, gen {gen}) failed: "
+                f"{type(_pe_exc).__name__}: {_pe_exc} — proposal slot skipped."
+            )
+            return MutationFailedProposal(
+                presample_ctx=pre_ctx,
+                parent_eval_result=None,
+                parent_n_uncached=0,
+            )
+    else:
+        # No-minibatch path: run train eval inside worker.
+        # eval_cache is a shared dict; safe for n=1 (single-task mode).
+        set_phase(HelixPhase.TRAIN_EVALUATION)
+        _train_result, _train_cached = _cached_eval(
+            _parent, config, "train", eval_cache
+        )
+        _train_result.candidate_id = _parent.id
+        _parent_eval = _train_result
+        # Encode was_cached as n_uncached (0 = was_cached, 1 = not cached)
+        _parent_n_uncached = 0 if _train_cached else 1
+
+    # ---- Step W2: Build eval_for_mutate ----
+    assert _parent_eval is not None
+    _eval_for_mutate = _parent_eval
+
+    # ---- Step W3: Skip-perfect check ----
+    # GEPA parity (reflective_mutation.py:308-327): fires on both
+    # minibatch and no-minibatch paths.  _parent_eval is always set
+    # at this point (minibatch eval OR train eval above).
+    if (
+        config.evolution.perfect_score_threshold is not None
+        and _parent_eval is not None
+        and all(
+            s >= config.evolution.perfect_score_threshold
+            for s in _parent_eval.instance_scores.values()
+        )
+    ):
+        return SkippedProposal(
+            presample_ctx=pre_ctx,
+            parent_eval_result=_parent_eval,
+            parent_n_uncached=_parent_n_uncached,
+        )
+
+    # ---- Step W4: LLM mutation ----
+    try:
+        _child = mutate(
+            parent=_parent,
+            eval_result=_eval_for_mutate,
+            new_id=_new_id,
+            config=config,
+            base_dir=worktrees_dir,
+            background=config.agent.background,
+            prepare_worktree=lambda cand: (
+                _refresh_and_snapshot_protected_evaluator_files(
+                    cand, config, project_root
+                )
+            ),
+        )
+    except Exception as _mu_exc:
+        # Re-raise PromptArtifactCollisionError (fatal for the whole run)
+        if isinstance(_mu_exc, PromptArtifactCollisionError):
+            raise
+        # For HelixError / RateLimitError and other errors, log and return llm_failed
+        if isinstance(_mu_exc, HelixError):
+            _mu_exc.operation = (
+                _mu_exc.operation or f"parallel mutate {_new_id}"
+            )
+            print_helix_error(_mu_exc)
+            if isinstance(_mu_exc, RateLimitError):
+                logger.error(
+                    "Mutation %s (parent: %s, gen %d) failed after all retries: "
+                    "%s: %s — proposal slot skipped.",
+                    _new_id, _parent.id, gen,
+                    type(_mu_exc).__name__, _mu_exc,
+                )
+                print_error(
+                    f"Mutation [bold]{_new_id}[/bold] hit rate limit after all "
+                    f"retries — proposal slot skipped. "
+                    f"Run [cyan]helix resume[/cyan] when rate limits clear."
+                )
+        else:
+            print_error(
+                f"Parallel mutation {_new_id} (parent: {_parent.id}, gen {gen}) "
+                f"failed with exception:\n{traceback.format_exc()}"
+            )
+        return MutationFailedProposal(
+            presample_ctx=pre_ctx,
+            parent_eval_result=_parent_eval,
+            parent_n_uncached=_parent_n_uncached,
+        )
+
+    if _child is None:
+        return MutationFailedProposal(
+            presample_ctx=pre_ctx,
+            parent_eval_result=_parent_eval,
+            parent_n_uncached=_parent_n_uncached,
+        )
+
+    # ---- Step W5: Tamper check ----
+    _tampered = _detect_evaluator_tamper(
+        _child, evaluator_manifest, config, project_root
+    )
+    if _tampered:
+        return TamperedProposal(
+            presample_ctx=pre_ctx,
+            parent_eval_result=_parent_eval,
+            child=_child,
+            tampered_paths=_tampered,
+            parent_n_uncached=_parent_n_uncached,
+            child_usage=_child.usage if _child.usage else None,
+        )
+
+    # ---- Step W6: Child minibatch eval ----
+    _child_eval: "EvalResult | None" = None
+    _child_n_uncached: int = 0
+    if _sub_ids is not None:
+        _ce, _cn = _cached_evaluate_batch(
+            _child,
+            list(_sub_ids),
+            minibatch_cache,  # use cache for child (unlike parent bypass)
+            config,
+            "train",
+            project_root,
+        )
+        _ce.candidate_id = _child.id
+        _child_eval = _ce
+        _child_n_uncached = _cn
+
+    return EvaluatedProposal(
+        presample_ctx=pre_ctx,
+        parent_eval_result=_parent_eval,
+        child=_child,
+        child_eval_result=_child_eval,
+        parent_n_uncached=_parent_n_uncached,
+        child_n_uncached=_child_n_uncached,
+        child_usage=_child.usage if _child.usage else None,
+    )
+
+def _dispatch_proposals(
+    presample_contexts: list[ProposalContext],
+    worker: Callable[[ProposalContext], ProposalResult],
+    *,
+    max_workers: int,
+    gen: int,
+) -> list[ProposalResult | None]:
+    """Run every sampled slot, returning results in sampled order.
+
+    A slot that raises an unexpected exception is degraded to a failed
+    proposal so its siblings still reach the apply phase;
+    ``PromptArtifactCollisionError`` is fatal for the whole run and
+    propagates.  A single slot keeps the historical in-thread path.
+    """
+
+    # One worker per proposal slot, all under a single bounded pool.  Budget
+    # charging stays out of here and belongs to the sequential apply phase.
+
+    set_phase(HelixPhase.MUTATION)
+
+    worker_results: "list[ProposalResult | None]" = [None] * len(presample_contexts)
+
+    _w_max = min(len(presample_contexts), max_workers)
+    if len(presample_contexts) > 1:
+        with ThreadPoolExecutor(max_workers=_w_max) as _wpool:
+            _wfutures = {
+                _wpool.submit(worker, _pctx): _widx
+                for _widx, _pctx in enumerate(presample_contexts)
+            }
+            for _wf in as_completed(_wfutures):
+                _widx = _wfutures[_wf]
+                try:
+                    worker_results[_widx] = _wf.result()
+                except PromptArtifactCollisionError:
+                    raise
+                except Exception as _wexc:
+                    _wpctx = presample_contexts[_widx]
+                    _wid = _wpctx[3]
+                    _wparent = _wpctx[0]
+                    print_warning(
+                        f"Worker for proposal {_wid} "
+                        f"(parent: {_wparent.id}, gen {gen}) "
+                        f"raised an unexpected exception: "
+                        f"{type(_wexc).__name__}: {_wexc} — proposal slot dropped."
+                    )
+                    worker_results[_widx] = MutationFailedProposal(
+                        presample_ctx=_wpctx,
+                        parent_eval_result=None,
+                        parent_n_uncached=0,
+                    )
+    else:
+        # n=1 sequential path (or single surviving slot after budget break)
+        for _idx, _pctx in enumerate(presample_contexts):
+            worker_results[_idx] = worker(_pctx)
+
+    return worker_results
+
+
 def run_evolution(
     config: HelixConfig,
     project_root: Path,
@@ -2130,362 +2482,38 @@ def _run_evolution_impl(
             assert isinstance(_np_raw, int)
             n_proposals = _np_raw
 
-            # -- Atomic-worker result types (sealed union via class hierarchy) --
-            # Using a proper class hierarchy instead of a single ``kind``-discriminated
-            # dataclass gives mypy --strict the isinstance narrowing it needs to verify
-            # field accesses in the acceptance loop without any asserts or TypeGuards.
-            from dataclasses import dataclass as _dc  # noqa: PLC0415
-
-            # Convenience alias for the pre-sample context tuple shared by all result types.
-            _ProposalCtx = tuple[Candidate, EvalResult | None, list[str] | None, str]
-
-            @_dc
-            class _SkippedResult:
-                """skip-perfect fired — LLM was not called."""
-                presample_ctx: _ProposalCtx
-                parent_eval_result: EvalResult
-                parent_n_uncached: int = 0
-
-            @_dc
-            class _LLMFailedResult:
-                """mutate() raised or returned None; parent_eval_result may be None."""
-                presample_ctx: _ProposalCtx
-                parent_eval_result: EvalResult | None
-                parent_n_uncached: int = 0
-
-            @_dc
-            class _TamperedResult:
-                """LLM produced a child that modified protected evaluator files."""
-                presample_ctx: _ProposalCtx
-                parent_eval_result: EvalResult
-                child: Candidate
-                tampered_paths: list[str]
-                parent_n_uncached: int = 0
-                child_usage: UsageStats | None = None
-
-            @_dc
-            class _SuccessResult:
-                """All steps completed; child_eval_result may be None (no-minibatch path)."""
-                presample_ctx: _ProposalCtx
-                parent_eval_result: EvalResult
-                child: Candidate
-                child_eval_result: EvalResult | None = None
-                parent_n_uncached: int = 0
-                child_n_uncached: int = 0
-                child_usage: UsageStats | None = None
-
-            _ProposalResult = (
-                _SkippedResult | _LLMFailedResult | _TamperedResult | _SuccessResult
+            presample_contexts, _budget_break = _plan_proposals(
+                config=config,
+                state=state,
+                frontier=frontier,
+                batch_sampler=batch_sampler,
+                train_loader=train_loader,
+                use_minibatch_gate=use_minibatch_gate,
+                gen=gen,
+                n_proposals=n_proposals,
             )
-
-
-            # ---- Step 1a: Build pre-sample contexts (SEQUENTIAL) ----
-            # GEPA core/engine.py:381-452 has three stages:
-            #   1. ``prepare_proposal`` — sequential (parent select + minibatch sample)
-            #   2. ``execute_proposal`` — PARALLEL (parent eval + reflect + child eval)
-            #   3. ``apply_proposal_output`` — sequential (budget + cache write)
-            # HELIX §1a mirrors GEPA's prepare_proposal: candidate selection,
-            # ``state.i`` bump, and minibatch sampling live here.  The parent
-            # minibatch EVAL is moved out to §1b (see below) to parallelise it,
-            # matching GEPA reflective_mutation.py:268 (``eval_curr = adapter.evaluate(...)``)
-            # running inside the thread pool submitted at engine.py:422-426.
-            #
-            # Entries are tuples ``(parent, parent_frontier_result, subsample_ids, new_id)``.
-            presample_contexts: list[
-                tuple[Candidate, EvalResult | None, list[str] | None, str]
-            ] = []
-            _budget_break = False
-
-            for _p_idx in range(n_proposals):
-                if budget_api.budget_exhausted(state, config):
-                    _budget_break = True
-                    break
-
-                # GEPA parity (engine.py:405-410): the FIRST proposal reuses
-                # the iteration slot already created at the top of the outer
-                # loop (state.i bumped at evolution.py loop head).  For each
-                # ADDITIONAL parallel proposal, GEPA bumps state.i again so
-                # the per-proposal counter advances independently of the
-                # outer loop.  The bump is unconditional (no minibatch gate).
-                if _p_idx > 0:
-                    budget_api.advance_proposal_counter(
-                        state, source="parallel_proposal"
-                    )
-
-                parent = frontier.select_parent()
-                parent_frontier_result = frontier._results.get(parent.id)
-
-                # --- Minibatch gate pre-sampling (GEPA §5.1) --------------
-                # Sample subsample ids.  ``state.i`` is now advanced at the
-                # top of the run loop (GEPA engine.py:649) — and again per
-                # extra parallel proposal above (engine.py:408) — so the
-                # sampler always sees the right counter.  The parent-on-
-                # minibatch eval is deferred to §1b so that N parent evals
-                # overlap under ``num_parallel_proposals > 1``
-                # (audit-mutation §C4 MODERATE E).
-                subsample_ids: list[str] | None = None
-                if (
-                    use_minibatch_gate
-                    and train_loader is not None
-                    and batch_sampler is not None
-                ):
-                    subsample_ids = batch_sampler.next_minibatch_ids(
-                        train_loader, state
-                    )
-                    TRACE.emit(
-                        EventType.SAMPLE_MINIBATCH,
-                        candidate_id=parent.id,
-                        example_ids=list(subsample_ids),
-                        split="train",
-                    )
-
-                # g (gen) and s (mutation_counter) advance together under n_proposals=1
-                # / merge_disabled defaults. They diverge when n_proposals > 1 (multiple
-                # s-slots per gen) or when merge fires (gen advances without incrementing s).
-                new_id = budget_api.next_mutation_id(state, gen)
-                presample_contexts.append(
-                    (parent, parent_frontier_result, subsample_ids, new_id)
-                )
-
-
-            # -- _run_proposal_worker closure (atomic per-proposal worker) --
-            # Replaces the old _eval_parent + _do_mutate split closures with a
-            # single atomic worker that runs the full GEPA execute_proposal shape:
-            #   parent_eval (reflective_mutation.py:268) →
-            #   skip-perfect (reflective_mutation.py:308) →
-            #   LLM mutate (reflective_mutation.py:369) →
-            #   tamper check → child_eval (reflective_mutation.py:420).
-            # Budget charging is deferred to the sequential acceptance loop
-            # (apply_proposal_output parity).
-            def _run_proposal_worker(
-                pre_ctx: _ProposalCtx,
-            ) -> "_SkippedResult | _LLMFailedResult | _TamperedResult | _SuccessResult":
-                """Atomic proposal worker — GEPA execute_proposal shape.
-
-                Runs inside a ThreadPoolExecutor. All parameters except pre_ctx
-                are captured from the enclosing scope (config, project_root,
-                frontier, minibatch_cache, eval_cache, worktrees_dir,
-                evaluator_manifest, use_minibatch_gate, gen).
-
-                Thread-safety:
-                - Reads frontier (read-only during worker phase) ✓
-                - Reads config, project_root (immutable) ✓
-                - Writes to per-candidate worktree only (no shared mutable state) ✓
-                - Budget mutations DEFERRED to sequential acceptance loop ✓
-                """
-                _parent, _pfr, _sub_ids, _new_id = pre_ctx
-
-                # ---- Step W1: Parent eval ----
-                # Minibatch path: run parent eval fresh (bypass cache, GEPA parity).
-                # No-minibatch path: run train eval (single-task mode, n=1 in practice).
-                _parent_eval: "EvalResult | None" = None
-                _parent_n_uncached: int = 0
-                if _sub_ids is not None:
-                    try:
-                        # Bypass minibatch_cache — mirrors GEPA reflective_mutation.py:268
-                        _mb, _n = _cached_evaluate_batch(
-                            _parent,
-                            list(_sub_ids),
-                            None,  # bypass minibatch_cache
-                            config,
-                            "train",
-                            project_root,
-                        )
-                        _mb.candidate_id = _parent.id
-                        _parent_eval = _mb
-                        _parent_n_uncached = _n
-                    except Exception as _pe_exc:
-                        print_warning(
-                            f"Parent eval for proposal {_new_id} "
-                            f"(parent: {_parent.id}, gen {gen}) failed: "
-                            f"{type(_pe_exc).__name__}: {_pe_exc} — proposal slot skipped."
-                        )
-                        return _LLMFailedResult(
-                            presample_ctx=pre_ctx,
-                            parent_eval_result=None,
-                            parent_n_uncached=0,
-                        )
-                else:
-                    # No-minibatch path: run train eval inside worker.
-                    # eval_cache is a shared dict; safe for n=1 (single-task mode).
-                    set_phase(HelixPhase.TRAIN_EVALUATION)
-                    _train_result, _train_cached = _cached_eval(
-                        _parent, config, "train", eval_cache
-                    )
-                    _train_result.candidate_id = _parent.id
-                    _parent_eval = _train_result
-                    # Encode was_cached as n_uncached (0 = was_cached, 1 = not cached)
-                    _parent_n_uncached = 0 if _train_cached else 1
-
-                # ---- Step W2: Build eval_for_mutate ----
-                assert _parent_eval is not None
-                _eval_for_mutate = _parent_eval
-
-                # ---- Step W3: Skip-perfect check ----
-                # GEPA parity (reflective_mutation.py:308-327): fires on both
-                # minibatch and no-minibatch paths.  _parent_eval is always set
-                # at this point (minibatch eval OR train eval above).
-                if (
-                    config.evolution.perfect_score_threshold is not None
-                    and _parent_eval is not None
-                    and all(
-                        s >= config.evolution.perfect_score_threshold
-                        for s in _parent_eval.instance_scores.values()
-                    )
-                ):
-                    return _SkippedResult(
-                        presample_ctx=pre_ctx,
-                        parent_eval_result=_parent_eval,
-                        parent_n_uncached=_parent_n_uncached,
-                    )
-
-                # ---- Step W4: LLM mutation ----
-                try:
-                    _child = mutate(
-                        parent=_parent,
-                        eval_result=_eval_for_mutate,
-                        new_id=_new_id,
-                        config=config,
-                        base_dir=worktrees_dir,
-                        background=config.agent.background,
-                        prepare_worktree=lambda cand: (
-                            _refresh_and_snapshot_protected_evaluator_files(
-                                cand, config, project_root
-                            )
-                        ),
-                    )
-                except Exception as _mu_exc:
-                    # Re-raise PromptArtifactCollisionError (fatal for the whole run)
-                    if isinstance(_mu_exc, PromptArtifactCollisionError):
-                        raise
-                    # For HelixError / RateLimitError and other errors, log and return llm_failed
-                    if isinstance(_mu_exc, HelixError):
-                        _mu_exc.operation = (
-                            _mu_exc.operation or f"parallel mutate {_new_id}"
-                        )
-                        print_helix_error(_mu_exc)
-                        if isinstance(_mu_exc, RateLimitError):
-                            logger.error(
-                                "Mutation %s (parent: %s, gen %d) failed after all retries: "
-                                "%s: %s — proposal slot skipped.",
-                                _new_id, _parent.id, gen,
-                                type(_mu_exc).__name__, _mu_exc,
-                            )
-                            print_error(
-                                f"Mutation [bold]{_new_id}[/bold] hit rate limit after all "
-                                f"retries — proposal slot skipped. "
-                                f"Run [cyan]helix resume[/cyan] when rate limits clear."
-                            )
-                    else:
-                        print_error(
-                            f"Parallel mutation {_new_id} (parent: {_parent.id}, gen {gen}) "
-                            f"failed with exception:\n{traceback.format_exc()}"
-                        )
-                    return _LLMFailedResult(
-                        presample_ctx=pre_ctx,
-                        parent_eval_result=_parent_eval,
-                        parent_n_uncached=_parent_n_uncached,
-                    )
-
-                if _child is None:
-                    return _LLMFailedResult(
-                        presample_ctx=pre_ctx,
-                        parent_eval_result=_parent_eval,
-                        parent_n_uncached=_parent_n_uncached,
-                    )
-
-                # ---- Step W5: Tamper check ----
-                _tampered = _detect_evaluator_tamper(
-                    _child, evaluator_manifest, config, project_root
-                )
-                if _tampered:
-                    return _TamperedResult(
-                        presample_ctx=pre_ctx,
-                        parent_eval_result=_parent_eval,
-                        child=_child,
-                        tampered_paths=_tampered,
-                        parent_n_uncached=_parent_n_uncached,
-                        child_usage=_child.usage if _child.usage else None,
-                    )
-
-                # ---- Step W6: Child minibatch eval ----
-                _child_eval: "EvalResult | None" = None
-                _child_n_uncached: int = 0
-                if _sub_ids is not None:
-                    _ce, _cn = _cached_evaluate_batch(
-                        _child,
-                        list(_sub_ids),
-                        minibatch_cache,  # use cache for child (unlike parent bypass)
-                        config,
-                        "train",
-                        project_root,
-                    )
-                    _ce.candidate_id = _child.id
-                    _child_eval = _ce
-                    _child_n_uncached = _cn
-
-                return _SuccessResult(
-                    presample_ctx=pre_ctx,
-                    parent_eval_result=_parent_eval,
-                    child=_child,
-                    child_eval_result=_child_eval,
-                    parent_n_uncached=_parent_n_uncached,
-                    child_n_uncached=_child_n_uncached,
-                    child_usage=_child.usage if _child.usage else None,
-                )
-
-            # ---- Step 2: Atomic workers (GEPA execute_proposal parity) ----
-            # One worker per proposal slot; all run in a single ThreadPoolExecutor.
-            # Each worker executes: parent_eval → skip-perfect → LLM → tamper → child_eval.
-            # Budget charging is deferred to the sequential acceptance loop (Step 3).
-            # GEPA parity: engine.py:422-443, reflective_mutation.py:268,308,369,420.
 
             if _budget_break and not presample_contexts:
                 print_warning("Budget exhausted mid-generation -- stopping.")
                 _save_state(state)
                 break
 
-            set_phase(HelixPhase.MUTATION)
-
-            worker_results: "list[_ProposalResult | None]" = [None] * len(presample_contexts)
-
-            from concurrent.futures import (  # noqa: PLC0415
-                ThreadPoolExecutor as _TPE,
-                as_completed as _ac,
+            worker_results = _dispatch_proposals(
+                presample_contexts,
+                lambda pre_ctx: _run_proposal_worker(
+                    pre_ctx,
+                    config=config,
+                    project_root=project_root,
+                    worktrees_dir=worktrees_dir,
+                    minibatch_cache=minibatch_cache,
+                    eval_cache=eval_cache,
+                    evaluator_manifest=evaluator_manifest,
+                    use_minibatch_gate=use_minibatch_gate,
+                    gen=gen,
+                ),
+                max_workers=config.evolution.max_workers,
+                gen=gen,
             )
-
-            _w_max = min(len(presample_contexts), config.evolution.max_workers)
-            if len(presample_contexts) > 1:
-                with _TPE(max_workers=_w_max) as _wpool:
-                    _wfutures = {
-                        _wpool.submit(_run_proposal_worker, _pctx): _widx
-                        for _widx, _pctx in enumerate(presample_contexts)
-                    }
-                    for _wf in _ac(_wfutures):
-                        _widx = _wfutures[_wf]
-                        try:
-                            worker_results[_widx] = _wf.result()
-                        except PromptArtifactCollisionError:
-                            raise
-                        except Exception as _wexc:
-                            _wpctx = presample_contexts[_widx]
-                            _wid = _wpctx[3]
-                            _wparent = _wpctx[0]
-                            print_warning(
-                                f"Worker for proposal {_wid} "
-                                f"(parent: {_wparent.id}, gen {gen}) "
-                                f"raised an unexpected exception: "
-                                f"{type(_wexc).__name__}: {_wexc} — proposal slot dropped."
-                            )
-                            worker_results[_widx] = _LLMFailedResult(
-                                presample_ctx=_wpctx,
-                                parent_eval_result=None,
-                                parent_n_uncached=0,
-                            )
-            else:
-                # n=1 sequential path (or single surviving slot after budget break)
-                for _idx, _pctx in enumerate(presample_contexts):
-                    worker_results[_idx] = _run_proposal_worker(_pctx)
 
             # ---- Step 3: Sequential acceptance (sampling order, GEPA engine.py:446-452) ----
             # Read worker results in pre-sampling order.  Budget mutations, lineage
@@ -2505,7 +2533,7 @@ def _run_evolution_impl(
 
                 # --- Handle non-success kinds (isinstance narrows wr for mypy) ---
 
-                if isinstance(wr, _LLMFailedResult):
+                if isinstance(wr, MutationFailedProposal):
                     # Charge parent eval budget if the parent eval ran successfully
                     # before the LLM call failed.
                     if _subsample_ids is not None and wr.parent_eval_result is not None:
@@ -2519,7 +2547,7 @@ def _run_evolution_impl(
                     print_warning(f"Mutation {_new_id} failed -- skipping.")
                     continue
 
-                if isinstance(wr, _SkippedResult):
+                if isinstance(wr, SkippedProposal):
                     # Charge parent eval budget (both paths)
                     if _subsample_ids is not None:
                         budget_api.charge_evaluation(
@@ -2555,7 +2583,7 @@ def _run_evolution_impl(
                         retryable_semantic_skip_count += 1
                     continue
 
-                if isinstance(wr, _TamperedResult):
+                if isinstance(wr, TamperedProposal):
                     # Charge parent eval budget
                     if _subsample_ids is not None:
                         budget_api.charge_evaluation(
@@ -2579,7 +2607,7 @@ def _run_evolution_impl(
                     _safe_remove_worktree(wr.child, label="tamper-rejected mutation candidate")
                     continue
 
-                # wr is _SuccessResult at this point (mypy narrows via isinstance exhaustion)
+                # wr is EvaluatedProposal at this point (mypy narrows via isinstance exhaustion)
                 child = wr.child
 
                 # Charge parent eval budget
@@ -2908,7 +2936,7 @@ def _run_evolution_impl(
             # resume the next iteration will be gen+1 — no rollback, no infinite loop.
             if (
                 not any(
-                    wr and isinstance(wr, (_SuccessResult, _TamperedResult))
+                    wr and isinstance(wr, (EvaluatedProposal, TamperedProposal))
                     for wr in worker_results
                 )
                 and semantic_skip_count

--- a/src/helix/merger.py
+++ b/src/helix/merger.py
@@ -130,7 +130,7 @@ def build_merge_prompt(
 
     Sections are emitted only when they have content, mirroring GEPA O.A.'s
     ``_build_reflection_prompt_template`` accumulator pattern
-    (``gepa/optimize_anything.py:501-596``).
+    in ``gepa_launcher.py``.
 
     **Diff section format** — two-diff (ancestor-relative) vs single (A↔B):
 

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -165,7 +165,7 @@ def _evaluator_failed(eval_result: EvalResult) -> bool:
 # section is suppressed) or a fully-formed Markdown section.  Empty
 # returns let ``build_mutation_prompt`` skip the section entirely —
 # mirrors GEPA's ``_build_reflection_prompt_template`` accumulator
-# pattern (``gepa/optimize_anything.py:501-596``).  Non-empty returns
+# pattern in ``gepa_launcher.py``.  Non-empty returns
 # may carry trailing whitespace; ``build_mutation_prompt`` rstrips
 # before joining sections with a uniform blank-line separator.
 
@@ -392,8 +392,8 @@ def _render_per_example_diagnostics(
     """Render per-example side_info as the mutation-prompt Diagnostics section.
 
     Mirrors GEPA's ``OptimizeAnythingAdapter.make_reflective_dataset`` +
-    ``format_samples`` at
-    ``src/gepa/adapters/optimize_anything_adapter/optimize_anything_adapter.py:524-553``
+    ``format_samples`` in
+    ``adapters/optimize_anything_adapter/optimize_anything_adapter.py``
     and ``src/gepa/strategies/instruction_proposal.py:54-95``:
 
       * each example gets an ``{'#' * example_header_level} Example <id>``
@@ -453,9 +453,10 @@ def _render_scores_section(eval_result: EvalResult) -> str:
     """Render ``## Current Evaluation Scores`` or ``""`` when no scores exist.
 
     Mirrors GEPA O.A.'s "only emit a section when there is content for it"
-    pattern (``gepa/optimize_anything.py:501-596``).  Previously HELIX
-    emitted the section with a ``"(no scores recorded)"`` placeholder; now
-    the section header is omitted entirely so the agent never sees a stub.
+    pattern in ``_build_reflection_prompt_template`` (``gepa_launcher.py``).
+    Previously HELIX emitted the section with a ``"(no scores recorded)"``
+    placeholder; now the section header is omitted entirely so the agent
+    never sees a stub.
     """
     lines = [f"  {k}: {v}" for k, v in sorted(eval_result.scores.items())]
     if not lines:
@@ -526,7 +527,7 @@ def build_mutation_prompt(
 
     Sections are emitted only when they have content, mirroring GEPA O.A.'s
     ``_build_reflection_prompt_template`` accumulator pattern
-    (``gepa/optimize_anything.py:501-596``).  Empty ``objective``, empty
+    in ``gepa_launcher.py``.  Empty ``objective``, empty
     ``eval_result.scores``, absent diagnostics, absent evaluator notes,
     absent stdout/stderr fallback, absent extra ASI, and absent
     ``background`` all skip their respective sections entirely instead of

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -1,12 +1,12 @@
 """Parse ``HELIX_RESULT=<per-example [score, side_info] pairs>``.
 
-GEPA ``optimize_anything`` evaluator-contract parity.  GEPA's O.A.
-evaluator returns ``(score: float, side_info: dict)`` **per example**
-(``src/gepa/optimize_anything.py:387-438``); the O.A. adapter then wraps
-that per-example stream into ``EvaluationBatch(scores=list[float],
-trajectories=list[SideInfo], ...)``
-(``optimize_anything_adapter.py:218-292``).  This parser hands HELIX
-the same per-example stream.
+GEPA ``optimize_anything`` evaluator-contract parity.  GEPA's
+``EvaluatorWrapper`` (``gepa.gepa_launcher``) normalises each
+per-example evaluator return to ``(score, output, side_info)``, and
+``OptimizeAnythingAdapter.evaluate`` packages the resulting per-example
+stream into an ``EvaluationBatch(scores=list[float],
+trajectories=list[SideInfo], ...)``.  This parser hands HELIX the same
+per-example stream.
 
 **BREAKING (pre-1.0):** ``helix_result`` previously accepted
 ``[score: float, side_info: dict]`` with an id-keyed
@@ -30,10 +30,10 @@ bare score::
 Element ``i`` corresponds to the id at position ``i`` in the
 ``helix_batch.json`` HELIX wrote pre-invocation (see
 :func:`helix.evolution._write_helix_batch`).  A bare ``float`` is
-normalised to ``(score, {})`` — matching GEPA O.A.'s
-``EvaluatorWrapper`` at ``src/gepa/optimize_anything.py:971`` which
-auto-wraps a bare score to ``(score, None, {})``.  Rich entries are
-a 2-element ``[score: float, side_info: dict]`` list.
+normalised to ``(score, {})`` — matching GEPA's ``EvaluatorWrapper``
+(``gepa.gepa_launcher``), which auto-wraps a bare evaluator return
+into ``(score, None, side_info)``.  Rich entries are a 2-element
+``[score: float, side_info: dict]`` list.
 
 ``len(payload) == len(ids)`` is required.
 
@@ -47,8 +47,9 @@ the mutation prompt's ``## Diagnostics`` section (GEPA
 
 Reserved key: ``side_info_i["scores"]``
 ---------------------------------------
-Mirrors GEPA's ``OptimizeAnythingAdapter._process_side_info``
-(``optimize_anything_adapter.py:260-272``).  When a per-example
+Mirrors GEPA's ``OptimizeAnythingAdapter._extract_objective_scores``,
+which pulls the same ``side_info["scores"]`` dict out per example and
+folds it into the batch's ``objective_scores``.  When a per-example
 ``side_info_i["scores"]`` is a dict of ``{objective_name: float}``,
 HELIX harvests it into the corresponding slot of
 :attr:`helix.population.EvalResult.objective_scores`
@@ -61,7 +62,7 @@ through on :class:`EvalResult`.
 Aggregate
 ---------
 * ``instance_scores = dict(zip(ids, [p[0] for p in payload]))`` —
-  feeds the minibatch gate at ``evolution.py:1920-1939`` as before.
+  feeds the minibatch gate in ``evolution.py``'s ``_gate_proposal`` as before.
 * ``scores["success"] = mean([p[0] for p in payload])`` — or 0.0 when
   ``returncode != 0`` or the payload is empty.
 
@@ -138,30 +139,29 @@ def _extract_helix_result_line(stdout: str) -> str | None:
 def _harvest_objective_scores(side_info: dict[str, Any]) -> dict[str, float]:
     """Extract ``side_info["scores"]`` into a ``dict[str, float]``.
 
-    Mirrors GEPA's ``OptimizeAnythingAdapter._process_side_info``
-    (``optimize_anything_adapter.py:260-272``): the reserved
-    ``"scores"`` key carries a dict of ``{objective_name: float}`` that
-    becomes the per-example ``objective_scores`` slot feeding the
-    multi-axis Pareto frontier.  Pairwise / Bradley-Terry payloads are
-    not implemented in HELIX yet, so non-scalar objective values fail
-    loudly instead of being dropped and misread as scalar objective
-    semantics.
+    Mirrors GEPA's ``OptimizeAnythingAdapter._extract_objective_scores``:
+    the reserved ``"scores"`` key carries a dict of
+    ``{objective_name: float}`` that becomes the per-example
+    ``objective_scores`` slot feeding the multi-axis Pareto frontier.
+    Pairwise / Bradley-Terry payloads are not implemented in HELIX yet,
+    so non-scalar objective values fail loudly instead of being dropped
+    and misread as scalar objective semantics.
 
     Stricter than upstream GEPA (a very minor improvement)
     ------------------------------------------------------
     GEPA's adapter does ``objective_score.update(side_info["scores"])``
     blindly, so non-finite / non-numeric / non-string-keyed entries
     sail through the parser and only blow up later inside
-    ``_aggregate_objective_scores`` (``state.py:432``) where the error
-    message is far less actionable.  HELIX validates at parse time and
-    raises :class:`EvaluatorError` with the offending key/value type.
+    ``GEPAState._aggregate_objective_scores`` where the error message
+    is far less actionable.  HELIX validates at parse time and raises
+    :class:`EvaluatorError` with the offending key/value type.
     Practical consequence: an evaluator built against upstream GEPA
     that legitimately emits finite numeric scalars under ``"scores"``
     is unaffected; only payloads that would break GEPA later are
     rejected here earlier.
 
-    Per-predictor namespacing (``param_name + "_specific_info"``,
-    ``optimize_anything_adapter.py:266-270``) is intentionally not
+    Per-predictor namespacing (``param_name + "_specific_info"``, also
+    handled by ``_extract_objective_scores``) is intentionally not
     replicated: HELIX evolves whole git worktrees rather than
     multi-component named-predictor programs.  See the tracking issue
     on ``KE7/helix`` for the architectural gap.
@@ -275,9 +275,8 @@ def parse(
         * ``objective_scores: list[dict[str, float]]`` — the
           ``side_info_i["scores"]`` harvest for each example, in id
           order.  GEPA analogue:
-          :attr:`gepa.core.adapter.EvaluationBatch.objective_scores`
-          (``src/gepa/core/adapter.py:26``).  Feeds the multi-axis
-          Pareto frontier; stored on
+          :attr:`gepa.core.adapter.EvaluationBatch.objective_scores`.
+          Feeds the multi-axis Pareto frontier; stored on
           :attr:`helix.population.EvalResult.objective_scores`.
 
     Raises
@@ -387,10 +386,10 @@ def parse(
 
     for eid, entry in zip(ids, payload):
         # GEPA optimize_anything union parity: per-example entry is
-        # either a bare score or a ``[score, side_info]`` pair.  The
-        # O.A. ``EvaluatorWrapper`` at
-        # ``src/gepa/optimize_anything.py:971`` auto-normalizes a bare
-        # float to ``(score, None, {})`` — HELIX does the same here,
+        # either a bare score or a ``[score, side_info]`` pair.  GEPA's
+        # ``EvaluatorWrapper`` (``gepa.gepa_launcher``) auto-normalizes
+        # a bare evaluator return to ``(score, None, side_info)`` —
+        # HELIX does the same here,
         # materialising ``side_info = {}`` for bare entries so the
         # downstream objective harvest is a no-op rather than a crash.
         # Mixed bare / rich within one payload is allowed.  ``bool`` is

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -135,8 +135,8 @@ class EvalResult:
     # Per-example objective-axis harvest: each slot is
     # ``side_info_i.get("scores", {})`` filtered down to
     # ``{str: float}`` entries.  GEPA analogue:
-    # :attr:`gepa.core.adapter.EvaluationBatch.objective_scores`
-    # (``src/gepa/core/adapter.py:26``).  Feeds the multi-axis Pareto
+    # :attr:`gepa.core.adapter.EvaluationBatch.objective_scores`.
+    # Feeds the multi-axis Pareto
     # frontier when ``evolution.frontier_type`` ∈ {"objective",
     # "hybrid", "cartesian"}; harmless on the default "instance" path.
     objective_scores: list[dict[str, float]] | None = None
@@ -346,27 +346,27 @@ class ParetoFrontier:
 
     Multi-axis frontier (GEPA ``FrontierType`` parity)
     ---------------------------------------------------
-    The ``frontier_type`` constructor arg mirrors GEPA's literal at
-    ``src/gepa/core/state.py:22-23``:
+    The ``frontier_type`` constructor arg mirrors GEPA's ``FrontierType``
+    literal in ``core/state.py``:
 
     - ``"instance"`` (default): per-example-id keyspace, built from
       ``EvalResult.instance_scores``.  Matches HELIX's historical
       behaviour and GEPA's ``frontier_type="instance"`` path.
     - ``"objective"``: per-objective-name keyspace, values = mean of
       that objective across the valset, built from
-      ``EvalResult.objective_scores``.  GEPA
-      ``_update_objective_pareto_front`` (``state.py:474-484``).
+      ``EvalResult.objective_scores``.  GEPA's
+      ``GEPAState._update_objective_pareto_front``.
     - ``"hybrid"``: union of the instance and objective keyspaces.
       A candidate survives if it's non-dominated on the combined
       keyset.
     - ``"cartesian"``: per ``(val_id, objective_name)`` keyspace.
-      GEPA ``_update_pareto_front_for_cartesian``
-      (``state.py:512-525``).
+      GEPA's ``GEPAState._update_pareto_front_for_cartesian``.
 
     The **acceptance gate stays positional** on ``scores_list``
-    regardless of ``frontier_type`` (GEPA ``acceptance.py:39-48``);
-    only the Pareto retention / parent-selection decision is
-    multi-axis.
+    regardless of ``frontier_type`` (GEPA's default
+    ``StrictImprovementAcceptance`` in ``strategies/acceptance.py``
+    sums subsample scores positionally); only the Pareto retention /
+    parent-selection decision is multi-axis.
 
     Implementation: each axis has its own ``_..._best`` /
     ``_..._best_score`` dict, populated on ``add()``.
@@ -392,7 +392,7 @@ class ParetoFrontier:
         # (val_id → best score).
         self._per_key_best: dict[str, set[str]] = {}
         self._per_key_best_score: dict[str, float] = {}
-        # ``"objective"`` axis — mirrors GEPAState.program_at_objective_pareto_front
+        # ``"objective"`` axis — mirrors GEPAState.program_at_pareto_front_objectives
         # (objective_name → {candidates tied for best mean-across-valset})
         # and ``objective_pareto_front`` (objective_name → best mean).
         self._objective_best: dict[str, set[str]] = {}
@@ -465,12 +465,16 @@ class ParetoFrontier:
     def _validate_objective_scores(self, cid: str, result: EvalResult) -> None:
         """Validate objective-score shape without rejecting empty axes.
 
-        Upstream GEPA tolerates missing or all-empty objective mappings and
-        its objective update simply no-ops. HELIX follows that behavior for
-        the update path while retaining a positional length invariant when
-        objective mappings are present. A warning records the degraded
-        non-instance run; objective-only selection later raises a typed,
-        actionable error if there is no objective frontier to sample.
+        Upstream GEPA raises a plain ``ValueError`` at both the seed-time
+        check in ``GEPAState.__init__`` and the per-update check in
+        ``GEPAState.update_state_with_new_program`` when
+        ``valset_evaluation.objective_scores_by_val_id`` is missing/empty
+        for an objective-bearing ``frontier_type``.  HELIX diverges here:
+        rather than raising immediately at add-time, it emits a warning
+        and no-ops, deferring the hard failure to selection time, where
+        objective-only selection raises a typed, actionable
+        :class:`MissingObjectiveScoresError` if there is no objective
+        frontier to sample.
 
         The positional length check remains a structural invariant for
         HELIX's list-shaped objective field.
@@ -514,11 +518,14 @@ class ParetoFrontier:
     def _update_objective(self, cid: str, result: EvalResult) -> None:
         """Update the per-objective frontier using mean-across-valset.
 
-        Mirrors GEPA's ``_update_objective_pareto_front``
-        (``state.py:474-484``) with its ``_per_prog_mean_objective_scores``
-        helper (``state.py:462-472``): for each objective name present
-        in any per-example slot, take the mean of that objective's
-        scores across the entire ``objective_scores`` list.
+        HELIX computes the per-candidate mean of each objective across
+        its own ``objective_scores`` list, then tracks the best mean
+        (and any candidates tied for it) per objective name — the same
+        two-stage shape as upstream GEPA, which aggregates per-val_id
+        objective scores into a per-program mean via
+        ``GEPAState._aggregate_objective_scores`` before handing that
+        pre-aggregated dict to ``GEPAState._update_objective_pareto_front``
+        for the best-tracking step.
         """
         # Empty or absent objective scores are an intentional no-op, matching
         # GEPA's ``if not objective_scores: return`` update behavior.
@@ -542,8 +549,8 @@ class ParetoFrontier:
     def _update_cartesian(self, cid: str, result: EvalResult) -> None:
         """Update the (val_id, objective_name) frontier.
 
-        Mirrors GEPA's ``_update_pareto_front_for_cartesian``
-        (``state.py:512-525``): each per-example ``objective_scores[i]``
+        Mirrors GEPA's ``GEPAState._update_pareto_front_for_cartesian``:
+        each per-example ``objective_scores[i]``
         slot is combined with the corresponding ``val_id`` (from
         ``instance_scores``' ordered keys) to form a tuple key.  We
         encode the tuple as ``f"{val_id}::{objective_name}"`` so the
@@ -630,8 +637,8 @@ class ParetoFrontier:
             return self._objective_best
         if self._frontier_type == "cartesian":
             return self._cartesian_best
-        # "hybrid": union of instance ∪ objective keyspaces (GEPA O.A.
-        # default — see src/gepa/optimize_anything.py:476).
+        # "hybrid": union of instance ∪ objective keyspaces — GEPA's
+        # default (``EngineConfig.frontier_type`` in ``gepa_launcher.py``).
         merged: dict[str, set[str]] = {}
         for k, v in self._per_key_best.items():
             merged[f"inst::{k}"] = v

--- a/src/helix/proposals.py
+++ b/src/helix/proposals.py
@@ -16,8 +16,9 @@ concurrently while the apply phase stays sequential and deterministic.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TypeAlias
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal, Protocol, TypeAlias
 
 from helix.display import UsageStats
 from helix.population import Candidate, EvalResult
@@ -76,3 +77,194 @@ class EvaluatedProposal:
 ProposalResult: TypeAlias = (
     SkippedProposal | MutationFailedProposal | TamperedProposal | EvaluatedProposal
 )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: one judgement per proposal
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScoreVectors:
+    """The two score vectors an acceptance criterion compares.
+
+    Field names and mutability match the ``_Proposal`` protocol in
+    ``helix.eval_policy``, which this is passed to.  It replaces the
+    ``SimpleNamespace`` the gate used to build, which satisfied that
+    protocol only at runtime.
+    """
+
+    subsample_scores_before: list[float] | None
+    subsample_scores_after: list[float] | None
+
+
+class AcceptanceCriterion(Protocol):
+    """Structural type of ``StrictImprovement`` / ``ImprovementOrEqual``."""
+
+    def should_accept(self, proposal: ScoreVectors, /) -> bool: ...
+
+
+@dataclass(frozen=True)
+class AcceptanceJudgement:
+    """What the criterion decided about one proposal, and by what margin."""
+
+    accepted: bool
+    before: list[float]
+    after: list[float]
+
+    @property
+    def improvement(self) -> float:
+        """``sum(after) - sum(before)`` — the margin the gate judged on.
+
+        Selection ranks on this rather than on the child's absolute score so
+        that a proposal from a weak parent competes on what it added, which
+        is the same quantity the acceptance criterion tested.
+        """
+        return sum(self.after) - sum(self.before)
+
+
+class AcceptanceMemo:
+    """Memoises one acceptance judgement per proposal slot.
+
+    ``best_improvement`` and ``top_k`` have to know the gate outcome for
+    every proposal in a batch before they can promote any of it, so the
+    criterion gets consulted in one place and the selected proposals get
+    re-examined in another.  Routing every consultation through this memo
+    makes the number of underlying ``should_accept`` calls a function of the
+    batch size alone — a selection strategy cannot change what the criterion
+    decided about a proposal by asking about it more or less often.
+    """
+
+    def __init__(self, criterion: AcceptanceCriterion) -> None:
+        self._criterion = criterion
+        self._judgements: dict[int, AcceptanceJudgement] = {}
+        # Number of times the underlying criterion actually ran.  Asserted on
+        # by the tests that pin the one-judgement-per-proposal property.
+        self.criterion_calls = 0
+
+    def judge(
+        self, order: int, before: list[float], after: list[float]
+    ) -> AcceptanceJudgement:
+        """Return the judgement for slot ``order``, computing it at most once."""
+        cached = self._judgements.get(order)
+        if cached is not None:
+            return cached
+        self.criterion_calls += 1
+        judgement = AcceptanceJudgement(
+            accepted=self._criterion.should_accept(
+                ScoreVectors(
+                    subsample_scores_before=before,
+                    subsample_scores_after=after,
+                )
+            ),
+            before=before,
+            after=after,
+        )
+        self._judgements[order] = judgement
+        return judgement
+
+
+# ---------------------------------------------------------------------------
+# Selection: which gated proposals reach the frontier
+# ---------------------------------------------------------------------------
+
+
+SelectionStrategy: TypeAlias = Literal[
+    "all_improvements", "best_improvement", "top_k"
+]
+
+
+@dataclass
+class GatedProposal:
+    """An evaluated proposal that cleared its acceptance gate.
+
+    ``order`` is the slot's index in *sampled* order, not completion order.
+    Every tie-break and the final apply order key off it, so a batch's
+    outcome is a function of the seed alone.
+    """
+
+    order: int
+    proposal: EvaluatedProposal
+    judgement: AcceptanceJudgement
+    gating_result: EvalResult
+    # Ids the gate compared on; None on the no-minibatch path.
+    subsample_ids: list[str] | None = field(default=None)
+
+    @property
+    def child(self) -> Candidate:
+        return self.proposal.child
+
+    @property
+    def improvement(self) -> float:
+        return self.judgement.improvement
+
+
+def select_all_improvements(gated: list[GatedProposal]) -> list[GatedProposal]:
+    """Promote every proposal that cleared the gate — the historical behaviour."""
+    return list(gated)
+
+
+def select_best_improvement(gated: list[GatedProposal]) -> list[GatedProposal]:
+    """Promote only the largest improvement, earliest-sampled winning ties.
+
+    ``max`` returns the first maximal element, so the winner is the first in
+    sampled order and never the one whose worker happened to finish first.
+    """
+    if not gated:
+        return []
+    return [max(gated, key=lambda g: g.improvement)]
+
+
+def select_top_k(gated: list[GatedProposal], k: int) -> list[GatedProposal]:
+    """Promote the ``k`` largest improvements, earliest-sampled winning ties.
+
+    The rank sort is stable over a list already in sampled order, so equal
+    improvements resolve to the earlier slot.  The survivors are then put
+    back into sampled order: ranking decides *which* proposals apply, never
+    the order they apply in.
+    """
+    ranked = sorted(gated, key=lambda g: -g.improvement)[:k]
+    return sorted(ranked, key=lambda g: g.order)
+
+
+def select_proposals(
+    gated: list[GatedProposal],
+    *,
+    strategy: SelectionStrategy,
+    top_k: int | None = None,
+) -> list[GatedProposal]:
+    """Apply the configured selection strategy to the gated proposals."""
+    if strategy == "all_improvements":
+        return select_all_improvements(gated)
+    if strategy == "best_improvement":
+        return select_best_improvement(gated)
+    if top_k is None:  # pragma: no cover - config validation rejects this
+        raise ValueError("proposal_selection='top_k' requires proposal_top_k")
+    return select_top_k(gated, top_k)
+
+
+def dedupe_children(
+    selected: list[GatedProposal], content_key: Callable[[Candidate], str]
+) -> tuple[list[GatedProposal], list[GatedProposal]]:
+    """Split ``selected`` into first-seen children and byte-identical repeats.
+
+    Two proposals in a batch can produce identical children — most easily
+    two of the N siblings of one parent, which start from the same worktree
+    and the same reflection.  Inserting both would put two frontier entries
+    on one point, double-charge a full validation for a score already known,
+    and skew parent selection toward whatever that point happens to be.
+
+    Sampled order decides which copy survives, so the survivor does not
+    depend on completion timing.
+    """
+    seen: dict[str, GatedProposal] = {}
+    unique: list[GatedProposal] = []
+    duplicates: list[GatedProposal] = []
+    for candidate_proposal in selected:
+        key = content_key(candidate_proposal.child)
+        if key in seen:
+            duplicates.append(candidate_proposal)
+            continue
+        seen[key] = candidate_proposal
+        unique.append(candidate_proposal)
+    return unique, duplicates

--- a/src/helix/proposals.py
+++ b/src/helix/proposals.py
@@ -218,13 +218,13 @@ def select_best_improvement(gated: list[GatedProposal]) -> list[GatedProposal]:
 def select_top_k(gated: list[GatedProposal], k: int) -> list[GatedProposal]:
     """Promote the ``k`` largest improvements, earliest-sampled winning ties.
 
-    The rank sort is stable over a list already in sampled order, so equal
-    improvements resolve to the earlier slot.  The survivors are then put
-    back into sampled order: ranking decides *which* proposals apply, never
-    the order they apply in.
+    The sort is stable over a list already in sampled order, so equal
+    improvements resolve to the earlier slot.  Survivors stay in *ranked*
+    order rather than being restored to sampled order: the apply phase can
+    still stop early on budget exhaustion, and applying best-first means
+    what survives a truncated batch is what the ranking preferred.
     """
-    ranked = sorted(gated, key=lambda g: -g.improvement)[:k]
-    return sorted(ranked, key=lambda g: g.order)
+    return sorted(gated, key=lambda g: -g.improvement)[:k]
 
 
 def select_proposals(

--- a/src/helix/proposals.py
+++ b/src/helix/proposals.py
@@ -1,0 +1,78 @@
+"""Typed results of one proposal attempt.
+
+A *proposal* is one (parent, minibatch) slot: evaluate the parent, reflect,
+mutate, check the result for evaluator tampering, then evaluate the child.
+Each attempt terminates in exactly one of the four results below.
+
+These are a sealed union expressed as a class hierarchy rather than one
+``kind``-discriminated dataclass: it gives ``mypy --strict`` the ``isinstance``
+narrowing it needs to verify field access in the apply phase without asserts
+or ``TypeGuard``s.
+
+Budget charging, lineage writes and frontier updates are deliberately absent —
+producing a proposal is pure with respect to run state, so the attempts can run
+concurrently while the apply phase stays sequential and deterministic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+from helix.display import UsageStats
+from helix.population import Candidate, EvalResult
+
+
+# ``(parent, parent_frontier_result, subsample_ids, reserved_child_id)`` — the
+# sequentially sampled context every attempt starts from.
+ProposalContext: TypeAlias = tuple[
+    Candidate, EvalResult | None, list[str] | None, str
+]
+
+
+@dataclass
+class SkippedProposal:
+    """Skip-perfect fired — the parent already scores perfectly; no LLM call."""
+
+    presample_ctx: ProposalContext
+    parent_eval_result: EvalResult
+    parent_n_uncached: int = 0
+
+
+@dataclass
+class MutationFailedProposal:
+    """``mutate()`` raised or returned None; ``parent_eval_result`` may be None."""
+
+    presample_ctx: ProposalContext
+    parent_eval_result: EvalResult | None
+    parent_n_uncached: int = 0
+
+
+@dataclass
+class TamperedProposal:
+    """The child modified protected evaluator files and must be rejected."""
+
+    presample_ctx: ProposalContext
+    parent_eval_result: EvalResult
+    child: Candidate
+    tampered_paths: list[str]
+    parent_n_uncached: int = 0
+    child_usage: UsageStats | None = None
+
+
+@dataclass
+class EvaluatedProposal:
+    """Every step completed; ``child_eval_result`` is None on the no-minibatch path."""
+
+    presample_ctx: ProposalContext
+    parent_eval_result: EvalResult
+    child: Candidate
+    child_eval_result: EvalResult | None = None
+    parent_n_uncached: int = 0
+    child_n_uncached: int = 0
+    child_usage: UsageStats | None = None
+
+
+ProposalResult: TypeAlias = (
+    SkippedProposal | MutationFailedProposal | TamperedProposal | EvaluatedProposal
+)

--- a/src/helix/proposals.py
+++ b/src/helix/proposals.py
@@ -249,8 +249,8 @@ def dedupe_children(
     """Split ``selected`` into first-seen children and byte-identical repeats.
 
     Two proposals in a batch can produce identical children — most easily
-    two of the N siblings of one parent, which start from the same worktree
-    and the same reflection.  Inserting both would put two frontier entries
+    multiple siblings of one parent, which start from the same worktree and
+    the same reflection.  Inserting both would put two frontier entries
     on one point, double-charge a full validation for a score already known,
     and skew parent selection toward whatever that point happens to be.
 

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -15,12 +15,13 @@ from typing import Any
 from helix.population import FrontierType
 
 
-# GEPA parity (audit-rng-state-persist D1):
-# GEPA core/state.py:153 declares ``_VALIDATION_SCHEMA_VERSION: ClassVar[int] = 5``
-# and migrates older state dicts on load (state.py:355-376).  HELIX previously
-# had no schema version on ``state.json``; subsequent bumps mark explicit
-# JSON-native schema additions (the unversioned predecessor is treated as
-# v0; ``load_state`` migrates by default-filling missing fields).
+# GEPA parity (rng-state-persist audit D1):
+# GEPA declares ``_VALIDATION_SCHEMA_VERSION: ClassVar[int] = 6`` on
+# ``GEPAState`` (``core/state.py``) and migrates older state dicts on load
+# in ``GEPAState.load``.  HELIX previously had no schema version on
+# ``state.json``; subsequent bumps mark explicit JSON-native schema
+# additions (the unversioned predecessor is treated as v0; ``load_state``
+# migrates by default-filling missing fields).
 SCHEMA_VERSION: int = 2
 
 
@@ -99,13 +100,13 @@ class EvolutionState:
     # Starts at -1 and is bumped to 0 before the first minibatch sample.
     # Mirrors GEPA ``state.i`` in core/state.py.
     i: int = -1
-    # GEPA parity (audit-rng-state-persist C/§3): per-program discovery budget.
+    # GEPA parity (rng-state-persist audit C/§3): per-program discovery budget.
     # GEPA tracks ``num_metric_calls_by_discovery: list[int]`` indexed by
-    # program_idx (state.py:177, appended at state.py:537).  HELIX uses
-    # candidate_id strings, so the dict keys by id and stores the value of
-    # ``state.budget.evaluations`` at the moment the candidate was added to
-    # the frontier.  Empty by default; populated at every accept site (seed,
-    # mutation, merge) in evolution.py.
+    # program_idx, appended to in ``GEPAState.update_state_with_new_program``
+    # (``core/state.py``).  HELIX uses candidate_id strings, so the dict
+    # keys by id and stores the value of ``state.budget.evaluations`` at the
+    # moment the candidate was added to the frontier.  Empty by default;
+    # populated at every accept site (seed, mutation, merge) in evolution.py.
     num_metric_calls_by_discovery: dict[str, int] = field(default_factory=dict)
     # Active Pareto-front snapshot for the selected ``frontier_type``.
     # ``frontier`` remains HELIX's append-only candidate id list; this
@@ -113,7 +114,7 @@ class EvolutionState:
     # conflating them with all evaluated candidates.
     active_frontier: dict[str, list[str]] = field(default_factory=dict)
     # Persisted ``evolution.frontier_type`` (GEPA ``FrontierType`` parity
-    # — ``src/gepa/core/state.py:22-23``).  Captured at evolve-time so
+    # — ``gepa/core/state.py``).  Captured at evolve-time so
     # read-only CLI commands (``helix frontier``, ``helix best``,
     # ``helix log``) display the frontier with the SAME dimensionality
     # the evolution run actually used — regardless of what
@@ -126,21 +127,23 @@ class EvolutionState:
     # a GEPA-style single pickled artifact: HELIX still persists worktrees,
     # evaluations, lineage, and state as separate artifacts.
     resume_semantics: dict[str, Any] = field(default_factory=dict)
-    # GEPA parity (audit-rng-state-persist D1): persisted schema version.
-    # Mirrors GEPA core/state.py:182 / class-var :153.  Bumped when the
-    # serialized schema changes; ``load_state`` migrates older payloads by
-    # supplying defaults for any missing fields.
+    # GEPA parity (rng-state-persist audit D1): persisted schema version.
+    # Mirrors GEPA's ``validation_schema_version`` field, stamped from the
+    # ``GEPAState._VALIDATION_SCHEMA_VERSION`` class-var (``core/state.py``).
+    # Bumped when the serialized schema changes; ``load_state`` migrates
+    # older payloads by supplying defaults for any missing fields.
     schema_version: int = SCHEMA_VERSION
 
 
 _STATE_FILENAME = "state.json"
 _STATE_DIR = ".helix"
-# GEPA parity (audit-rng-state-persist C1): companion pickle for the
-# per-(candidate_hash, example_id) eval cache.  GEPA pickles the whole state
-# dict, which round-trips its tuple-keyed ``EvaluationCache._cache`` for free
-# (gepa/core/state.py:306-340).  HELIX persists state as JSON, which cannot
-# encode tuple keys, so the cache lives in a sibling pickle alongside
-# ``state.json``.  Loaded conditionally on ``config.evolution.cache_evaluation``.
+# GEPA parity (rng-state-persist audit C1): companion pickle for the
+# per-(candidate_hash, example_id) eval cache.  ``GEPAState.save`` pickles
+# the whole state object, which round-trips its tuple-keyed
+# ``EvaluationCache._cache`` for free (``core/state.py``).  HELIX persists
+# state as JSON, which cannot encode tuple keys, so the cache lives in a
+# sibling pickle alongside ``state.json``.  Loaded conditionally on
+# ``config.evolution.cache_evaluation``.
 _EVAL_CACHE_FILENAME = "eval_cache.pkl"
 
 
@@ -158,7 +161,7 @@ def save_state(state: EvolutionState, base_dir: Path) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
 
     data = {
-        # GEPA parity (audit-rng-state-persist D1): schema_version is written
+        # GEPA parity (rng-state-persist audit D1): schema_version is written
         # FIRST so a stripped/legacy state.json without it loads as v0 and
         # triggers the migration branch in ``load_state``.
         "schema_version": SCHEMA_VERSION,
@@ -202,8 +205,8 @@ def load_state(base_dir: Path) -> EvolutionState | None:
     with open(target) as f:
         data = json.load(f)
 
-    # GEPA parity (audit-rng-state-persist D1): migrate older payloads.
-    # GEPA's analogue is ``GEPAState._upgrade_state_dict`` (state.py:402-420):
+    # GEPA parity (rng-state-persist audit D1): migrate older payloads.
+    # GEPA's analogue is ``GEPAState._upgrade_state_dict`` (``core/state.py``):
     # supply defaults for any missing fields, then bump the version stamp.
     # HELIX treats a missing ``schema_version`` as v0 (the unversioned
     # predecessor) and falls through into the same default-fill path.
@@ -260,9 +263,9 @@ def load_state(base_dir: Path) -> EvolutionState | None:
 def save_eval_cache(cache_dict: dict[Any, Any], base_dir: Path) -> None:
     """Atomically pickle the per-(candidate, example) eval cache.
 
-    GEPA parity (audit-rng-state-persist C1): mirrors the cache-survival
-    behaviour of ``GEPAState.save`` at gepa/core/state.py:306-340.  HELIX
-    uses JSON for ``state.json`` (which cannot round-trip tuple keys), so the
+    GEPA parity (rng-state-persist audit C1): mirrors the cache-survival
+    behaviour of ``GEPAState.save`` (``core/state.py``).  HELIX uses JSON
+    for ``state.json`` (which cannot round-trip tuple keys), so the
     cache is written to a sibling pickle.  Caller should pass
     ``MinibatchEvalCache._cache`` directly.  No-op semantics for an empty
     cache: the file is still written so that resume can reliably distinguish
@@ -286,11 +289,11 @@ def save_eval_cache(cache_dict: dict[Any, Any], base_dir: Path) -> None:
 def load_eval_cache(base_dir: Path) -> dict[Any, Any] | None:
     """Load the per-(candidate, example) eval cache, or None if absent.
 
-    GEPA parity (audit-rng-state-persist C1): mirrors the cache-restore
-    behaviour at gepa/core/state.py:348-376.  Returns the raw dict so the
-    caller can install it on a freshly constructed cache instance (the
-    caller decides whether caching is enabled — see ``initialize_gepa_state``
-    at gepa/core/state.py:683-687 for the equivalent gating).
+    GEPA parity (rng-state-persist audit C1): mirrors the cache-restore
+    behaviour of ``GEPAState.load`` (``core/state.py``).  Returns the raw
+    dict so the caller can install it on a freshly constructed cache
+    instance (the caller decides whether caching is enabled — see
+    ``initialize_gepa_state`` (``core/state.py``) for the equivalent gating).
     """
     target = _eval_cache_path(base_dir)
     if not target.exists():

--- a/tests/unit/test_align_iteration.py
+++ b/tests/unit/test_align_iteration.py
@@ -2,18 +2,22 @@
 
 Covers three audit findings:
 
-- **M1** (audit-init-engine.md B1/B2, audit-mutation.md C1) — perfect-score
+- **M1** (findings B1/B2, C1) — perfect-score
   hitting the threshold skips ONE proposal (``continue``) instead of
   terminating the run (``break``), and uses the GEPA per-example
   ``all(s >= threshold)`` criterion instead of mean ``aggregate_score()``.
-  GEPA reference: ``reflective_mutation.py:308-327``.
-- **M2** (audit-init-engine.md B3) — merge-branch fail-fast paths fall
+  GEPA reference: the per-task perfect-score skip in
+  ``ReflectiveMutationProposer.propose`` (``proposer/reflective_mutation/
+  reflective_mutation.py``).
+- **M2** (finding B3) — merge-branch fail-fast paths fall
   through to reflective mutation instead of consuming the iteration.
   Only an actually-evaluated merge (accepted or rejected) consumes the
-  iteration.  GEPA reference: ``engine.py:664-741``.
-- **MODERATE D** (audit-mutation.md C3) — legacy (no-minibatch) mutation
-  gating uses sum-score acceptance only (GEPA ``engine.py:287-303`` /
-  ``reflective_mutation.py:420``); the old ``degrades()`` pre-check is
+  iteration.  GEPA reference: the merge-then-mutation dispatch in
+  ``GEPAEngine.run()``'s main loop (``core/engine.py``).
+- **MODERATE D** (finding C3) — legacy (no-minibatch) mutation
+  gating uses sum-score acceptance only (GEPA's ``StrictImprovementAcceptance
+  .should_accept`` in ``strategies/acceptance.py``, applied via
+  ``GEPAEngine``'s acceptance criterion); the old ``degrades()`` pre-check is
   removed so the legacy path matches the minibatch path.
 
 All tests run with ``val_stage_size=None`` (default) to exercise the
@@ -37,7 +41,7 @@ from tests.unit.test_evolution import (  # type: ignore[import-untyped]
 
 
 class TestPerfectScoreContinues:
-    """GEPA parity (M1) — audit-init-engine.md B1.
+    """GEPA parity (M1) — finding B1.
 
     Pre-fix: perfect-score set ``_budget_break=True`` + broke the inner loop,
     and the outer ``if _budget_break and not proposal_contexts: break`` exited
@@ -76,20 +80,21 @@ class TestPerfectScoreContinues:
             f"`_budget_break = True; break` at the perfect-score check)."
         )
         # Every parent (the seed, reused across gens) reports perfect
-        # scores, so mutation is skipped in every generation — per
-        # GEPA reflective_mutation.py:308-327 the proposal is dropped
-        # but the outer iteration loop continues.
+        # scores, so mutation is skipped in every generation — per GEPA's
+        # per-task perfect-score skip in ``ReflectiveMutationProposer
+        # .propose`` the proposal is dropped but the outer iteration loop
+        # continues.
         all_mocks["mutate"].assert_not_called()
 
     def test_perfect_score_uses_per_example_all_not_mean(
         self, mocker, tmp_path, all_mocks  # noqa: F811
     ):
-        """GEPA parity (M1) — audit-init-engine.md B2.
+        """GEPA parity (M1) — finding B2.
 
         Pre-fix: criterion was ``aggregate_score() >= threshold`` (mean),
         which fires on ``{0.5, 1.0, 1.0}`` at ``threshold=0.8`` because
-        the mean is 0.83.  GEPA reflective_mutation.py:311 uses
-        ``all(s >= perfect_score)`` — the 0.5 per-example score would
+        the mean is 0.83.  GEPA's ``ReflectiveMutationProposer.propose``
+        uses ``all(s >= perfect_score)`` — the 0.5 per-example score would
         prevent the skip, so mutation must proceed.
         """
         seed = make_candidate("g0-s0")
@@ -130,12 +135,15 @@ class TestPerfectScoreContinues:
 
 
 class TestMergeFallthroughToMutation:
-    """GEPA parity (M2) — audit-init-engine.md B3.
+    """GEPA parity (M2) — finding B3.
 
     When the merge gate is entered but no merge is actually evaluated
     (no triplet, pair already attempted, overlap floor fails, merge op
     failed, tamper-reject pre-eval), GEPA falls through to reflective
-    mutation in the SAME iteration (engine.py:741-742).  Pre-fix HELIX
+    mutation in the SAME iteration — ``GEPAEngine.run()``'s merge branch
+    only ``continue``s past reflective mutation when a merge proposal was
+    actually produced and evaluated (accepted or rejected); otherwise
+    control falls through into reflective mutation.  Pre-fix HELIX
     ``continue``d on every merge-gate entry regardless of whether an
     attempt happened.
     """
@@ -145,10 +153,10 @@ class TestMergeFallthroughToMutation:
     ):
         """``merge()`` returns None (Claude Code / subprocess failure) →
         no merged candidate instantiated → no eval → GEPA falls through
-        to reflective mutation (audit-init-engine.md B3).
+        to reflective mutation (finding B3).
 
         Pre-fix HELIX: ``print_error`` fell through to the end-of-merge
-        ``save_state/update/continue`` at evolution.py ~1343 (INSIDE the
+        ``save_state/update/continue`` sequence (INSIDE the
         ``if triplet is not None`` nesting), consuming the iteration.
         """
         seed = make_candidate("g0-s0")
@@ -197,7 +205,7 @@ class TestMergeFallthroughToMutation:
             f"failure falls through); got {all_mocks['mutate'].call_count}. "
             f"Pre-fix: 1 (merge branch consumed gen 2 via the "
             f"end-of-merge `continue` even though ``merged is None`` "
-            f"meant no eval happened — audit-init-engine.md B3)."
+            f"meant no eval happened — finding B3)."
         )
         # Sanity: merge was attempted (find_merge_triplet returned a
         # triplet, merge(...) was called), but returned None.
@@ -207,7 +215,8 @@ class TestMergeFallthroughToMutation:
         self, mocker, tmp_path, all_mocks  # noqa: F811
     ):
         """Guard rail: when a merge IS attempted (eval runs), the iteration
-        is still consumed (GEPA engine.py:719 on accept, 737 on reject).
+        is still consumed — ``GEPAEngine.run()``'s merge branch ``continue``s
+        past reflective mutation on both the accept and reject paths.
 
         Failing this test would mean the M2 fix over-corrected and let
         mutation also run on the same iteration as an actual merge.
@@ -253,7 +262,8 @@ class TestMergeFallthroughToMutation:
         # AND accepted, so mutation does NOT run in gen 2.  Total: 1.
         assert all_mocks["mutate"].call_count == 1, (
             f"When a merge is actually attempted in gen 2, mutation must "
-            f"NOT also run (GEPA engine.py:719 `continue`).  Got "
+            f"NOT also run (GEPA's merge-accept path `continue`s past "
+            f"reflective mutation).  Got "
             f"{all_mocks['mutate'].call_count} mutate calls."
         )
         all_mocks["merge"].assert_called_once()
@@ -265,14 +275,16 @@ class TestMergeFallthroughToMutation:
 
 
 class TestLegacyGatingUsesSumOnly:
-    """GEPA parity (MODERATE D) — audit-mutation.md C3.
+    """GEPA parity (MODERATE D) — finding C3.
 
-    GEPA has a single acceptance path: ``should_accept(proposal, state)``
-    on sum-score (engine.py:287-303, reflective_mutation.py:420).  HELIX's
-    legacy (no-train-loader) path previously ran ``degrades()`` as a
-    pre-check, applying a tolerance that GEPA does not have.  After the
-    fix, ``degrades()`` is not consulted on the legacy path; the same
-    ``acceptance`` criterion used by the minibatch path gates everything.
+    GEPA has a single acceptance path: ``StrictImprovementAcceptance
+    .should_accept`` (``strategies/acceptance.py``) accepts only when the
+    new subsample-score sum is strictly greater than the old sum — no
+    tolerance.  HELIX's legacy (no-train-loader) path previously ran
+    ``degrades()`` as a pre-check, applying a tolerance that GEPA does not
+    have.  After the fix, ``degrades()`` is not consulted on the legacy
+    path; the same ``acceptance`` criterion used by the minibatch path
+    gates everything.
     """
 
     def test_degrades_is_not_called_in_legacy_path(
@@ -288,7 +300,7 @@ class TestLegacyGatingUsesSumOnly:
             called.append(1)
             raise AssertionError(
                 "degrades() must NOT be called in legacy gating "
-                "(GEPA parity MODERATE D — audit-mutation.md C3)."
+                "(GEPA parity MODERATE D — finding C3)."
             )
 
         monkeypatch.setattr(_evo, "degrades", _boom)

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -69,6 +69,64 @@ def test_budget_exhausted_preserves_evaluation_cap_semantics() -> None:
     assert budget.budget_exhausted(make_state(250), make_config(-1)) is False
 
 
+def test_batch_budget_guard_pins_the_documented_maximum_overshoot() -> None:
+    """An eight-unit batch admitted at 19/20 may finish at 27, not 28."""
+    state = make_state(19)
+
+    guard = budget.begin_batch_budget_guard(
+        state, max_evaluations=20, max_in_flight_evaluations=8
+    )
+
+    assert guard.maximum_overshoot == 7
+    state.budget.evaluations = 27
+    budget.enforce_batch_budget_guard(
+        state, guard, actual_in_flight_evaluations=8
+    )
+
+
+def test_batch_budget_guard_rejects_excess_in_flight_work() -> None:
+    state = make_state(19)
+    guard = budget.begin_batch_budget_guard(
+        state, max_evaluations=20, max_in_flight_evaluations=8
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"in-flight.*actual 9, permitted 8",
+    ):
+        budget.enforce_batch_budget_guard(
+            state, guard, actual_in_flight_evaluations=9
+        )
+
+
+def test_batch_budget_guard_rejects_excess_overshoot() -> None:
+    state = make_state(19)
+    guard = budget.begin_batch_budget_guard(
+        state, max_evaluations=20, max_in_flight_evaluations=8
+    )
+    # Simulate an accounting defect: reported in-flight work remains within
+    # the declared bound but the ledger advanced one extra unit.
+    state.budget.evaluations = 28
+
+    with pytest.raises(
+        ValueError,
+        match=r"overshoot.*actual 8, permitted 7",
+    ):
+        budget.enforce_batch_budget_guard(
+            state, guard, actual_in_flight_evaluations=8
+        )
+
+
+def test_batch_budget_guard_rejects_a_negative_in_flight_bound() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"actual -1, permitted >= 0",
+    ):
+        budget.begin_batch_budget_guard(
+            make_state(), max_evaluations=20, max_in_flight_evaluations=-1
+        )
+
+
 def test_charge_evaluation_updates_counter_and_emits_event() -> None:
     state = make_state(3)
 

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -110,7 +110,7 @@ class TestEvolutionConfigNewFields:
         cfg = EvolutionConfig()
         assert cfg.minibatch_size == 3
         # GEPA parity: max_workers defaults to os.cpu_count() or 32
-        # (optimize_anything.py:485).
+        # (GEPA's ``EngineConfig.max_workers`` in ``gepa_launcher.py``).
         import os
 
         assert cfg.max_workers == (os.cpu_count() or 32)
@@ -178,29 +178,11 @@ class TestEvolutionConfigNewFields:
         with pytest.raises(ValidationError):
             EvolutionConfig(num_sampled_groups=1, num_examples_per_group=2)
 
-    def test_num_parallel_proposals_auto_resolves(self):
-        """GEPA parity: ``num_parallel_proposals="auto"`` resolves to
-        ``max(1, max_workers // minibatch_size)`` in model_post_init.
-
-        Mirrors GEPA ``optimize_anything._resolve_num_parallel_proposals``
-        (src/gepa/optimize_anything.py:1108-1116).
-        """
-        cfg = EvolutionConfig(
-            num_parallel_proposals="auto",
-            max_workers=10,
-            minibatch_size=3,
-        )
-        assert cfg.num_parallel_proposals == 3  # 10 // 3
-
-    def test_num_parallel_proposals_auto_clamps_to_one(self):
-        """When ``max_workers < minibatch_size``, ``"auto"`` clamps to 1
-        (GEPA: ``max(1, max_workers // minibatch_size)``)."""
-        cfg = EvolutionConfig(
-            num_parallel_proposals="auto",
-            max_workers=2,
-            minibatch_size=5,
-        )
-        assert cfg.num_parallel_proposals == 1
+    def test_num_parallel_proposals_auto_rejected(self):
+        """``num_parallel_proposals`` is a plain int; the old ``"auto"``
+        sentinel is no longer accepted and must fail validation."""
+        with pytest.raises(ValidationError):
+            EvolutionConfig(num_parallel_proposals="auto")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_e2e_multi_axis.py
+++ b/tests/unit/test_e2e_multi_axis.py
@@ -18,14 +18,13 @@ on ``scores_list`` regardless of ``frontier_type``, and the e2e story
 is about the multi-axis retention path.
 
 GEPA cross-references:
-  * Evaluator contract — per-example ``(score, side_info)``:
-    ``src/gepa/optimize_anything.py:387-438``.
+  * Evaluator contract — per-example ``(score, side_info)``: the
+    ``Evaluator`` protocol in ``gepa_launcher.py``.
   * ``side_info["scores"]`` → ``objective_scores`` harvest:
-    ``optimize_anything_adapter.py:260-272``.
-  * ``FrontierType`` literal:
-    ``src/gepa/core/state.py:22-23``.
-  * O.A. default ``"hybrid"``:
-    ``src/gepa/optimize_anything.py:476``.
+    ``_extract_objective_scores`` in ``optimize_anything_adapter.py``.
+  * ``FrontierType`` literal, defined in ``core/state.py``.
+  * O.A. default ``"hybrid"``: GEPA's ``EngineConfig.frontier_type``
+    in ``gepa_launcher.py``.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -1,6 +1,6 @@
 """Unit tests for helix.evolution — the HELIX evolution loop.
 
-Ported from GEPA's evolution loop test scenarios (gepa-research.md).
+Ported from GEPA's evolution loop test scenarios.
 
 Covers:
 - degrades() helper (gating acceptance/rejection/tie logic)
@@ -115,8 +115,8 @@ def make_config(
     """Build a HelixConfig for evolution unit tests.
 
     ``frontier_type`` defaults to ``"hybrid"`` to match
-    :class:`EvolutionConfig`'s GEPA-O.A. default
-    (``src/gepa/optimize_anything.py:476``).  The companion
+    :class:`EvolutionConfig`'s GEPA-O.A. default — GEPA's
+    ``EngineConfig.frontier_type`` in ``gepa_launcher.py``.  The companion
     :func:`make_eval_result` synthesises per-example
     ``objective_scores`` slots so results pass
     :meth:`ParetoFrontier._validate_objective_scores` under the default;
@@ -192,8 +192,8 @@ def all_mocks(mocker):
         "record_entry": mocker.patch("helix.evolution.record_entry"),
         "generate_seed": mocker.patch("helix.evolution.generate_seed", return_value={}),
         "HelixLiveDisplay": mocker.patch("helix.evolution.HelixLiveDisplay"),
-        # GEPA parity (merge-pairing audit D1):
-        # the merge branch now enforces GEPA's ``len(parent_program_for_candidate) < 3``
+        # GEPA parity (merge-pairing audit D1): the merge branch now
+        # enforces GEPA's ``len(parent_program_for_candidate) < 3``
         # early-exit (merge.py:130-131), i.e. you need two siblings plus one
         # ancestor.  Provide a 3-entry dummy lineage by default so merge tests
         # that mock ``find_merge_triplet`` directly continue to exercise the
@@ -1455,10 +1455,10 @@ class TestMergeBehavior:
             f"merge eval must route through val, saw splits: "
             f"{[s for s, _ in merged_eval_calls]}"
         )
-        # GEPA parity (merge-gate audit M3):
-        # after the subsample gate passes, HELIX now runs a SECOND (full-val)
-        # eval on the merged candidate mirroring GEPA ``engine.py:690`` →
-        # ``_run_full_eval_and_add`` → ``_evaluate_on_valset``.  With
+        # GEPA parity (merge-gate audit M3): after the subsample gate
+        # passes, HELIX now runs a SECOND (full-val) eval on the merged
+        # candidate mirroring GEPA's ``_run_full_eval_and_add`` in
+        # ``core/engine.py``.  With
         # val_size=None (single-task/no-example mode) the full-val path falls through
         # to ``_cached_eval`` which calls ``run_evaluator`` *without*
         # instance_ids.  Assert the *first* call is the subsample
@@ -1540,9 +1540,8 @@ class TestMergeBehavior:
         # GEPA parity (merge-gate audit M3): the first merge eval is the
         # subsample gate (exactly ``merge_subsample_size`` ids drawn from
         # the common val intersection); subsequent calls are the
-        # GEPA-aligned post-acceptance full-val pass (merge-gate audit
-        # M3).  Assert only the first
-        # call against the subsample contract.
+        # GEPA-aligned post-acceptance full-val pass.  Assert only the
+        # first call against the subsample contract.
         first_batch = merged_eval_batches[0]
         assert len(first_batch) == 3, (
             f"merge subsample must use exactly merge_subsample_size ids, "
@@ -1685,8 +1684,8 @@ class TestMergeBehavior:
         Once the subsample gate passes, HELIX runs a SECOND (full-val)
         eval on the merged candidate and uses THAT result for
         ``frontier.add`` / ``state.instance_scores[merged.id]`` — mirrors
-        GEPA ``engine.py:688-696`` → ``_run_full_eval_and_add``
-        (engine.py:175-197) → ``_evaluate_on_valset`` (engine.py:154-173).
+        GEPA's ``_run_full_eval_and_add`` in ``core/engine.py``, which
+        runs a full-valset evaluation before adding the candidate.
 
         Before this fix, the frontier entry for the merged candidate
         only carried scores for the 5 subsample ids, so
@@ -1696,7 +1695,8 @@ class TestMergeBehavior:
         and over-representing them as tiebreak-eliminated candidates.
 
         Regression invariant: ``val_stage_size`` gates the mutation path
-        only (src/helix/evolution.py:719) — it does not affect the merge
+        only (consumed via ``_stage_val_example_ids()`` in the proposal's
+        staged-val gate) — it does not affect the merge
         flow — so the full-val pass runs regardless of its value.
         """
         seed = make_candidate("g0-s0")

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -332,7 +332,9 @@ class TestMinibatchGateIntegration:
     def test_perfect_minibatch_skip_advances_generation(
         self, tmp_path: Path, all_mocks: dict[str, Any]
     ) -> None:
-        """Perfect minibatch skip advances gen unconditionally (GEPA engine.py:649).
+        """Perfect minibatch skip advances gen unconditionally (GEPA parity:
+        ``state.i`` is incremented unconditionally at the top of
+        ``GEPAEngine.run()``'s main loop, before any merge/reflective branch).
 
         After Change 1 (unconditional gen increment), a perfect-subsample skip
         no longer rolls back to retry the same generation slot.  Gen was already
@@ -917,7 +919,7 @@ class TestMinibatchGateIntegration:
 #
 # These tests directly exercise the new per-example cache-consumer helper
 # that wires HELIX's minibatch eval sites up to the GEPA
-# ``cached_evaluate_full`` semantics (gepa/core/state.py:94-130).
+# ``GEPAState.cached_evaluate_full`` semantics (``core/state.py``).
 # ---------------------------------------------------------------------------
 
 
@@ -1522,10 +1524,13 @@ class TestWriteHelixBatchStringIds:
 
 
 # ---------------------------------------------------------------------------
-# MODERATE E (audit-mutation §C4) — parent minibatch eval runs in parallel
-# worker threads, matching GEPA core/engine.py:381-452 which submits
-# ``execute_proposal`` (reflective_mutation.py:239-285) — including
-# ``adapter.evaluate`` at :268 — to a ``ThreadPoolExecutor``.
+# MODERATE E (finding C4) — parent minibatch eval runs in parallel
+# worker threads.  HELIX's bounded-executor design mirrors the general shape
+# of GEPA's adapter-level concurrent evaluation dispatch (``GEPAAdapter
+# .evaluate`` in ``core/adapter.py``, invoked via ``default_batch_evaluate``);
+# GEPA's own reflective-mutation proposer evaluates parent/child minibatches
+# through a single batched adapter call rather than a per-proposal thread
+# pool.
 #
 # Parent minibatch accounting counts evaluations: one budget unit per uncached
 # example, and zero for pure cache hits.
@@ -1538,7 +1543,7 @@ class TestParentMinibatchParallelism:
     ) -> None:
         """Under ``num_parallel_proposals > 1`` the N parent-minibatch evals
         must be dispatched to a ``ThreadPoolExecutor`` (call-count evidence
-        of concurrency per audit-mutation §C4 MODERATE E).
+        of concurrency per finding C4 MODERATE E).
 
         We cannot block on a barrier because parents share the same seed
         worktree and the per-worktree file-handoff lock correctly serialises
@@ -1628,8 +1633,9 @@ class TestMaxWorkersBoundsParentEvalPool:
         ``num_parallel_proposals=3`` we must never see >2 parent evals
         running concurrently, even though 3 proposals are pre-sampled.
 
-        Mirrors GEPA ``EngineConfig.max_workers`` plumbing
-        (optimize_anything.py:485).
+        Mirrors GEPA's ``EngineConfig.max_workers`` plumbing
+        (``gepa_launcher.py``), which bounds a ``ThreadPoolExecutor`` in the
+        optimize-anything adapter's parallel-evaluation helpers.
         """
         import threading
         import time
@@ -1689,8 +1695,8 @@ class TestParentEvalExceptionDoesNotAbortGeneration:
         self, tmp_path: Path, all_mocks: dict[str, Any]
     ) -> None:
         """Fix B: when one of N parent-eval futures raises, the remaining
-        proposals must still complete.  Mirrors GEPA engine.py:427-443
-        which wraps ``future.result()`` in try/except so a single eval
+        proposals must still complete — HELIX's own isolation guarantee for
+        its bounded parent-eval ``ThreadPoolExecutor`` so a single eval
         failure does not abort the generation.
         """
         train_path = _write_train_jsonl(tmp_path, n=6)
@@ -1764,13 +1770,16 @@ class TestParentMinibatchBudgetCharge:
         self, tmp_path: Path, all_mocks: dict[str, Any]
     ) -> None:
         """Parent minibatch evals always charge the full minibatch size (GEPA
-        reflective_mutation.py:268-269 parity: minibatch path bypasses cache).
+        parity: the minibatch path bypasses the read side of the cache).
 
         Change 2: ``_eval_parent`` now passes ``None`` instead of
         ``minibatch_cache`` to ``_cached_evaluate_batch``, matching GEPA's
-        ``execute_proposal`` which calls ``adapter.evaluate(ctx.minibatch, ...)``
-        directly, never through the cache.  Both iterations therefore invoke the
-        evaluator subprocess for the parent and charge 2 budget units each.
+        ``ReflectiveMutationProposer`` which evaluates parent/child
+        minibatches via ``adapter.evaluate``/``batch_evaluate`` directly —
+        results are written into ``state.evaluation_cache`` afterward
+        (``put_batch``) but never read through it first.  Both iterations
+        therefore invoke the evaluator subprocess for the parent and charge
+        2 budget units each.
         """
         train_path = _write_train_jsonl(tmp_path, n=2)  # 2 ids → minibatch always [0,1]
         seed = _make_candidate("g0-s0")
@@ -1806,7 +1815,8 @@ class TestParentMinibatchBudgetCharge:
 
         # max_generations=2: the parent (seed) is evaluated on [0,1] in BOTH
         # iterations because Change 2 bypasses the minibatch cache for parent
-        # evals, matching GEPA reflective_mutation.py:268.
+        # evals, matching GEPA's ``ReflectiveMutationProposer`` (which never
+        # reads parent/child minibatch evals through the cache).
         config = _make_minibatch_config(
             train_path,
             minibatch_size=2,
@@ -1963,7 +1973,8 @@ class TestEvaluationCacheThreadSafety:
 
 
 class TestStateIBumpUnconditional:
-    """GEPA parity (engine.py:649): ``state.i`` must advance once per outer
+    """GEPA parity: ``state.i`` is incremented unconditionally at the top of
+    ``GEPAEngine.run()``'s main loop, so it must advance once per outer
     iteration regardless of which path (mutation, merge, early-exit) is
     taken.  Previously HELIX bumped ``state.i`` only inside the §1a
     minibatch pre-sample loop, so iterations that exited early (perfect
@@ -2020,9 +2031,10 @@ class TestStateIBumpUnconditional:
 
 
 class TestStrictInstanceScoresAccess:
-    """GEPA parity (adapter.py:154 — len(outputs) == len(scores) ==
-    len(batch)): a missing instance id in a parent or child minibatch
-    eval is an evaluator bug, not a benign zero.  HELIX must raise.
+    """GEPA parity: ``GEPAAdapter.evaluate``'s documented contract
+    (``core/adapter.py``) requires ``len(scores) == len(batch)`` — a
+    missing instance id in a parent or child minibatch eval is an
+    evaluator bug, not a benign zero.  HELIX must raise.
     """
 
     def test_missing_id_in_child_minibatch_raises(
@@ -2051,10 +2063,12 @@ class TestStrictInstanceScoresAccess:
 
         all_mocks["run_evaluator"].side_effect = run_eval
 
-        # Cache must be OFF: the cache layer (_cached_evaluate_batch's
-        # _evaluator at evolution.py:704-727) silently zeros missing ids
-        # before they reach the acceptance criterion, so we can only
-        # exercise the strict-access invariant on the no-cache path.
+        # Cache must be OFF: with caching on, ``_cached_evaluate_batch``'s
+        # inner ``_evaluator`` closure raises its own "Evaluator did not
+        # return scores" assertion before the result ever reaches the
+        # acceptance criterion (see test_missing_id_in_cached_evaluator_raises
+        # below); only the no-cache path lets a missing id reach the
+        # acceptance criterion's own strict-id check exercised here.
         config = _make_minibatch_config(
             train_path,
             minibatch_size=2,
@@ -2072,7 +2086,8 @@ class TestStrictInstanceScoresAccess:
         must enforce the same strict-id invariant as the acceptance path.
         With ``cache_evaluation=True`` (default), a missing id reported by
         the evaluator must raise before the cached scores reach the
-        acceptance criterion.  Mirrors the fix at evolution.py:730-738.
+        acceptance criterion.  Mirrors the strict-id assert inside
+        ``_cached_evaluate_batch``'s inner ``_evaluator`` closure.
         """
         train_path = _write_train_jsonl(tmp_path, n=4)
         seed = _make_candidate("g0-s0")
@@ -2345,9 +2360,12 @@ class TestAlwaysPerfectDataTerminates:
     must not produce an infinite loop.
 
     Three GEPA-aligned guards independently prevent NB-2:
-      1. gen advances unconditionally at top of loop (Change 1, engine.py:649)
+      1. gen advances unconditionally at top of loop (Change 1; mirrors the
+         unconditional ``state.i += 1`` at the top of ``GEPAEngine.run()``)
       2. Parent minibatch eval bypasses cache — always charges budget (Change 2)
-      3. Mandatory stopping condition check (Change 3, api.py:262-265)
+      3. Mandatory stopping condition check (Change 3; mirrors the
+         ``ValueError`` ``gepa.api.optimize`` raises when no stopping
+         condition is configured)
 
     This test exercises the gen-advance guard (1) and budget guard (2) together:
     max_generations=5 must be the loop exit trigger, with 5 skip records written.
@@ -2419,13 +2437,13 @@ class TestAlwaysPerfectDataTerminates:
 
 
 # ---------------------------------------------------------------------------
-# Change 3: mandatory stopping condition validation (GEPA api.py:262-265)
+# Change 3: mandatory stopping condition validation (GEPA api.py)
 # ---------------------------------------------------------------------------
 
 
 class TestStoppingConditionValidation:
-    """Mirror GEPA api.py:262-265: run_evolution must raise ValueError when
-    no effective stopping condition is configured.
+    """Mirror GEPA's ``gepa.api.optimize``: run_evolution must raise
+    ValueError when no effective stopping condition is configured.
 
     In helix, max_generations (loop bound, default 10) is the primary stop
     and max_evaluations (budget cap, -1 = disabled) is secondary.  The guard
@@ -2500,18 +2518,21 @@ class TestStoppingConditionValidation:
 #
 # The atomic-worker pattern merges parent-eval + LLM + child-eval into one
 # atomic worker per proposal slot, all running inside a single
-# ThreadPoolExecutor.  Budget charging is deferred to the sequential
-# acceptance loop (GEPA apply_proposal_output parity,
-# reflective_mutation.py:472).
+# ThreadPoolExecutor.  Budget charging is deferred to a sequential
+# acceptance loop, run only after the parallel workers finish.  This is
+# HELIX's own design; it no longer has a direct upstream GEPA counterpart —
+# GEPA's own ``ReflectiveMutationProposer`` now dispatches parent/child
+# minibatch evaluation as a single batched adapter call rather than a
+# per-proposal thread pool.
 #
-# NOTE: Tests 1–4 will likely fail against the CURRENT evolution.py (before
-# W1's changes implement the atomic worker).  They are written correctly for
-# the atomic-worker design and should pass after W1's commit is merged.
+# The atomic-worker design is implemented in the current evolution.py; all
+# tests in this class pass against it.
 # ---------------------------------------------------------------------------
 
 
 class TestAtomicProposalWorker:
-    """Tests for the atomic proposal worker (GEPA execute_proposal parity)."""
+    """Tests for the atomic proposal worker (HELIX's own design; see the
+    module-level note above on why this no longer mirrors GEPA 1:1)."""
 
     def test_worker_executes_parent_eval_and_child_eval_on_same_thread(
         self, tmp_path: Path, all_mocks: dict[str, Any]
@@ -2520,10 +2541,11 @@ class TestAtomicProposalWorker:
 
         Under the atomic-worker design, each proposal worker executes parent_eval →
         skip-perfect → LLM → child_eval atomically in a single
-        ThreadPoolExecutor worker thread (GEPA execute_proposal shape,
-        reflective_mutation.py:268,308,369,420).  The child eval therefore
-        must NOT run on the main thread — unlike the current three-stage
-        pipeline where Step 3 (child eval) is sequential on the main thread.
+        ThreadPoolExecutor worker thread — HELIX's own design (see the
+        module-level note above on why this is no longer a 1:1 GEPA mirror).
+        The child eval therefore must NOT run on the main thread — unlike the
+        current three-stage pipeline where Step 3 (child eval) is sequential
+        on the main thread.
 
         Verification: record threading.get_ident() for parent evals (seed.id,
         split=train, instance_ids not None) and child evals (non-seed,
@@ -2650,9 +2672,11 @@ class TestAtomicProposalWorker:
 
         Under the atomic-worker design, each worker catches non-fatal exceptions from
         mutate() and returns ``_ProposalResult(kind='llm_failed', ...)`` rather
-        than propagating the exception out of the worker (GEPA
-        reflective_mutation.py:369-420 error path).  The pool continues with
-        the remaining slots.
+        than propagating the exception out of the worker — the same per-task
+        isolation shape as GEPA's ``ReflectiveMutationProposer.propose``,
+        which wraps each task's proposal-prep step in its own try/except and
+        continues with the remaining tasks on failure.  The pool continues
+        with the remaining slots.
 
         Config: n=3 proposals.  The first mutate() call (thread-safely tracked)
         raises RuntimeError; the other two return valid candidates.
@@ -2717,7 +2741,9 @@ class TestAtomicProposalWorker:
         """With n=3, parent minibatch evals are dispatched to a thread pool.
 
         Under the atomic-worker design, all N atomic workers run inside a single
-        ThreadPoolExecutor (GEPA engine.py:422-443 parity).  With n=3 proposals
+        ThreadPoolExecutor — HELIX's own bounded-concurrency design (see the
+        module-level note above on GEPA's now-batched proposal dispatch).
+        With n=3 proposals
         and a time.sleep(0.05) inside each parent eval, the pool must spawn
         multiple worker threads simultaneously.
 
@@ -2787,8 +2813,9 @@ class TestAtomicProposalWorker:
         """budget.evaluations never decreases across consecutive save_state calls.
 
         Under the atomic-worker design, budget mutations happen only inside the sequential
-        acceptance loop (GEPA apply_proposal_output parity,
-        reflective_mutation.py:472) — never inside the parallel workers.
+        acceptance loop — HELIX's own design (see the module-level note above
+        on GEPA's now-batched proposal dispatch) — never inside the parallel
+        workers.
         Capturing ``state.budget.evaluations`` at each ``save_state`` call must
         therefore produce a monotonically non-decreasing sequence, regardless of
         which order the parallel workers completed.

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -2,7 +2,7 @@
 
 Ported from GEPA's merge pair-selection behavior
 (gepa/proposer/merge.py:87-115, 118-207).  Covers the post-align-merge
-changes spelled out in the merge-pairing audit:
+changes spelled out below:
 
 - B1: overlap-floor filter moved INTO the retry loop.
 - B2: attempted-pair filter moved INTO the retry loop.

--- a/tests/unit/test_merger.py
+++ b/tests/unit/test_merger.py
@@ -73,8 +73,8 @@ class TestBuildMergePrompt:
 
     def test_background_section_omitted_when_none(self):
         """GEPA parity: empty optional inputs skip the section entirely
-        instead of emitting a placeholder.  Mirrors GEPA O.A.'s
-        ``_build_reflection_prompt_template`` (optimize_anything.py:501-596),
+        instead of emitting a placeholder.  Mirrors GEPA's
+        ``_build_reflection_prompt_template`` in ``gepa_launcher.py``,
         which only appends a section when its content is non-empty.
         """
         prompt = build_merge_prompt("goal", None, None, "")

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -118,8 +118,8 @@ class TestBuildMutationPrompt:
 
     def test_background_section_omitted_when_none(self):
         """GEPA parity: empty optional inputs skip the section entirely
-        instead of emitting a placeholder.  Mirrors GEPA O.A.'s
-        ``_build_reflection_prompt_template`` (optimize_anything.py:501-596),
+        instead of emitting a placeholder.  Mirrors GEPA's
+        ``_build_reflection_prompt_template`` in ``gepa_launcher.py``,
         which only appends a section when its content is non-empty.
         """
         er = make_eval_result()
@@ -251,7 +251,8 @@ class TestTurnBudgetArticleAgreement:
 class TestPerExampleDiagnostics:
     """``build_mutation_prompt`` renders ``eval_result.per_example_side_info``
     as the Diagnostics section under the new GEPA O.A. contract
-    (``optimize_anything_adapter.py:524-553`` + ``format_samples``
+    (``OptimizeAnythingAdapter.make_reflective_dataset`` in
+    ``optimize_anything_adapter.py`` + ``format_samples``
     at ``gepa/strategies/instruction_proposal.py:54-95``).  The legacy
     batch-level ``side_info`` rendering is used only when
     ``per_example_side_info`` is absent.

--- a/tests/unit/test_parser_helix_result.py
+++ b/tests/unit/test_parser_helix_result.py
@@ -172,8 +172,8 @@ class TestHelixResultHappyPath:
 
 
 class TestObjectiveScoresHarvest:
-    """Mirrors GEPA's ``OptimizeAnythingAdapter._process_side_info``
-    (``optimize_anything_adapter.py:260-272``): each per-example
+    """Mirrors GEPA's ``OptimizeAnythingAdapter._extract_objective_scores``
+    in ``optimize_anything_adapter.py``: each per-example
     ``side_info["scores"]`` dict is harvested into the corresponding
     slot of ``objective_scores``.  No frontier wiring yet (that's a
     later commit in this branch); this test just pins the harvest.
@@ -257,9 +257,10 @@ class TestObjectiveScoresHarvest:
 
 
 class TestBareAndMixedForms:
-    """Per-example entry matches GEPA O.A.'s ``tuple[float, SideInfo] | float``
-    union (``src/gepa/optimize_anything.py:971``): either a bare score or a
-    ``[score, side_info]`` pair.  Mixed within one payload is allowed."""
+    """Per-example entry matches GEPA O.A.'s evaluator return-type union —
+    a bare score, or a ``[score, side_info]`` pair (see GEPA's
+    ``_normalize_result`` in ``oa/eval_server.py``).  Mixed within one
+    payload is allowed."""
 
     def test_all_bare_scores_accepted(self, tmp_path: Path) -> None:
         """``HELIX_RESULT=[s_0, s_1, s_2]`` — all bare floats."""

--- a/tests/unit/test_population_multi_axis_frontier.py
+++ b/tests/unit/test_population_multi_axis_frontier.py
@@ -6,16 +6,16 @@ Pins the per-axis state accumulation (``_per_key_best``,
 :meth:`get_non_dominated`, and :meth:`select_parent`.
 
 Cross-references:
-  * GEPA ``FrontierType`` literal: ``src/gepa/core/state.py:22-23``.
-  * ``_update_objective_pareto_front``: ``state.py:474-484``.
-  * ``_update_pareto_front_for_cartesian``: ``state.py:512-525``.
-  * O.A. default ``frontier_type="hybrid"``:
-    ``src/gepa/optimize_anything.py:476`` — rationale for HELIX's own
-    default (``evolution.frontier_type``).
+  * GEPA's ``FrontierType`` literal, defined in ``core/state.py``.
+  * ``_update_objective_pareto_front`` in ``core/state.py``.
+  * ``_update_pareto_front_for_cartesian`` in ``core/state.py``.
+  * O.A. default ``frontier_type="hybrid"``: GEPA's
+    ``EngineConfig.frontier_type`` in ``gepa_launcher.py`` — rationale
+    for HELIX's own default (``evolution.frontier_type``).
 
 The acceptance gate is **not** tested here: it remains positional on
-``scores_list`` regardless of ``frontier_type`` (GEPA
-``acceptance.py:39-48``).
+raw score lists regardless of ``frontier_type`` (GEPA's
+``StrictImprovementAcceptance.should_accept`` in ``strategies/acceptance.py``).
 """
 
 from __future__ import annotations
@@ -93,8 +93,8 @@ class TestDefaultFrontierTypeBackCompat:
 class TestObjectiveFrontier:
     def test_objective_best_tracks_mean_across_valset(self):
         """``_objective_best_score[obj]`` = max over candidates of
-        mean(obj-score across valset), mirroring GEPA
-        ``_update_objective_pareto_front`` + ``_per_prog_mean_objective_scores``.
+        mean(obj-score across valset), mirroring GEPA's
+        ``_update_objective_pareto_front``.
         """
         frontier = ParetoFrontier(frontier_type="objective")
         # Candidate a: obj_alpha mean = (0.8+0.2)/2 = 0.5

--- a/tests/unit/test_pxn_proposals.py
+++ b/tests/unit/test_pxn_proposals.py
@@ -28,7 +28,7 @@ from helix.config import (
     WorktreeConfig,
 )
 from helix.evolution import run_evolution
-from helix.population import Candidate, EvalResult
+from helix.population import Candidate, EvalResult, ParetoFrontier
 from helix.proposals import (
     AcceptanceJudgement,
     AcceptanceMemo,
@@ -870,3 +870,215 @@ class TestDroppedProposalsAreRecorded:
         }
         assert by_reason["g1-s1"] == "minibatch_gate"
         assert by_reason["g1-s3"] == "proposal_selection"
+
+
+# ---------------------------------------------------------------------------
+# 7. Cost model and budget accounting under P×N
+# ---------------------------------------------------------------------------
+
+
+def _eval_log(all_mocks: dict[str, Any], seed_id: str, child_scores: dict[str, float]) -> list[tuple[str, str, int]]:
+    """Wire scored children and return a log of (candidate_id, split, n_examples)."""
+    calls: list[tuple[str, str, int]] = []
+    all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
+
+    def run_eval(
+        candidate: Candidate,
+        config: HelixConfig,
+        split: str = "val",
+        instance_ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> EvalResult:
+        calls.append((candidate.id, split, 0 if instance_ids is None else len(instance_ids)))
+        if instance_ids is None:
+            return _make_result(candidate.id, {"v1": 0.5})
+        if split == "train":
+            score = 0.3 if candidate.id == seed_id else child_scores[candidate.id]
+            return _make_result(candidate.id, {i: score for i in instance_ids})
+        return _make_result(candidate.id, {i: 0.7 for i in instance_ids})
+
+    all_mocks["run_evaluator"].side_effect = run_eval
+    return calls
+
+
+class TestCostModel:
+    def test_selection_saves_validation_not_gate_work(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Every proposal is still evaluated on its minibatch.
+
+        ``best_improvement`` is a validation-cost knob, not a gate-cost knob:
+        all P*N children are still mutated and gated, and only the winner is
+        promoted to full validation.  A reader sizing a run needs this to be
+        explicit — picking ``best_improvement`` does not make N cheap.
+        """
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        calls = _eval_log(
+            all_mocks, seed.id, {"g1-s1": 0.4, "g1-s2": 0.9, "g1-s3": 0.6}
+        )
+
+        config = _make_config(
+            train_path,
+            num_parallel_proposals=1,
+            mutations_per_parent=3,
+            proposal_selection="best_improvement",
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        child_gate = [c for c in calls if c[0] != seed.id and c[1] == "train"]
+        child_val = [c for c in calls if c[0] != seed.id and c[1] == "val"]
+        assert len(child_gate) == 3, "all N children must still be gated"
+        assert len(child_val) == 1, "only the selected child reaches full val"
+        assert all_mocks["mutate"].call_count == 3, "all N mutations still run"
+
+    def test_parent_draws_equal_p_not_p_times_n(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        """P=3, N=2 draws 3 parents, not 6 — N is 'more tries at this parent'."""
+        train_path = _write_train_jsonl(tmp_path, n=20)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _eval_log(all_mocks, seed.id, {f"g1-s{i}": 0.9 for i in range(1, 7)})
+
+        spy = mocker.spy(ParetoFrontier, "select_parent")
+
+        config = _make_config(
+            train_path, num_parallel_proposals=3, mutations_per_parent=2
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert spy.call_count == 3, (
+            f"Expected P=3 parent draws for a 3x2 batch; got {spy.call_count}"
+        )
+
+    def test_budget_ledger_matches_examples_actually_evaluated(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """The ledger equals independently counted evaluator work (caching off)."""
+        train_path = _write_train_jsonl(tmp_path, n=20)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        calls = _eval_log(all_mocks, seed.id, {f"g1-s{i}": 0.9 for i in range(1, 5)})
+
+        config = _make_config(
+            train_path,
+            num_parallel_proposals=2,
+            mutations_per_parent=2,
+            cache_evaluation=False,
+            max_evaluations=100_000,
+        )
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert result.budget.evaluations == sum(n for _, _, n in calls), (
+            f"budget ledger {result.budget.evaluations} != "
+            f"{sum(n for _, _, n in calls)} examples actually evaluated"
+        )
+
+    def test_budget_is_monotonic_across_a_pxn_batch(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Charges are sequential, so the ledger never decreases mid-batch."""
+        train_path = _write_train_jsonl(tmp_path, n=20)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _eval_log(all_mocks, seed.id, {f"g1-s{i}": 0.9 for i in range(1, 5)})
+
+        snapshots: list[int] = []
+        all_mocks["save_state"].side_effect = lambda state, _p: snapshots.append(
+            state.budget.evaluations
+        )
+
+        config = _make_config(
+            train_path, num_parallel_proposals=2, mutations_per_parent=2
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert snapshots
+        assert snapshots == sorted(snapshots), f"ledger went backwards: {snapshots}"
+
+    def test_budget_overshoot_is_bounded_by_the_batch_size(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """The documented overshoot bound, enforced.
+
+        ``max_evaluations`` is checked between slots, so a batch already
+        dispatched runs to completion.  The engine documents the resulting
+        overshoot as at most P*N parent-minibatch evals plus P*N child evals;
+        this pins that bound rather than leaving it as prose.
+        """
+        train_path = _write_train_jsonl(tmp_path, n=20)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _eval_log(all_mocks, seed.id, {f"g1-s{i}": 0.9 for i in range(1, 30)})
+
+        p, n, mb = 2, 2, 2
+        cap = 30
+        config = _make_config(
+            train_path,
+            minibatch_size=mb,
+            num_parallel_proposals=p,
+            mutations_per_parent=n,
+            max_generations=20,
+            max_evaluations=cap,
+            cache_evaluation=False,
+        )
+        result = run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        bound = cap + 2 * p * n * mb
+        assert result.budget.evaluations <= bound, (
+            f"overshoot {result.budget.evaluations - cap} exceeds the documented "
+            f"bound of 2*P*N*minibatch_size = {2 * p * n * mb}"
+        )
+
+
+class TestDeterminism:
+    def test_identical_config_produces_an_identical_run(
+        self, tmp_path: Path, mocker: Any
+    ) -> None:
+        """Same seed, same batch — completion timing must not leak in."""
+
+        def _one_run(run_idx: int) -> list[str]:
+            mocks = {
+                k: mocker.patch(f"helix.evolution.{k}")
+                for k in (
+                    "create_seed_worktree", "run_evaluator", "mutate", "remove_worktree",
+                    "save_state", "init_base_dir", "_save_evaluation", "record_entry",
+                    "snapshot_candidate", "set_phase", "print_info", "print_success",
+                    "print_warning", "print_error", "render_budget", "render_generation",
+                    "_check_evaluator_script_exists",
+                )
+            }
+            mocks["merge"] = mocker.patch("helix.evolution.merge", return_value=None)
+            mocks["load_state"] = mocker.patch(
+                "helix.evolution.load_state", return_value=None
+            )
+            mocks["_load_evaluation"] = mocker.patch(
+                "helix.evolution._load_evaluation", return_value=None
+            )
+            mocks["load_lineage"] = mocker.patch(
+                "helix.evolution.load_lineage", return_value={}
+            )
+            mocks["find_merge_triplet"] = mocker.patch(
+                "helix.evolution.find_merge_triplet", return_value=None
+            )
+            run_dir = tmp_path / f"run{run_idx}"
+            run_dir.mkdir()
+            train_path = _write_train_jsonl(run_dir, n=12)
+            seed = _make_candidate("g0-s0")
+            mocks["create_seed_worktree"].return_value = seed
+            trace = _install_trace(mocks, seed.id)
+            mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
+
+            config = _make_config(
+                train_path,
+                num_parallel_proposals=2,
+                mutations_per_parent=2,
+                proposal_selection="top_k",
+                proposal_top_k=2,
+            )
+            run_evolution(config, run_dir, run_dir / ".helix")
+            return _apply_phase(trace) + _worker_evals(trace)
+
+        assert _one_run(1) == _one_run(2)

--- a/tests/unit/test_pxn_proposals.py
+++ b/tests/unit/test_pxn_proposals.py
@@ -360,11 +360,10 @@ class TestSelectionFunctions:
         batch = [_gated(0, 0.5), _gated(1, 0.9), _gated(2, 0.1), _gated(3, 0.7)]
         assert [g.order for g in select_top_k(batch, 2)] == [1, 3]
 
-    def test_top_k_returns_survivors_in_sampled_order(self) -> None:
-        """Ranking decides *which* proposals apply, never the order they apply in."""
-        batch = [_gated(0, 0.1), _gated(1, 0.9), _gated(2, 0.5)]
-        # Ranked 1 (0.9), 2 (0.5), 0 (0.1) — applied 1 then 2.
-        assert [g.order for g in select_top_k(batch, 2)] == [1, 2]
+    def test_top_k_applies_best_first(self) -> None:
+        """Survivors stay ranked, so a truncated batch keeps the best work."""
+        batch = [_gated(0, 0.5), _gated(1, 0.9)]
+        assert [g.order for g in select_top_k(batch, 2)] == [1, 0]
 
     def test_top_k_breaks_ties_toward_earliest_sampled(self) -> None:
         batch = [_gated(0, 0.9), _gated(1, 0.9), _gated(2, 0.9)]
@@ -372,7 +371,7 @@ class TestSelectionFunctions:
 
     def test_top_k_larger_than_batch_returns_everything(self) -> None:
         batch = [_gated(0, 0.5), _gated(1, 0.9)]
-        assert [g.order for g in select_top_k(batch, 10)] == [0, 1]
+        assert sorted(g.order for g in select_top_k(batch, 10)) == [0, 1]
 
     def test_negative_improvements_still_rank(self) -> None:
         """A gated proposal always improved on *its own* parent; ranking is relative."""
@@ -770,3 +769,104 @@ class TestMinibatchRepeatWarning:
 
         warnings = [str(c.args[0]) for c in all_mocks["print_warning"].call_args_list]
         assert not any("minibatches will repeat" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# 6. Dropped proposals stay accountable
+# ---------------------------------------------------------------------------
+
+
+class TestDroppedProposalsAreRecorded:
+    """A dropped child already has a lineage entry; it must not point at nothing.
+
+    A proposal that clears the gate gets its lineage entry written before
+    selection runs.  If selection or dedupe then drops it, the drop has to
+    land in ``attempts/`` like a gate rejection does — otherwise reading a
+    run back shows a mutation that was attempted, charged, and then simply
+    vanished.
+    """
+
+    def test_selection_drop_lands_in_the_attempts_ledger(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        save_attempt = mocker.patch("helix.evolution._save_attempt_result")
+
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _scored_children(
+            all_mocks, seed.id, {"g1-s1": 0.4, "g1-s2": 0.9, "g1-s3": 0.6}
+        )
+
+        config = _make_config(
+            train_path,
+            num_parallel_proposals=1,
+            mutations_per_parent=3,
+            proposal_selection="best_improvement",
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        dropped = [
+            c
+            for c in save_attempt.call_args_list
+            if c.kwargs.get("reason") == "proposal_selection"
+        ]
+        assert len(dropped) == 2, (
+            "Both gate-passing losers must be recorded, not silently removed"
+        )
+        assert {c.args[1].candidate_id for c in dropped} == {"g1-s1", "g1-s3"}
+        assert all(c.kwargs["status"] == "rejected" for c in dropped)
+
+    def test_duplicate_drop_lands_in_the_attempts_ledger(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        save_attempt = mocker.patch("helix.evolution._save_attempt_result")
+        mocker.patch(
+            "helix.evolution._candidate_content_key", side_effect=lambda c: "same"
+        )
+
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _scored_children(all_mocks, seed.id, {"g1-s1": 0.9, "g1-s2": 0.9})
+
+        config = _make_config(
+            train_path, num_parallel_proposals=1, mutations_per_parent=2
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        dropped = [
+            c
+            for c in save_attempt.call_args_list
+            if c.kwargs.get("reason") == "duplicate_child"
+        ]
+        assert [c.args[1].candidate_id for c in dropped] == ["g1-s2"]
+
+    def test_drop_reasons_are_distinguishable_from_gate_rejections(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        """s1 loses on the criterion; s3 loses on selection. Different reasons."""
+        save_attempt = mocker.patch("helix.evolution._save_attempt_result")
+
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        # s1 scores below the parent's 0.3 → criterion rejection.
+        _scored_children(
+            all_mocks, seed.id, {"g1-s1": 0.1, "g1-s2": 0.9, "g1-s3": 0.6}
+        )
+
+        config = _make_config(
+            train_path,
+            num_parallel_proposals=1,
+            mutations_per_parent=3,
+            proposal_selection="best_improvement",
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        by_reason = {
+            c.args[1].candidate_id: c.kwargs.get("reason")
+            for c in save_attempt.call_args_list
+        }
+        assert by_reason["g1-s1"] == "minibatch_gate"
+        assert by_reason["g1-s3"] == "proposal_selection"

--- a/tests/unit/test_pxn_proposals.py
+++ b/tests/unit/test_pxn_proposals.py
@@ -308,10 +308,10 @@ class TestConfigValidation:
         with pytest.raises(ValueError, match="max_workers must be >= 1"):
             EvolutionConfig(max_workers=w)
 
-    def test_max_workers_checked_before_auto_resolution(self) -> None:
-        """``max(1, 0 // k)`` must not launder a zero worker count into P=1."""
+    def test_max_workers_checked_before_num_parallel_proposals(self) -> None:
+        """A zero worker count is rejected regardless of a valid P."""
         with pytest.raises(ValueError, match="max_workers must be >= 1"):
-            EvolutionConfig(num_parallel_proposals="auto", max_workers=0)
+            EvolutionConfig(num_parallel_proposals=5, max_workers=0)
 
     def test_defaults_are_the_historical_single_proposal_shape(self) -> None:
         cfg = EvolutionConfig()

--- a/tests/unit/test_pxn_proposals.py
+++ b/tests/unit/test_pxn_proposals.py
@@ -1,0 +1,772 @@
+"""Tests for the P×N proposal batch: sampling, selection, and dedupe.
+
+``num_parallel_proposals`` (P) picks how many parents an iteration proposes
+from; ``mutations_per_parent`` (N) picks how many children each of those
+parents gets.  ``proposal_selection`` then decides how many of the children
+that clear the acceptance gate are actually promoted to full validation.
+
+The first test in this file is a *golden trace*: it pins the exact ordered
+sequence of side effects the default configuration produces, so the apply
+phase restructure that P×N required cannot silently reorder budget charges,
+snapshots or evaluations for runs that never opt in.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from helix.config import (
+    DatasetConfig,
+    EvaluatorConfig,
+    EvolutionConfig,
+    HelixConfig,
+    SeedlessConfig,
+    WorktreeConfig,
+)
+from helix.evolution import run_evolution
+from helix.population import Candidate, EvalResult
+from helix.proposals import (
+    AcceptanceJudgement,
+    AcceptanceMemo,
+    EvaluatedProposal,
+    GatedProposal,
+    ScoreVectors,
+    select_all_improvements,
+    select_best_improvement,
+    select_proposals,
+    select_top_k,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors tests/unit/test_evolution_minibatch.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(cid: str = "g0-s0") -> Candidate:
+    return Candidate(
+        id=cid,
+        worktree_path=f"/tmp/helix/{cid}",
+        branch_name=f"helix/{cid}",
+        generation=0,
+        parent_id=None,
+        parent_ids=[],
+        operation="seed",
+    )
+
+
+def _make_result(cid: str, scores: dict[str, float]) -> EvalResult:
+    return EvalResult(
+        candidate_id=cid,
+        scores={},
+        asi={},
+        instance_scores=dict(scores),
+    )
+
+
+def _write_train_jsonl(path: Path, n: int = 6) -> Path:
+    p = path / "train.jsonl"
+    with open(p, "w") as f:
+        for i in range(n):
+            f.write(json.dumps({"idx": i, "x": i}) + "\n")
+    return p
+
+
+def _make_config(
+    train_path: Path,
+    *,
+    minibatch_size: int = 2,
+    max_generations: int = 1,
+    max_evaluations: int = 10_000,
+    **evo: Any,
+) -> HelixConfig:
+    evo_kwargs: dict[str, Any] = dict(
+        max_generations=max_generations,
+        max_evaluations=max_evaluations,
+        perfect_score_threshold=None,
+        minibatch_size=minibatch_size,
+        cache_evaluation=True,
+        frontier_type="instance",
+    )
+    evo_kwargs.update(evo)
+    return HelixConfig(
+        objective="P×N test",
+        evaluator=EvaluatorConfig(command="pytest -q"),
+        dataset=DatasetConfig(val_size=None),
+        seedless=SeedlessConfig(train_path=train_path),
+        evolution=EvolutionConfig(**evo_kwargs),
+        worktree=WorktreeConfig(),
+    )
+
+
+@pytest.fixture
+def all_mocks(mocker: Any) -> dict[str, Any]:
+    return {
+        "create_seed_worktree": mocker.patch("helix.evolution.create_seed_worktree"),
+        "run_evaluator": mocker.patch("helix.evolution.run_evaluator"),
+        "mutate": mocker.patch("helix.evolution.mutate"),
+        "merge": mocker.patch("helix.evolution.merge", return_value=None),
+        "remove_worktree": mocker.patch("helix.evolution.remove_worktree"),
+        "load_state": mocker.patch("helix.evolution.load_state", return_value=None),
+        "save_state": mocker.patch("helix.evolution.save_state"),
+        "init_base_dir": mocker.patch("helix.evolution.init_base_dir"),
+        "_save_evaluation": mocker.patch("helix.evolution._save_evaluation"),
+        "_load_evaluation": mocker.patch(
+            "helix.evolution._load_evaluation", return_value=None
+        ),
+        "record_entry": mocker.patch("helix.evolution.record_entry"),
+        "load_lineage": mocker.patch("helix.evolution.load_lineage", return_value={}),
+        "find_merge_triplet": mocker.patch(
+            "helix.evolution.find_merge_triplet", return_value=None
+        ),
+        "snapshot_candidate": mocker.patch("helix.evolution.snapshot_candidate"),
+        "set_phase": mocker.patch("helix.evolution.set_phase"),
+        "print_info": mocker.patch("helix.evolution.print_info"),
+        "print_success": mocker.patch("helix.evolution.print_success"),
+        "print_warning": mocker.patch("helix.evolution.print_warning"),
+        "print_error": mocker.patch("helix.evolution.print_error"),
+        "render_budget": mocker.patch("helix.evolution.render_budget"),
+        "render_generation": mocker.patch("helix.evolution.render_generation"),
+        "_check_evaluator_script_exists": mocker.patch(
+            "helix.evolution._check_evaluator_script_exists"
+        ),
+    }
+
+
+def _install_trace(all_mocks: dict[str, Any], seed_id: str) -> list[str]:
+    """Record an ordered, human-readable log of the run's side effects.
+
+    Only the effects the apply phase is responsible for sequencing are
+    recorded: evaluations (the budget-charged unit), lineage writes, state
+    saves, snapshots and worktree removals.
+    """
+    trace: list[str] = []
+
+    def run_eval(
+        candidate: Candidate,
+        config: HelixConfig,
+        split: str = "val",
+        instance_ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> EvalResult:
+        ids = "-" if instance_ids is None else ",".join(instance_ids)
+        trace.append(f"eval {candidate.id} {split} [{ids}]")
+        if instance_ids is None:
+            return _make_result(candidate.id, {"v1": 0.5})
+        if split == "train":
+            # Parent scores low, every child improves → all clear the gate.
+            score = 0.3 if candidate.id == seed_id else 0.9
+            return _make_result(candidate.id, {i: score for i in instance_ids})
+        return _make_result(candidate.id, {i: 0.7 for i in instance_ids})
+
+    all_mocks["run_evaluator"].side_effect = run_eval
+    all_mocks["save_state"].side_effect = lambda *a, **k: trace.append("save_state")
+    all_mocks["snapshot_candidate"].side_effect = lambda c, *a, **k: trace.append(
+        f"snapshot {c.id}"
+    )
+    all_mocks["record_entry"].side_effect = lambda _p, entry, *a, **k: trace.append(
+        f"lineage {entry.id}<-{entry.parent}"
+    )
+    all_mocks["remove_worktree"].side_effect = lambda c, *a, **k: trace.append(
+        f"remove {c.id if isinstance(c, Candidate) else c}"
+    )
+    all_mocks["_save_evaluation"].side_effect = lambda _d, r, *a, **k: trace.append(
+        f"frontier {r.candidate_id}"
+    )
+    return trace
+
+
+def _apply_phase(trace: list[str]) -> list[str]:
+    """Drop the train-minibatch evals, which run concurrently in the workers.
+
+    Their completion order is thread-timing dependent and deliberately not a
+    guarantee.  Everything left is sequenced by the apply phase and *is* a
+    guarantee — that is what the golden trace pins.
+    """
+    return [e for e in trace if not e.startswith("eval ") or " val " in e]
+
+
+def _worker_evals(trace: list[str]) -> list[str]:
+    return sorted(e for e in trace if e.startswith("eval ") and " train " in e)
+
+
+# ---------------------------------------------------------------------------
+# 1. The default path must not move
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultPathUnchanged:
+    def test_all_improvements_n1_golden_trace(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Default config (P=2, N=1, all_improvements) keeps its exact ordering.
+
+        Written and pinned against the pre-P×N implementation.  ``P=2`` is
+        used rather than ``P=1`` because it is the smallest configuration in
+        which gate and apply *interleave* across proposals — the exact
+        property the ``best_improvement`` / ``top_k`` strategies had to break
+        and that ``all_improvements`` must keep.  A two-phase
+        gate-all-then-apply-all rewrite of the shared path would reorder this
+        list; that is the regression this test exists to catch.
+        """
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
+
+        trace = _install_trace(all_mocks, seed.id)
+
+        config = _make_config(train_path, num_parallel_proposals=2)
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert _apply_phase(trace) == [
+            "eval g0-s0 val [0,1,2,3,4,5]",
+            "frontier g0-s0",
+            "save_state",
+            "lineage g0-s0<-None",
+            # Proposal 0 is gated *and* fully applied before proposal 1 is
+            # touched.  A gate-all-then-apply-all rewrite would hoist both
+            # lineage writes above both val evals.
+            "lineage g1-s1<-g0-s0",
+            "save_state",
+            "snapshot g1-s1",
+            "eval g1-s1 val [0,1,2,3,4,5]",
+            "frontier g1-s1",
+            "lineage g1-s2<-g0-s0",
+            "save_state",
+            "snapshot g1-s2",
+            "eval g1-s2 val [0,1,2,3,4,5]",
+            "frontier g1-s2",
+            "save_state",
+        ]
+        # Two parents sampled with replacement (both the seed here), two
+        # disjoint minibatch draws, one child evaluated on each.
+        assert _worker_evals(trace) == [
+            "eval g0-s0 train [4,1]",
+            "eval g0-s0 train [5,2]",
+            "eval g1-s1 train [4,1]",
+            "eval g1-s2 train [5,2]",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# 2. Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_top_k_requires_proposal_top_k(self) -> None:
+        with pytest.raises(ValueError, match="proposal_top_k is required"):
+            EvolutionConfig(proposal_selection="top_k")
+
+    @pytest.mark.parametrize("k", [0, -1, 5])
+    def test_top_k_must_be_within_batch_size(self, k: int) -> None:
+        # P*N = 2*2 = 4, so 5 is out of range and 0 / -1 are degenerate.
+        with pytest.raises(ValueError, match="proposal_top_k must be between 1 and"):
+            EvolutionConfig(
+                proposal_selection="top_k",
+                proposal_top_k=k,
+                num_parallel_proposals=2,
+                mutations_per_parent=2,
+            )
+
+    def test_top_k_at_batch_size_is_accepted(self) -> None:
+        cfg = EvolutionConfig(
+            proposal_selection="top_k",
+            proposal_top_k=4,
+            num_parallel_proposals=2,
+            mutations_per_parent=2,
+        )
+        assert cfg.proposal_top_k == 4
+
+    @pytest.mark.parametrize(
+        "strategy", ["all_improvements", "best_improvement"]
+    )
+    def test_top_k_rejected_for_other_strategies(self, strategy: str) -> None:
+        """A bound that would silently do nothing is a config error, not a default."""
+        with pytest.raises(ValueError, match="only valid when"):
+            EvolutionConfig(proposal_selection=strategy, proposal_top_k=1)
+
+    @pytest.mark.parametrize("n", [0, -1])
+    def test_non_positive_mutations_per_parent_rejected(self, n: int) -> None:
+        with pytest.raises(ValueError, match="mutations_per_parent must be >= 1"):
+            EvolutionConfig(mutations_per_parent=n)
+
+    @pytest.mark.parametrize("p", [0, -1])
+    def test_non_positive_num_parallel_proposals_rejected(self, p: int) -> None:
+        """Previously accepted: P<=0 planned an empty batch every iteration."""
+        with pytest.raises(ValueError, match="num_parallel_proposals must be >= 1"):
+            EvolutionConfig(num_parallel_proposals=p)
+
+    @pytest.mark.parametrize("w", [0, -1])
+    def test_non_positive_max_workers_rejected(self, w: int) -> None:
+        with pytest.raises(ValueError, match="max_workers must be >= 1"):
+            EvolutionConfig(max_workers=w)
+
+    def test_max_workers_checked_before_auto_resolution(self) -> None:
+        """``max(1, 0 // k)`` must not launder a zero worker count into P=1."""
+        with pytest.raises(ValueError, match="max_workers must be >= 1"):
+            EvolutionConfig(num_parallel_proposals="auto", max_workers=0)
+
+    def test_defaults_are_the_historical_single_proposal_shape(self) -> None:
+        cfg = EvolutionConfig()
+        assert cfg.mutations_per_parent == 1
+        assert cfg.proposal_selection == "all_improvements"
+        assert cfg.proposal_top_k is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Selection functions in isolation
+# ---------------------------------------------------------------------------
+
+
+def _gated(order: int, improvement: float, child_id: str = "") -> GatedProposal:
+    """A GatedProposal carrying just enough to be selected over."""
+    child = _make_candidate(child_id or f"c{order}")
+    ctx = (_make_candidate("p"), None, None, child.id)
+    return GatedProposal(
+        order=order,
+        proposal=EvaluatedProposal(presample_ctx=ctx, parent_eval_result=None, child=child),  # type: ignore[arg-type]
+        judgement=AcceptanceJudgement(
+            accepted=True, before=[0.0], after=[improvement]
+        ),
+        gating_result=_make_result(child.id, {}),
+    )
+
+
+class TestSelectionFunctions:
+    def test_all_improvements_keeps_everything_in_sampled_order(self) -> None:
+        batch = [_gated(0, 0.5), _gated(1, 0.9), _gated(2, 0.1)]
+        assert [g.order for g in select_all_improvements(batch)] == [0, 1, 2]
+
+    def test_best_improvement_picks_the_largest(self) -> None:
+        batch = [_gated(0, 0.5), _gated(1, 0.9), _gated(2, 0.1)]
+        assert [g.order for g in select_best_improvement(batch)] == [1]
+
+    def test_best_improvement_breaks_ties_toward_earliest_sampled(self) -> None:
+        """Completion order must never decide a tie — sampled order does."""
+        batch = [_gated(0, 0.4), _gated(1, 0.9), _gated(2, 0.9)]
+        assert [g.order for g in select_best_improvement(batch)] == [1]
+
+    def test_best_improvement_on_empty_batch(self) -> None:
+        assert select_best_improvement([]) == []
+
+    def test_top_k_picks_the_k_largest(self) -> None:
+        batch = [_gated(0, 0.5), _gated(1, 0.9), _gated(2, 0.1), _gated(3, 0.7)]
+        assert [g.order for g in select_top_k(batch, 2)] == [1, 3]
+
+    def test_top_k_returns_survivors_in_sampled_order(self) -> None:
+        """Ranking decides *which* proposals apply, never the order they apply in."""
+        batch = [_gated(0, 0.1), _gated(1, 0.9), _gated(2, 0.5)]
+        # Ranked 1 (0.9), 2 (0.5), 0 (0.1) — applied 1 then 2.
+        assert [g.order for g in select_top_k(batch, 2)] == [1, 2]
+
+    def test_top_k_breaks_ties_toward_earliest_sampled(self) -> None:
+        batch = [_gated(0, 0.9), _gated(1, 0.9), _gated(2, 0.9)]
+        assert [g.order for g in select_top_k(batch, 2)] == [0, 1]
+
+    def test_top_k_larger_than_batch_returns_everything(self) -> None:
+        batch = [_gated(0, 0.5), _gated(1, 0.9)]
+        assert [g.order for g in select_top_k(batch, 10)] == [0, 1]
+
+    def test_negative_improvements_still_rank(self) -> None:
+        """A gated proposal always improved on *its own* parent; ranking is relative."""
+        batch = [_gated(0, -0.5), _gated(1, -0.1)]
+        assert [g.order for g in select_best_improvement(batch)] == [1]
+
+    @pytest.mark.parametrize(
+        "strategy,expected",
+        [("all_improvements", [0, 1, 2]), ("best_improvement", [1])],
+    )
+    def test_dispatcher_routes_to_the_named_strategy(
+        self, strategy: Any, expected: list[int]
+    ) -> None:
+        batch = [_gated(0, 0.5), _gated(1, 0.9), _gated(2, 0.1)]
+        picked = select_proposals(batch, strategy=strategy, top_k=None)
+        assert [g.order for g in picked] == expected
+
+    def test_dispatcher_routes_top_k(self) -> None:
+        batch = [_gated(0, 0.5), _gated(1, 0.9), _gated(2, 0.1)]
+        picked = select_proposals(batch, strategy="top_k", top_k=1)
+        assert [g.order for g in picked] == [1]
+
+
+# ---------------------------------------------------------------------------
+# 4. Acceptance memo
+# ---------------------------------------------------------------------------
+
+
+class _CountingCriterion:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def should_accept(self, proposal: ScoreVectors) -> bool:
+        self.calls += 1
+        return sum(proposal.subsample_scores_after or []) > sum(
+            proposal.subsample_scores_before or []
+        )
+
+
+class TestAcceptanceMemo:
+    def test_repeated_consultation_runs_the_criterion_once(self) -> None:
+        criterion = _CountingCriterion()
+        memo = AcceptanceMemo(criterion)
+        first = memo.judge(0, [0.1], [0.9])
+        again = memo.judge(0, [0.1], [0.9])
+        assert first is again
+        assert criterion.calls == 1
+        assert memo.criterion_calls == 1
+
+    def test_distinct_slots_are_judged_independently(self) -> None:
+        criterion = _CountingCriterion()
+        memo = AcceptanceMemo(criterion)
+        assert memo.judge(0, [0.1], [0.9]).accepted is True
+        assert memo.judge(1, [0.9], [0.1]).accepted is False
+        assert criterion.calls == 2
+
+    def test_improvement_is_the_gate_margin(self) -> None:
+        memo = AcceptanceMemo(_CountingCriterion())
+        judgement = memo.judge(0, [0.1, 0.2], [0.5, 0.4])
+        assert judgement.improvement == pytest.approx(0.6)
+
+
+# ---------------------------------------------------------------------------
+# 5. P×N planning and selection, end to end
+# ---------------------------------------------------------------------------
+
+
+def _scored_children(
+    all_mocks: dict[str, Any], seed_id: str, child_scores: dict[str, float]
+) -> list[str]:
+    """Wire N children with per-child minibatch scores; return the frontier log."""
+    all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
+
+    def run_eval(
+        candidate: Candidate,
+        config: HelixConfig,
+        split: str = "val",
+        instance_ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> EvalResult:
+        if instance_ids is None:
+            return _make_result(candidate.id, {"v1": 0.5})
+        if split == "train":
+            score = 0.3 if candidate.id == seed_id else child_scores[candidate.id]
+            return _make_result(candidate.id, {i: score for i in instance_ids})
+        return _make_result(candidate.id, {i: 0.7 for i in instance_ids})
+
+    all_mocks["run_evaluator"].side_effect = run_eval
+
+    promoted: list[str] = []
+    all_mocks["_save_evaluation"].side_effect = lambda _d, r, *a, **k: promoted.append(
+        r.candidate_id
+    )
+    return promoted
+
+
+class TestPxNPlanning:
+    def test_n_children_per_parent_each_on_its_own_minibatch(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """P=1, N=3 proposes three children from one parent, on three minibatches."""
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
+        trace = _install_trace(all_mocks, seed.id)
+
+        config = _make_config(
+            train_path, num_parallel_proposals=1, mutations_per_parent=3
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        child_evals = [
+            e for e in _worker_evals(trace) if not e.startswith("eval g0-s0 ")
+        ]
+        assert len(child_evals) == 3, (
+            f"P=1 N=3 must propose 3 children; got {child_evals}"
+        )
+        # Each slot draws its own minibatch, so the three children are gated
+        # on three different example sets.
+        batches = {e.split("[")[1] for e in child_evals}
+        assert len(batches) == 3, (
+            f"Each of the N slots must draw its own minibatch; got {batches}"
+        )
+        # All three share the one sampled parent (parent-major planning).
+        assert all("<-g0-s0" in e for e in trace if e.startswith("lineage g1-"))
+
+    def test_p_times_n_is_the_batch_size(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """P=2, N=2 proposes four children."""
+        train_path = _write_train_jsonl(tmp_path, n=12)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+
+        all_mocks["mutate"].side_effect = lambda **kw: _make_candidate(kw["new_id"])
+        trace = _install_trace(all_mocks, seed.id)
+
+        config = _make_config(
+            train_path, num_parallel_proposals=2, mutations_per_parent=2
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert sorted(e for e in trace if e.startswith("lineage g1-")) == [
+            "lineage g1-s1<-g0-s0",
+            "lineage g1-s2<-g0-s0",
+            "lineage g1-s3<-g0-s0",
+            "lineage g1-s4<-g0-s0",
+        ]
+
+
+class TestSelectionEndToEnd:
+    def test_all_improvements_promotes_every_passer(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        promoted = _scored_children(
+            all_mocks, seed.id, {"g1-s1": 0.4, "g1-s2": 0.9, "g1-s3": 0.6}
+        )
+
+        config = _make_config(
+            train_path, num_parallel_proposals=1, mutations_per_parent=3
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert sorted(p for p in promoted if p != seed.id) == [
+            "g1-s1",
+            "g1-s2",
+            "g1-s3",
+        ]
+
+    def test_best_improvement_promotes_only_the_largest(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """Only the biggest gate margin reaches full validation and the frontier."""
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        promoted = _scored_children(
+            all_mocks, seed.id, {"g1-s1": 0.4, "g1-s2": 0.9, "g1-s3": 0.6}
+        )
+
+        config = _make_config(
+            train_path,
+            num_parallel_proposals=1,
+            mutations_per_parent=3,
+            proposal_selection="best_improvement",
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert [p for p in promoted if p != seed.id] == ["g1-s2"]
+
+    def test_top_k_promotes_exactly_k(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        promoted = _scored_children(
+            all_mocks, seed.id, {"g1-s1": 0.4, "g1-s2": 0.9, "g1-s3": 0.6}
+        )
+
+        config = _make_config(
+            train_path,
+            num_parallel_proposals=1,
+            mutations_per_parent=3,
+            proposal_selection="top_k",
+            proposal_top_k=2,
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        # The two largest margins, applied in sampled order.
+        assert [p for p in promoted if p != seed.id] == ["g1-s2", "g1-s3"]
+
+    def test_unselected_passers_are_removed_not_left_dangling(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """A child that cleared the gate but lost selection must be cleaned up."""
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _scored_children(
+            all_mocks, seed.id, {"g1-s1": 0.4, "g1-s2": 0.9, "g1-s3": 0.6}
+        )
+
+        removed: list[str] = []
+        all_mocks["remove_worktree"].side_effect = lambda c, *a, **k: removed.append(
+            c.id if isinstance(c, Candidate) else str(c)
+        )
+
+        config = _make_config(
+            train_path,
+            num_parallel_proposals=1,
+            mutations_per_parent=3,
+            proposal_selection="best_improvement",
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert sorted(removed) == ["g1-s1", "g1-s3"]
+
+    def test_selection_consults_one_judgement_per_proposal(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        """The criterion runs once per proposal, not once per consultation.
+
+        ``best_improvement`` has to know every proposal's gate outcome before
+        it can promote any of them, and then works with the winner. Routing
+        that through the memo keeps the number of underlying judgements equal
+        to the batch size.
+        """
+        from helix.eval_policy import StrictImprovementAcceptance
+
+        spy = mocker.spy(StrictImprovementAcceptance, "should_accept")
+
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _scored_children(
+            all_mocks, seed.id, {"g1-s1": 0.4, "g1-s2": 0.9, "g1-s3": 0.6}
+        )
+
+        config = _make_config(
+            train_path,
+            num_parallel_proposals=1,
+            mutations_per_parent=3,
+            proposal_selection="best_improvement",
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert spy.call_count == 3, (
+            f"Expected one acceptance judgement per proposal (3); got "
+            f"{spy.call_count}"
+        )
+
+
+class TestChildDedupe:
+    def test_byte_identical_siblings_collapse_to_one_frontier_entry(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        """Two siblings on the same tree must not both enter the frontier."""
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        promoted = _scored_children(
+            all_mocks, seed.id, {"g1-s1": 0.9, "g1-s2": 0.9, "g1-s3": 0.6}
+        )
+        # s1 and s2 committed the same tree; s3 is its own.
+        mocker.patch(
+            "helix.evolution._candidate_content_key",
+            side_effect=lambda c: {"g1-s1": "tree-a", "g1-s2": "tree-a"}.get(
+                c.id, f"tree-{c.id}"
+            ),
+        )
+
+        config = _make_config(
+            train_path, num_parallel_proposals=1, mutations_per_parent=3
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert [p for p in promoted if p != seed.id] == ["g1-s1", "g1-s3"], (
+            "The duplicate sibling must be dropped before frontier insertion"
+        )
+
+    def test_duplicate_survivor_is_the_earlier_sampled_slot(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _scored_children(all_mocks, seed.id, {"g1-s1": 0.9, "g1-s2": 0.9})
+        mocker.patch(
+            "helix.evolution._candidate_content_key", side_effect=lambda c: "same"
+        )
+
+        removed: list[str] = []
+        all_mocks["remove_worktree"].side_effect = lambda c, *a, **k: removed.append(
+            c.id if isinstance(c, Candidate) else str(c)
+        )
+
+        config = _make_config(
+            train_path, num_parallel_proposals=1, mutations_per_parent=2
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert removed == ["g1-s2"]
+
+    def test_single_slot_batches_skip_the_content_key_entirely(
+        self, tmp_path: Path, all_mocks: dict[str, Any], mocker: Any
+    ) -> None:
+        """P=N=1 has no sibling to collide with, so it pays nothing for dedupe."""
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _scored_children(all_mocks, seed.id, {"g1-s1": 0.9})
+        key_spy = mocker.patch(
+            "helix.evolution._candidate_content_key", side_effect=lambda c: c.id
+        )
+
+        config = _make_config(
+            train_path,
+            num_parallel_proposals=1,
+            mutations_per_parent=1,
+            cache_evaluation=False,
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        assert key_spy.call_count == 0
+
+
+class TestMinibatchRepeatWarning:
+    def test_warns_when_batch_exceeds_available_minibatches(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        """P*N=4 over 6 examples at minibatch_size=2 leaves only 3 disjoint draws."""
+        train_path = _write_train_jsonl(tmp_path, n=6)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _scored_children(
+            all_mocks,
+            seed.id,
+            {"g1-s1": 0.9, "g1-s2": 0.9, "g1-s3": 0.9, "g1-s4": 0.9},
+        )
+
+        config = _make_config(
+            train_path,
+            minibatch_size=2,
+            num_parallel_proposals=2,
+            mutations_per_parent=2,
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        warnings = [str(c.args[0]) for c in all_mocks["print_warning"].call_args_list]
+        assert any("minibatches will repeat within an iteration" in w for w in warnings), (
+            f"Expected a minibatch-repeat warning; got {warnings}"
+        )
+
+    def test_no_warning_when_the_train_set_is_large_enough(
+        self, tmp_path: Path, all_mocks: dict[str, Any]
+    ) -> None:
+        train_path = _write_train_jsonl(tmp_path, n=20)
+        seed = _make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        _scored_children(all_mocks, seed.id, {"g1-s1": 0.9, "g1-s2": 0.9})
+
+        config = _make_config(
+            train_path,
+            minibatch_size=2,
+            num_parallel_proposals=1,
+            mutations_per_parent=2,
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+
+        warnings = [str(c.args[0]) for c in all_mocks["print_warning"].call_args_list]
+        assert not any("minibatches will repeat" in w for w in warnings)

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -1,15 +1,18 @@
 """Unit tests for GEPA-aligned state persistence.
 
-Covers the additions called out in the RNG/state-persistence audit
-(MODERATE_DIVERGENCE — schema thin vs GEPA):
+Covers the additions called out in an internal divergence audit
+(schema thin vs GEPA):
 
 * C1 — per-(candidate, example) eval cache survives save → load round-trip
-  (GEPA core/state.py:185, 306-340, 348-376, 683-687).
+  (GEPA's ``evaluation_cache`` field plus ``GEPAState.save``/``GEPAState.load``
+  and the cache-sync logic in ``initialize_gepa_state``, all in
+  ``core/state.py``).
 * C/§3 — per-program discovery budget (``num_metric_calls_by_discovery``)
-  is persisted on every accept site (GEPA core/state.py:177, 537).
+  is persisted on every accept site (GEPA's ``num_metric_calls_by_discovery``
+  field, appended to in ``update_state_with_new_program``, ``core/state.py``).
 * D1 — schema_version is written and a missing version is treated as the
-  unversioned predecessor with defaulted new fields (GEPA core/state.py:153,
-  402-420).
+  unversioned predecessor with defaulted new fields (GEPA's
+  ``_VALIDATION_SCHEMA_VERSION`` and ``_upgrade_state_dict``, ``core/state.py``).
 * Backward compatibility — pre-migration state.json files load cleanly
   with new fields populated to defaults.
 * Resume fidelity — when val_stage_size is None the new state additions
@@ -80,7 +83,7 @@ def _make_full_state() -> EvolutionState:
 def test_state_roundtrip_preserves_all_fields(tmp_path: Path) -> None:
     """save_state → load_state must deep-equal the original on every field.
 
-    Audit ref: RNG/state-persistence audit C/§3 + D1.
+    Audit ref: C/§3 + D1.
     """
     state = _make_full_state()
     save_state(state, tmp_path)
@@ -122,7 +125,7 @@ def _write_legacy_state_json(base_dir: Path) -> None:
     legacy = {
         # Note: deliberately omits "schema_version" and
         # "num_metric_calls_by_discovery".  Mirrors the on-disk format that
-        # existed before audit-rng-state-persist D1 was addressed.
+        # existed before rng-state-persist audit D1 was addressed.
         "generation": 1,
         "frontier": ["g0-s0"],
         "instance_scores": {"g0-s0": {"task_a": 0.5}},
@@ -162,8 +165,8 @@ def test_load_legacy_state_populates_defaults(tmp_path: Path) -> None:
 def test_load_state_rejects_newer_schema_version(tmp_path: Path) -> None:
     """A future-version state.json must be rejected with a clear error.
 
-    Audit ref: D1 — schema migration path (analogous to GEPA's schema check
-    at gepa/core/state.py:355-376).
+    Audit ref: D1 — schema migration path (analogous to GEPA's schema-version
+    check in ``GEPAState.load``, ``core/state.py``).
     """
     helix_dir = tmp_path / ".helix"
     helix_dir.mkdir(parents=True)
@@ -190,7 +193,8 @@ def test_eval_cache_pickle_roundtrip(tmp_path: Path) -> None:
 
     Audit ref: C1 — JSON cannot encode tuple keys; we use a sibling pickle
     so the per-(candidate_hash, example_id) cache survives crash/resume the
-    same way GEPA's pickled state does (gepa/core/state.py:306-340, 348-376).
+    same way GEPA's pickled state does (``GEPAState.save``/``GEPAState.load``,
+    ``core/state.py``).
     """
     cache: MinibatchEvalCache[object, str] = MinibatchEvalCache[object, str]()
     cache.put({"prompt.md": "v1"}, "task_a", output="out-a", score=0.4)


### PR DESCRIPTION
## Scope

This PR ships the P×N proposal scheduler plus explicit in-memory budget guards. It does not implement slot-granular batch checkpointing; that remains the deferred [2/2] work.

## Resume semantics

Resume is generation-granular. An interruption discards the in-flight generation and restarts from the last completed generation. Reconciliation preserves completed state without corrupting it, double-charging the budget, duplicating frontier entries, or leaving orphaned worktrees. A partially completed P×N batch is not resumed slot-by-slot.

The RNG is reseeded for each invocation, so a resumed search can diverge from an uninterrupted search.

Evidence from one unplanned multi-hour interruption: budget `336 → 336`, cost `$0.77971 → $0.77971`, identical frontier with no duplicates, five lineage ids, three preserved full-validation results, and frontier-members-only worktrees. Resume reported generation 3 and the following generation completed gate → validate → promote. This covers one interruption point only; it does not cover the apply phase or a partially written state file.

## Budget guards

The scheduler now records a conservative per-batch in-flight evaluation bound and validates the observed charge after the admitted batch drains. The permitted overshoot follows `max(0, U - 1)`; tests retain the measured `cap 20 → consumed 27` (`overshoot 7 = width - 1`) behavior and drive both rejecting guard paths.

## Known deliberate coverage gaps

- `num_parallel_proposals = "auto"` is not yet exercised end-to-end through `run_evolution`.
- The determinism test does not force out-of-order worker completion.
- There is no sandbox-enabled P×N test.

These are coverage gaps, not known scheduler defects.