### PR TITLE
fix(circle_packing): stop the evaluator inheriting an arbitrary python3

### DIFF
--- a/examples/circle_packing/README.md
+++ b/examples/circle_packing/README.md
@@ -51,3 +51,22 @@ No Sonnet, no Opus, no extended thinking — just Haiku with low effort and a ha
 - `evaluate.py` — scorer that checks validity and returns `Σ rᵢ`.
 - `helix.toml` — project configuration.
 - `solve_optimized.py` — a hand-tuned reference implementation that scores **2.635982**. It is not used during evolution; it is provided as a sanity check / target for comparison.
+
+## Requirements
+
+The solver uses `numpy` and `scipy` and requires Python 3.10+ for PEP 604
+(`X | None`) annotations. The evaluator command in `helix.toml` pins an
+interpreter and installs those two packages itself via `uv`, so no manual
+setup is needed and a fresh clone reproduces the reference score.
+
+Verify the baseline before trusting a run:
+
+```bash
+cd $(mktemp -d) && cp <repo>/examples/circle_packing/evaluate.py . \
+  && cp <repo>/examples/circle_packing/solve_optimized.py solve.py \
+  && uv run --no-project --python 3.12 --with numpy --with scipy python3 evaluate.py
+# {"score": 2.635982, "violations": 0, ...}
+```
+
+A score of `0.0` with `"ERROR: Could not import solve.py"` means the evaluator
+reached the wrong interpreter, not that the candidate is bad.

--- a/examples/circle_packing/helix.toml
+++ b/examples/circle_packing/helix.toml
@@ -6,7 +6,12 @@ objective = "Maximize the sum of radii of 26 non-overlapping circles packed in a
 # passthrough_env = ["CUDA_VISIBLE_DEVICES", "MUJOCO_GL", "HF_HOME"]
 
 [evaluator]
-command = "python3 evaluate.py"
+# The solver needs numpy + scipy and PEP 604 (`X | None`) annotations, so the
+# evaluator must not inherit whatever bare `python3` happens to be on PATH --
+# on macOS that is a 3.9 interpreter with no scipy, which scores every
+# candidate 0.0 including the reference solution.  Pin the interpreter and
+# bring the dependencies with it so a fresh clone reproduces the benchmark.
+command = "uv run --no-project --python 3.12 --with numpy --with scipy python3 evaluate.py"
 score_parser = "json_score"
 
 [evolution]


### PR DESCRIPTION
The circle_packing example scored **0.0 for every candidate — including its own reference solution** — so the documented 2.6360 result was not reproducible.

## Root cause

Not the solver. The evaluator command was `python3 evaluate.py`, which resolves to whatever is first on `PATH`. Here that is the Xcode 3.9 interpreter, with a user-site numpy that trips numpy's own *"do not import from the source directory"* guard and no scipy at all.

`evaluate.py` catches the `ImportError` and reports `score: 0.0` — **indistinguishable from a genuinely bad candidate**. An entire evolution run would look like it simply made no progress.

`solve_optimized.py` additionally uses PEP 604 `X | None` annotations, so even a 3.9 interpreter with a working numpy fails with a `TypeError`.

## Fix

```
uv run --no-project --python 3.12 --with numpy --with scipy python3 evaluate.py
```

`--no-project` is deliberate: a fresh clone reproduces the benchmark without syncing the repo environment, and HELIX does not acquire a scipy dependency for one example's sake.

## Verified end to end

| | before | after |
|---|---|---|
| `solve_optimized.py` (reference) | 0.0 | **2.635982**, 0 violations |
| `solve.py` (naive seed) | 0.0 | **0.979764**, 0 violations |

circle_packing was the only example still using a bare `python3`; `web_researcher` already used `uv run`.