### PR TITLE
ci: lint the workflows, and fix everything the linters found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # `stack/**` covers stacked PRs, which target an integration branch rather
+    # than main. Without it their `branches:` filter never matches and CI is
+    # silently skipped -- a green-looking PR that ran nothing.
+    branches: [main, "stack/**"]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -11,10 +13,44 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --all-extras
       - run: uv run pytest tests/unit/ -q
       - run: uv run mypy --strict src/helix/
+
+  # Lint the workflows themselves. actionlint checks workflow structure,
+  # expression types, and the shell inside every `run:`; zizmor checks the
+  # security properties (template injection, unpinned actions, credential
+  # persistence, permission scope).
+  #
+  # Two ways this gate can pass while checking almost nothing. Both are silent,
+  # so neither is obvious from a green run:
+  #
+  #   1. actionlint runs its shellcheck integration only when a `shellcheck`
+  #      binary is on PATH. Without one it skips every SC rule and still exits
+  #      0. GitHub's ubuntu-latest image ships shellcheck, so CI is covered --
+  #      but a local `actionlint` run on a workstation without it reports clean
+  #      on scripts CI will reject. Install shellcheck before trusting a local
+  #      run.
+  #   2. zizmor's ref-version-mismatch is an online audit. Without a GitHub
+  #      token it is skipped silently, so GH_TOKEN below is load-bearing, not
+  #      decoration.
+  lint-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      # ubuntu-latest ships shellcheck; assert it rather than assume it, so
+      # this job cannot silently degrade to structure-only checking.
+      - run: shellcheck --version
+      - run: uvx --from actionlint-py==1.7.7.23 actionlint -color
+      - run: uvx zizmor==1.16.3 --persona=regular .github/workflows/
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-runners.yml
+++ b/.github/workflows/publish-runners.yml
@@ -27,13 +27,15 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -41,7 +43,7 @@ jobs:
 
       - name: Build and push base by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: docker/base.Dockerfile
@@ -49,13 +51,14 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}-base,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digests-base-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -72,17 +75,17 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/digests
           pattern: digests-base-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -90,7 +93,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE_PREFIX }}-base
           tags: |
@@ -101,6 +104,12 @@ jobs:
       - name: Create and push merged manifest list
         working-directory: /tmp/digests
         run: |
+          # Both substitutions below are deliberately unquoted: each expands to
+          # a *list* of separate arguments (`-t a -t b`, then one image
+          # reference per digest file), which is exactly the word splitting
+          # SC2046 warns about. Quoting either one would collapse it into a
+          # single malformed argument.
+          # shellcheck disable=SC2046
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_PREFIX }}-base@sha256:%s ' *)
@@ -136,13 +145,15 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -160,7 +171,7 @@ jobs:
 
       - name: Build and push backend by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ matrix.image.dockerfile }}
@@ -170,13 +181,14 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digests-${{ matrix.image.name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -202,17 +214,17 @@ jobs:
           - name: opencode
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/digests
           pattern: digests-${{ matrix.image.name }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -220,7 +232,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }}
           tags: |
@@ -231,6 +243,12 @@ jobs:
       - name: Create and push merged manifest list
         working-directory: /tmp/digests
         run: |
+          # Both substitutions below are deliberately unquoted: each expands to
+          # a *list* of separate arguments (`-t a -t b`, then one image
+          # reference per digest file), which is exactly the word splitting
+          # SC2046 warns about. Quoting either one would collapse it into a
+          # single malformed argument.
+          # shellcheck disable=SC2046
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }}@sha256:%s ' *)
@@ -271,7 +289,7 @@ jobs:
           fi
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -279,7 +297,11 @@ jobs:
 
       - name: Pull and verify
         shell: bash
+        env:
+          IMAGE_NAME: ${{ matrix.image.name }}
+          IMAGE_TAG: ${{ steps.tag.outputs.value }}
+          SMOKE_COMMAND: ${{ matrix.image.command }}
         run: |
-          image="${IMAGE_PREFIX}-${{ matrix.image.name }}:${{ steps.tag.outputs.value }}"
+          image="${IMAGE_PREFIX}-${IMAGE_NAME}:${IMAGE_TAG}"
           docker pull "$image"
-          docker run --rm "$image" sh -lc '${{ matrix.image.command }}'
+          docker run --rm "$image" sh -lc "$SMOKE_COMMAND"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Everything else must be pinned to a full commit SHA.
+        "*": hash-pin
+        # PyPA explicitly publishes `release/v1` as the ref Trusted Publishing
+        # users should track, and ships security fixes to that branch. Pinning
+        # it to a hash would opt this repository out of those fixes, and the
+        # PyPI release path cannot be rehearsed on a pull request. Tracked as a
+        # deliberate exception rather than a silent global suppression.
+        "pypa/gh-action-pypi-publish": ref-pin


### PR DESCRIPTION
Extracted from #43, which had accumulated these lint gates without them being related to its stated purpose (publishing pinned runner images). They stand on their own and should land first.

**+101 / −29 across 4 files** (`git diff --shortstat origin/main...chore/workflow-lint-gates`).

## What this adds

A `lint-workflows` CI job running **actionlint** (workflow structure, expression types, and shellcheck over every `run:` body) and **zizmor** (template injection, unpinned actions, credential persistence, permission scope).

## What it immediately found

The gate went red on its first run against `main`. All 23 findings were real and are fixed here:

| Finding | Count | Fix |
|---|---|---|
| `unpinned-uses` | 15 | every action pinned to a full commit SHA, version in a trailing comment |
| `artipacked` | 4 | `persist-credentials: false` on every checkout |
| `template-injection` | 3 | `${{ }}` moved out of shell bodies into `env:` |
| `excessive-permissions` | 1 | `contents: read` at the top of `ci.yml` |
| `SC2046` (shellcheck) | 4 | see below |

The four SC2046 hits are the two `docker buildx imagetools create` invocations. Both substitutions there are *deliberately* unquoted — each expands to a list of separate arguments (`-t a -t b`, then one image reference per digest file). Quoting either would collapse it into a single malformed argument, so they carry a `# shellcheck disable=SC2046` directive explaining why, rather than a "fix" that would break them.

`.github/zizmor.yml` records one deliberate exception: PyPA publishes `release/v1` as the ref Trusted Publishing users should track and ships security fixes to that branch, so hash-pinning it would opt this repo out of them. It is an explicit policy entry, not a blanket suppression.

## Two ways this gate silently checks almost nothing

Both produce a **green** run, so neither is visible from CI status. Documented inline:

1. **actionlint runs shellcheck only when a `shellcheck` binary is on PATH.** Without one it skips every SC rule and still exits 0. That is exactly how a local run reports clean on scripts CI will reject. The job now asserts `shellcheck --version` before linting, so it cannot degrade to structure-only checking unnoticed.
2. **zizmor's `ref-version-mismatch` is an online audit**, skipped silently without a token. `GH_TOKEN` is load-bearing, not decoration.

## Verification

- `uv run pytest tests/unit -q` → **867 passed**
- `uv run mypy --strict src/helix/` → clean
- `actionlint` and `zizmor --persona=regular` → clean, run locally with shellcheck 0.11.0 on PATH

`mypy` over `tools/` is deliberately **not** here — `tools/` does not exist on `main` yet. It belongs with the PR that introduces it.
