### PR TITLE
chore: add Renovate configuration for automated dependency updates

### DIFF
--- a/.github/workflows/publish-runners.yml
+++ b/.github/workflows/publish-runners.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - "v*"
+  schedule:
+    # Weekly rebuild so the images pick up whatever the unpinned agent CLI
+    # installs (npm latest / curl-installer latest) resolve to, without
+    # waiting on a release tag. 12:00 UTC Monday is before 6am in
+    # America/Los_Angeles year-round (04:00 PST / 05:00 PDT), matching the
+    # cadence and timezone this repo's Renovate config already uses
+    # ("before 6am on monday", "timezone": "America/Los_Angeles").
+    - cron: "0 12 * * 1"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/publish-runners.yml
+++ b/.github/workflows/publish-runners.yml
@@ -4,14 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  schedule:
-    # Weekly rebuild so the images pick up whatever the unpinned agent CLI
-    # installs (npm latest / curl-installer latest) resolve to, without
-    # waiting on a release tag. 12:00 UTC Monday is before 6am in
-    # America/Los_Angeles year-round (04:00 PST / 05:00 PDT), matching the
-    # cadence and timezone this repo's Renovate config already uses
-    # ("before 6am on monday", "timezone": "America/Los_Angeles").
-    - cron: "0 12 * * 1"
   workflow_dispatch:
 
 env:

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "description": "The base image FROM must stay digest-pinned, never a floating tag.",
+      "description": "Pin Docker base images by digest so runner image builds are reproducible.",
       "matchManagers": ["dockerfile"],
       "pinDigests": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -14,12 +14,6 @@
       "description": "The base image FROM must stay digest-pinned, never a floating tag.",
       "matchManagers": ["dockerfile"],
       "pinDigests": true
-    },
-    {
-      "description": "Workflow actions are hash-pinned; zizmor's unpinned-uses rule fails CI otherwise. pypa/gh-action-pypi-publish is exempt by policy (see .github/zizmor.yml) and must stay on release/v1, because PyPA ships security fixes to that branch.",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["!pypa/gh-action-pypi-publish"],
-      "pinDigests": true
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":semanticCommits"
+  ],
+  "timezone": "America/Los_Angeles",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 5,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "The base image FROM must stay digest-pinned, never a floating tag.",
+      "matchManagers": ["dockerfile"],
+      "pinDigests": true
+    },
+    {
+      "description": "Workflow actions are hash-pinned; zizmor's unpinned-uses rule fails CI otherwise. pypa/gh-action-pypi-publish is exempt by policy (see .github/zizmor.yml) and must stay on release/v1, because PyPA ships security fixes to that branch.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["!pypa/gh-action-pypi-publish"],
+      "pinDigests": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"]
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -11,9 +11,16 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "description": "Pin Docker base images by digest so runner image builds are reproducible.",
+      "description": "Pin the runner base image (docker/base.Dockerfile) by digest so runner image builds are reproducible.",
       "matchManagers": ["dockerfile"],
+      "matchFileNames": ["docker/base.Dockerfile"],
       "pinDigests": true
+    },
+    {
+      "description": "The backend Dockerfiles only FROM the locally built helix-runner-base image, which exists on no registry, so Renovate would just emit lookup warnings for them. Their agent CLI installs (npm latest / curl installers) are unpinned by design; the weekly publish-runners rebuild is what tracks those.",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": ["docker/*.Dockerfile", "!docker/base.Dockerfile"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## What

Adds a 30-line Renovate configuration: weekly Monday dependency updates, at most 5 concurrent PRs, semantic commits, GitHub Action digest pinning, digest pinning for the runner base image, and immediate vulnerability alerts.

This PR is Renovate-only. The weekly `publish-runners` rebuild that used to ride along here now lives in PR #71 (together with the node-user image verification and the `resolve-tag` job), so `.github/workflows/publish-runners.yml` is untouched by this diff.

## Why

Keep dependency maintenance predictable while retaining immutable references for Actions and the base image.

## Review focus

- Renovate: the `dockerfile` digest-pinning rule is scoped with `matchFileNames` to `docker/base.Dockerfile` (the only Dockerfile that `FROM`s a registry image). The other five Dockerfiles start with `ARG BASE_IMAGE=helix-runner-base:latest` / `FROM ${BASE_IMAGE}`, which Renovate would resolve to a nonexistent Docker Hub library image and emit lookup warnings for; a second rule disables the `dockerfile` manager for `docker/*.Dockerfile` minus `base.Dockerfile`. Their agent CLI installs (`npm install -g` latest, `curl | bash` for cursor) stay unpinned by design — the weekly rebuild in #71 is what tracks those, and the dockerfile manager would never have touched them anyway (it only extracts `FROM`/`COPY --from` images).
- Neither rule overrides Renovate's recommended defaults beyond what the rule needs.

## Validation

- `renovate.json` parses as JSON; 30 lines, 2 package rules, and a +30/−0 configuration-only diff.
- `renovate-config-validator --strict renovate.json` (renovate 44.74.1): `Config validated successfully`.
- `git diff origin/main --stat` after merging `main`: only `renovate.json`.
