### PR TITLE
fix(config): make minibatch_size default mode-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BEHAVIOUR CHANGE — `evolution.minibatch_size` default is now mode-aware.**
+  When `minibatch_size` is omitted it resolves to **1** in single-task /
+  no-example mode (no `[dataset].train_size` and no `[seedless].train_path`)
+  and stays **3** in multi-task / generalization mode. Previously every mode
+  got a flat 3, which was only ever the multi-task half of the intended
+  default. Single-task is HELIX's default mode, so this affects existing
+  configs that relied on the implicit 3 — including `examples/circle_packing`.
+
+  **The change is user-visible only through `num_parallel_proposals = "auto"`,
+  and there it triples proposal width.** `"auto"` derives
+  `max(1, max_workers // minibatch_size)`, and the resolved `P` drives the
+  proposal-slot loop. A single-task run with `max_workers = 12` and
+  `"auto"` now opens **12** proposal slots per generation where it previously
+  opened 4 — verified end-to-end against the evolution loop. More proposals
+  per generation means more mutation agent invocations per generation, so
+  review `max_workers` before your next single-task `"auto"` run.
+
+  Single-task runs that pin `num_parallel_proposals` to an integer see no
+  behavioural change: with no training split HELIX builds no batch sampler, so
+  `minibatch_size` is never read for sampling and metric-call counts are
+  unaffected. For those configs this is a parity/consistency fix only.
+
+  An explicitly written `minibatch_size` is never rewritten in either
+  direction: set `minibatch_size = 3` to keep the previous behaviour exactly.
+
 ## [0.2.2] - 2026-05-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default. Single-task is HELIX's default mode, so this affects existing
   configs that relied on the implicit 3 — including `examples/circle_packing`.
 
-  **The change is user-visible only through `num_parallel_proposals = "auto"`,
-  and there it triples proposal width.** `"auto"` derives
+  **The change is user-visible only through `num_parallel_proposals = "auto"`.**
+  `"auto"` derives
   `max(1, max_workers // minibatch_size)`, and the resolved `P` drives the
-  proposal-slot loop. A single-task run with `max_workers = 12` and
-  `"auto"` now opens **12** proposal slots per generation where it previously
-  opened 4 — verified end-to-end against the evolution loop. More proposals
-  per generation means more mutation agent invocations per generation, so
-  review `max_workers` before your next single-task `"auto"` run.
+  proposal-slot loop. Removing the divisor of 3 generally widens a
+  single-task proposal batch, but the exact factor depends on integer
+  flooring and the minimum-one clamp: for example, `max_workers = 12` changes
+  from 4 slots to 12, while 8 changes from 2 to 8 and 2 changes from 1 to 2.
+  More proposals per generation means more mutation agent invocations per
+  generation, so review `max_workers` before your next single-task `"auto"`
+  run.
 
   Single-task runs that pin `num_parallel_proposals` to an integer see no
   behavioural change: with no training split HELIX builds no batch sampler, so
@@ -32,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   An explicitly written `minibatch_size` is never rewritten in either
   direction: set `minibatch_size = 3` to keep the previous behaviour exactly.
+  Pydantic's `HelixConfig.model_copy(update=...)` does not rerun validation,
+  so rebuild from raw config (with `minibatch_size` omitted) rather than using
+  it to switch dataset mode.
 
 ## [0.2.2] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,10 @@ merge_subsample_size = 5         # stratified val subsample size for merge accep
 max_workers = 8                  # thread-pool cap for parent-eval + mutation pools
                                  # (default: os.cpu_count(), or 32 if that returns None)
 num_parallel_proposals = 1       # parallel mutations per generation; "auto" resolves to max_workers // minibatch_size
-minibatch_size = 3               # train-set minibatch size for reflective mutation
+minibatch_size = 3               # train-set minibatch size for reflective mutation.
+                                 # Mode-aware default when omitted: 1 in single-task mode
+                                 # (no [dataset].train_size and no [seedless].train_path),
+                                 # 3 in multi-task mode. An explicit value always wins.
 cache_evaluation = true          # reuse per-instance evaluator results
 acceptance_criterion = "strict_improvement"
 val_stage_size = 0               # optional first-N val gate before full val

--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ minibatch_size = 3               # train-set minibatch size for reflective mutat
                                  # Mode-aware default when omitted: 1 in single-task mode
                                  # (no [dataset].train_size and no [seedless].train_path),
                                  # 3 in multi-task mode. An explicit value always wins.
+                                 # model_copy(update=...) does not recompute this default;
+                                 # rebuild from raw config when changing dataset mode.
 cache_evaluation = true          # reuse per-instance evaluator results
 acceptance_criterion = "strict_improvement"
 val_stage_size = 0               # optional first-N val gate before full val

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -10,7 +10,14 @@ import warnings
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from helix.backends import (
     BackendName,
@@ -179,6 +186,16 @@ class DatasetConfig(BaseModel):
             "{worktree}/helix_batch.json."
         ),
     )
+
+    @field_validator("train_size", "val_size", mode="before")
+    @classmethod
+    def _reject_boolean_cardinality(cls, value: Any, info: Any) -> Any:
+        """Reject bools before Pydantic's normal int coercion accepts them."""
+        if isinstance(value, bool):
+            raise ValueError(
+                f"dataset.{info.field_name} must be an integer, not a boolean"
+            )
+        return value
 
     def model_post_init(self, __context: object) -> None:  # noqa: D401
         if self.train_size is not None and self.train_size < 0:
@@ -607,6 +624,14 @@ class HelixConfig(BaseModel):
 
     Combines all configuration sections (objective, evaluator, dataset,
     evolution, agent, worktree) and validates compatibility constraints.
+
+    Validation runs when the model is constructed. Pydantic's
+    :meth:`model_copy` deliberately does not rerun validators, so it must not
+    be used to switch between single-task and multi-task mode: an omitted
+    default is already a concrete ``minibatch_size`` and any resolved
+    ``num_parallel_proposals="auto"`` is already an integer. Rebuild from the
+    raw configuration mapping (with ``minibatch_size`` omitted) when changing
+    the training split.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -663,6 +688,10 @@ class HelixConfig(BaseModel):
         keeps 3.  An ``evolution`` section supplied as an already-constructed
         :class:`EvolutionConfig` is likewise left untouched — the caller built
         it deliberately and any ``"auto"`` on it is already resolved.
+
+        Pydantic's ``model_copy(update=...)`` does not run this validator. It
+        is not a safe way to change a config's dataset mode; construct a fresh
+        ``HelixConfig`` from raw input instead.
         """
         if not isinstance(data, dict):
             return data

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -10,7 +10,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from helix.backends import (
     BackendName,
@@ -18,6 +18,21 @@ from helix.backends import (
     EFFORT_VALID_VALUES,
     backend_display_name,
 )
+
+# Mode-aware ``evolution.minibatch_size`` defaults.
+#
+# Multi-task / generalization mode samples k distinct training examples per
+# reflective mutation and genuinely gains signal from k > 1.  Single-task /
+# no-example mode has exactly one task, so there is nothing for k > 1 to
+# sample: ``run_evolution`` builds no train loader and therefore no batch
+# sampler, and ``minibatch_size`` is never read on that path.
+#
+# It is still read as the divisor in the ``num_parallel_proposals="auto"``
+# derivation (``max(1, max_workers // minibatch_size)``), which is where the
+# flat default was actually doing damage — single-task "auto" runs derived a
+# third of the proposal width they should have.
+SINGLE_TASK_MINIBATCH_SIZE = 1
+MULTI_TASK_MINIBATCH_SIZE = 3
 
 
 def _load_dotenv_file(path: Path) -> None:
@@ -332,10 +347,17 @@ class EvolutionConfig(BaseModel):
         ),
     )
     minibatch_size: int = Field(
-        default=3,
+        default=MULTI_TASK_MINIBATCH_SIZE,
         description=(
-            "Number of training examples per reflective mutation. "
-            "GEPA parity: ReflectionConfig.reflection_minibatch_size default."
+            "Number of training examples per reflective mutation. The "
+            "default is mode-aware and is applied by HelixConfig: "
+            f"{SINGLE_TASK_MINIBATCH_SIZE} in single-task / no-example mode "
+            "(no training split configured — there is only one task, so "
+            "nothing to sample) and "
+            f"{MULTI_TASK_MINIBATCH_SIZE} in multi-task / generalization "
+            "mode (a training split is configured). Also used as the divisor "
+            "when num_parallel_proposals='auto'. Set this explicitly to "
+            "override the mode-aware default in either direction."
         ),
     )
     max_workers: int = Field(
@@ -550,6 +572,36 @@ class WorktreeConfig(BaseModel):
     cleanup_dominated: bool = False
 
 
+def _raw_section_field(section: Any, name: str) -> Any:
+    """Read *name* from a config section that may be a mapping or a model."""
+    if isinstance(section, dict):
+        return section.get(name)
+    return getattr(section, name, None)
+
+
+def _has_training_split(data: dict[str, Any]) -> bool:
+    """True when the raw config selects multi-task / generalization mode.
+
+    Mirrors the runtime predicate that decides whether a train loader (and
+    therefore the minibatch gate) exists at all — ``evolution.py`` builds one
+    from ``seedless.train_path`` and falls back to a synthetic range loader
+    over ``dataset.train_size``.  Either one means real training examples get
+    sampled per reflective mutation; neither means there is a single task.
+    """
+    if _raw_section_field(data.get("seedless"), "train_path") is not None:
+        return True
+    train_size = _raw_section_field(data.get("dataset"), "train_size")
+    if train_size is None or isinstance(train_size, bool):
+        return False
+    try:
+        # Match Pydantic's own coercion so a quoted ``train_size = "10"``
+        # is still read as multi-task. A value that cannot be an int is left
+        # for DatasetConfig to reject with a proper validation error.
+        return int(train_size) > 0
+    except (TypeError, ValueError):
+        return False
+
+
 class HelixConfig(BaseModel):
     """Top-level HELIX configuration.
 
@@ -585,6 +637,53 @@ class HelixConfig(BaseModel):
     agent: AgentConfig = Field(default_factory=AgentConfig)
     sandbox: SandboxConfig = Field(default_factory=SandboxConfig)
     worktree: WorktreeConfig = Field(default_factory=WorktreeConfig)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_mode_aware_minibatch_default(cls, data: Any) -> Any:
+        """Inject the single-task ``evolution.minibatch_size`` default.
+
+        ``minibatch_size`` lives on :class:`EvolutionConfig`, but the *mode*
+        that selects its default is decided by ``seedless.train_path`` /
+        ``dataset.train_size``, which live in other sections.  ``HelixConfig``
+        is the only place that sees both.
+
+        This must run **before** ``EvolutionConfig`` is constructed, not after.
+        ``EvolutionConfig.model_post_init`` resolves
+        ``num_parallel_proposals="auto"`` to
+        ``max(1, max_workers // minibatch_size)`` at *its own* construction
+        time, which happens before ``HelixConfig.model_post_init``.  Correcting
+        ``minibatch_size`` after the fact would leave an already-resolved
+        ``"auto"`` silently derived from the wrong divisor.  Rewriting the raw
+        mapping keeps the whole derivation consistent with no re-resolution.
+
+        Operating on the raw mapping also makes "explicitly set" unambiguous:
+        presence of the ``minibatch_size`` key *is* explicitness, so a config
+        that deliberately writes ``minibatch_size = 3`` in single-task mode
+        keeps 3.  An ``evolution`` section supplied as an already-constructed
+        :class:`EvolutionConfig` is likewise left untouched — the caller built
+        it deliberately and any ``"auto"`` on it is already resolved.
+        """
+        if not isinstance(data, dict):
+            return data
+        if "evolution" not in data:
+            evolution: dict[str, Any] = {}
+        else:
+            raw = data["evolution"]
+            # Anything that is not a plain mapping (an EvolutionConfig
+            # instance, or a bad value for EvolutionConfig to reject) is
+            # passed through untouched.
+            if not isinstance(raw, dict) or "minibatch_size" in raw:
+                return data
+            evolution = raw
+        if _has_training_split(data):
+            return data
+        patched = dict(data)
+        patched["evolution"] = {
+            **evolution,
+            "minibatch_size": SINGLE_TASK_MINIBATCH_SIZE,
+        }
+        return patched
 
     def model_post_init(self, __context: object) -> None:
         if self.seedless.enabled and not self.objective.strip():

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -104,6 +104,10 @@ class TestDatasetConfigSizes:
 class TestEvolutionConfigNewFields:
     def test_defaults(self):
         cfg = EvolutionConfig()
+        # EvolutionConfig on its own cannot see whether a training split is
+        # configured, so its field default is the multi-task value. HelixConfig
+        # applies the mode-aware default (1 in single-task mode) — see
+        # tests/unit/test_minibatch_mode_default.py.
         assert cfg.minibatch_size == 3
         # GEPA parity: max_workers defaults to os.cpu_count() or 32
         # (optimize_anything.py:485).

--- a/tests/unit/test_minibatch_mode_default.py
+++ b/tests/unit/test_minibatch_mode_default.py
@@ -1,0 +1,236 @@
+"""Mode-aware ``evolution.minibatch_size`` default.
+
+The default is 1 in single-task / no-example mode (no training split
+configured) and 3 in multi-task / generalization mode (a training split is
+configured via ``seedless.train_path`` or ``dataset.train_size``).
+
+The one user-visible consequence in single-task mode runs through
+``num_parallel_proposals``.  In single-task mode no train loader exists, so
+``run_evolution`` never builds a batch sampler and ``minibatch_size`` is never
+read for sampling — it does *not* change the number of metric calls there.  It
+is read as the divisor when ``num_parallel_proposals="auto"`` resolves to
+``max(1, max_workers // minibatch_size)``, and that resolved ``P`` drives the
+proposal-slot loop unconditionally.  So the whole observable effect of this
+default flows through that one derivation, which is why it is covered both at
+the config layer (``TestAutoWidthUsesCorrectedMinibatch``) and end-to-end
+against the real evolution loop (``TestAutoWidthReachesTheProposalLoop``).
+
+That also makes *ordering* load-bearing.  ``EvolutionConfig.model_post_init``
+resolves ``"auto"`` at ``EvolutionConfig`` construction time, which happens
+before ``HelixConfig.model_post_init`` runs.  A mode-aware default applied
+after ``HelixConfig`` is built would leave an already-resolved ``"auto"``
+derived from the stale divisor — silently correct-looking ``minibatch_size``
+with a wrong ``P``.  The auto-width tests fail against any such after-the-fact
+implementation.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from helix.config import (
+    MULTI_TASK_MINIBATCH_SIZE,
+    SINGLE_TASK_MINIBATCH_SIZE,
+    EvolutionConfig,
+    HelixConfig,
+    load_config,
+)
+from helix.evolution import run_evolution
+from tests.unit.test_evolution import (  # type: ignore[import-untyped]
+    all_mocks,  # noqa: F401, F811 — re-exported pytest fixture
+    make_candidate,
+    make_eval_result,
+)
+
+BASE: dict[str, object] = {
+    "objective": "Maximise the score",
+    "evaluator": {"command": "pytest"},
+}
+
+
+def _config(**overrides: object) -> HelixConfig:
+    return HelixConfig.model_validate({**BASE, **overrides})
+
+
+class TestModeAwareDefault:
+    def test_single_task_omitted_resolves_to_one(self):
+        """No training split + no explicit value -> 1."""
+        cfg = _config()
+        assert cfg.evolution.minibatch_size == SINGLE_TASK_MINIBATCH_SIZE == 1
+
+    def test_single_task_with_other_evolution_keys_still_resolves_to_one(self):
+        """Injection must merge into an existing [evolution] table, not
+        replace it."""
+        cfg = _config(evolution={"max_generations": 7, "max_workers": 4})
+        assert cfg.evolution.minibatch_size == 1
+        assert cfg.evolution.max_generations == 7
+        assert cfg.evolution.max_workers == 4
+
+    def test_multi_task_via_train_path_omitted_stays_three(self):
+        cfg = _config(seedless={"train_path": "/tmp/train.jsonl"})
+        assert cfg.evolution.minibatch_size == MULTI_TASK_MINIBATCH_SIZE == 3
+
+    def test_multi_task_via_train_size_omitted_stays_three(self):
+        """``dataset.train_size`` is the Architecture A training split: it
+        synthesises a range train loader, so it is multi-task mode too."""
+        cfg = _config(dataset={"train_size": 10})
+        assert cfg.evolution.minibatch_size == 3
+
+    def test_zero_train_size_is_single_task(self):
+        """A zero cardinality builds no train loader, so it is not a split."""
+        cfg = _config(dataset={"train_size": 0})
+        assert cfg.evolution.minibatch_size == 1
+
+    def test_explicit_three_in_single_task_mode_is_preserved(self):
+        """A deliberately written value is never silently rewritten."""
+        cfg = _config(evolution={"minibatch_size": 3})
+        assert cfg.evolution.minibatch_size == 3
+
+    def test_explicit_one_in_multi_task_mode_is_preserved(self):
+        cfg = _config(
+            dataset={"train_size": 10},
+            evolution={"minibatch_size": 1},
+        )
+        assert cfg.evolution.minibatch_size == 1
+
+    def test_prebuilt_evolution_config_is_left_untouched(self):
+        """An ``EvolutionConfig`` instance was built deliberately by the
+        caller and already resolved its own ``"auto"``; do not rewrite it."""
+        cfg = _config(evolution=EvolutionConfig())
+        assert cfg.evolution.minibatch_size == 3
+
+    def test_standalone_evolution_config_default_is_the_multi_task_value(self):
+        """``EvolutionConfig`` alone cannot see the mode, so its field default
+        stays at the multi-task value; only ``HelixConfig`` knows better."""
+        assert EvolutionConfig().minibatch_size == 3
+
+
+class TestAutoWidthUsesCorrectedMinibatch:
+    """The ordering test.
+
+    ``"auto"`` must be derived from the *corrected* minibatch size.  An
+    implementation that mutates ``minibatch_size`` on an already-constructed
+    ``HelixConfig`` leaves ``num_parallel_proposals`` at ``12 // 3 == 4`` here
+    and fails.
+    """
+
+    def test_single_task_auto_derives_from_one(self):
+        cfg = _config(evolution={"num_parallel_proposals": "auto", "max_workers": 12})
+        assert cfg.evolution.minibatch_size == 1
+        assert cfg.evolution.num_parallel_proposals == 12  # 12 // 1, not 12 // 3
+
+    def test_multi_task_auto_derives_from_three(self):
+        cfg = _config(
+            seedless={"train_path": "/tmp/train.jsonl"},
+            evolution={"num_parallel_proposals": "auto", "max_workers": 12},
+        )
+        assert cfg.evolution.minibatch_size == 3
+        assert cfg.evolution.num_parallel_proposals == 4  # 12 // 3
+
+    def test_explicit_minibatch_in_single_task_still_drives_auto(self):
+        cfg = _config(
+            evolution={
+                "num_parallel_proposals": "auto",
+                "max_workers": 12,
+                "minibatch_size": 3,
+            }
+        )
+        assert cfg.evolution.num_parallel_proposals == 4  # 12 // 3
+
+
+class TestLoadedFromToml:
+    def test_single_task_toml_gets_one(self, tmp_path: Path):
+        toml = tmp_path / "helix.toml"
+        toml.write_text(
+            textwrap.dedent("""
+            objective = "Pack circles"
+
+            [evaluator]
+            command = "python3 evaluate.py"
+
+            [evolution]
+            max_generations = 30
+            num_parallel_proposals = "auto"
+            max_workers = 6
+        """)
+        )
+        cfg = load_config(toml)
+        assert cfg.evolution.minibatch_size == 1
+        assert cfg.evolution.num_parallel_proposals == 6
+
+    def test_multi_task_toml_keeps_three(self, tmp_path: Path):
+        toml = tmp_path / "helix.toml"
+        toml.write_text(
+            textwrap.dedent("""
+            objective = "Generalise"
+
+            [evaluator]
+            command = "pytest"
+
+            [dataset]
+            train_size = 8
+
+            [evolution]
+            num_parallel_proposals = "auto"
+            max_workers = 6
+        """)
+        )
+        cfg = load_config(toml)
+        assert cfg.evolution.minibatch_size == 3
+        assert cfg.evolution.num_parallel_proposals == 2
+
+    def test_roundtrip_through_model_dump_is_stable(self):
+        """``model_dump`` emits an explicit ``minibatch_size``, so re-validating
+        a dumped single-task config must not drift."""
+        cfg = _config()
+        restored = HelixConfig.model_validate(cfg.model_dump())
+        assert restored.evolution.minibatch_size == 1
+
+
+class TestAutoWidthReachesTheProposalLoop:
+    """End-to-end: the corrected divisor really does widen the proposal loop.
+
+    This is the test that demonstrates the change has an observable effect at
+    all. It drives the real ``run_evolution`` loop with I/O mocked and counts
+    proposal slots via ``mutate`` calls, rather than asserting on the resolved
+    config value a second time.
+    """
+
+    @staticmethod
+    def _run(tmp_path, all_mocks, evolution: dict[str, object]) -> int:  # noqa: F811
+        all_mocks["create_seed_worktree"].return_value = make_candidate("g0-s0")
+        # Every slot's mutation fails fast: we are counting slots, not
+        # acceptances, so the loop stays cheap and deterministic.
+        all_mocks["mutate"].return_value = None
+        all_mocks["run_evaluator"].side_effect = (
+            lambda candidate, config, split=None, instances=None, **kw: (
+                make_eval_result(candidate.id, {"i1": 0.5})
+            )
+        )
+        cfg = HelixConfig.model_validate(
+            {
+                **BASE,
+                "evolution": {
+                    "max_generations": 1,
+                    "max_evaluations": -1,
+                    "perfect_score_threshold": None,
+                    "num_parallel_proposals": "auto",
+                    "max_workers": 12,
+                    **evolution,
+                },
+            }
+        )
+        run_evolution(cfg, tmp_path, tmp_path / ".helix")
+        return int(all_mocks["mutate"].call_count)
+
+    def test_single_task_auto_opens_max_workers_slots(self, tmp_path, all_mocks):  # noqa: F811
+        """max_workers=12 // corrected minibatch 1 -> 12 proposal slots."""
+        assert self._run(tmp_path, all_mocks, {}) == 12
+
+    def test_explicit_minibatch_three_still_opens_a_third_of_them(
+        self, tmp_path, all_mocks
+    ):  # noqa: F811
+        """The pre-fix behaviour, still reachable by writing the value
+        explicitly: 12 // 3 -> 4 proposal slots."""
+        assert self._run(tmp_path, all_mocks, {"minibatch_size": 3}) == 4

--- a/tests/unit/test_minibatch_mode_default.py
+++ b/tests/unit/test_minibatch_mode_default.py
@@ -29,6 +29,9 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 
+import pytest
+from pydantic import ValidationError
+
 from helix.config import (
     MULTI_TASK_MINIBATCH_SIZE,
     SINGLE_TASK_MINIBATCH_SIZE,
@@ -38,7 +41,7 @@ from helix.config import (
 )
 from helix.evolution import run_evolution
 from tests.unit.test_evolution import (  # type: ignore[import-untyped]
-    all_mocks,  # noqa: F401, F811 — re-exported pytest fixture
+    all_mocks as _all_mocks,
     make_candidate,
     make_eval_result,
 )
@@ -47,6 +50,12 @@ BASE: dict[str, object] = {
     "objective": "Maximise the score",
     "evaluator": {"command": "pytest"},
 }
+
+
+@pytest.fixture(name="evolution_mocks")
+def _evolution_mocks(mocker):
+    """Expose the shared evolution I/O fixture without a name collision."""
+    return _all_mocks.__wrapped__(mocker)
 
 
 def _config(**overrides: object) -> HelixConfig:
@@ -81,6 +90,13 @@ class TestModeAwareDefault:
         """A zero cardinality builds no train loader, so it is not a split."""
         cfg = _config(dataset={"train_size": 0})
         assert cfg.evolution.minibatch_size == 1
+
+    def test_boolean_train_size_is_rejected(self):
+        """Booleans are not dataset cardinalities, despite ``bool`` being an int."""
+        with pytest.raises(
+            ValidationError, match="dataset.train_size must be an integer"
+        ):
+            _config(dataset={"train_size": True})
 
     def test_explicit_three_in_single_task_mode_is_preserved(self):
         """A deliberately written value is never silently rewritten."""
@@ -198,16 +214,27 @@ class TestAutoWidthReachesTheProposalLoop:
     """
 
     @staticmethod
-    def _run(tmp_path, all_mocks, evolution: dict[str, object]) -> int:  # noqa: F811
-        all_mocks["create_seed_worktree"].return_value = make_candidate("g0-s0")
+    def _run_config(tmp_path, evolution_mocks, cfg: HelixConfig) -> tuple[int, int]:
+        evolution_mocks["create_seed_worktree"].return_value = make_candidate("g0-s0")
         # Every slot's mutation fails fast: we are counting slots, not
         # acceptances, so the loop stays cheap and deterministic.
-        all_mocks["mutate"].return_value = None
-        all_mocks["run_evaluator"].side_effect = (
+        evolution_mocks["mutate"].return_value = None
+        evolution_mocks["run_evaluator"].side_effect = (
             lambda candidate, config, split=None, instances=None, **kw: (
                 make_eval_result(candidate.id, {"i1": 0.5})
             )
         )
+        run_evolution(cfg, tmp_path, tmp_path / ".helix")
+        assert isinstance(cfg.evolution.num_parallel_proposals, int)
+        return (
+            cfg.evolution.num_parallel_proposals,
+            int(evolution_mocks["mutate"].call_count),
+        )
+
+    @classmethod
+    def _run(
+        cls, tmp_path, evolution_mocks, evolution: dict[str, object]
+    ) -> tuple[int, int]:
         cfg = HelixConfig.model_validate(
             {
                 **BASE,
@@ -221,16 +248,21 @@ class TestAutoWidthReachesTheProposalLoop:
                 },
             }
         )
-        run_evolution(cfg, tmp_path, tmp_path / ".helix")
-        return int(all_mocks["mutate"].call_count)
+        return cls._run_config(tmp_path, evolution_mocks, cfg)
 
-    def test_single_task_auto_opens_max_workers_slots(self, tmp_path, all_mocks):  # noqa: F811
+    def test_single_task_auto_opens_max_workers_slots(self, tmp_path, evolution_mocks):
         """max_workers=12 // corrected minibatch 1 -> 12 proposal slots."""
-        assert self._run(tmp_path, all_mocks, {}) == 12
+        resolved_p, planned_proposals = self._run(tmp_path, evolution_mocks, {})
+        assert resolved_p == 12
+        assert planned_proposals == 12
 
     def test_explicit_minibatch_three_still_opens_a_third_of_them(
-        self, tmp_path, all_mocks
-    ):  # noqa: F811
+        self, tmp_path, evolution_mocks
+    ):
         """The pre-fix behaviour, still reachable by writing the value
         explicitly: 12 // 3 -> 4 proposal slots."""
-        assert self._run(tmp_path, all_mocks, {"minibatch_size": 3}) == 4
+        resolved_p, planned_proposals = self._run(
+            tmp_path, evolution_mocks, {"minibatch_size": 3}
+        )
+        assert resolved_p == 4
+        assert planned_proposals == 4


### PR DESCRIPTION
## Summary

`evolution.minibatch_size` now defaults to **1** in single-task / no-example
mode and **3** in multi-task mode, while preserving every explicit value. The
top-level `model_validator(mode="before")` rewrites the raw mapping before
`EvolutionConfig` resolves `num_parallel_proposals = "auto"`, preventing a
stale derived proposal width.

Boolean dataset cardinalities are rejected, so Pydantic cannot coerce `true`
to `1` and select the wrong mode.

`"auto"` is supported correctly whether or not a checked-in example uses it.
The end-to-end unit test drives the real `run_evolution` proposal loop,
asserting both the resolved `P` and the number of planned proposal slots.

## Why the default is applied to the raw mapping

Pydantic's `model_copy(update=...)` deliberately skips validation, so patching
a built config does not re-resolve anything downstream of the patched value —
and by that point both the implicit `minibatch_size` default and the resolved
`"auto"` proposal width are concrete. Switching dataset modes therefore
requires rebuilding from raw config.

## Behaviour

The user-visible effect remains limited to single-task configurations using
`num_parallel_proposals = "auto"`, which resolves as
`max(1, max_workers // minibatch_size)`. For example, `max_workers=12` changes
from 4 to 12 slots, `8` from 2 to 8, and `2` from 1 to 2. Proposal-width growth
depends on integer flooring and the minimum-one clamp, so it is not always
threefold. Integer proposal widths are unchanged, and single-task metric-call
counts are unchanged because no train sampler is constructed.

## Verification

- `uv sync --extra dev`
- `uv run pytest tests/unit -q` — 885 passed
- `uv run mypy --strict src/helix/` — clean
- `uv run ruff check src/helix/config.py tests/unit/test_minibatch_mode_default.py`
- `uv run ruff format --check src/helix/config.py tests/unit/test_minibatch_mode_default.py`
