### PR TITLE
chore: let Renovate maintain dependencies and action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":semanticCommits"
+  ],
+  "timezone": "America/Los_Angeles",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 5,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "The base image FROM must stay digest-pinned, never a floating tag.",
+      "matchManagers": ["dockerfile"],
+      "pinDigests": true
+    },
+    {
+      "description": "Workflow actions are hash-pinned; zizmor's unpinned-uses rule fails CI otherwise. pypa/gh-action-pypi-publish is exempt by policy (see .github/zizmor.yml) and must stay on release/v1, because PyPA ships security fixes to that branch.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["!pypa/gh-action-pypi-publish"],
+      "pinDigests": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"]
+  }
+}


### PR DESCRIPTION
Extracted from #43, where it was riding along without being related to that PR's purpose.

**+29 / −0 across 1 file** (`git diff --shortstat origin/main...chore/renovate-config`).

## Why

The repository has no Renovate configuration, so nothing keeps hash-pinned GitHub Actions current. Hash pinning *without* an updater is a slow failure mode: the pins are correct the day they land and quietly rot afterwards — arguably worse than a floating tag, because nothing signals the rot.

This pairs with the zizmor `unpinned-uses` gate in #53: **zizmor enforces that actions are pinned, Renovate keeps the pins moving.** Neither is much use alone.

`pypa/gh-action-pypi-publish` is excluded for the same reason `.github/zizmor.yml` exempts it — PyPA ships security fixes to `release/v1`, and pinning it opts this repo out of them. The exemption is stated in both places rather than being an unexplained divergence.

## Scope

Deliberately limited to what applies repository-wide: the base preset, the schedule, GitHub Actions digest pinning, Dockerfile `FROM` digest pinning, and vulnerability alerts.

Rules for the mutation-runner CLI pins are **not** here — they reference `docker/package.json`, which does not exist on `main`. They belong with the change that introduces those pins (#43).

## Verification

`renovate-config-validator` → *Config validated successfully against 1 file(s)*.

Ordering note: independent of #53 and #54; can land in any order relative to them. #43 builds on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)