### PR TITLE
fix(auth): never auto-forward an Anthropic API key into agent containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (behaviour):** `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` present in
+  your shell are no longer forwarded into agent subprocesses or agent containers.
+  Anthropic backends (`claude`, `opencode`) authenticate through
+  `helix sandbox login <backend>`; an API key in the agent environment silently
+  overrode that login, so a user who had just logged in ran on the key instead
+  without being told. HELIX now resolves the ambiguity in favour of login.
+
+  Before — key auto-forwarded, `helix sandbox login claude` silently ineffective:
+
+  ```console
+  $ export ANTHROPIC_API_KEY=sk-ant-...
+  $ helix sandbox login claude   # credentials written to the helix-auth-claude volume
+  $ helix evolve                 # agent runs on the API key; the login is ignored
+  ```
+
+  After — the login is used, and the dropped key is announced:
+
+  ```console
+  $ helix evolve
+  WARNING  ANTHROPIC_API_KEY found in the environment but NOT forwarded to Claude
+           Code: Anthropic backends authenticate via `helix sandbox login claude` ...
+  ```
+
+  **Migration.** Either run `helix sandbox login <backend>` (recommended), or opt
+  the key in explicitly in `helix.toml`:
+
+  ```toml
+  [env]
+  ANTHROPIC_API_KEY = "sk-ant-..."
+  # or, to take the value from your shell:
+  # passthrough_env = ["ANTHROPIC_API_KEY"]
+  ```
+
+  On the explicit path HELIX warns that the key takes precedence over any login
+  credential, so neither outcome is silent. The OpenAI path is unaffected:
+  `OPENAI_API_KEY` and `OPENCODE_API_KEY` are still auto-forwarded for `opencode`,
+  as are `CURSOR_API_KEY` and the Gemini keys, and evaluator/sidecar credential
+  handling is untouched.
+
 ## [0.2.2] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ rng_seed = 0
 # Fixed non-secret env values injected into evaluator and agent subprocesses
 # after passthrough_env. Useful for repeatable run-local service endpoints.
 # ANTHROPIC_BASE_URL = "https://model-service.example.invalid/v1"
+# Anthropic backends (claude, opencode) authenticate via
+# `helix sandbox login <backend>`. An ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN
+# in your shell is NOT forwarded to agents, because it would silently override
+# that login. Set it here (or in passthrough_env) to opt in deliberately.
 # ANTHROPIC_API_KEY = "dummy"
 
 [evaluator]

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -61,6 +61,17 @@ DEFAULT_BACKEND_IMAGES: dict[str, str] = {
     "opencode": "ghcr.io/ke7/helix-evo-runner-opencode:latest",
 }
 
+AGENT_LOGIN_IDENTITY_ENV: tuple[str, ...] = ("USER", "LOGNAME")
+"""Non-secret identity variables preserved for every agent CLI.
+
+Agent CLIs resolve stored interactive credentials independently.  Claude Code
+on macOS, for example, needs ``USER`` to locate its Keychain entry even when
+``HOME`` is present.  ``LOGNAME`` is harmless, conventional on Unix-like
+systems, and provides compatibility for CLIs that use that spelling instead.
+Keep this narrowly scoped to agent subprocesses: evaluator environments retain
+their existing strict allowlist.
+"""
+
 ANTHROPIC_KEY_ENV: tuple[str, ...] = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
 """Anthropic API-key credentials that HELIX never auto-forwards to an agent.
 

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -61,11 +61,32 @@ DEFAULT_BACKEND_IMAGES: dict[str, str] = {
     "opencode": "ghcr.io/ke7/helix-evo-runner-opencode:latest",
 }
 
+ANTHROPIC_KEY_ENV: tuple[str, ...] = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+"""Anthropic API-key credentials that HELIX never auto-forwards to an agent.
+
+Anthropic backends authenticate through *login* — ``helix sandbox login
+<backend>`` writes OAuth / subscription credentials into the persistent
+``helix-auth-<backend>`` Docker volume that agent containers mount at
+``/home/node``.  These env vars are the mutually exclusive alternative: when
+one is present in an agent's environment the CLI bills against the API key and
+the login credential sitting in the auth volume is ignored.
+
+Auto-forwarding them therefore silently revokes the login the user just
+performed.  HELIX resolves the ambiguity in favour of login and requires an
+explicit opt-in (top-level ``passthrough_env`` or ``[env]`` in ``helix.toml``)
+before an API key reaches an agent.  See ``helix.mutator._add_backend_auth_env``.
+"""
+
+ANTHROPIC_LOGIN_BACKENDS: frozenset[str] = frozenset({"claude", "opencode"})
+"""Backends whose CLI reads :data:`ANTHROPIC_KEY_ENV` in preference to login."""
+
 BACKEND_AUTH_ENV: dict[str, tuple[str, ...]] = {
-    "claude": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
+    # NOTE: "claude" is deliberately absent, and "opencode" deliberately omits
+    # ANTHROPIC_API_KEY — see ANTHROPIC_KEY_ENV above.  Only credentials with
+    # no login-based alternative are auto-forwarded.
     "cursor": ("CURSOR_API_KEY",),
     "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
-    "opencode": ("OPENCODE_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"),
+    "opencode": ("OPENCODE_API_KEY", "OPENAI_API_KEY"),
 }
 
 BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -80,6 +80,10 @@ command = "uv run python evaluate.py"
 # Fixed non-secret env values injected into evaluator and agent subprocesses
 # after passthrough_env. Useful for repeatable run-local service endpoints.
 # ANTHROPIC_BASE_URL = "https://model-service.example.invalid/v1"
+# Anthropic backends (claude, opencode) authenticate via
+# `helix sandbox login <backend>`. An ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN
+# in your shell is NOT forwarded to agents, because it would silently override
+# that login. Set it here (or in passthrough_env) to opt in deliberately.
 # ANTHROPIC_API_KEY = "dummy"
 
 [evolution]

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from helix.backends import (
+    AGENT_LOGIN_IDENTITY_ENV,
     ANTHROPIC_KEY_ENV,
     ANTHROPIC_LOGIN_BACKENDS,
     BACKEND_AUTH_ENV,
@@ -741,6 +742,46 @@ def _add_backend_auth_env(env: dict[str, str], backend: str) -> None:
         if key in os.environ and key not in env:
             env[key] = os.environ[key]
     _warn_on_anthropic_key(env, backend)
+
+
+def _agent_passthrough_env(passthrough_env: list[str] | None) -> list[str]:
+    """Return configured passthrough values plus safe login identity values.
+
+    Stored-login resolution is a first-class agent authentication path, not a
+    feature users should have to repair by discovering an OS-specific variable.
+    Values named here are non-secret and apply only to agent CLIs; evaluator
+    subprocesses still receive their original strict environment.
+    """
+    return list(dict.fromkeys([*AGENT_LOGIN_IDENTITY_ENV, *(passthrough_env or [])]))
+
+
+def _looks_like_authentication_failure(stdout: str, stderr: str) -> bool:
+    """Return whether a backend failure appears to be an authentication error."""
+    text = f"{stdout}\n{stderr}".lower()
+    return any(
+        marker in text
+        for marker in (
+            "not logged in",
+            "please run /login",
+            "authentication failed",
+            "unauthenticated",
+            "not authenticated",
+        )
+    )
+
+
+def _agent_failure_suggestion(
+    *, stdout: str, stderr: str, env: dict[str, str]
+) -> str:
+    """Describe the scrubbed environment when an agent authentication fails."""
+    if not _looks_like_authentication_failure(stdout, stderr):
+        return "Check stderr for rate limits, permission errors, or model availability."
+    names = ", ".join(sorted(env)) or "(none)"
+    return (
+        "Authentication failed. The agent environment after HELIX scrubbing "
+        f"contained these variable names (not values): {names}. "
+        "Confirm the selected backend's login is available to that environment."
+    )
 
 
 # Backends already warned about an Anthropic API key, so a run with many
@@ -1626,7 +1667,7 @@ def invoke_claude_code(
     )
     cmd_str = shlex.join(args)
     backend_env = _scrub_environment(
-        passthrough_env=passthrough_env, fixed_env=fixed_env
+        passthrough_env=_agent_passthrough_env(passthrough_env), fixed_env=fixed_env
     )
     _add_backend_auth_env(backend_env, backend)
     if backend == "gemini":
@@ -1768,7 +1809,11 @@ def invoke_claude_code(
             stdout=result.stdout,
             stderr=result.stderr,
             exit_code=result.returncode,
-            suggestion="Check stderr for rate limits, permission errors, or model availability.",
+            suggestion=_agent_failure_suggestion(
+                stdout=result.stdout,
+                stderr=result.stderr,
+                env=backend_env,
+            ),
         )
     finally:
         _write_backend_artifacts(

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -10,7 +10,12 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
-from helix.backends import BACKEND_AUTH_ENV, backend_display_name
+from helix.backends import (
+    ANTHROPIC_KEY_ENV,
+    ANTHROPIC_LOGIN_BACKENDS,
+    BACKEND_AUTH_ENV,
+    backend_display_name,
+)
 from helix.display import UsageStats
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, SandboxConfig
@@ -720,10 +725,65 @@ def _write_mutation_prompt_artifact(worktree_path: str, prompt: str) -> str:
 
 
 def _add_backend_auth_env(env: dict[str, str], backend: str) -> None:
-    """Pass official headless auth env vars without requiring TOML config."""
+    """Pass official headless auth env vars without requiring TOML config.
+
+    Anthropic API keys are excluded from the auto-forwarded set (see
+    :data:`helix.backends.ANTHROPIC_KEY_ENV`).  Anthropic backends authenticate
+    through ``helix sandbox login <backend>``, and an API key present in the
+    agent's environment silently overrides that login.  HELIX never makes that
+    choice on the user's behalf: the key reaches an agent only when explicitly
+    listed in top-level ``passthrough_env`` or ``[env]`` in ``helix.toml``, which
+    ``_scrub_environment`` has already applied to *env* by the time we get here.
+
+    Either way the user is told which credential won.
+    """
     for key in BACKEND_AUTH_ENV.get(backend, ()):
         if key in os.environ and key not in env:
             env[key] = os.environ[key]
+    _warn_on_anthropic_key(env, backend)
+
+
+# Backends already warned about an Anthropic API key, so a run with many
+# candidates emits one warning per backend rather than one per mutation.
+_ANTHROPIC_KEY_WARNED: set[str] = set()
+
+
+def _warn_on_anthropic_key(env: dict[str, str], backend: str) -> None:
+    """Report which Anthropic credential the agent will end up using."""
+    if backend not in ANTHROPIC_LOGIN_BACKENDS:
+        return
+    opted_in = sorted(key for key in ANTHROPIC_KEY_ENV if key in env)
+    ambient = sorted(
+        key for key in ANTHROPIC_KEY_ENV if key in os.environ and key not in env
+    )
+    if not opted_in and not ambient:
+        return
+    if backend in _ANTHROPIC_KEY_WARNED:
+        return
+    _ANTHROPIC_KEY_WARNED.add(backend)
+
+    backend_name = backend_display_name(backend)
+    if opted_in:
+        logger.warning(
+            "%s is configured with %s. An Anthropic API key takes precedence "
+            "over the login credential in the helix-auth-%s volume, so this run "
+            "bills against the API key and ignores `helix sandbox login %s`. "
+            "Remove it from passthrough_env / [env] to use the login instead.",
+            backend_name,
+            ", ".join(opted_in),
+            backend,
+            backend,
+        )
+    else:
+        logger.warning(
+            "%s found in the environment but NOT forwarded to %s: Anthropic "
+            "backends authenticate via `helix sandbox login %s`, and an API key "
+            "would silently override that login. To use the API key anyway, add "
+            "it to passthrough_env or [env] in helix.toml.",
+            ", ".join(ambient),
+            backend_name,
+            backend,
+        )
 
 
 def _build_backend_args(
@@ -769,9 +829,7 @@ def _build_backend_args(
             # is valid TOML basic-string syntax for all printable ASCII — safe
             # for any realistic effort value.  See ``codex exec --help`` for
             # the full ``-c`` interface.
-            args.extend(
-                ["-c", f"model_reasoning_effort={json.dumps(config.effort)}"]
-            )
+            args.extend(["-c", f"model_reasoning_effort={json.dumps(config.effort)}"])
         args.append(_prompt_file_instruction(prompt_artifact_name))
         return args
 

--- a/tests/unit/test_backend_auth_env.py
+++ b/tests/unit/test_backend_auth_env.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from helix.config import AgentConfig, SandboxConfig
+from helix.exceptions import MutationError
 from helix.mutator import invoke_claude_code
 import helix.mutator as mutator
 
@@ -59,6 +60,51 @@ def _env_of(mock) -> dict[str, str]:
 
 
 class TestAnthropicKeyNotForwardedByDefault:
+    def test_claude_login_environment_keeps_identity_and_excludes_api_credentials(
+        self, tmp_path: Path, monkeypatch, local_run
+    ):
+        """The scrubbed Claude environment can resolve a stored login.
+
+        On macOS, Claude Code's Keychain lookup needs ``USER``.  This asserts
+        the environment that reaches the real Claude subprocess has the
+        complete non-secret login identity (rather than merely checking a
+        configuration allowlist), while both API credential overrides remain
+        absent.
+        """
+        mock_run = local_run()
+        monkeypatch.setenv("HOME", "/home/login-user")
+        monkeypatch.setenv("USER", "login-user")
+        monkeypatch.setenv("LOGNAME", "login-logname")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-should-not-travel")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token-should-not-travel")
+
+        invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="claude"))
+
+        env = _env_of(mock_run)
+        assert env["HOME"] == "/home/login-user"
+        assert env["USER"] == "login-user"
+        assert env["LOGNAME"] == "login-logname"
+        assert not {"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"} & set(env)
+
+    def test_default_login_identity_does_not_clobber_explicit_passthrough(
+        self, tmp_path: Path, monkeypatch, local_run
+    ):
+        """Configured passthrough values coexist with the default identity."""
+        mock_run = local_run()
+        monkeypatch.setenv("USER", "login-user")
+        monkeypatch.setenv("HELIX_LOGIN_TEST_SETTING", "preserve-me")
+
+        invoke_claude_code(
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend="claude"),
+            passthrough_env=["HELIX_LOGIN_TEST_SETTING"],
+        )
+
+        env = _env_of(mock_run)
+        assert env["USER"] == "login-user"
+        assert env["HELIX_LOGIN_TEST_SETTING"] == "preserve-me"
+
     @pytest.mark.parametrize("key", ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"])
     def test_claude_unsandboxed_does_not_forward(
         self, key: str, tmp_path: Path, monkeypatch, local_run
@@ -229,6 +275,27 @@ class TestExplicitOptIn:
 
 
 class TestUserIsTold:
+    def test_auth_failure_reports_the_scrubbed_agent_environment(
+        self, tmp_path: Path, monkeypatch, mocker
+    ):
+        """Authentication errors reveal the non-secret env names the agent got."""
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout="",
+            stderr="Not logged in · Please run /login",
+            returncode=1,
+        )
+        monkeypatch.setenv("USER", "login-user")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-should-not-travel")
+
+        with pytest.raises(MutationError) as exc_info:
+            invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="claude"))
+
+        suggestion = exc_info.value.suggestion
+        assert "environment after HELIX scrubbing contained" in suggestion
+        assert "USER" in suggestion
+        assert "ANTHROPIC_API_KEY" not in suggestion
+
     def test_dropped_key_is_announced(
         self, tmp_path: Path, monkeypatch, local_run, caplog
     ):

--- a/tests/unit/test_backend_auth_env.py
+++ b/tests/unit/test_backend_auth_env.py
@@ -1,0 +1,307 @@
+"""Anthropic API keys are never auto-forwarded into agent subprocesses.
+
+Anthropic backends authenticate by *login*: ``helix sandbox login <backend>``
+writes credentials into the persistent ``helix-auth-<backend>`` Docker volume
+that agent containers mount at ``/home/node``.  An ``ANTHROPIC_API_KEY`` in the
+agent's environment is the mutually exclusive alternative — when present, the
+CLI bills the API key and the login credential is ignored.
+
+HELIX used to forward that variable automatically, which meant a user who had
+just run ``helix sandbox login claude`` had their login silently revoked by a
+key merely sitting in their shell.  These tests pin the corrected behaviour:
+the login wins by default, and the API key travels only on an explicit opt-in.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from helix.config import AgentConfig, SandboxConfig
+from helix.mutator import invoke_claude_code
+import helix.mutator as mutator
+
+
+CLAUDE_STDOUT = '{"type":"system","subtype":"init","session_id":"sess_123"}\n'
+OPENCODE_STDOUT = '{"type":"result","sessionID":"ses_abc"}\n'
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_state():
+    """The 'key not forwarded' warning is emitted once per backend per run."""
+    mutator._ANTHROPIC_KEY_WARNED.clear()
+    yield
+    mutator._ANTHROPIC_KEY_WARNED.clear()
+
+
+@pytest.fixture
+def local_run(mocker):
+    """Patch the unsandboxed subprocess branch and expose the env it received."""
+
+    def _run(stdout: str = CLAUDE_STDOUT):
+        mock = mocker.patch("helix.mutator.subprocess.run")
+        mock.return_value = MagicMock(stdout=stdout, stderr="", returncode=0)
+        return mock
+
+    return _run
+
+
+def _env_of(mock) -> dict[str, str]:
+    return mock.call_args.kwargs["env"]
+
+
+# ---------------------------------------------------------------------------
+# Default: not forwarded
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicKeyNotForwardedByDefault:
+    @pytest.mark.parametrize("key", ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"])
+    def test_claude_unsandboxed_does_not_forward(
+        self, key: str, tmp_path: Path, monkeypatch, local_run
+    ):
+        mock_run = local_run()
+        monkeypatch.setenv(key, "sk-ant-should-not-travel")
+
+        invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="claude"))
+
+        assert key not in _env_of(mock_run), (
+            f"{key} was forwarded to the claude agent; Anthropic backends must "
+            "authenticate through `helix sandbox login claude` unless the user "
+            "opted the key in explicitly"
+        )
+
+    def test_opencode_drops_anthropic_key_but_keeps_openai(
+        self, tmp_path: Path, monkeypatch, local_run
+    ):
+        mock_run = local_run(OPENCODE_STDOUT)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-should-not-travel")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-authorized")
+        monkeypatch.setenv("OPENCODE_API_KEY", "sk-opencode-authorized")
+
+        invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="opencode"))
+
+        env = _env_of(mock_run)
+        assert "ANTHROPIC_API_KEY" not in env
+        # The OpenAI path is authorized and must keep working.
+        assert env["OPENAI_API_KEY"] == "sk-openai-authorized"
+        assert env["OPENCODE_API_KEY"] == "sk-opencode-authorized"
+
+    def test_non_anthropic_backends_still_auto_forward(
+        self, tmp_path: Path, monkeypatch, local_run
+    ):
+        """The change is scoped to Anthropic credentials only."""
+        mock_run = local_run()
+        monkeypatch.setenv("CURSOR_API_KEY", "cursor-key")
+
+        invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="cursor"))
+
+        assert _env_of(mock_run)["CURSOR_API_KEY"] == "cursor-key"
+
+
+# ---------------------------------------------------------------------------
+# The sandboxed branch — the one _add_backend_auth_env never gated
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxedAgentBranch:
+    """``_add_backend_auth_env`` runs before the sandbox branch is chosen.
+
+    It has no sandbox gate at all, so the key used to be injected as a
+    ``docker run -e`` argument into the very container that mounts the login
+    volume.  Both branches must be covered.
+    """
+
+    def test_sandboxed_claude_container_gets_no_anthropic_key(
+        self, tmp_path: Path, monkeypatch, mocker
+    ):
+        mock_sandboxed = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_sandboxed.return_value = MagicMock(
+            stdout=CLAUDE_STDOUT, stderr="", returncode=0
+        )
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-should-not-travel")
+
+        invoke_claude_code(
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend="claude"),
+            sandbox=SandboxConfig(enabled=True),
+        )
+
+        assert "ANTHROPIC_API_KEY" not in _env_of(mock_sandboxed)
+
+    def test_login_credential_is_not_silently_suppressed(
+        self, tmp_path: Path, monkeypatch, mocker
+    ):
+        """Regression: the contradiction that motivated this change.
+
+        A sandboxed agent run mounts ``helix-auth-claude`` at /home/node — the
+        volume ``helix sandbox login claude`` wrote credentials into.  If HELIX
+        also injects an ambient ANTHROPIC_API_KEY into that container, the CLI
+        prefers the key and the login the user just performed is silently dead.
+        The container env must carry no Anthropic API credential, so the
+        mounted login credential is the one that gets used.
+        """
+        mock_sandboxed = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_sandboxed.return_value = MagicMock(
+            stdout=CLAUDE_STDOUT, stderr="", returncode=0
+        )
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-ambient")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "sk-ant-ambient-token")
+
+        invoke_claude_code(
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend="claude"),
+            sandbox=SandboxConfig(enabled=True),
+        )
+
+        env = _env_of(mock_sandboxed)
+        assert not {"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"} & set(env), (
+            "an ambient API key reached the container that mounts the login "
+            "volume, silently disabling `helix sandbox login claude`"
+        )
+        # The auth volume is still mounted for the agent scope.
+        assert mock_sandboxed.call_args.kwargs["scope"] == "agent"
+        assert mock_sandboxed.call_args.kwargs["agent_backend"] == "claude"
+
+
+# ---------------------------------------------------------------------------
+# The escape hatch
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitOptIn:
+    def test_fixed_env_opt_in_forwards_the_key(
+        self, tmp_path: Path, monkeypatch, local_run
+    ):
+        """``[env]`` in helix.toml is a deliberate, recorded choice."""
+        mock_run = local_run()
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        invoke_claude_code(
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend="claude"),
+            fixed_env={"ANTHROPIC_API_KEY": "sk-ant-explicit"},
+        )
+
+        assert _env_of(mock_run)["ANTHROPIC_API_KEY"] == "sk-ant-explicit"
+
+    def test_passthrough_env_opt_in_forwards_the_key(
+        self, tmp_path: Path, monkeypatch, local_run
+    ):
+        """``passthrough_env`` names the variable explicitly in helix.toml."""
+        mock_run = local_run()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-explicit")
+
+        invoke_claude_code(
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend="claude"),
+            passthrough_env=["ANTHROPIC_API_KEY"],
+        )
+
+        assert _env_of(mock_run)["ANTHROPIC_API_KEY"] == "sk-ant-explicit"
+
+    def test_opencode_opt_in_forwards_the_key(
+        self, tmp_path: Path, monkeypatch, local_run
+    ):
+        mock_run = local_run(OPENCODE_STDOUT)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-explicit")
+
+        invoke_claude_code(
+            str(tmp_path),
+            "prompt",
+            AgentConfig(backend="opencode"),
+            passthrough_env=["ANTHROPIC_API_KEY"],
+        )
+
+        assert _env_of(mock_run)["ANTHROPIC_API_KEY"] == "sk-ant-explicit"
+
+
+# ---------------------------------------------------------------------------
+# Neither outcome is silent
+# ---------------------------------------------------------------------------
+
+
+class TestUserIsTold:
+    def test_dropped_key_is_announced(
+        self, tmp_path: Path, monkeypatch, local_run, caplog
+    ):
+        local_run()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-ambient")
+
+        with caplog.at_level(logging.WARNING, logger="helix.mutator"):
+            invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="claude"))
+
+        text = caplog.text
+        assert "ANTHROPIC_API_KEY" in text
+        assert "NOT forwarded" in text
+        assert "helix sandbox login claude" in text
+
+    def test_opt_in_precedence_over_login_is_announced(
+        self, tmp_path: Path, monkeypatch, local_run, caplog
+    ):
+        """The both-present case: HELIX says which credential won."""
+        local_run()
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        with caplog.at_level(logging.WARNING, logger="helix.mutator"):
+            invoke_claude_code(
+                str(tmp_path),
+                "prompt",
+                AgentConfig(backend="claude"),
+                fixed_env={"ANTHROPIC_API_KEY": "sk-ant-explicit"},
+            )
+
+        text = caplog.text
+        assert "takes precedence" in text
+        assert "helix-auth-claude" in text
+
+    def test_no_warning_without_an_anthropic_credential(
+        self, tmp_path: Path, monkeypatch, local_run, caplog
+    ):
+        local_run()
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+
+        with caplog.at_level(logging.WARNING, logger="helix.mutator"):
+            invoke_claude_code(str(tmp_path), "prompt", AgentConfig(backend="claude"))
+
+        assert "ANTHROPIC" not in caplog.text
+
+    def test_warning_is_emitted_once_per_backend(
+        self, tmp_path: Path, monkeypatch, local_run, caplog
+    ):
+        """A run has many candidates; the warning must not spam per mutation."""
+        local_run()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-ambient")
+
+        with caplog.at_level(logging.WARNING, logger="helix.mutator"):
+            for _ in range(3):
+                invoke_claude_code(
+                    str(tmp_path), "prompt", AgentConfig(backend="claude")
+                )
+
+        assert caplog.text.count("NOT forwarded") == 1
+
+
+# ---------------------------------------------------------------------------
+# Registry-level invariant
+# ---------------------------------------------------------------------------
+
+
+def test_no_anthropic_name_in_the_auto_forward_registry():
+    """Guards against a future backend re-adding an Anthropic key to the table."""
+    from helix.backends import ANTHROPIC_KEY_ENV, BACKEND_AUTH_ENV
+
+    for backend, names in BACKEND_AUTH_ENV.items():
+        leaked = set(names) & set(ANTHROPIC_KEY_ENV)
+        assert not leaked, (
+            f"BACKEND_AUTH_ENV[{backend!r}] auto-forwards {sorted(leaked)}; "
+            "Anthropic credentials require an explicit opt-in"
+        )


### PR DESCRIPTION
## Summary

This PR completes the login-safe authentication path for Anthropic-backed agents.

- Stops automatic forwarding of `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`; login is the default and an API key requires an explicit `[env]` or `passthrough_env` opt-in.
- Preserves non-secret `USER` and `LOGNAME` for every agent CLI by default. On macOS, Claude Code needs `USER` to resolve the stored Keychain login; evaluator scrubbing remains unchanged.
- On an authentication failure, reports the names (never values) of environment variables that actually reached the agent.

## Root cause and user impact

The original scrub reduced an agent environment to `PATH`, `HOME`, and `HELIX_*`. Claude Code's macOS Keychain lookup requires `USER`, so an otherwise valid stored login appeared as:

```
Not logged in · Please run /login
```

Combined with the key-forwarding defect this PR fixes, that produced a dangerous split:

| User state | Previous result |
| --- | --- |
| Logged in, no API key | “Not logged in” |
| Logged in, ambient API key | Run succeeds using the API key, silently bypassing the login |

Neither case made the paying credential clear. In practice an API key was effectively mandatory for the Claude backend—sandboxed and unsandboxed—even though the documented login path existed. This PR makes login functional and prevents an ambient key from silently taking over.

`USER` is now a default rather than a documented opt-in because requiring users to discover an OS-specific identity variable would recreate the same authentication trap. `LOGNAME` is included as the conventional companion used by Unix-like tools; both are non-secret. Applying this narrowly to all agent CLIs also avoids the same hidden login-resolution dependency in Codex, Cursor, Gemini, or OpenCode, while keeping evaluator environments strictly scrubbed.

## Explicit API-key opt-in

An API key remains available only when deliberately configured:

```toml
# Either forward an explicit value:
[env]
ANTHROPIC_API_KEY = "sk-ant-..."

# Or pass the ambient one through. Note this is TOP-LEVEL: placing it under
# [env] would parse as env.passthrough_env and silently do nothing.
passthrough_env = ["ANTHROPIC_API_KEY"]
```

When chosen, HELIX warns that the key takes precedence over the stored login.

## Validation

- New tests were run first and failed before the fix: missing `USER` in the real Claude subprocess environment, preserved explicit passthrough, and absent auth-failure environment diagnostic.
- `uv run pytest tests/unit -q` → 884 passed
- `uv run mypy --strict src/helix/` → Success: no issues found in 29 source files
- `uv run ruff check src/helix/backends.py src/helix/mutator.py tests/unit/test_backend_auth_env.py` → clean

