### PR TITLE
docs(circle_packing): correct the benchmark figure and the claim it supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,9 +647,9 @@ Pack 26 non-overlapping circles in a unit square, maximizing sum of radii.
 |---|:---:|---|
 | Seed (naive concentric grid) | 0.9798 | — |
 | **HELIX best (gen 14 of 30)** | **2.6360** | `haiku` · `low` effort · `max_turns=20` |
-| GEPA optimize_anything ([blog](https://gepa-ai.github.io/gepa/blog/2026/02/18/introducing-optimize-anything/)) | 2.635 | gemini-3-flash |
+| GEPA optimize_anything ([blog](https://gepa-ai.github.io/gepa/blog/2026/02/18/introducing-optimize-anything/)) | 2.63598+ | gemini-3-flash |
 
-> **Note:** HELIX **beat the GEPA blog benchmark** (2.6360 vs 2.635) using Claude Haiku with low reasoning effort and a 20-turn per mutation budget. See [`examples/circle_packing/`](examples/circle_packing/) for the full fixture including `solve_optimized.py` (the best evolved solution).
+> **Note:** HELIX **matched the best published result** (2.635982 vs 2.63598+) using Claude Haiku with low reasoning effort and a 20-turn per mutation budget, and exceeded AlphaEvolve's 2.6358. See [`examples/circle_packing/`](examples/circle_packing/) for the full fixture including `solve_optimized.py` (the best evolved solution).
 
 ---
 

--- a/examples/circle_packing/README.md
+++ b/examples/circle_packing/README.md
@@ -15,7 +15,7 @@ This will evolve `solve.py` against `evaluate.py` using the configuration in `he
 
 ## Expected result
 
-Starting from a trivial seed solver scoring **0.9798**, HELIX evolves a solution that reaches **2.6360**, beating the published GEPA benchmark score of **2.635**.
+Starting from a trivial seed solver scoring **0.9798**, HELIX evolves a solution that reaches **2.635982** — matching the best published result of **2.63598+**, and above AlphaEvolve's **2.6358**.
 
 Score progression along the winning lineage:
 

--- a/examples/circle_packing/helix.toml
+++ b/examples/circle_packing/helix.toml
@@ -24,7 +24,7 @@ background = """
 Circle packing benchmark: pack 26 non-overlapping circles in a unit square [0,1]x[0,1].
 Each circle is (x, y, r) with r <= x, r <= y, r <= 1-x, r <= 1-y (inside bounds).
 No two circles overlap: dist(c_i, c_j) >= r_i + r_j.
-Score = sum of all radii. Current GEPA benchmark: 2.635. AlphaEvolve: ~2.635.
+Score = sum of all radii. Best published result: 2.63598+. AlphaEvolve: 2.6358.
 
 PROVEN WINNING STRATEGIES:
 1. Use scipy.optimize (minimize with SLSQP or L-BFGS-B) for gradient-based optimization
@@ -42,5 +42,5 @@ KNOWN GOOD APPROACH (scipy):
 - Use scipy.optimize.minimize with method='SLSQP' or 'trust-constr'
 - Multiple random starts, keep best valid solution
 
-Target score > 2.635 to beat GEPA benchmark.
+Target score >= 2.63598 to match the best published result.
 """

--- a/examples/circle_packing/solve_optimized.py
+++ b/examples/circle_packing/solve_optimized.py
@@ -1,7 +1,7 @@
 """
 Optimized circle packing for 26 circles in unit square.
 Uses scipy SLSQP + iterated local search (single-circle relocation).
-Achieves > 2.635 (beats GEPA/AlphaEvolve benchmark).
+Achieves 2.635982, matching the best published result and above AlphaEvolve's 2.6358.
 """
 import math
 import time
@@ -14,7 +14,7 @@ TIME_BUDGET = 50.0  # seconds
 # Priority seeds known to produce good base solutions
 PRIORITY_SEEDS = [230, 13, 10, 7, 5, 2, 42, 100, 150, 200]
 
-# Known high-quality configuration (score ≈ 2.635982, beats GEPA 2.635 benchmark)
+# Known high-quality configuration (score ≈ 2.635982, matches the 2.63598+ published result)
 # Derived from seed 230 base + ILS relocation of circle 11
 KNOWN_BEST_CONFIG = [
     (0.4955317611, 0.7246573608, 0.1176296263),


### PR DESCRIPTION
## The problem

Five files cited **2.635** as the published benchmark result. That figure appears nowhere in the source they link to.

| | value |
|---|---|
| published result | **2.63598+** |
| AlphaEvolve | **2.6358** |
| our evolved solver (`solve_optimized.py`) | **2.635982** |

The README additionally rounded our 2.635982 to **2.6360**, which made a **0.000002** difference read as a win.

## The correction

Against the real published figure our result is a **match**, not a beat. Against AlphaEvolve's 2.6358 there is a real, if small, margin. All seven sites now say so.

The claim is still worth making — a trivial **0.9798** seed evolving to a specialised optimiser's level is the interesting part, and it does not need a "beat" framing to stand up. It now survives someone checking the arithmetic.

## Scope

Documentation and comments only. No code, no config semantics, no tests affected.

`README.md` (2), `examples/circle_packing/README.md` (1), `examples/circle_packing/helix.toml` (2), `examples/circle_packing/solve_optimized.py` (2).