### PR TITLE
fix(mutator): use --auto for opencode non-interactive runs

### DIFF
--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -812,7 +812,7 @@ def _build_backend_args(
             "run",
             "--format",
             "json",
-            "--dangerously-skip-permissions",
+            "--auto",
         ]
         if config.model:
             args.extend(["--model", config.model])

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1074,7 +1074,7 @@ class TestInvokeClaudeCode:
             (
                 "opencode",
                 ["opencode", "run"],
-                ["--format", "json", "--dangerously-skip-permissions"],
+                ["--format", "json", "--auto"],
             ),
         ],
     )


### PR DESCRIPTION
opencode's non-interactive invocation passed `--dangerously-skip-permissions`, which the current CLI
does not accept — it exits before doing any work, so every sandboxed opencode mutation failed.

It now passes `--auto`, which is that CLI's flag for the same thing. From `opencode run --help` (1.18.5):

```
--auto   auto-approve permissions that are not explicitly denied (dangerous!)
```

## Validation

- `uv run pytest` — 922 passed
- `uv run ruff check src/ tests/` — all checks passed
- `uv run mypy --strict src/helix/` — clean, 26 source files
