### PR TITLE
Isolate sandbox login credentials per candidate; replace gemini backend with agy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,16 @@ jobs:
   docker-integration:
     # Real-Docker proof that per-candidate auth volumes actually isolate
     # credentials. Every credential used is synthetic, so this job needs no
-    # backend secrets: the runner images are anonymously pullable from GHCR,
-    # and the seeding helper runs in the backend's own runner image rather
-    # than introducing a third-party one.
+    # backend secrets.
+    #
+    # The fixture images are built from this checkout's own Dockerfiles
+    # rather than pulled from GHCR: a pulled image only reflects the last
+    # *published* build, so a PR that edits a Dockerfile would be tested
+    # against code it isn't changing, and a PR that adds a new backend could
+    # never go green -- its image can't exist on GHCR until after it merges.
+    # Building locally means every PR is validated against exactly the
+    # images its own diff produces. The seeding helper still runs in the
+    # backend's own runner image rather than introducing a third-party one.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -32,13 +39,23 @@ jobs:
         with:
           python-version: "3.12"
       - run: uv sync --all-extras
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       # The tests skip when a fixture image is absent. A fresh runner has
-      # none, so without this pull the job would pass while running nothing.
-      - name: Pull fixture images
-        run: |
-          for b in claude codex cursor gemini opencode; do
-            docker pull -q "ghcr.io/ke7/helix-evo-runner-$b:latest"
-          done
+      # none, so without this build the job would pass while running
+      # nothing. `docker buildx bake` (see docker/docker-bake.hcl) builds
+      # the base image once, then every backend's Dockerfile against it in
+      # parallel, using Buildx's named-context feature to point each
+      # backend's `FROM` straight at the base build's own output instead of
+      # a registry -- so build order only matters between the base and the
+      # backends, never among the backends themselves. Each target loads
+      # into the local Docker engine (`--load`, no registry push) under the
+      # exact tag `DEFAULT_BACKEND_IMAGES` in `src/helix/backends.py`
+      # resolves, and each caches independently through the GitHub Actions
+      # cache so an unrelated change doesn't invalidate every other image's
+      # layers.
+      - name: Build fixture images
+        run: docker buildx bake -f docker/docker-bake.hcl --load
       # STRICT=1 turns any remaining skip into a failure, so this job can
       # never be green without actually exercising the isolation tests.
       - run: uv run pytest tests/integration/ -m docker_integration -q -rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,16 @@ jobs:
         with:
           python-version: "3.12"
       - run: uv sync --all-extras
-      - run: uv run pytest tests/integration/ -m docker_integration -q
+      # The tests skip when a fixture image is absent. A fresh runner has
+      # none, so without this pull the job would pass while running nothing.
+      - name: Pull fixture images
+        run: |
+          docker pull -q python:3.13-alpine
+          for b in claude codex cursor gemini opencode; do
+            docker pull -q "ghcr.io/ke7/helix-evo-runner-$b:latest"
+          done
+      # STRICT=1 turns any remaining skip into a failure, so this job can
+      # never be green without actually exercising the isolation tests.
+      - run: uv run pytest tests/integration/ -m docker_integration -q -rs
+        env:
+          HELIX_DOCKER_TESTS_STRICT: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     # Real-Docker proof that per-candidate auth volumes actually isolate
     # credentials. Every credential used is synthetic, so this job needs no
     # backend secrets; the runner images are anonymously pullable from GHCR
-    # and the seeding helper runs in python:3.13-alpine.
+    # and the seeding helper runs in the agent's own backend runner image.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -35,7 +35,6 @@ jobs:
       # none, so without this pull the job would pass while running nothing.
       - name: Pull fixture images
         run: |
-          docker pull -q python:3.13-alpine
           for b in claude codex cursor gemini opencode; do
             docker pull -q "ghcr.io/ke7/helix-evo-runner-$b:latest"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,17 @@ jobs:
       - run: uv sync --all-extras
       - run: uv run pytest tests/unit/ -q
       - run: uv run mypy --strict src/helix/
+
+  docker-integration:
+    # Real-Docker proof that per-candidate auth volumes actually isolate
+    # credentials. Every credential used is synthetic, so this job needs no
+    # backend secrets; the runner images are anonymously pullable from GHCR
+    # and the seeding helper runs in python:3.13-alpine.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.12"
+      - run: uv sync --all-extras
+      - run: uv run pytest tests/integration/ -m docker_integration -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - run: uv sync --all-extras
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      # `docker buildx bake` talks to the GitHub Actions cache directly
+      # (rather than through an action that wraps it, like
+      # docker/build-push-action), so the cache's URL and token need to
+      # reach it as plain environment variables.
+      - name: Expose GitHub Actions cache to Buildx
+        uses: crazy-max/ghaction-github-runtime@v3
       # The tests skip when a fixture image is absent. A fresh runner has
       # none, so without this build the job would pass while running
       # nothing. `docker buildx bake` (see docker/docker-bake.hcl) builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
   docker-integration:
     # Real-Docker proof that per-candidate auth volumes actually isolate
     # credentials. Every credential used is synthetic, so this job needs no
-    # backend secrets; the runner images are anonymously pullable from GHCR
-    # and the seeding helper runs in the agent's own backend runner image.
+    # backend secrets: the runner images are anonymously pullable from GHCR,
+    # and the seeding helper runs in the backend's own runner image rather
+    # than introducing a third-party one.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish-runners.yml
+++ b/.github/workflows/publish-runners.yml
@@ -116,14 +116,14 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - name: agy
+            dockerfile: docker/agy.Dockerfile
           - name: claude
             dockerfile: docker/claude.Dockerfile
           - name: codex
             dockerfile: docker/codex.Dockerfile
           - name: cursor
             dockerfile: docker/cursor.Dockerfile
-          - name: gemini
-            dockerfile: docker/gemini.Dockerfile
           - name: opencode
             dockerfile: docker/opencode.Dockerfile
         platform:
@@ -195,10 +195,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - name: agy
           - name: claude
           - name: codex
           - name: cursor
-          - name: gemini
           - name: opencode
     steps:
       - name: Download digests
@@ -248,14 +248,14 @@ jobs:
         image:
           - name: base
             command: "python --version && uv --version && git --version"
+          - name: agy
+            command: "agy --version"
           - name: claude
             command: "claude --version"
           - name: codex
             command: "codex --version"
           - name: cursor
             command: "cursor agent --version"
-          - name: gemini
-            command: "gemini --version"
           - name: opencode
             command: "opencode --version"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **BREAKING**: Removed the `gemini` mutation backend and replaced it with
+  `agy` (Google's Antigravity CLI). Configs with `agent.backend = "gemini"`
+  are rejected; migrate to `"agy"`. `helix-auth-gemini` sandbox volumes are
+  no longer read; run `helix sandbox login agy` to create `helix-auth-agy`.
+  Unlike `gemini`, `agy` propagates `agent.effort` to its CLI (`--effort`,
+  same `low`/`medium`/`high` values as `claude`) instead of silently
+  ignoring it.
 - **BREAKING**: Removed the `evaluator.score_parser` configuration field. The built-in
   `helix_result` parser is now implicit; configurations that still provide the
   removed field are rejected by Pydantic's `extra="forbid"` validation.

--- a/README.md
+++ b/README.md
@@ -341,9 +341,9 @@ rng_seed = 0
 # after passthrough_env. Useful for repeatable run-local service endpoints.
 # ANTHROPIC_BASE_URL = "https://model-service.example.invalid/v1"
 # ANTHROPIC_API_KEY = "dummy"
-# See "Docker Sandboxing" below: for some backends, a credential-shaped
-# `[env]`/`passthrough_env` value outranks the sandbox.auth = "volume"
-# seeded login.
+# A credential-shaped value here reaches the agent even under
+# sandbox.auth = "volume", and the backend CLI decides which credential
+# wins. See "Docker Sandboxing" below.
 
 [evaluator]
 command = "uv run python evaluate.py"
@@ -632,27 +632,25 @@ helix sandbox login claude
 helix sandbox status claude
 ```
 
-**`sandbox.auth = "volume"` seeds a login, but a configured `[env]`/
-`passthrough_env` credential can still be what the agent actually
-authenticates with** — HELIX passes those values through to the agent in
-both auth modes (that is the whole point of `[env]`: it also reaches
-non-sandboxed and `auth = "env"` runs), and each backend CLI, not HELIX,
-decides which credential source wins when more than one is present. Per
-backend, from each CLI's own documented/observed precedence:
+**Under `sandbox.auth = "volume"`, a credential-shaped `[env]` /
+`passthrough_env` value can still be what the agent actually authenticates
+with.** HELIX forwards configured values to the agent in both auth modes, and
+each backend CLI — not HELIX — decides which credential source wins when a
+seeded login and a credential-shaped environment variable are both present.
 
-| Backend | If both a seeded login and a configured credential env var are present |
-| --- | --- |
-| `claude` | The env var wins. Anthropic's own docs put `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_API_KEY` above subscription/`\`/login\`` credentials, and specifically call out that in non-interactive mode (which is how HELIX always invokes `claude`) the key "is always used when present." |
-| `gemini` | The env var appears to win — Google's docs say `GEMINI_API_KEY`/`GOOGLE_API_KEY` must be unset to fall back to a stored login. Not independently confirmed against HELIX's exact seeded-login flow; treat as likely, not certain. |
-| `codex` | The seeded login appears to win by default — community reports describe `OPENAI_API_KEY` being ignored once a ChatGPT login exists, unless `preferred_auth_method = "apikey"` is set in the backend's own config. Not confirmed against OpenAI's own precedence docs (no page states this order explicitly). |
-| `cursor` | Undetermined — no documentation found stating the precedence between a `cursor-agent` login and `CURSOR_API_KEY`. |
-| `opencode` | Undetermined — secondary sources disagree on whether `auth.json` or an env var wins. |
+| Backend | Precedence when both are present | Basis |
+| --- | --- | --- |
+| `claude` | The environment variable wins. Anthropic's documentation ranks `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_API_KEY` above subscription and `/login` credentials, and states that in non-interactive mode — which is how HELIX always invokes `claude` — the key is always used when present. | Vendor documentation |
+| `gemini` | The environment variable probably wins: Google's documentation describes unsetting `GEMINI_API_KEY` / `GOOGLE_API_KEY` in order to fall back to a stored login. | Vendor documentation; not retested against HELIX's seeded-login flow |
+| `codex` | Undetermined. Codex's own `preferred_auth_method` setting is the documented way to state which credential you intend to use, rather than relying on a default order. | Not determined |
+| `cursor` | Undetermined, for a `cursor-agent` login versus `CURSOR_API_KEY`. | Not determined |
+| `opencode` | Undetermined, for `auth.json` versus an environment variable. | Not determined |
 
-If you configure a credential-shaped `[env]`/`passthrough_env` value for
-`claude` or `gemini` under `auth = "volume"`, assume it — not the seeded
-login — is what authenticates the agent. For `codex`, `cursor`, and
-`opencode`, don't rely on either direction until it's verified against
-that CLI's actual behavior.
+Read "undetermined" as *we did not establish it*, not as a defect in those
+CLIs. The safe rule for every backend: set a credential-shaped `[env]` /
+`passthrough_env` value only when you intend it to authenticate the agent. To
+know which credential a given run actually used, check that backend CLI's own
+reporting — do not infer it from `sandbox.auth`.
 
 For Claude, HELIX uses `claude setup-token` for sandbox login because that is
 the flow that works cleanly in browserless Docker/SSH-style environments; it

--- a/README.md
+++ b/README.md
@@ -632,6 +632,15 @@ helix sandbox login claude
 helix sandbox status claude
 ```
 
+For `sandbox.auth = "env"`, skip the login volume: the credential comes from a
+name you configure directly in `[env]` or `passthrough_env`, the same as any
+other value, and `sandbox.auth_env_allow` must list that name. `auth_env_allow`
+does not filter or restrict what `[env]` / `passthrough_env` deliver — that
+transport works identically in both auth modes. It is a required declaration
+of which name(s) an `auth = "env"` configuration expects to supply, checked
+against the rest of the config, not a separate permission a value must also
+clear.
+
 **Under `sandbox.auth = "volume"`, a credential-shaped `[env]` /
 `passthrough_env` value can still be what the agent actually authenticates
 with.** HELIX forwards configured values to the agent in both auth modes, and

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Evolutionary optimization for full codebases using agentic coding tools as the mutation engine and git worktrees as the population pool.**
 
-HELIX brings reflective Pareto evolution out of the single-artifact setting and into real software projects: entire repositories, multi-turn agentic mutation, tool use, web research, and verification loops, all inside a single evolutionary stage. Supported mutation backends include Claude Code, Codex CLI, Cursor Agent, Gemini CLI, and OpenCode.
+HELIX brings reflective Pareto evolution out of the single-artifact setting and into real software projects: entire repositories, multi-turn agentic mutation, tool use, web research, and verification loops, all inside a single evolutionary stage. Supported mutation backends include Antigravity CLI, Claude Code, Codex CLI, Cursor Agent, and OpenCode.
 
 <br>
 
@@ -109,7 +109,7 @@ flowchart TD
     subgraph DOCKER["🐳  Docker Sandbox  —  isolated execution environment"]
         direction LR
         subgraph ANET["  Agent Network  (normal egress)  "]
-            AGENT["Mutation / Merge Container\n──────────────────────────\nclaude · codex · cursor\ngemini · opencode\nAuth: private candidate store"]:::agent
+            AGENT["Mutation / Merge Container\n──────────────────────────\nagy · claude · codex\ncursor · opencode\nAuth: private candidate store"]:::agent
         end
         subgraph ENET["  Private Evaluator Network  (helix-eval-*)  "]
             ERUN["Eval Runners\n(short-lived,\ncopied workspace)"]:::eval
@@ -201,7 +201,7 @@ Install and start Docker, then log in to your selected backend inside its
 persistent sandbox auth volume:
 
 ```bash
-helix sandbox login claude      # or codex, cursor, gemini, opencode
+helix sandbox login claude      # or agy, codex, cursor, opencode
 helix sandbox status claude
 ```
 
@@ -412,7 +412,7 @@ frontier_type = "instance"       # Pareto dimensionality (GEPA FrontierType pari
                                  # raise MissingObjectiveScoresError at selection.
 
 [agent]
-backend = "claude"               # "claude" | "codex" | "cursor" | "gemini" | "opencode"
+backend = "claude"               # "agy" | "claude" | "codex" | "cursor" | "opencode"
 # model = "sonnet"               # optional backend-specific model name
 effort = "medium"                # optional: "low" | "medium" | "high" | "xhigh" | "max"
 max_turns = 20
@@ -649,8 +649,8 @@ seeded login and a credential-shaped environment variable are both present.
 
 | Backend | Precedence when both are present | Basis |
 | --- | --- | --- |
+| `agy` | Undetermined. A separate, service-account-style Application Default Credentials path exists (`gcloud auth application-default login`, activated via `AGY_ADC_AUTH=true`) alongside the personal-account OAuth login HELIX seeds, but which one wins when both are present has not been investigated. | Not determined |
 | `claude` | The environment variable wins. Anthropic's documentation ranks `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_API_KEY` above subscription and `/login` credentials, and states that in non-interactive mode — which is how HELIX always invokes `claude` — the key is always used when present. | Vendor documentation |
-| `gemini` | The environment variable probably wins: Google's documentation describes unsetting `GEMINI_API_KEY` / `GOOGLE_API_KEY` in order to fall back to a stored login. | Vendor documentation; not retested against HELIX's seeded-login flow |
 | `codex` | Undetermined. Codex's own `preferred_auth_method` setting is the documented way to state which credential you intend to use, rather than relying on a default order. | Not determined |
 | `cursor` | Undetermined, for a `cursor-agent` login versus `CURSOR_API_KEY`. | Not determined |
 | `opencode` | Undetermined, for `auth.json` versus an environment variable. | Not determined |
@@ -665,14 +665,13 @@ For Claude, HELIX uses `claude setup-token` for sandbox login because that is
 the flow that works cleanly in browserless Docker/SSH-style environments; it
 prints a URL and then accepts the code from the browser in the terminal.
 Codex similarly uses `codex login --device-auth` so the callback does not depend
-on a localhost server inside the container. Gemini starts its normal
-interactive CLI with `--skip-trust` so its authentication picker is not blocked
-by the temporary sandbox workspace trust prompt. OpenCode starts the normal TUI
-so you can choose the provider/model and complete provider login in one setup
-session.
+on a localhost server inside the container. Antigravity CLI (`agy`) has no
+dedicated login subcommand, so HELIX starts its normal interactive CLI, same
+as OpenCode, which starts the normal TUI so you can choose the provider/model
+and complete provider login in one setup session.
 
-The volume names are `helix-auth-claude`, `helix-auth-codex`,
-`helix-auth-cursor`, `helix-auth-gemini`, and `helix-auth-opencode`.
+The volume names are `helix-auth-agy`, `helix-auth-claude`, `helix-auth-codex`,
+`helix-auth-cursor`, and `helix-auth-opencode`.
 This avoids copying host credential stores into Docker. On macOS, Claude/Cursor
 browser-login tokens may live in Keychain; on Linux they may live in
 Secret Service/libsecret, GNOME Keyring, KWallet, or another desktop keyring.
@@ -683,10 +682,10 @@ usual. Docker Desktop supports `host.docker.internal`; Linux users can set
 `add_host_gateway = true`.
 
 By default HELIX chooses a published backend-specific mutator image from
-`agent.backend`: `ghcr.io/ke7/helix-evo-runner-claude`,
+`agent.backend`: `ghcr.io/ke7/helix-evo-runner-agy`,
+`ghcr.io/ke7/helix-evo-runner-claude`,
 `ghcr.io/ke7/helix-evo-runner-codex`,
-`ghcr.io/ke7/helix-evo-runner-cursor`,
-`ghcr.io/ke7/helix-evo-runner-gemini`, or
+`ghcr.io/ke7/helix-evo-runner-cursor`, or
 `ghcr.io/ke7/helix-evo-runner-opencode`. To build locally instead, build the
 shared base first with
 `docker build -t helix-runner-base:latest -f docker/base.Dockerfile .`, then
@@ -826,7 +825,7 @@ stderr as fallback debug context.
 --evaluator TEXT     Override the evaluator command
 --generations INT   Override max_generations
 --no-merge          Disable merge operations
---backend BACKEND   Override the mutation backend [claude|codex|cursor|gemini|opencode]
+--backend BACKEND   Override the mutation backend [agy|claude|codex|cursor|opencode]
 --model TEXT        Override the backend model (backend-specific naming)
 --effort LEVEL      Reasoning effort: low | medium | high | xhigh | max
 ```
@@ -913,10 +912,10 @@ BSD 3-Clause License. See [LICENSE](LICENSE) for details.
 HELIX's core evolutionary algorithm is based on **GEPA optimize_anything** by Agrawal, Lee, Ma, Elmaaroufi, Tan, Seshia, Sen, Klein, Stoica, Gonzalez, Khattab, Dimakis, and Zaharia. Their work on applying reflective Pareto evolution to any text made HELIX possible — we extended their algorithm to full codebases and agentic mutation but the foundation is theirs.
 
 - **[GEPA optimize_anything](https://gepa-ai.github.io/gepa/blog/2026/02/18/introducing-optimize-anything/)** — The algorithmic foundation: minibatch-gated Pareto evolution with reflective LLM mutation
+- **[Antigravity CLI](https://antigravity.google/cli)** — Supported HELIX mutation backend
 - **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — Supported HELIX mutation backend
 - **[Codex CLI](https://developers.openai.com/codex/cli)** — Supported HELIX mutation backend
 - **[Cursor CLI](https://cursor.com/cli/)** — Supported HELIX mutation backend
-- **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — Supported HELIX mutation backend
 - **[OpenCode](https://opencode.ai/docs/cli/)** — Supported HELIX mutation backend
 - **[OMAR](http://omar.tech/)** — The multi-agent orchestration system used to build HELIX
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ runner_image = "my-evaluator-runner:latest"
 command = "python -m benchmark_server"
 endpoint = "http://helix-evaluator:8080/evaluate"
 startup_timeout_seconds = 120
+# API keys needed only by the scoring service; they never reach mutation agents.
+passthrough_env = ["OPENAI_API_KEY"]
 
 [sandbox]
 enabled = true
@@ -418,8 +420,8 @@ enabled = false                  # true = run agent/evaluator subprocesses in Do
 # image = "ghcr.io/ke7/helix-evo-runner-claude:latest"  # optional; defaults from agent.backend
 network = "bridge"               # "bridge" | "none" | "host"
 skip_special_files = true        # skip FIFOs/sockets/devices during workspace sync
-auth = "login"                  # "login" (default) or explicit-key "env"
-# Login credentials are seeded into a fresh candidate volume; agents never
+auth = "volume"                # "volume" (default) or explicit-key "env"
+# Volume credentials are seeded into a fresh candidate volume; agents never
 # mount the persistent helix-auth-<backend> login volume.
 
 [worktree]
@@ -617,7 +619,7 @@ sockets, and device nodes by default. Set `skip_special_files = false` only if
 you want unsupported workspace file types to raise instead of being ignored.
 
 `helix sandbox login <backend>` writes to a persistent operator-facing volume.
-For `sandbox.auth = "login"` (the default), HELIX seeds only the credential
+For `sandbox.auth = "volume"` (the default), HELIX seeds only the credential
 files into a fresh candidate-owned volume and mounts that volume below a private
 tmpfs home; no agent container mounts the login volume. Evaluator sidecar and
 runner containers never receive it. Run the login flow once per backend:

--- a/README.md
+++ b/README.md
@@ -341,6 +341,9 @@ rng_seed = 0
 # after passthrough_env. Useful for repeatable run-local service endpoints.
 # ANTHROPIC_BASE_URL = "https://model-service.example.invalid/v1"
 # ANTHROPIC_API_KEY = "dummy"
+# See "Docker Sandboxing" below: for some backends, a credential-shaped
+# `[env]`/`passthrough_env` value outranks the sandbox.auth = "volume"
+# seeded login.
 
 [evaluator]
 command = "uv run python evaluate.py"
@@ -628,6 +631,28 @@ runner containers never receive it. Run the login flow once per backend:
 helix sandbox login claude
 helix sandbox status claude
 ```
+
+**`sandbox.auth = "volume"` seeds a login, but a configured `[env]`/
+`passthrough_env` credential can still be what the agent actually
+authenticates with** — HELIX passes those values through to the agent in
+both auth modes (that is the whole point of `[env]`: it also reaches
+non-sandboxed and `auth = "env"` runs), and each backend CLI, not HELIX,
+decides which credential source wins when more than one is present. Per
+backend, from each CLI's own documented/observed precedence:
+
+| Backend | If both a seeded login and a configured credential env var are present |
+| --- | --- |
+| `claude` | The env var wins. Anthropic's own docs put `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_API_KEY` above subscription/`\`/login\`` credentials, and specifically call out that in non-interactive mode (which is how HELIX always invokes `claude`) the key "is always used when present." |
+| `gemini` | The env var appears to win — Google's docs say `GEMINI_API_KEY`/`GOOGLE_API_KEY` must be unset to fall back to a stored login. Not independently confirmed against HELIX's exact seeded-login flow; treat as likely, not certain. |
+| `codex` | The seeded login appears to win by default — community reports describe `OPENAI_API_KEY` being ignored once a ChatGPT login exists, unless `preferred_auth_method = "apikey"` is set in the backend's own config. Not confirmed against OpenAI's own precedence docs (no page states this order explicitly). |
+| `cursor` | Undetermined — no documentation found stating the precedence between a `cursor-agent` login and `CURSOR_API_KEY`. |
+| `opencode` | Undetermined — secondary sources disagree on whether `auth.json` or an env var wins. |
+
+If you configure a credential-shaped `[env]`/`passthrough_env` value for
+`claude` or `gemini` under `auth = "volume"`, assume it — not the seeded
+login — is what authenticates the agent. For `codex`, `cursor`, and
+`opencode`, don't rely on either direction until it's verified against
+that CLI's actual behavior.
 
 For Claude, HELIX uses `claude setup-token` for sandbox login because that is
 the flow that works cleanly in browserless Docker/SSH-style environments; it

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ flowchart TD
     subgraph DOCKER["🐳  Docker Sandbox  —  isolated execution environment"]
         direction LR
         subgraph ANET["  Agent Network  (normal egress)  "]
-            AGENT["Mutation / Merge Container\n──────────────────────────\nclaude · codex · cursor\ngemini · opencode\nAuth: helix-auth-BACKEND"]:::agent
+            AGENT["Mutation / Merge Container\n──────────────────────────\nclaude · codex · cursor\ngemini · opencode\nAuth: private candidate store"]:::agent
         end
         subgraph ENET["  Private Evaluator Network  (helix-eval-*)  "]
             ERUN["Eval Runners\n(short-lived,\ncopied workspace)"]:::eval
@@ -418,8 +418,9 @@ enabled = false                  # true = run agent/evaluator subprocesses in Do
 # image = "ghcr.io/ke7/helix-evo-runner-claude:latest"  # optional; defaults from agent.backend
 network = "bridge"               # "bridge" | "none" | "host"
 skip_special_files = true        # skip FIFOs/sockets/devices during workspace sync
-# Agent containers mount a persistent Docker auth volume named
-# helix-auth-<backend>. Run `helix sandbox login <backend>` once per backend.
+auth = "login"                  # "login" (default) or explicit-key "env"
+# Login credentials are seeded into a fresh candidate volume; agents never
+# mount the persistent helix-auth-<backend> login volume.
 
 [worktree]
 base_dir = ".helix/worktrees"
@@ -615,10 +616,11 @@ During copy and sync, HELIX skips unsupported special files such as FIFOs,
 sockets, and device nodes by default. Set `skip_special_files = false` only if
 you want unsupported workspace file types to raise instead of being ignored.
 
-Agent containers mount a persistent Docker auth volume at `/home/node`;
-evaluator sidecar and runner containers never receive it. Run
-`helix sandbox login <backend>` once per backend to complete that CLI's normal
-login flow inside the same Linux container environment HELIX will use later:
+`helix sandbox login <backend>` writes to a persistent operator-facing volume.
+For `sandbox.auth = "login"` (the default), HELIX seeds only the credential
+files into a fresh candidate-owned volume and mounts that volume below a private
+tmpfs home; no agent container mounts the login volume. Evaluator sidecar and
+runner containers never receive it. Run the login flow once per backend:
 
 ```bash
 helix sandbox login claude

--- a/docker/agy.Dockerfile
+++ b/docker/agy.Dockerfile
@@ -1,0 +1,16 @@
+ARG BASE_IMAGE=helix-runner-base:latest
+FROM ${BASE_IMAGE}
+
+# The installer places the binary under /root/.local/bin, a directory only
+# root can traverse. HELIX always runs the agent as uid 1000 (see
+# _RUNNER_UID_GID in sandbox.py), so a symlink straight into /root would
+# resolve to nothing for that user -- confirmed by actually running this
+# image as uid 1000, not just as root. Copy the binary out to /opt (world-
+# traversable, same fix cursor.Dockerfile already applies to its own
+# root-owned install) before exposing it on PATH.
+RUN curl -fsSL https://antigravity.google/cli/install.sh | bash \
+    && cp /root/.local/bin/agy /opt/agy \
+    && chmod 755 /opt/agy \
+    && ln -s /opt/agy /usr/local/bin/agy
+
+WORKDIR /workspace

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,5 +1,5 @@
 group "default" {
-  targets = ["base", "claude", "codex", "cursor", "gemini", "opencode"]
+  targets = ["base", "agy", "claude", "codex", "cursor", "opencode"]
 }
 
 # Tagged distinctly from the `:latest` every backend Dockerfile's `ARG
@@ -30,6 +30,15 @@ target "backend" {
   }
 }
 
+target "agy" {
+  inherits   = ["backend"]
+  context    = "."
+  dockerfile = "docker/agy.Dockerfile"
+  tags       = ["ghcr.io/ke7/helix-evo-runner-agy:latest"]
+  cache-from = ["type=gha,scope=fixture-agy"]
+  cache-to   = ["type=gha,mode=max,scope=fixture-agy"]
+}
+
 target "claude" {
   inherits   = ["backend"]
   context    = "."
@@ -55,15 +64,6 @@ target "cursor" {
   tags       = ["ghcr.io/ke7/helix-evo-runner-cursor:latest"]
   cache-from = ["type=gha,scope=fixture-cursor"]
   cache-to   = ["type=gha,mode=max,scope=fixture-cursor"]
-}
-
-target "gemini" {
-  inherits   = ["backend"]
-  context    = "."
-  dockerfile = "docker/gemini.Dockerfile"
-  tags       = ["ghcr.io/ke7/helix-evo-runner-gemini:latest"]
-  cache-from = ["type=gha,scope=fixture-gemini"]
-  cache-to   = ["type=gha,mode=max,scope=fixture-gemini"]
 }
 
 target "opencode" {

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,0 +1,76 @@
+group "default" {
+  targets = ["base", "claude", "codex", "cursor", "gemini", "opencode"]
+}
+
+# Tagged distinctly from the `:latest` every backend Dockerfile's `ARG
+# BASE_IMAGE` defaults to. Buildx's named-context override (below) that
+# repoints a backend's `FROM ${BASE_IMAGE}` at this target's own build
+# result -- instead of a registry pull -- only takes effect for a
+# non-`:latest` reference; passed as `BASE_IMAGE` build-arg per backend, it
+# never changes what a plain, un-overridden build defaults to.
+target "base" {
+  context    = "."
+  dockerfile = "docker/base.Dockerfile"
+  tags       = ["helix-runner-base:ci-build"]
+  cache-from = ["type=gha,scope=fixture-base"]
+  cache-to   = ["type=gha,mode=max,scope=fixture-base"]
+}
+
+# Every backend Dockerfile does `FROM ${BASE_IMAGE}`. Pointing that
+# reference at the `base` target's own build result (rather than a registry
+# pull or the host daemon's image store) lets one `docker buildx bake`
+# build the whole fixture set -- base once, then every backend in parallel
+# -- without ever pushing an intermediate image anywhere.
+target "backend" {
+  args = {
+    BASE_IMAGE = "helix-runner-base:ci-build"
+  }
+  contexts = {
+    "helix-runner-base:ci-build" = "target:base"
+  }
+}
+
+target "claude" {
+  inherits   = ["backend"]
+  context    = "."
+  dockerfile = "docker/claude.Dockerfile"
+  tags       = ["ghcr.io/ke7/helix-evo-runner-claude:latest"]
+  cache-from = ["type=gha,scope=fixture-claude"]
+  cache-to   = ["type=gha,mode=max,scope=fixture-claude"]
+}
+
+target "codex" {
+  inherits   = ["backend"]
+  context    = "."
+  dockerfile = "docker/codex.Dockerfile"
+  tags       = ["ghcr.io/ke7/helix-evo-runner-codex:latest"]
+  cache-from = ["type=gha,scope=fixture-codex"]
+  cache-to   = ["type=gha,mode=max,scope=fixture-codex"]
+}
+
+target "cursor" {
+  inherits   = ["backend"]
+  context    = "."
+  dockerfile = "docker/cursor.Dockerfile"
+  tags       = ["ghcr.io/ke7/helix-evo-runner-cursor:latest"]
+  cache-from = ["type=gha,scope=fixture-cursor"]
+  cache-to   = ["type=gha,mode=max,scope=fixture-cursor"]
+}
+
+target "gemini" {
+  inherits   = ["backend"]
+  context    = "."
+  dockerfile = "docker/gemini.Dockerfile"
+  tags       = ["ghcr.io/ke7/helix-evo-runner-gemini:latest"]
+  cache-from = ["type=gha,scope=fixture-gemini"]
+  cache-to   = ["type=gha,mode=max,scope=fixture-gemini"]
+}
+
+target "opencode" {
+  inherits   = ["backend"]
+  context    = "."
+  dockerfile = "docker/opencode.Dockerfile"
+  tags       = ["ghcr.io/ke7/helix-evo-runner-opencode:latest"]
+  cache-from = ["type=gha,scope=fixture-opencode"]
+  cache-to   = ["type=gha,mode=max,scope=fixture-opencode"]
+}

--- a/docker/gemini.Dockerfile
+++ b/docker/gemini.Dockerfile
@@ -1,6 +1,0 @@
-ARG BASE_IMAGE=helix-runner-base:latest
-FROM ${BASE_IMAGE}
-
-RUN npm install -g @google/gemini-cli
-
-WORKDIR /workspace

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -204,18 +204,14 @@ uses relative paths only.  Initial candidates are:
 Two manifest entries carry evidence worth stating precisely, because the
 Readiness column above claims less than "Ready" for both.
 
-*Cursor keeps its settings and its credential in different directories.* The
-CLI resolves its settings directory as `$CURSOR_CONFIG_DIR`, else
-`$XDG_CONFIG_HOME/cursor`, else `$HOME/.cursor`; `cli-config.json` lives there
-and holds editor, display, permission, and model preferences and no credential
-at all. The credential goes through a separate resolver that on Linux always
-joins `$XDG_CONFIG_HOME` (else `$HOME/.config`) with the application name, so
-with neither variable set the CLI reads and writes exactly
-`$HOME/.config/cursor/auth.json`, at mode 0600, holding an access/refresh token
-pair. A candidate seeded from the settings file reports itself signed out; a
-candidate seeded from the credential path reports itself signed in. Both halves
-of the correction are load-bearing: changing only the source path or only the
-mount destination still reports signed out. That end-to-end check used a
+*Cursor keeps its settings and its credential in different directories,* which
+is why its row names `.config/cursor/auth.json` rather than the settings file
+in the settings directory.  The two resolvers are recorded beside the entry
+they explain, in `AUTH_CREDENTIAL_MANIFEST` in `src/helix/sandbox.py`.  A
+candidate seeded from the settings file reports itself signed out; a candidate
+seeded from the credential path reports itself signed in. Both halves of the
+correction are load-bearing: changing only the source path or only the mount
+destination still reports signed out. That end-to-end check used a
 synthetic record, and the CLI's status command grades a local parse, so it
 establishes that the path is right — not that any grant is valid. It cannot yet
 be raised to a real-grant test on macOS, where the same CLI stores its
@@ -283,12 +279,8 @@ auth_env_allow = []
   transport key is exposed in configuration.  Those would make a small source
   choice into a second configuration language.
 
-This keeps `auth_env_allow` as a declared, validated statement of intent, not
-as a second, parallel transport gate.  Making it an actual runtime filter
-would mean `auth = "env"` resolves `[env]`/`passthrough_env` differently from
-every other HELIX code path -- exactly the second configuration language the
-previous paragraph rules out.  Backend manifests and runtime cleanup are
-implementation details, not new user knobs.
+Backend manifests and runtime cleanup are implementation details, not new user
+knobs.
 
 ## What HELIX does not do to the agent environment
 
@@ -349,8 +341,3 @@ final Docker argv and live Docker objects, not merely on a helper function.
    changed record reaches the source volume.  Do not run the observer against
    the same grant.
 
-`auth = "volume"` names the credential *source*: HELIX copies the allowlisted
-credential files from the operator login volume into a fresh per-candidate
-volume, and never mounts `helix-auth-<backend>` in an agent container.
-`auth = "env"` is the separate explicit API-key mechanism and requires a
-non-empty `auth_env_allow`.  There is no third mode.

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -60,7 +60,7 @@ credential with it, or the split was never demonstrated.
 | Backend | Can the credential be split from the state written beside it? |
 | --- | --- |
 | Claude | No knob found that moves the per-run state without also moving the credential. |
-| Gemini | Same: the home knob available to us moves the credential too. |
+| Agy | Same: the traced credential sits inside its own per-install state directory (settings, cache, logs) with no separate relocation knob found; the whole directory moves together by construction. |
 | Cursor | A config/data split looks plausible, but we did not demonstrate one. |
 | OpenCode | The relocation knob we found moves the session database and the credential together. |
 | Codex | Closest: its agent-memory databases *can* be redirected out of the shared directory.  `models_cache.json` is still written there, which is enough to defeat the split. |
@@ -147,8 +147,8 @@ current default:
 | Alternative | Assessment |
 | --- | --- |
 | Per-user local derived image | This is option (e): no candidate-time copy, but local secret layers, cache retention, and a rotation/image-identity lifecycle. |
-| Long-lived credential sidecar | No supported common CLI protocol lets Claude, Codex, Cursor, Gemini, and OpenCode delegate their local credential lookup to a broker.  A new HTTPS/token proxy would be backend-specific, network-visible, and itself a long-lived shared stateful service.  It is a new auth product, not a smaller projection mechanism. |
-| Each candidate logs itself in | Not viable for interactive OAuth.  At the CLI versions pinned by HELIX's runner images, Claude's login help offered subscription/console, email, and SSO choices but no headless token input; Codex offered `--device-auth` (user-mediated) and `--with-api-key` (a distinct explicit API-key path); Cursor's `NO_OPEN_BROWSER` suppresses browser opening rather than supplying a credential; Gemini's `-p` is headless prompting, not login; and OpenCode exposes provider management, but we found no generic non-interactive OAuth import.  Re-check against a current CLI before relying on this row. |
+| Long-lived credential sidecar | No supported common CLI protocol lets Claude, Codex, Cursor, Agy, and OpenCode delegate their local credential lookup to a broker.  A new HTTPS/token proxy would be backend-specific, network-visible, and itself a long-lived shared stateful service.  It is a new auth product, not a smaller projection mechanism. |
+| Each candidate logs itself in | Not viable for interactive OAuth.  At the CLI versions pinned by HELIX's runner images, Claude's login help offered subscription/console, email, and SSO choices but no headless token input; Codex offered `--device-auth` (user-mediated) and `--with-api-key` (a distinct explicit API-key path); Cursor's `NO_OPEN_BROWSER` suppresses browser opening rather than supplying a credential; Agy's `--print` is headless prompting, not login; and OpenCode exposes provider management, but we found no generic non-interactive OAuth import.  Re-check against a current CLI before relying on this row. |
 
 The one non-interactive path found is Codex `--with-api-key`; it is an explicit
 environment/API-key workflow and remains covered by `auth = "env"`.  It does
@@ -198,7 +198,7 @@ uses relative paths only.  Initial candidates are:
 | Claude | `.claude/.credentials.json` → `.credentials.json` mounted at `$HOME/.claude` | Ready, subject to real-grant end-to-end test |
 | Codex | `.codex/auth.json` → `auth.json` mounted at `$HOME/.codex` | Ready, subject to real-grant end-to-end test |
 | Cursor | `.config/cursor/auth.json` → `auth.json` mounted at `$HOME/.config/cursor` | Path and shape read out of the shipped runner image's CLI bundle and confirmed end to end with a synthetic record; not yet confirmed against a real grant |
-| Gemini | `.gemini/oauth_creds.json` → `oauth_creds.json` mounted at `$HOME/.gemini`, plus a synthesized `settings.json` naming the auth method | Auth-method gate confirmed cleared end to end with a synthetic record; not yet confirmed against a real grant |
+| Agy | `.gemini/antigravity-cli/antigravity-oauth-token` → `antigravity-oauth-token` mounted at `$HOME/.gemini/antigravity-cli` | Derived, not yet confirmed against a real grant: the path was traced with `strace` against a real, unauthenticated Linux binary, which is stronger evidence than the other rows' CLI-bundle reads, but no authenticated seed has been attempted. A synthetic file at that path also does not clear the CLI's auth-method gate the way the other rows' synthetic records do (see below) |
 | OpenCode | `.local/share/opencode/auth.json` → `auth.json` mounted at its XDG data auth directory | Needs live-login verification of the complete required file set |
 
 Two manifest entries carry evidence worth stating precisely, because the
@@ -217,17 +217,23 @@ establishes that the path is right — not that any grant is valid. It cannot ye
 be raised to a real-grant test on macOS, where the same CLI stores its
 credential in the system keychain rather than in any file.
 
-*Gemini keeps its credential and its settings side by side in one directory.*
-Because the candidate mount replaces that whole directory, the settings file an
-interactive login leaves behind disappears with it, and the CLI refuses before
-it ever looks at the credential: it reports that no auth method is set. HELIX
-therefore writes a minimal settings file into the candidate volume naming the
-method the copied credential was issued under. That file is settings, not a
-secret, so HELIX synthesizes it rather than copying the operator's own — which
-would also drag unrelated operator preferences into every candidate, and would
-fail the seed helper's mode guard, since the CLI writes its settings file
-world-readable and its credential private. With the sibling in place the
-refusal is gone and the CLI proceeds to load the credential from the mount.
+*Agy's manifest entry is derived, not yet confirmed against a real grant.*
+The credential path was obtained by `strace`-ing a real, unauthenticated Linux
+build of the CLI — the same rigor class as Cursor's row above. What it does
+not yet do is clear the CLI's own auth-method gate: placing a synthetic
+OAuth-token-shaped file at that path makes the CLI open it and then fail with
+`unknown auth method:` rather than `not logged in`, meaning the real file
+likely carries, or is paired with a settings field naming, an explicit
+auth-method discriminator — the same kind of requirement HELIX's previous
+Gemini CLI backend needed a synthesized settings sibling to satisfy, before
+it was removed in favor of agy. HELIX's seed
+mechanism only ever copies the credential file opaquely (see `_seed_command`
+in `src/helix/sandbox.py`), so the manifest entry above is safe to ship
+without knowing that discriminator's shape: `AUTH_SYNTHESIZED_SIBLINGS`
+deliberately carries no `agy` entry yet. The first real
+`helix sandbox login agy` run inside the runner image is what will confirm
+the manifest end to end and reveal whether a sibling entry turns out to be
+needed.
 
 The mechanism is common; its manifest is backend-specific.  No backend needs a
 custom agent image merely to receive the credential.  The helper is one generic

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -197,9 +197,41 @@ uses relative paths only.  Initial candidates are:
 | --- | --- | --- |
 | Claude | `.claude/.credentials.json` → `.credentials.json` mounted at `$HOME/.claude` | Ready, subject to real-grant end-to-end test |
 | Codex | `.codex/auth.json` → `auth.json` mounted at `$HOME/.codex` | Ready, subject to real-grant end-to-end test |
-| Cursor | `.cursor/cli-config.json` → `cli-config.json` mounted at `$HOME/.cursor` | Needs credential-shape and live-login verification |
-| Gemini | `.gemini/oauth_creds.json` plus any login-required account record | Needs a measured login-volume manifest; current observed source was not OAuth-backed |
+| Cursor | `.config/cursor/auth.json` → `auth.json` mounted at `$HOME/.config/cursor` | Path and shape read out of the shipped runner image's CLI bundle and confirmed end to end with a synthetic record; not yet confirmed against a real grant |
+| Gemini | `.gemini/oauth_creds.json` → `oauth_creds.json` mounted at `$HOME/.gemini`, plus a synthesized `settings.json` naming the auth method | Auth-method gate confirmed cleared end to end with a synthetic record; not yet confirmed against a real grant |
 | OpenCode | `.local/share/opencode/auth.json` → `auth.json` mounted at its XDG data auth directory | Needs live-login verification of the complete required file set |
+
+Two manifest entries carry evidence worth stating precisely, because the
+Readiness column above claims less than "Ready" for both.
+
+*Cursor keeps its settings and its credential in different directories.* The
+CLI resolves its settings directory as `$CURSOR_CONFIG_DIR`, else
+`$XDG_CONFIG_HOME/cursor`, else `$HOME/.cursor`; `cli-config.json` lives there
+and holds editor, display, permission, and model preferences and no credential
+at all. The credential goes through a separate resolver that on Linux always
+joins `$XDG_CONFIG_HOME` (else `$HOME/.config`) with the application name, so
+with neither variable set the CLI reads and writes exactly
+`$HOME/.config/cursor/auth.json`, at mode 0600, holding an access/refresh token
+pair. A candidate seeded from the settings file reports itself signed out; a
+candidate seeded from the credential path reports itself signed in. Both halves
+of the correction are load-bearing: changing only the source path or only the
+mount destination still reports signed out. That end-to-end check used a
+synthetic record, and the CLI's status command grades a local parse, so it
+establishes that the path is right — not that any grant is valid. It cannot yet
+be raised to a real-grant test on macOS, where the same CLI stores its
+credential in the system keychain rather than in any file.
+
+*Gemini keeps its credential and its settings side by side in one directory.*
+Because the candidate mount replaces that whole directory, the settings file an
+interactive login leaves behind disappears with it, and the CLI refuses before
+it ever looks at the credential: it reports that no auth method is set. HELIX
+therefore writes a minimal settings file into the candidate volume naming the
+method the copied credential was issued under. That file is settings, not a
+secret, so HELIX synthesizes it rather than copying the operator's own — which
+would also drag unrelated operator preferences into every candidate, and would
+fail the seed helper's mode guard, since the CLI writes its settings file
+world-readable and its credential private. With the sibling in place the
+refusal is gone and the CLI proceeds to load the credential from the mount.
 
 The mechanism is common; its manifest is backend-specific.  No backend needs a
 custom agent image merely to receive the credential.  The helper is one generic

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -1,7 +1,6 @@
 # Sandbox auth projection: volume mode source, private state per candidate
 
-**Status:** proposed; implementation requires approval.  This document changes
-no runtime behavior.
+**Status:** accepted.
 
 ## Decision in one paragraph
 
@@ -38,16 +37,13 @@ candidate can mount that volume and it is destroyed at cleanup.
 
 ## Why a shared writable auth directory is retired
 
-The prior rejection of shared-volume agent execution remains correct, even
-though the rejection exception itself will be removed.  A writable auth
-directory cannot be made candidate-independent with a denylist: OAuth rotation
-requires write and rename authority in the credential directory, so an agent
-can create an unenumerated file which a later agent reads.  Resetting a *single*
-shared directory between samples can address sequential residue, but cannot
-address P×N candidates that run at the same time.
+A writable auth directory cannot be made candidate-independent with a denylist:
+OAuth rotation requires write and rename authority in the credential directory,
+so an agent can create an unenumerated file which a later agent reads.
+Resetting a *single* shared directory between samples can address sequential
+residue, but cannot address P×N candidates that run at the same time.
 
-The backend evidence behind that decision is retained here so that a future
-change does not reintroduce a direct shared mount:
+Per-backend constraints under the retired shared-store design:
 
 | Backend | Finding under the retired shared-store design |
 | --- | --- |
@@ -55,7 +51,7 @@ change does not reintroduce a direct shared mount:
 | Gemini | Per-run state lives beside the credential; its available home knob moves the credential too. |
 | Cursor | A config/data split looks plausible but was not verified. Plausible is not an isolation proof. |
 | OpenCode | Its session DB shares the only relocation knob with the credential. |
-| Codex | Agent-memory databases do isolate: across three clean full-layout runs, `CODEX_SQLITE_HOME` left the shared directory untouched and redirected six files. Codex nevertheless fails on `models_cache.json` alone; it must not be described as leaking agent memory. |
+| Codex | Agent-memory databases do isolate: `CODEX_SQLITE_HOME` redirects them and leaves the shared directory untouched. Codex nevertheless fails on `models_cache.json` alone; it must not be described as leaking agent memory. |
 
 `models_cache.json` is carrying state: its presence and version change later
 control flow by skipping or refetching network work.  That result, and the
@@ -65,8 +61,7 @@ mount the login volume in an agent container again.
 ## Credential-transfer options considered
 
 The credential must cross from the login volume to a candidate without making
-the login volume visible to that candidate.  The working image prototype is
-important evidence, not a reason to choose its transport by default.
+the login volume visible to that candidate.
 
 | Option | Secret in agent env / Docker metadata | Agent-image requirement | Runtime-path impact | Rotation and isolation | Verdict |
 | --- | --- | --- | --- | --- | --- |
@@ -76,37 +71,26 @@ important evidence, not a reason to choose its transport by default.
 | (d) Read-only bind of the credential file | No | No | Low only in the happy path | Cannot preserve credential-file rotation; parent-path ownership is also problematic | Reject |
 | (e) Credential baked into a local derived image | No | One local derivative per backend/credential revision | Low at launch; requires local build, image selection, and rotation rebuild lifecycle | **Does satisfy candidate isolation**, but persists the secret in image layers/cache | Reject as default |
 
-### Evidence gathered for this choice
+### Mount-layout constraints behind the verdicts
 
-The stock local Claude runner (`2.1.120`) and Codex runner (`0.125.0`) were
-probed without any real credential, network access, or login volume mount.
-Both lack their target dot-directory in the base image.  A direct file bind
-causes Docker to create the intervening directory as `root:root`; Codex then
-fails at startup with `Error loading configuration: Permission denied`.  The
-same topology gives Claude a root-owned `.claude` parent.  This repeats the
-mount-layout lesson from the working Claude prototype: tests that omit HELIX's
-real nested mounts and ownership topology are not integration evidence.
+Stock backend runner images do not contain their target dot-directory.  A
+direct file bind therefore makes Docker create the intervening directory as
+`root:root`: Codex fails at startup with `Error loading configuration:
+Permission denied`, and Claude gets a root-owned `.claude` parent.  Any
+credential path must create that directory itself with the runner uid/gid.  A
+test that omits HELIX's real nested mounts and ownership topology does not
+exercise this constraint.
 
-A `docker create` followed by `docker cp` of a Claude credential file also
-failed before start because `/home/node/.claude` is absent in the unmodified
-image.  Making (b) work requires a bootstrap container or injected startup
-command, plus materializing the source credential on the host between two
-copies.  When `docker cp` was instead aimed at an already-existing target
-directory, it installed the synthetic file as root-owned `0644`, so (b) also
-needs a privileged ownership/mode repair before a normal `node` agent can
-rotate it.  In contrast, a synthetic source-volume → candidate-volume seed,
-followed by a node-owned private write and atomic rename, completed locally in
-327 ms.  That is a setup measurement, not a claim about OAuth; it is about
-0.4% of a 90-second mutation budget and should be remeasured in the integration
-suite.
+That same absent dot-directory blocks (b): `docker create` → `docker cp` fails
+before start, so (b) additionally needs a bootstrap container or injected
+startup command and must materialize the source credential on the host between
+two copies.  Aimed at an already-existing target directory, `docker cp`
+installs the file root-owned `0644`, so (b) also needs a privileged
+ownership/mode repair before a normal `node` agent can rotate it.
 
-The read-only bind probe cannot establish live OAuth rotation because it used a
-synthetic, unauthenticated record.  It does establish that (d) is not a trivial
-drop-in topology.  More fundamentally, a read-only credential file cannot
-support a successful atomic refresh write, so it cannot meet the desired normal
-CLI semantics even if a particular command tolerates it before expiry.  A
-dedicated-grant test remains required for the exact Claude and Codex refresh
-behavior.
+Option (d) is not a trivial drop-in topology, and more fundamentally a
+read-only credential file cannot support an atomic refresh write, so it cannot
+meet normal CLI semantics even where a command tolerates it before expiry.
 
 ### Option (e): local credential image
 
@@ -115,15 +99,10 @@ would start from the same read-only credential layer and can write only to its
 own container overlay; it receives no shared writable store.  Isolation is not
 the reason to reject it.
 
-Its operational cost is also lower than it may first appear.  Against the
-cached local Claude base, a synthetic 516-byte credential image took 558 ms for
-the first build and 371 ms after changing only the credential `COPY` input.
-Copying that 516-byte file into a stopped container took 35 ms, or 0.039% of a
-90-second mutation.  The complete synthetic candidate-volume seed and private
-atomic-write check took 327 ms, or 0.36% of the same budget.  These are local
-Docker measurements, not portability promises, but they show that avoiding
-candidate-time plumbing saves milliseconds rather than meaningful mutation
-time.
+Latency is not the reason either.  Every candidate-time credential path in this
+table — image rebuild, container copy, volume seed — costs milliseconds against
+a mutation budget measured in tens of seconds, so avoiding candidate-time
+plumbing saves no meaningful mutation time.
 
 The baked design loses on lifecycle and at-rest exposure, not latency:
 
@@ -132,20 +111,19 @@ The baked design loses on lifecycle and at-rest exposure, not latency:
   layer; build cache can retain it even after the visible image tag is removed.
   A candidate volume is credential-bearing only until its narrow cleanup path
   runs, while a tmpfs home dies with its container.
-- An observed access-token rotation requires rebuilding the local derivative
-  and switching future candidates to its new identity.  Access credentials
-  rotated roughly every eight hours in two observations.  If a stale baked
-  record cannot refresh in a fresh candidate, every candidate using that one
-  image fails together.  Whether a candidate can self-refresh remains
-  unmeasured, so this is a real synchronized-risk path rather than a claim that
-  refresh is broken.
+- Access credentials are short-lived, on the order of hours.  Each rotation
+  requires rebuilding the local derivative and switching future candidates to
+  its new identity.  If a stale baked record cannot refresh in a fresh
+  candidate, every candidate using that one image fails together.  Whether a
+  candidate can self-refresh remains unmeasured, so this is a real
+  synchronized-risk path rather than a claim that refresh is broken.
 - Published runner images are registry artifacts pinned by digest.  Baking
   cannot modify those artifacts: it creates a local `FROM <published digest>`
   derivative and requires HELIX to track its base digest, local image id, and
   source-volume revision.  That is a second identity and rotation-update
   lifecycle, rather than the existing one source-of-truth volume.
 
-The 35–327 ms avoided by (e) does not justify adding a long-lived credential
+The milliseconds avoided by (e) do not justify adding a long-lived credential
 layer and an image-rebuild state machine.  Preserve (e) as an operator-managed
 experimental option if needed, but do not make it the default.
 
@@ -219,17 +197,11 @@ for `auth = "volume"` until its manifest is confirmed by an authenticated
 candidate test.  In particular, Cursor's unverified split must not be promoted
 to a claim of readiness merely because a candidate volume would isolate it.
 
-## Earlier image-side experiments
+## Operator-owned image auth is outside the contract
 
-An earlier image experiment authenticated in a private home, removed its
-input from the process environment before agent exec, wrote mode `0600`, and
-failed closed on malformed data. It also exposed the root-owned nested
-transcript-parent failure that this design avoids with a uid/gid-correct tmpfs
-HOME and pre-created nested mount path. Its nine-hour, 37-generation run is
-useful evidence for the livebench write-up.
-
-It is not a HELIX auth mechanism. HELIX has exactly two paths: `auth =
-"volume"` and `auth = "env"`. HELIX contains no projection-variable name,
+An image that carries its own credential is not a HELIX auth mechanism. HELIX
+has exactly two paths: `auth = "volume"` and `auth = "env"`.
+HELIX contains no projection-variable name,
 encoding, decoding, runner-image selection, or compatibility branch. An
 operator-owned image may independently interpret an allowlisted environment
 value under `auth = "env"`; that image behavior is outside HELIX's contract.
@@ -257,9 +229,8 @@ auth_env_allow = []
 
 This retains `auth_env_allow` because it is the actual final scrub allowlist
 for named values.  It does not use that key as hidden plumbing for volume
-credentials.  The validation/documentation change should stay roughly 30–50
-lines; backend manifests and runtime cleanup are implementation details, not
-new user knobs.
+credentials.  Backend manifests and runtime cleanup are implementation details,
+not new user knobs.
 
 ## Deletions and documentation to retain
 
@@ -276,25 +247,22 @@ HELIX must not forbid or otherwise manipulate a variable it does not set.  The
 existing warning for both credential forms being present remains the right
 diagnostic for an ambiguous explicit-env configuration.
 
-The history in [Why a shared writable auth directory is retired](#why-a-shared-writable-auth-directory-is-retired)
-stays as product documentation.  Delete the retirement code, not the reason
-for structural isolation.
+Delete the retirement code, not the reason for structural isolation recorded in
+[Why a shared writable auth directory is retired](#why-a-shared-writable-auth-directory-is-retired).
 
 ## Rotation and its open question
 
 The candidate auth volume is writable, so a backend can attempt its normal
 in-container OAuth refresh and atomic rename.  Any refreshed credential stays
 only in that candidate volume and dies when the volume is removed; it is never
-written back to the login volume. The earlier image experiment observed the
-same candidate-local rotation boundary during a nine-hour, 37-generation run.
+written back to the login volume.
 
-Whether in-container OAuth refresh works at all is **unmeasured**.  Two prior
-attempts were void: the supervising process shared the grant and its own API
-activity revoked the grant under observation.  They do not show refresh working
-or broken.  Resolving the question requires a dedicated grant whose observer
-does not use it.
+Whether in-container OAuth refresh works at all is **unmeasured**.  Measuring
+it requires a dedicated grant whose observer does not use it: an observer that
+shares the grant revokes it through its own API activity, which yields no
+signal either way.
 
-## Verification plan
+## Verification requirements
 
 Unit and integration tests must make the structural boundary observable on the
 final Docker argv and live Docker objects, not merely on a helper function.
@@ -321,7 +289,7 @@ final Docker argv and live Docker objects, not merely on a helper function.
    deletion path, and makes manual cleanup actionable.
 7. **Real mount topology.** Run the Claude test with tmpfs `HOME`, the nested
    transcript bind, workspace bind, and runner user.  This guards against the
-   root-owned intervening-directory failure found by the proven runner.
+   root-owned intervening-directory failure.
 8. **Dedicated-grant rotation test.** For Claude and Codex, start a candidate
    after its access token expires while retaining a valid refresh token, then
    distinguish authenticated refresh from a revoked-grant failure.  Confirm no

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -1,4 +1,4 @@
-# Sandbox auth projection: login volume as source, private state per candidate
+# Sandbox auth projection: volume mode source, private state per candidate
 
 **Status:** proposed; implementation requires approval.  This document changes
 no runtime behavior.
@@ -8,7 +8,7 @@ no runtime behavior.
 Keep `helix sandbox login <backend>` and the backend-specific
 `helix-auth-<backend>` volume.  They remain the operator-facing login store and
 the source of truth.  A mutation agent must never mount that shared volume.
-For `sandbox.auth = "login"`, HELIX will make a new, random,
+For `sandbox.auth = "volume"`, HELIX will make a new, random,
 candidate-owned Docker volume; a short-lived seeding helper copies an allowlist
 of credential files from the login volume into it; and the agent mounts only
 that candidate volume inside an otherwise private tmpfs `HOME`.  The candidate
@@ -29,6 +29,10 @@ candidate can mount that volume and it is destroyed at cleanup.
   not write it, and the seeding helper mounts it read-only.
 - This design is about agent authentication.  Evaluators and credentialed
   sidecars retain their existing, separately scoped configuration.
+- `evaluator.sidecar.passthrough_env` is the explicit allowlist for host values
+  needed by the private scoring service. Its names must be disjoint from
+  `sandbox.auth_env_allow`, so a sidecar credential cannot become an
+  agent credential.
 - It is not a mechanism for returning a refreshed credential to the login
   volume.  That limitation is stated in [Rotation](#rotation-and-its-open-question).
 
@@ -166,7 +170,7 @@ entrypoint, and persistent credential image.
 
 ## Recommended mechanism: per-candidate credential-only volume
 
-For each sandboxed agent candidate using `auth = "login"`:
+For each sandboxed agent candidate using `auth = "volume"`:
 
 1. HELIX creates a random, labelled Docker volume owned by that candidate.
    The name and labels contain run/candidate identity and backend, never a
@@ -211,7 +215,7 @@ The mechanism is common; its manifest is backend-specific.  No backend needs a
 custom agent image merely to receive the credential.  The helper is one generic
 HELIX utility action, not five entrypoints; it must be pinned and tested like
 other runtime tooling.  A backend is not enabled
-for `auth = "login"` until its manifest is confirmed by an authenticated
+for `auth = "volume"` until its manifest is confirmed by an authenticated
 candidate test.  In particular, Cursor's unverified split must not be promoted
 to a claim of readiness merely because a candidate volume would isolate it.
 
@@ -225,7 +229,7 @@ HOME and pre-created nested mount path. Its nine-hour, 37-generation run is
 useful evidence for the livebench write-up.
 
 It is not a HELIX auth mechanism. HELIX has exactly two paths: `auth =
-"login"` and `auth = "env"`. HELIX contains no projection-variable name,
+"volume"` and `auth = "env"`. HELIX contains no projection-variable name,
 encoding, decoding, runner-image selection, or compatibility branch. An
 operator-owned image may independently interpret an allowlisted environment
 value under `auth = "env"`; that image behavior is outside HELIX's contract.
@@ -238,11 +242,11 @@ mechanism.  The production surface stays small:
 ```toml
 [sandbox]
 enabled = true
-auth = "login"  # "login" (from helix-auth-<backend>) or "env" (explicit host value)
+auth = "volume"  # "volume" (from helix-auth-<backend>) or "env" (explicit host value)
 auth_env_allow = []
 ```
 
-- `auth = "login"` selects the candidate-volume projection described here.
+- `auth = "volume"` selects the candidate-volume projection described here.
   `auth_env_allow` must be empty: no credential transport variable is needed.
 - `auth = "env"` means an explicit host environment value is the credential
   source; `auth_env_allow` remains the non-empty scrub allowlist of names that
@@ -252,7 +256,7 @@ auth_env_allow = []
   choice into a second configuration language.
 
 This retains `auth_env_allow` because it is the actual final scrub allowlist
-for named values.  It does not use that key as hidden plumbing for login
+for named values.  It does not use that key as hidden plumbing for volume
 credentials.  The validation/documentation change should stay roughly 30–50
 lines; backend manifests and runtime cleanup are implementation details, not
 new user knobs.
@@ -295,7 +299,7 @@ does not use it.
 Unit and integration tests must make the structural boundary observable on the
 final Docker argv and live Docker objects, not merely on a helper function.
 
-1. **No shared source mount.** For every login-enabled backend, assert the
+1. **No shared source mount.** For every volume-enabled backend, assert the
    final agent argv and `docker inspect` contain no `helix-auth-<backend>`
    mount.  The seeding helper may contain that name only as a read-only source;
    it must not be the agent container.
@@ -324,26 +328,9 @@ final Docker argv and live Docker objects, not merely on a helper function.
    changed record reaches the source volume.  Do not run the observer against
    the same grant.
 
-## Migration and errors
-
-`sandbox.auth = "volume"` is invalid after this change because it describes
-the retired mount mechanism, not a source.  Config loading should fail before
-Docker is invoked with:
-
-```
-sandbox.auth = "volume" has been replaced by "login".
-  auth = "login" reads the credential from helix-auth-<backend> at candidate
-  start, copies only the credential into a private candidate store, and never
-  mounts the shared login volume in an agent container.
-  Set sandbox.auth = "login"; do not use environment credential transport.
-```
-
-Existing `auth = "env"` configurations continue to mean explicit named host
-values and continue to require a non-empty `auth_env_allow`.  Configurations
-that set `auth_env_allow` with `auth = "login"` fail with an error explaining
-that login copying has no environment transport. `auth = "env"` remains the
-separate, explicit API-key mechanism and is gated by `auth_env_allow`.
-
-This makes the ordinary login-volume workflow structural and image-neutral. It
-also introduces the small `sandbox.auth` and `auth_env_allow` configuration
-contract needed for an explicit choice of credential source.
+The value `auth = "volume"` names the credential source, not the old shared
+mount behavior. It still selects the projection above: HELIX copies the
+allowlisted credential files from the operator login volume into a fresh,
+per-candidate volume, and never mounts `helix-auth-<backend>` in an agent
+container. `auth = "env"` remains the separate explicit API-key mechanism and
+requires a non-empty `auth_env_allow`.

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -35,28 +35,43 @@ candidate can mount that volume and it is destroyed at cleanup.
 - It is not a mechanism for returning a refreshed credential to the login
   volume.  That limitation is stated in [Rotation](#rotation-and-its-open-question).
 
-## Why a shared writable auth directory is retired
+## Why the agent auth store must be per-candidate
 
-A writable auth directory cannot be made candidate-independent with a denylist:
-OAuth rotation requires write and rename authority in the credential directory,
-so an agent can create an unenumerated file which a later agent reads.
-Resetting a *single* shared directory between samples can address sequential
-residue, but cannot address P×N candidates that run at the same time.
+This is the constraint the rest of the document follows from.
 
-Per-backend constraints under the retired shared-store design:
+An auth directory shared by more than one candidate cannot be made
+candidate-independent by enumerating what to clear between candidates.  OAuth
+rotation needs write and rename authority in the credential directory, so a
+candidate can leave behind a file the clearing list does not know about, and
+the next candidate to mount that directory reads it.  Clearing a *single*
+shared directory between samples addresses sequential residue at best; it
+cannot address P×N candidates that run at the same time.
 
-| Backend | Finding under the retired shared-store design |
+Mounting one shared login volume into every agent container is removed as of
+this document, not merely discouraged.  Anyone running a configuration where
+agent containers still mount `helix-auth-<backend>` should move to the
+per-candidate mechanism below.
+
+Keeping a shared store and relocating the per-run state away from the
+credential was investigated as the alternative.  It does not survive contact
+with any of the five backends: either the knob that moves the state moves the
+credential with it, or the split was never demonstrated.
+
+| Backend | Can the credential be split from the state written beside it? |
 | --- | --- |
-| Claude | Per-run state lives beside the credential; it cannot be relocated as a split store. |
-| Gemini | Per-run state lives beside the credential; its available home knob moves the credential too. |
-| Cursor | A config/data split looks plausible but was not verified. Plausible is not an isolation proof. |
-| OpenCode | Its session DB shares the only relocation knob with the credential. |
-| Codex | Agent-memory databases do isolate: `CODEX_SQLITE_HOME` redirects them and leaves the shared directory untouched. Codex nevertheless fails on `models_cache.json` alone; it must not be described as leaking agent memory. |
+| Claude | No knob found that moves the per-run state without also moving the credential. |
+| Gemini | Same: the home knob available to us moves the credential too. |
+| Cursor | A config/data split looks plausible, but we did not demonstrate one. |
+| OpenCode | The relocation knob we found moves the session database and the credential together. |
+| Codex | Closest: its agent-memory databases *can* be redirected out of the shared directory.  `models_cache.json` is still written there, which is enough to defeat the split. |
 
-`models_cache.json` is carrying state: its presence and version change later
-control flow by skipping or refetching network work.  That result, and the
-structural writable-directory argument above, are sufficient reasons never to
-mount the login volume in an agent container again.
+State the Codex row precisely, because it is easy to repeat as something
+sharper than it is.  `models_cache.json` is a cache — not agent memory, not a
+credential.  It counts here only because it carries state whose presence and
+version change later control flow by skipping or refetching network work, and
+because it lands in the directory the split was supposed to leave empty.  That,
+plus the structural argument above, is why no agent container mounts the login
+volume.
 
 ## Credential-transfer options considered
 
@@ -65,7 +80,7 @@ the login volume visible to that candidate.
 
 | Option | Secret in agent env / Docker metadata | Agent-image requirement | Runtime-path impact | Rotation and isolation | Verdict |
 | --- | --- | --- | --- | --- | --- |
-| (a) Base64 environment variable plus entrypoint | Yes: visible in `docker inspect`, PID 1 environment, and process listings until the entrypoint unsets it | Yes, per backend | Small | Per-candidate tmpfs gives good isolation; refreshed state dies with the container | Not a HELIX mechanism. An operator may arrange this inside their own image over an allowlisted `auth = "env"` variable; HELIX does not encode, name, decode, select, or document that arrangement as a path. |
+| (a) Base64 environment variable plus entrypoint | Yes: visible in `docker inspect`, PID 1 environment, and process listings until the entrypoint unsets it | Yes, per backend | Small | Per-candidate tmpfs gives good isolation; refreshed state dies with the container | Not a HELIX mechanism; see [Operator-owned image auth is outside the contract](#operator-owned-image-auth-is-outside-the-contract). |
 | (b) `docker create` → `docker cp` → `docker start` | No | No | High: replaces one `docker run` with create/copy/start, including stdin, output capture, timeout, and cleanup paths | Can isolate, but needs a helper/source copy and a short-lived host file | Do not choose |
 | (c) Candidate auth volume seeded from login volume | No secret in env or container metadata | No per-backend runner image | Moderate, localized to agent launch and cleanup | Writable private auth store; no shared mount; rotation is candidate-local | **Recommended** |
 | (d) Read-only bind of the credential file | No | No | Low only in the happy path | Cannot preserve credential-file rotation; parent-path ownership is also problematic | Reject |
@@ -94,17 +109,14 @@ meet normal CLI semantics even where a command tolerates it before expiry.
 
 ### Option (e): local credential image
 
-This option genuinely satisfies the isolation requirement.  Every candidate
-would start from the same read-only credential layer and can write only to its
-own container overlay; it receives no shared writable store.  Isolation is not
-the reason to reject it.
+Option (e) satisfies the isolation requirement: every candidate starts from the
+same read-only credential layer and can write only to its own container
+overlay, so it receives no shared writable store.  Nor is it slower — every
+candidate-time credential path in this table (image rebuild, container copy,
+volume seed) costs milliseconds against a mutation budget measured in tens of
+seconds.
 
-Latency is not the reason either.  Every candidate-time credential path in this
-table — image rebuild, container copy, volume seed — costs milliseconds against
-a mutation budget measured in tens of seconds, so avoiding candidate-time
-plumbing saves no meaningful mutation time.
-
-The baked design loses on lifecycle and at-rest exposure, not latency:
+It is rejected as the default on lifecycle and at-rest exposure:
 
 - The credential is recoverable from a local image layer by exporting or
   extracting layers.  `docker history` identifies the credential-bearing
@@ -136,7 +148,7 @@ current default:
 | --- | --- |
 | Per-user local derived image | This is option (e): no candidate-time copy, but local secret layers, cache retention, and a rotation/image-identity lifecycle. |
 | Long-lived credential sidecar | No supported common CLI protocol lets Claude, Codex, Cursor, Gemini, and OpenCode delegate their local credential lookup to a broker.  A new HTTPS/token proxy would be backend-specific, network-visible, and itself a long-lived shared stateful service.  It is a new auth product, not a smaller projection mechanism. |
-| Each candidate logs itself in | Not viable for interactive OAuth.  The installed Claude login help offers subscription/console, email, and SSO choices but no headless token input.  Codex offers `--device-auth` (user-mediated) and `--with-api-key` (a distinct explicit API-key path).  Cursor exposes `NO_OPEN_BROWSER`, which suppresses browser opening rather than supplying a credential.  Gemini's `-p` is headless prompting, not login; HELIX's login command remains interactive.  OpenCode exposes provider management but no verified generic non-interactive OAuth import. |
+| Each candidate logs itself in | Not viable for interactive OAuth.  At the CLI versions pinned by HELIX's runner images, Claude's login help offered subscription/console, email, and SSO choices but no headless token input; Codex offered `--device-auth` (user-mediated) and `--with-api-key` (a distinct explicit API-key path); Cursor's `NO_OPEN_BROWSER` suppresses browser opening rather than supplying a credential; Gemini's `-p` is headless prompting, not login; and OpenCode exposes provider management, but we found no generic non-interactive OAuth import.  Re-check against a current CLI before relying on this row. |
 
 The one non-interactive path found is Codex `--with-api-key`; it is an explicit
 environment/API-key workflow and remains covered by `auth = "env"`.  It does
@@ -191,11 +203,12 @@ uses relative paths only.  Initial candidates are:
 
 The mechanism is common; its manifest is backend-specific.  No backend needs a
 custom agent image merely to receive the credential.  The helper is one generic
-HELIX utility action, not five entrypoints; it must be pinned and tested like
-other runtime tooling.  A backend is not enabled
-for `auth = "volume"` until its manifest is confirmed by an authenticated
-candidate test.  In particular, Cursor's unverified split must not be promoted
-to a claim of readiness merely because a candidate volume would isolate it.
+HELIX utility action, not five entrypoints; it runs in the backend's own runner
+image, and must be pinned and tested like other runtime tooling.  A backend is
+not enabled for `auth = "volume"` until its manifest is confirmed by an
+authenticated candidate test.  Candidate-volume isolation is not itself
+evidence that a manifest is correct: a backend whose Readiness column above is
+not `Ready` still needs that test, however well the volume would isolate it.
 
 ## Operator-owned image auth is outside the contract
 
@@ -237,23 +250,18 @@ for named values already declared in `[env]`/`passthrough_env`.  It does not
 use that key as hidden plumbing for volume credentials.  Backend manifests and
 runtime cleanup are implementation details, not new user knobs.
 
-## Deletions and documentation to retain
+## What HELIX does not do to the agent environment
 
-The implementation removes:
+HELIX must not forbid, rename, or otherwise manipulate an environment variable
+it does not itself set.  There is accordingly no denylist of credential
+variable names and no per-variable policy branch: a name reaches the agent
+because the configuration named it, or it does not reach the agent at all.
+Warning when two credential forms are configured at once remains the right
+diagnostic for an ambiguous explicit-env configuration; refusing the run is
+not.
 
-- `VolumeModeUnsupportedError` and its long retired-mode remediation text;
-- the agent-execution paths that mount `helix-auth-<backend>`, including any
-  post-run transcript copy that remounts it;
-- `OAUTH_SUPPRESSING_ENV`;
-- `FORBIDDEN_AUTH_ENV_NAMES` and every policy branch that specially handles
-  `CLAUDE_CODE_OAUTH_TOKEN`.
-
-HELIX must not forbid or otherwise manipulate a variable it does not set.  The
-existing warning for both credential forms being present remains the right
-diagnostic for an ambiguous explicit-env configuration.
-
-Delete the retirement code, not the reason for structural isolation recorded in
-[Why a shared writable auth directory is retired](#why-a-shared-writable-auth-directory-is-retired).
+No agent-execution path mounts `helix-auth-<backend>` — including the post-run
+transcript path, which uses a per-candidate bind instead.
 
 ## Rotation and its open question
 
@@ -301,9 +309,8 @@ final Docker argv and live Docker objects, not merely on a helper function.
    changed record reaches the source volume.  Do not run the observer against
    the same grant.
 
-The value `auth = "volume"` names the credential source, not the old shared
-mount behavior. It still selects the projection above: HELIX copies the
-allowlisted credential files from the operator login volume into a fresh,
-per-candidate volume, and never mounts `helix-auth-<backend>` in an agent
-container. `auth = "env"` remains the separate explicit API-key mechanism and
-requires a non-empty `auth_env_allow`.
+`auth = "volume"` names the credential *source*: HELIX copies the allowlisted
+credential files from the operator login volume into a fresh per-candidate
+volume, and never mounts `helix-auth-<backend>` in an agent container.
+`auth = "env"` is the separate explicit API-key mechanism and requires a
+non-empty `auth_env_allow`.  There is no third mode.

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -234,21 +234,29 @@ auth_env_allow = []
 - `auth = "volume"` selects the candidate-volume projection described here.
   `auth_env_allow` must be empty: no credential transport variable is needed.
 - `auth = "env"` means an explicit `[env]`/`passthrough_env` value is the
-  credential source; `auth_env_allow` is a non-empty, explicitly configured
-  *additional* gate, not an allowlist that by itself grants passage.  A name
-  in `auth_env_allow` only widens what a value already declared in `[env]` or
-  `passthrough_env` is allowed to resolve to -- from a literal `[env]` value
-  to the matching ambient host variable when `[env]` gives it no literal
-  value.  A name present in `auth_env_allow` alone, undeclared in `[env]` /
-  `passthrough_env`, never reaches the agent.
+  credential source; `auth_env_allow` must be non-empty, and its names must
+  overlap with the union of `[env]` and `passthrough_env` (enforced by
+  `SandboxConfig.model_post_init`). Beyond that check, and the
+  `HelixConfig` disjointness check against
+  `evaluator.sidecar.passthrough_env` described above, `auth_env_allow` is
+  not consulted at runtime. It does not gate which `[env]`/`passthrough_env`
+  values reach the agent -- that transport already runs, in both auth modes,
+  through the same scrubbing HELIX applies everywhere else. Whether a name
+  reaches the agent is decided entirely by `[env]` and `passthrough_env`.
+  `auth_env_allow` is a declaration: it records, in one place, which
+  credential name(s) an `auth = "env"` configuration is expected to supply,
+  so a reader (and the two validators above) can check that declaration
+  against the rest of the config. It grants nothing by itself.
 - No `auth_projection_*`, file path, volume name, or backend-specific
   transport key is exposed in configuration.  Those would make a small source
   choice into a second configuration language.
 
-This retains `auth_env_allow` because it is the actual credential-widening gate
-for named values already declared in `[env]`/`passthrough_env`.  It does not
-use that key as hidden plumbing for volume credentials.  Backend manifests and
-runtime cleanup are implementation details, not new user knobs.
+This keeps `auth_env_allow` as a declared, validated statement of intent, not
+as a second, parallel transport gate.  Making it an actual runtime filter
+would mean `auth = "env"` resolves `[env]`/`passthrough_env` differently from
+every other HELIX code path -- exactly the second configuration language the
+previous paragraph rules out.  Backend manifests and runtime cleanup are
+implementation details, not new user knobs.
 
 ## What HELIX does not do to the agent environment
 

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -195,54 +195,81 @@ uses relative paths only.  Initial candidates are:
 
 | Backend | Login-volume source → candidate auth-volume destination | Readiness |
 | --- | --- | --- |
-| Claude | `.claude/.credentials.json` → `.credentials.json` mounted at `$HOME/.claude` | Ready, subject to real-grant end-to-end test |
-| Codex | `.codex/auth.json` → `auth.json` mounted at `$HOME/.codex` | Ready, subject to real-grant end-to-end test |
-| Cursor | `.config/cursor/auth.json` → `auth.json` mounted at `$HOME/.config/cursor` | Path and shape read out of the shipped runner image's CLI bundle and confirmed end to end with a synthetic record; not yet confirmed against a real grant |
-| Agy | `.gemini/antigravity-cli/antigravity-oauth-token` → `antigravity-oauth-token` mounted at `$HOME/.gemini/antigravity-cli` | Derived, not yet confirmed against a real grant: the path was traced with `strace` against a real, unauthenticated Linux binary, which is stronger evidence than the other rows' CLI-bundle reads, but no authenticated seed has been attempted. A synthetic file at that path also does not clear the CLI's auth-method gate the way the other rows' synthetic records do (see below) |
-| OpenCode | `.local/share/opencode/auth.json` → `auth.json` mounted at its XDG data auth directory | Needs live-login verification of the complete required file set |
+| Claude | `.claude/.credentials.json` → `.credentials.json` mounted at `$HOME/.claude` | Verified end to end against a real grant: seeded from the real login volume through HELIX's own candidate-volume path, `claude auth status --text` exited 0 inside the candidate and reported `Login method: Claude Max account`. |
+| Codex | `.codex/auth.json` → `auth.json` mounted at `$HOME/.codex` | Verified end to end against a real grant: `codex login status` exited 0 inside the candidate and reported `Logged in using ChatGPT`. |
+| Cursor | `.config/cursor/auth.json` → `auth.json` mounted at `$HOME/.config/cursor` | Verified end to end against a real grant: `cursor-agent status` exited 0 inside the candidate and reported a signed-in confirmation naming the authenticated account. |
+| Agy | `.gemini/antigravity-cli/antigravity-oauth-token` → `antigravity-oauth-token` mounted at `$HOME/.gemini/antigravity-cli` | Derived, not yet confirmed against a real grant: the path was traced with `strace` against a real, unauthenticated Linux binary. Agy's login volume holds no credential yet, so there has been nothing to seed a candidate from or probe, and the credential file's JSON shape remains unknown. |
+| OpenCode | `.local/share/opencode/auth.json` → `auth.json` mounted at its XDG data auth directory | Verified end to end against a real grant: `auth list` exited 0 inside the candidate and reported `1 credentials`. |
 
-Two manifest entries carry evidence worth stating precisely, because the
-Readiness column above claims less than "Ready" for both.
+Four of the five manifest entries are now confirmed end to end against a real
+grant, not a synthetic record.  The fifth, Agy, is not, and the difference is
+worth recording precisely rather than folded into one word.
 
-*Cursor keeps its settings and its credential in different directories,* which
-is why its row names `.config/cursor/auth.json` rather than the settings file
-in the settings directory.  The two resolvers are recorded beside the entry
-they explain, in `AUTH_CREDENTIAL_MANIFEST` in `src/helix/sandbox.py`.  A
-candidate seeded from the settings file reports itself signed out; a candidate
-seeded from the credential path reports itself signed in. Both halves of the
-correction are load-bearing: changing only the source path or only the mount
-destination still reports signed out. That end-to-end check used a
-synthetic record, and the CLI's status command grades a local parse, so it
-establishes that the path is right — not that any grant is valid. It cannot yet
-be raised to a real-grant test on macOS, where the same CLI stores its
-credential in the system keychain rather than in any file.
+**Claude, Codex, Cursor, and OpenCode were each probed through HELIX's own
+candidate-volume path** — `run_sandboxed_command(..., scope="agent",
+auth="volume")` → `_create_candidate_auth_volume` → `_seed_candidate_auth_volume`
+→ the agent's own Docker argv → cleanup — seeded from that backend's real,
+already-authenticated login volume, and checked from inside the candidate
+container with the backend's own free, no-spend status command (the four
+status lines quoted in the table above). None of the four spends a token,
+starts a generation, or calls a model; each is a local, read-only status
+check. The build host used for this check has no arm64 runner image yet, so
+all four containers ran under Docker's amd64-on-arm64 emulation. All four
+still passed, which means the emulation did not manufacture a false result —
+and HELIX's CI already builds and runs these images as amd64, so the
+confirmed path is the one that ships.
+
+*Cursor keeps its settings and its credential in different directories,*
+which is why its row names `.config/cursor/auth.json` rather than the
+settings file in the settings directory.  The two resolvers are recorded
+beside the entry they explain, in `AUTH_CREDENTIAL_MANIFEST` in
+`src/helix/sandbox.py`.  A candidate seeded from the settings file reports
+itself signed out; a candidate seeded from the credential path reports itself
+signed in.  Both halves of the correction are load-bearing: changing only the
+source path or only the mount destination still reports signed out.  The
+real-grant check above confirms this reading holds for an authenticated
+account, not only for the synthetic record this row was first checked
+against.
 
 *Agy's manifest entry is derived, not yet confirmed against a real grant.*
-The credential path was obtained by `strace`-ing a real, unauthenticated Linux
-build of the CLI — the same rigor class as Cursor's row above. What it does
-not yet do is clear the CLI's own auth-method gate: placing a synthetic
-OAuth-token-shaped file at that path makes the CLI open it and then fail with
-`unknown auth method:` rather than `not logged in`, meaning the real file
-likely carries, or is paired with a settings field naming, an explicit
-auth-method discriminator — the same kind of requirement HELIX's previous
-Gemini CLI backend needed a synthesized settings sibling to satisfy, before
-it was removed in favor of agy. HELIX's seed
-mechanism only ever copies the credential file opaquely (see `_seed_command`
-in `src/helix/sandbox.py`), so the manifest entry above is safe to ship
-without knowing that discriminator's shape: `AUTH_SYNTHESIZED_SIBLINGS`
-deliberately carries no `agy` entry yet. The first real
-`helix sandbox login agy` run inside the runner image is what will confirm
-the manifest end to end and reveal whether a sibling entry turns out to be
-needed.
+The credential path was obtained by `strace`-ing a real, unauthenticated
+Linux build of the CLI — the same technique that first established Cursor's
+credential path, before Cursor's row above was raised to a real-grant
+confirmation. There is no credential in Agy's login volume yet, so no
+candidate has been seeded and no status command has been run against one.
+Separately, a synthetic OAuth-token-shaped file placed at that path makes the
+CLI open it and then fail with `unknown auth method:` rather than
+`not logged in`, meaning the real file likely carries, or is paired with a
+settings field naming, an explicit auth-method discriminator — the kind of
+requirement `AUTH_SYNTHESIZED_SIBLINGS` exists to hold entries for; a prior
+backend HELIX no longer ships once needed exactly such an entry, which is why
+the dict exists at all. HELIX's seed mechanism only ever copies the
+credential file opaquely (see `_seed_command` in `src/helix/sandbox.py`), so
+the manifest entry above is safe to ship without knowing that discriminator's
+shape: `AUTH_SYNTHESIZED_SIBLINGS` deliberately carries no `agy` entry yet. A
+real `helix sandbox login agy` run, once there is a credential to seed from,
+is what will confirm the manifest end to end and reveal whether a sibling
+entry turns out to be needed.
 
 The mechanism is common; its manifest is backend-specific.  No backend needs a
 custom agent image merely to receive the credential.  The helper is one generic
 HELIX utility action, not five entrypoints; it runs in the backend's own runner
-image, and must be pinned and tested like other runtime tooling.  A backend is
-not enabled for `auth = "volume"` until its manifest is confirmed by an
-authenticated candidate test.  Candidate-volume isolation is not itself
-evidence that a manifest is correct: a backend whose Readiness column above is
-not `Ready` still needs that test, however well the volume would isolate it.
+image, and must be pinned and tested like other runtime tooling.  Nothing in
+`src/helix/` gates which backends may use `auth = "volume"` on whether their
+manifest is confirmed — every backend in the manifest is enabled today, Agy
+included.  "Verified end to end against a real grant" above is this project's own
+publication standard for what it has actually checked, not a runtime switch:
+Agy is published, and enabled, ahead of that bar because its path evidence is
+real even though its credential shape is not, and because there is not yet a
+credential to run that check against. What an operator experiences when a
+backend's login volume is missing or unusable is not silence and not a
+code-level refusal to run that backend at all: the seed step fails closed
+before any agent container starts, with a message naming the specific
+cause — an empty login volume, an unsafe credential file, or one that fails
+to parse — and pointing at `helix sandbox login <backend>`.  Candidate-volume
+isolation is not itself evidence that a manifest is correct: a backend whose
+credential path is not yet confirmed against a real grant still needs that
+confirmation, however well the volume would isolate it.
 
 ## Operator-owned image auth is outside the contract
 

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -220,17 +220,22 @@ auth_env_allow = []
 
 - `auth = "volume"` selects the candidate-volume projection described here.
   `auth_env_allow` must be empty: no credential transport variable is needed.
-- `auth = "env"` means an explicit host environment value is the credential
-  source; `auth_env_allow` remains the non-empty scrub allowlist of names that
-  may reach the agent.  It is not inferred from backend or host state.
+- `auth = "env"` means an explicit `[env]`/`passthrough_env` value is the
+  credential source; `auth_env_allow` is a non-empty, explicitly configured
+  *additional* gate, not an allowlist that by itself grants passage.  A name
+  in `auth_env_allow` only widens what a value already declared in `[env]` or
+  `passthrough_env` is allowed to resolve to -- from a literal `[env]` value
+  to the matching ambient host variable when `[env]` gives it no literal
+  value.  A name present in `auth_env_allow` alone, undeclared in `[env]` /
+  `passthrough_env`, never reaches the agent.
 - No `auth_projection_*`, file path, volume name, or backend-specific
   transport key is exposed in configuration.  Those would make a small source
   choice into a second configuration language.
 
-This retains `auth_env_allow` because it is the actual final scrub allowlist
-for named values.  It does not use that key as hidden plumbing for volume
-credentials.  Backend manifests and runtime cleanup are implementation details,
-not new user knobs.
+This retains `auth_env_allow` because it is the actual credential-widening gate
+for named values already declared in `[env]`/`passthrough_env`.  It does not
+use that key as hidden plumbing for volume credentials.  Backend manifests and
+runtime cleanup are implementation details, not new user knobs.
 
 ## Deletions and documentation to retain
 

--- a/docs/design/sandbox-auth-projection.md
+++ b/docs/design/sandbox-auth-projection.md
@@ -1,0 +1,349 @@
+# Sandbox auth projection: login volume as source, private state per candidate
+
+**Status:** proposed; implementation requires approval.  This document changes
+no runtime behavior.
+
+## Decision in one paragraph
+
+Keep `helix sandbox login <backend>` and the backend-specific
+`helix-auth-<backend>` volume.  They remain the operator-facing login store and
+the source of truth.  A mutation agent must never mount that shared volume.
+For `sandbox.auth = "login"`, HELIX will make a new, random,
+candidate-owned Docker volume; a short-lived seeding helper copies an allowlist
+of credential files from the login volume into it; and the agent mounts only
+that candidate volume inside an otherwise private tmpfs `HOME`.  The candidate
+volume starts with credentials only and is removed after the candidate.  Thus
+both sequential and concurrent candidates have disjoint writable auth state.
+
+This is an allowlist, not a denylist: the initial candidate auth store is
+constructed from the credential manifest alone.  An agent can create arbitrary
+files beside its credential, including rotated credentials, but no other
+candidate can mount that volume and it is destroyed at cleanup.
+
+## Scope and non-goals
+
+- Login, status, and logout continue to mount `helix-auth-<backend>` exactly as
+  they do today.  The guarantee is **no agent container** mounts it, not that
+  HELIX never mounts it.
+- The login volume remains writable to its login command.  Agent containers do
+  not write it, and the seeding helper mounts it read-only.
+- This design is about agent authentication.  Evaluators and credentialed
+  sidecars retain their existing, separately scoped configuration.
+- It is not a mechanism for returning a refreshed credential to the login
+  volume.  That limitation is stated in [Rotation](#rotation-and-its-open-question).
+
+## Why a shared writable auth directory is retired
+
+The prior rejection of shared-volume agent execution remains correct, even
+though the rejection exception itself will be removed.  A writable auth
+directory cannot be made candidate-independent with a denylist: OAuth rotation
+requires write and rename authority in the credential directory, so an agent
+can create an unenumerated file which a later agent reads.  Resetting a *single*
+shared directory between samples can address sequential residue, but cannot
+address P×N candidates that run at the same time.
+
+The backend evidence behind that decision is retained here so that a future
+change does not reintroduce a direct shared mount:
+
+| Backend | Finding under the retired shared-store design |
+| --- | --- |
+| Claude | Per-run state lives beside the credential; it cannot be relocated as a split store. |
+| Gemini | Per-run state lives beside the credential; its available home knob moves the credential too. |
+| Cursor | A config/data split looks plausible but was not verified. Plausible is not an isolation proof. |
+| OpenCode | Its session DB shares the only relocation knob with the credential. |
+| Codex | Agent-memory databases do isolate: across three clean full-layout runs, `CODEX_SQLITE_HOME` left the shared directory untouched and redirected six files. Codex nevertheless fails on `models_cache.json` alone; it must not be described as leaking agent memory. |
+
+`models_cache.json` is carrying state: its presence and version change later
+control flow by skipping or refetching network work.  That result, and the
+structural writable-directory argument above, are sufficient reasons never to
+mount the login volume in an agent container again.
+
+## Credential-transfer options considered
+
+The credential must cross from the login volume to a candidate without making
+the login volume visible to that candidate.  The working image prototype is
+important evidence, not a reason to choose its transport by default.
+
+| Option | Secret in agent env / Docker metadata | Agent-image requirement | Runtime-path impact | Rotation and isolation | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| (a) Base64 environment variable plus entrypoint | Yes: visible in `docker inspect`, PID 1 environment, and process listings until the entrypoint unsets it | Yes, per backend | Small | Per-candidate tmpfs gives good isolation; refreshed state dies with the container | Not a HELIX mechanism. An operator may arrange this inside their own image over an allowlisted `auth = "env"` variable; HELIX does not encode, name, decode, select, or document that arrangement as a path. |
+| (b) `docker create` → `docker cp` → `docker start` | No | No | High: replaces one `docker run` with create/copy/start, including stdin, output capture, timeout, and cleanup paths | Can isolate, but needs a helper/source copy and a short-lived host file | Do not choose |
+| (c) Candidate auth volume seeded from login volume | No secret in env or container metadata | No per-backend runner image | Moderate, localized to agent launch and cleanup | Writable private auth store; no shared mount; rotation is candidate-local | **Recommended** |
+| (d) Read-only bind of the credential file | No | No | Low only in the happy path | Cannot preserve credential-file rotation; parent-path ownership is also problematic | Reject |
+| (e) Credential baked into a local derived image | No | One local derivative per backend/credential revision | Low at launch; requires local build, image selection, and rotation rebuild lifecycle | **Does satisfy candidate isolation**, but persists the secret in image layers/cache | Reject as default |
+
+### Evidence gathered for this choice
+
+The stock local Claude runner (`2.1.120`) and Codex runner (`0.125.0`) were
+probed without any real credential, network access, or login volume mount.
+Both lack their target dot-directory in the base image.  A direct file bind
+causes Docker to create the intervening directory as `root:root`; Codex then
+fails at startup with `Error loading configuration: Permission denied`.  The
+same topology gives Claude a root-owned `.claude` parent.  This repeats the
+mount-layout lesson from the working Claude prototype: tests that omit HELIX's
+real nested mounts and ownership topology are not integration evidence.
+
+A `docker create` followed by `docker cp` of a Claude credential file also
+failed before start because `/home/node/.claude` is absent in the unmodified
+image.  Making (b) work requires a bootstrap container or injected startup
+command, plus materializing the source credential on the host between two
+copies.  When `docker cp` was instead aimed at an already-existing target
+directory, it installed the synthetic file as root-owned `0644`, so (b) also
+needs a privileged ownership/mode repair before a normal `node` agent can
+rotate it.  In contrast, a synthetic source-volume → candidate-volume seed,
+followed by a node-owned private write and atomic rename, completed locally in
+327 ms.  That is a setup measurement, not a claim about OAuth; it is about
+0.4% of a 90-second mutation budget and should be remeasured in the integration
+suite.
+
+The read-only bind probe cannot establish live OAuth rotation because it used a
+synthetic, unauthenticated record.  It does establish that (d) is not a trivial
+drop-in topology.  More fundamentally, a read-only credential file cannot
+support a successful atomic refresh write, so it cannot meet the desired normal
+CLI semantics even if a particular command tolerates it before expiry.  A
+dedicated-grant test remains required for the exact Claude and Codex refresh
+behavior.
+
+### Option (e): local credential image
+
+This option genuinely satisfies the isolation requirement.  Every candidate
+would start from the same read-only credential layer and can write only to its
+own container overlay; it receives no shared writable store.  Isolation is not
+the reason to reject it.
+
+Its operational cost is also lower than it may first appear.  Against the
+cached local Claude base, a synthetic 516-byte credential image took 558 ms for
+the first build and 371 ms after changing only the credential `COPY` input.
+Copying that 516-byte file into a stopped container took 35 ms, or 0.039% of a
+90-second mutation.  The complete synthetic candidate-volume seed and private
+atomic-write check took 327 ms, or 0.36% of the same budget.  These are local
+Docker measurements, not portability promises, but they show that avoiding
+candidate-time plumbing saves milliseconds rather than meaningful mutation
+time.
+
+The baked design loses on lifecycle and at-rest exposure, not latency:
+
+- The credential is recoverable from a local image layer by exporting or
+  extracting layers.  `docker history` identifies the credential-bearing
+  layer; build cache can retain it even after the visible image tag is removed.
+  A candidate volume is credential-bearing only until its narrow cleanup path
+  runs, while a tmpfs home dies with its container.
+- An observed access-token rotation requires rebuilding the local derivative
+  and switching future candidates to its new identity.  Access credentials
+  rotated roughly every eight hours in two observations.  If a stale baked
+  record cannot refresh in a fresh candidate, every candidate using that one
+  image fails together.  Whether a candidate can self-refresh remains
+  unmeasured, so this is a real synchronized-risk path rather than a claim that
+  refresh is broken.
+- Published runner images are registry artifacts pinned by digest.  Baking
+  cannot modify those artifacts: it creates a local `FROM <published digest>`
+  derivative and requires HELIX to track its base digest, local image id, and
+  source-volume revision.  That is a second identity and rotation-update
+  lifecycle, rather than the existing one source-of-truth volume.
+
+The 35–327 ms avoided by (e) does not justify adding a long-lived credential
+layer and an image-rebuild state machine.  Preserve (e) as an operator-managed
+experimental option if needed, but do not make it the default.
+
+## Does the credential need to move at all?
+
+The following alternatives avoid one kind of transfer, but none is a better
+current default:
+
+| Alternative | Assessment |
+| --- | --- |
+| Per-user local derived image | This is option (e): no candidate-time copy, but local secret layers, cache retention, and a rotation/image-identity lifecycle. |
+| Long-lived credential sidecar | No supported common CLI protocol lets Claude, Codex, Cursor, Gemini, and OpenCode delegate their local credential lookup to a broker.  A new HTTPS/token proxy would be backend-specific, network-visible, and itself a long-lived shared stateful service.  It is a new auth product, not a smaller projection mechanism. |
+| Each candidate logs itself in | Not viable for interactive OAuth.  The installed Claude login help offers subscription/console, email, and SSO choices but no headless token input.  Codex offers `--device-auth` (user-mediated) and `--with-api-key` (a distinct explicit API-key path).  Cursor exposes `NO_OPEN_BROWSER`, which suppresses browser opening rather than supplying a credential.  Gemini's `-p` is headless prompting, not login; HELIX's login command remains interactive.  OpenCode exposes provider management but no verified generic non-interactive OAuth import. |
+
+The one non-interactive path found is Codex `--with-api-key`; it is an explicit
+environment/API-key workflow and remains covered by `auth = "env"`.  It does
+not preserve the interactive login volume as source of truth.  Therefore the
+credential must be made available to a login-authenticated candidate somehow;
+the candidate-volume seed is the smallest current mechanism that avoids an
+agent environment secret, Docker configuration secret, custom runner
+entrypoint, and persistent credential image.
+
+## Recommended mechanism: per-candidate credential-only volume
+
+For each sandboxed agent candidate using `auth = "login"`:
+
+1. HELIX creates a random, labelled Docker volume owned by that candidate.
+   The name and labels contain run/candidate identity and backend, never a
+   credential.  Collision is an error; a pre-existing volume is never reused.
+2. HELIX runs a fixed, short-lived generic seeding helper with network disabled,
+   `no-new-privileges`, the login volume mounted read-only at a private source
+   path, and the new candidate volume mounted read-write at a private
+   destination path.  It copies only the backend manifest's credential files,
+   creates the needed directories with the runner uid/gid, applies the required
+   file modes, validates the manifest's minimal backend-specific record schema,
+   and exits.  It does not list, archive, or copy the source home.  A malformed
+   or incomplete record aborts here, before the agent container is created.
+3. HELIX starts the ordinary backend runner with a uid/gid-correct tmpfs
+   `HOME`, the candidate volume mounted only at that backend's auth directory,
+   and any existing per-candidate transcript bind at its nested transcript
+   location.  It does not receive the login volume, an environment credential,
+   or a credential-bearing command argument.
+4. After success, failure, cancellation, or timeout, HELIX removes the agent
+   container and then removes that exact candidate volume.  Failed removal is
+   reported as a credential-cleanup failure and includes a safe manual cleanup
+   identifier; it must never be treated as successful cleanup.  It must refuse
+   to remove any volume not carrying the candidate label/prefix and must never
+   target `helix-auth-*`.
+
+The candidate volume starts as an allowlisted auth directory, rather than a
+copy of the source home.  During a run it may accumulate backend state, but it
+is inaccessible to sibling agents and removed afterwards.  The surrounding
+tmpfs makes unrelated `HOME` state container-local as well.
+
+The source manifest is code-owned, versioned with the runner contract, and
+uses relative paths only.  Initial candidates are:
+
+| Backend | Login-volume source → candidate auth-volume destination | Readiness |
+| --- | --- | --- |
+| Claude | `.claude/.credentials.json` → `.credentials.json` mounted at `$HOME/.claude` | Ready, subject to real-grant end-to-end test |
+| Codex | `.codex/auth.json` → `auth.json` mounted at `$HOME/.codex` | Ready, subject to real-grant end-to-end test |
+| Cursor | `.cursor/cli-config.json` → `cli-config.json` mounted at `$HOME/.cursor` | Needs credential-shape and live-login verification |
+| Gemini | `.gemini/oauth_creds.json` plus any login-required account record | Needs a measured login-volume manifest; current observed source was not OAuth-backed |
+| OpenCode | `.local/share/opencode/auth.json` → `auth.json` mounted at its XDG data auth directory | Needs live-login verification of the complete required file set |
+
+The mechanism is common; its manifest is backend-specific.  No backend needs a
+custom agent image merely to receive the credential.  The helper is one generic
+HELIX utility action, not five entrypoints; it must be pinned and tested like
+other runtime tooling.  A backend is not enabled
+for `auth = "login"` until its manifest is confirmed by an authenticated
+candidate test.  In particular, Cursor's unverified split must not be promoted
+to a claim of readiness merely because a candidate volume would isolate it.
+
+## Earlier image-side experiments
+
+An earlier image experiment authenticated in a private home, removed its
+input from the process environment before agent exec, wrote mode `0600`, and
+failed closed on malformed data. It also exposed the root-owned nested
+transcript-parent failure that this design avoids with a uid/gid-correct tmpfs
+HOME and pre-created nested mount path. Its nine-hour, 37-generation run is
+useful evidence for the livebench write-up.
+
+It is not a HELIX auth mechanism. HELIX has exactly two paths: `auth =
+"login"` and `auth = "env"`. HELIX contains no projection-variable name,
+encoding, decoding, runner-image selection, or compatibility branch. An
+operator-owned image may independently interpret an allowlisted environment
+value under `auth = "env"`; that image behavior is outside HELIX's contract.
+
+## Configuration surface
+
+`auth` describes the **source of the credential**, not the mount or transport
+mechanism.  The production surface stays small:
+
+```toml
+[sandbox]
+enabled = true
+auth = "login"  # "login" (from helix-auth-<backend>) or "env" (explicit host value)
+auth_env_allow = []
+```
+
+- `auth = "login"` selects the candidate-volume projection described here.
+  `auth_env_allow` must be empty: no credential transport variable is needed.
+- `auth = "env"` means an explicit host environment value is the credential
+  source; `auth_env_allow` remains the non-empty scrub allowlist of names that
+  may reach the agent.  It is not inferred from backend or host state.
+- No `auth_projection_*`, file path, volume name, or backend-specific
+  transport key is exposed in configuration.  Those would make a small source
+  choice into a second configuration language.
+
+This retains `auth_env_allow` because it is the actual final scrub allowlist
+for named values.  It does not use that key as hidden plumbing for login
+credentials.  The validation/documentation change should stay roughly 30–50
+lines; backend manifests and runtime cleanup are implementation details, not
+new user knobs.
+
+## Deletions and documentation to retain
+
+The implementation removes:
+
+- `VolumeModeUnsupportedError` and its long retired-mode remediation text;
+- the agent-execution paths that mount `helix-auth-<backend>`, including any
+  post-run transcript copy that remounts it;
+- `OAUTH_SUPPRESSING_ENV`;
+- `FORBIDDEN_AUTH_ENV_NAMES` and every policy branch that specially handles
+  `CLAUDE_CODE_OAUTH_TOKEN`.
+
+HELIX must not forbid or otherwise manipulate a variable it does not set.  The
+existing warning for both credential forms being present remains the right
+diagnostic for an ambiguous explicit-env configuration.
+
+The history in [Why a shared writable auth directory is retired](#why-a-shared-writable-auth-directory-is-retired)
+stays as product documentation.  Delete the retirement code, not the reason
+for structural isolation.
+
+## Rotation and its open question
+
+The candidate auth volume is writable, so a backend can attempt its normal
+in-container OAuth refresh and atomic rename.  Any refreshed credential stays
+only in that candidate volume and dies when the volume is removed; it is never
+written back to the login volume. The earlier image experiment observed the
+same candidate-local rotation boundary during a nine-hour, 37-generation run.
+
+Whether in-container OAuth refresh works at all is **unmeasured**.  Two prior
+attempts were void: the supervising process shared the grant and its own API
+activity revoked the grant under observation.  They do not show refresh working
+or broken.  Resolving the question requires a dedicated grant whose observer
+does not use it.
+
+## Verification plan
+
+Unit and integration tests must make the structural boundary observable on the
+final Docker argv and live Docker objects, not merely on a helper function.
+
+1. **No shared source mount.** For every login-enabled backend, assert the
+   final agent argv and `docker inspect` contain no `helix-auth-<backend>`
+   mount.  The seeding helper may contain that name only as a read-only source;
+   it must not be the agent container.
+2. **Credential-only seed.** Seed a disposable source with a credential canary
+   and unrelated state canaries.  The candidate volume contains the credential
+   paths and no unrelated source state before the agent starts.
+3. **No credential in agent environment or metadata.** Assert the agent
+   environment, command, labels, and inspect configuration omit credential
+   values. The candidate-volume name alone is not secret.
+4. **Malformed and missing source fail closed.** Missing, malformed, oversized,
+   or wrong-mode source material must prevent the agent from starting with a
+   stable, redacted error.  This is mandatory: silently continuing turns a
+   credential transport bug into a misleading `not logged in` failure.
+5. **Sibling isolation.** In concurrent C1/C2 and sequential A→B canaries,
+   make A/C1 write a state marker next to its credential; B/C2 must not read
+   it.  Assert different candidate volume identities and successful removal.
+6. **Cleanup failure is loud and narrow.** Force volume-removal failure and
+   verify the result names only the candidate volume, retains no shared-volume
+   deletion path, and makes manual cleanup actionable.
+7. **Real mount topology.** Run the Claude test with tmpfs `HOME`, the nested
+   transcript bind, workspace bind, and runner user.  This guards against the
+   root-owned intervening-directory failure found by the proven runner.
+8. **Dedicated-grant rotation test.** For Claude and Codex, start a candidate
+   after its access token expires while retaining a valid refresh token, then
+   distinguish authenticated refresh from a revoked-grant failure.  Confirm no
+   changed record reaches the source volume.  Do not run the observer against
+   the same grant.
+
+## Migration and errors
+
+`sandbox.auth = "volume"` is invalid after this change because it describes
+the retired mount mechanism, not a source.  Config loading should fail before
+Docker is invoked with:
+
+```
+sandbox.auth = "volume" has been replaced by "login".
+  auth = "login" reads the credential from helix-auth-<backend> at candidate
+  start, copies only the credential into a private candidate store, and never
+  mounts the shared login volume in an agent container.
+  Set sandbox.auth = "login"; do not use environment credential transport.
+```
+
+Existing `auth = "env"` configurations continue to mean explicit named host
+values and continue to require a non-empty `auth_env_allow`.  Configurations
+that set `auth_env_allow` with `auth = "login"` fail with an error explaining
+that login copying has no environment transport. `auth = "env"` remains the
+separate, explicit API-key mechanism and is gated by `auth_env_allow`.
+
+This makes the ordinary login-volume workflow structural and image-neutral. It
+also introduces the small `sandbox.auth` and `auth_env_allow` configuration
+contract needed for an explicit choice of credential source.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,4 +83,5 @@ timeout = 60
 timeout_method = "thread"
 markers = [
     "diff_harness: differential-testing harness (phases 2-4)",
+    "docker_integration: requires a real Docker daemon and local fixture image",
 ]

--- a/skills/helix/SKILL.md
+++ b/skills/helix/SKILL.md
@@ -48,9 +48,10 @@ evaluator-side changes are discarded. HELIX also starts a warm evaluator
 sidecar once per `helix evolve` on a private Docker network. Mutation agents
 run on the normal agent network and cannot reach the sidecar. Evaluator-runner
 containers run only during evaluation, join the private network, call the
-sidecar, print `HELIX_RESULT`, and exit. Agent containers get a persistent
-backend auth volume such as `helix-auth-claude`; candidate workspaces do not
-persist between mutations except through HELIX's accepted worktree sync.
+sidecar, print `HELIX_RESULT`, and exit. Agent containers get a private
+per-candidate credential volume seeded from the operator's `helix-auth-claude`
+login volume, which they never mount; candidate workspaces do not persist
+between mutations except through HELIX's accepted worktree sync.
 
 ## Security Boundary
 

--- a/skills/helix/references/run-debug.md
+++ b/skills/helix/references/run-debug.md
@@ -103,12 +103,15 @@ For backend diagnostics in a candidate worktree, inspect:
 
 The backend result JSON includes normalized usage metadata and, for Claude Code,
 `transcript_artifacts` entries when HELIX can copy the JSONL transcript. In
-Docker sandbox mode HELIX copies Claude transcripts from the backend auth volume
-at `/home/node/.claude/projects/-workspace/<session_id>.jsonl` into the
-candidate worktree before syncing changes back. Codex structured stdout is
-preserved in `.helix_backend_stdout.txt`; durable Codex transcript copying is an
-extension point because HELIX does not currently know a stable Codex transcript
-path in the sandbox auth volume.
+Docker sandbox mode HELIX bind-mounts a candidate-local host directory over
+Claude's in-container transcript path
+(`/home/node/.claude/projects/-workspace/<session_id>.jsonl`), so the agent
+container writes the transcript straight to that bind instead of to the
+persistent backend auth volume; HELIX then syncs it from the bind into the
+candidate worktree along with the rest of the workspace. Codex structured
+stdout is preserved in `.helix_backend_stdout.txt`; durable Codex transcript
+copying is an extension point because HELIX does not currently know a stable
+Codex transcript path.
 
 ## Resuming
 

--- a/skills/helix/references/run-debug.md
+++ b/skills/helix/references/run-debug.md
@@ -189,10 +189,10 @@ helix sandbox logout claude
 
 Backend login behavior:
 
+- Agy: full interactive `agy` launch (no dedicated login subcommand)
 - Claude: `claude setup-token`
 - Codex: `codex login --device-auth`
 - Cursor: `cursor-agent login`
-- Gemini: `gemini --skip-trust`
 - OpenCode: full `opencode` TUI for provider/model/login setup
 
 Network:

--- a/skills/helix/references/run-debug.md
+++ b/skills/helix/references/run-debug.md
@@ -106,9 +106,9 @@ The backend result JSON includes normalized usage metadata and, for Claude Code,
 Docker sandbox mode HELIX bind-mounts a candidate-local host directory over
 Claude's in-container transcript path
 (`/home/node/.claude/projects/-workspace/<session_id>.jsonl`), so the agent
-container writes the transcript straight to that bind instead of to the
-persistent backend auth volume; HELIX then syncs it from the bind into the
-candidate worktree along with the rest of the workspace. Codex structured
+container writes the transcript straight to that bind; HELIX then syncs it
+into the candidate worktree along with the rest of the workspace. No
+credential volume is involved. Codex structured
 stdout is preserved in `.helix_backend_stdout.txt`; durable Codex transcript
 copying is an extension point because HELIX does not currently know a stable
 Codex transcript path.

--- a/skills/helix/references/toml.md
+++ b/skills/helix/references/toml.md
@@ -212,9 +212,9 @@ Sandbox behavior:
 - `helix.toml`, `.env`, `.env.*`, `.git`, and HELIX artifacts are excluded
   from sandbox workspace copies/sync-back.
 - Claude Code transcript preservation is enabled by default for agent
-  sandboxes. HELIX looks for
-  `/home/node/.claude/projects/-workspace/<session_id>.jsonl` in the auth
-  volume and copies it to
+  sandboxes. HELIX bind-mounts a candidate-local host directory over
+  `/home/node/.claude/projects/-workspace/<session_id>.jsonl` (never the
+  auth volume) and syncs it back to
   `.helix_artifacts/backend_transcripts/claude/<session_id>.jsonl`.
   Set `preserve_backend_transcripts = false` under `[sandbox]` to disable it,
   or override `transcript_artifact_dir` / `claude_transcript_root` for custom

--- a/skills/helix/references/toml.md
+++ b/skills/helix/references/toml.md
@@ -207,7 +207,9 @@ Sandbox behavior:
   call the sidecar, and exit.
 - The sidecar sees only what the runner sends over the endpoint.
 - Evaluator-runner changes are discarded.
-- Agent auth volume mounts at `/home/node`.
+- `/home/node` is a private tmpfs; the candidate credential volume mounts at
+  the backend's own auth directory beneath it (e.g. `/home/node/.claude` for
+  Claude), not at `/home/node` itself.
 - Evaluator containers do not get agent auth volumes.
 - `helix.toml`, `.env`, `.env.*`, `.git`, and HELIX artifacts are excluded
   from sandbox workspace copies/sync-back.

--- a/skills/helix/references/toml.md
+++ b/skills/helix/references/toml.md
@@ -155,7 +155,7 @@ Important choices:
 
 ```toml
 [agent]
-backend = "claude"  # claude | codex | cursor | gemini | opencode
+backend = "claude"  # agy | claude | codex | cursor | opencode
 model = "sonnet"
 effort = "medium"
 max_turns = 20
@@ -169,9 +169,10 @@ network boundary, not from telling the agent not to edit evaluator files.
 
 Backend notes:
 
+- Agy: usually `agy`, optional model/effort.
 - Claude: usually `claude`, `max_turns`, optional model/effort.
 - Codex: usually `codex`, model optional.
-- Cursor/Gemini/OpenCode: check CLI support and model naming before pinning.
+- Cursor/OpenCode: check CLI support and model naming before pinning.
 
 ## Sandbox
 

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -64,12 +64,14 @@ DEFAULT_BACKEND_IMAGES: dict[str, str] = {
 AGENT_LOGIN_IDENTITY_ENV: tuple[str, ...] = ("USER", "LOGNAME")
 """Non-secret identity variables preserved for host/unsandboxed agent CLIs.
 
-Agent CLIs resolve stored interactive credentials independently. Claude Code
-on macOS, for example, needs ``USER`` to locate its Keychain entry even when
-``HOME`` is present. ``LOGNAME`` is harmless, conventional on Unix-like
-systems, and provides compatibility for CLIs that use that spelling instead.
-Keep this narrowly scoped to agent subprocesses: evaluator environments retain
-their existing strict allowlist.
+Agent CLIs resolve stored interactive credentials on their own, and some need
+to know who the host user is to do it: Claude Code on macOS, for example, uses
+``USER`` to locate its Keychain entry even when ``HOME`` is set. ``LOGNAME`` is
+the conventional Unix spelling of the same thing and costs nothing to include.
+
+Host path only. A sandboxed agent gets neither name: its credential is a file
+under a tmpfs ``HOME``, so there is no keychain for an identity to unlock.
+Evaluator environments keep their existing strict allowlist.
 """
 
 BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Literal, TypeAlias
 
 
-BackendName: TypeAlias = Literal["claude", "codex", "cursor", "gemini", "opencode"]
+BackendName: TypeAlias = Literal["agy", "claude", "codex", "cursor", "opencode"]
 
-BACKENDS: tuple[BackendName, ...] = ("claude", "codex", "cursor", "gemini", "opencode")
+BACKENDS: tuple[BackendName, ...] = ("agy", "claude", "codex", "cursor", "opencode")
 
 
 # ---------------------------------------------------------------------------
@@ -18,6 +18,7 @@ BACKENDS: tuple[BackendName, ...] = ("claude", "codex", "cursor", "gemini", "ope
 # budget" on backends that expose one.  The string value is forwarded to a
 # backend-native CLI flag in ``helix.mutator``:
 #
+#   - ``agy``:       ``--effort <value>``   (Antigravity CLI reasoning effort)
 #   - ``claude``:    ``--effort <value>``   (Claude Code thinking budget)
 #   - ``codex``:     ``-c model_reasoning_effort=<value>`` (Codex CLI config)
 #   - ``opencode``:  ``--variant <value>``  (model variant selector)
@@ -27,7 +28,7 @@ BACKENDS: tuple[BackendName, ...] = ("claude", "codex", "cursor", "gemini", "ope
 # without hard-coding backend knowledge into ``HelixConfig``.
 
 EFFORT_AWARE_BACKENDS: frozenset[BackendName] = frozenset(
-    {"claude", "codex", "opencode"}
+    {"agy", "claude", "codex", "opencode"}
 )
 """Backends that propagate ``agent.effort`` to their underlying CLI."""
 
@@ -40,24 +41,25 @@ EFFORT_AWARE_BACKENDS: frozenset[BackendName] = frozenset(
 # surfaces), users will see a non-fatal "not a recognized value" warning
 # until this map is updated; the value still passes through to the CLI.
 EFFORT_VALID_VALUES: dict[BackendName, frozenset[str] | None] = {
+    "agy": frozenset({"low", "medium", "high"}),
     "claude": frozenset({"low", "medium", "high"}),
     "codex": frozenset({"minimal", "low", "medium", "high", "xhigh"}),
     "opencode": None,  # variant strings are model-specific; opencode validates them.
 }
 
 BACKEND_DISPLAY_NAMES: dict[str, str] = {
+    "agy": "Antigravity CLI",
     "claude": "Claude Code",
     "codex": "Codex CLI",
     "cursor": "Cursor Agent",
-    "gemini": "Gemini CLI",
     "opencode": "OpenCode",
 }
 
 DEFAULT_BACKEND_IMAGES: dict[str, str] = {
+    "agy": "ghcr.io/ke7/helix-evo-runner-agy:latest",
     "claude": "ghcr.io/ke7/helix-evo-runner-claude:latest",
     "codex": "ghcr.io/ke7/helix-evo-runner-codex:latest",
     "cursor": "ghcr.io/ke7/helix-evo-runner-cursor:latest",
-    "gemini": "ghcr.io/ke7/helix-evo-runner-gemini:latest",
     "opencode": "ghcr.io/ke7/helix-evo-runner-opencode:latest",
 }
 
@@ -75,6 +77,28 @@ Evaluator environments keep their existing strict allowlist.
 """
 
 BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {
+    "agy": {
+        # No dedicated non-interactive login subcommand; the bare interactive
+        # launch is the login flow, same pattern as ``opencode`` below.
+        "login": ["agy"],
+        # ``agy models`` returns exit 0 even when logged out, so it cannot be
+        # used as the status signal. Probe the credential file directly
+        # instead, mirroring claude's file-probe pattern above.
+        "status": [
+            "sh",
+            "-lc",
+            'set -eu; test -s "${HOME:-/home/node}/.gemini/antigravity-cli/antigravity-oauth-token"',
+        ],
+        # Surgical: only remove agy's own state directory. ``~/.gemini`` is
+        # shared with legacy gemini-cli state (``~/.gemini/config``), so a
+        # blanket ``rm -rf ~/.gemini`` would destroy state this backend
+        # doesn't own.
+        "logout": [
+            "sh",
+            "-lc",
+            'set -eu; rm -rf "${HOME:-/home/node}/.gemini/antigravity-cli"',
+        ],
+    },
     "claude": {
         "login": ["claude", "auth", "login", "--claudeai"],
         # ``claude auth status --text`` returns 0 even when there are no
@@ -100,17 +124,6 @@ BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {
         "login": ["cursor-agent", "login"],
         "status": ["cursor-agent", "status"],
         "logout": ["cursor-agent", "logout"],
-    },
-    "gemini": {
-        "login": ["gemini", "--skip-trust"],
-        "status": ["gemini", "--version"],
-        # The auth volume is mounted at /home/node, so logout must scrub
-        # only Gemini's state directory rather than the whole home tree.
-        "logout": [
-            "sh",
-            "-lc",
-            'set -eu; rm -rf "/home/node/.gemini" "/home/node/.config/google-gemini"',
-        ],
     },
     "opencode": {
         "login": ["opencode"],

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -104,9 +104,8 @@ BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {
     "gemini": {
         "login": ["gemini", "--skip-trust"],
         "status": ["gemini", "--version"],
-        # The auth volume is mounted at /home/node and is shared across
-        # backends, so logout must scrub only Gemini's state directory rather
-        # than the whole home tree.
+        # The auth volume is mounted at /home/node, so logout must scrub
+        # only Gemini's state directory rather than the whole home tree.
         "logout": [
             "sh",
             "-lc",

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -61,13 +61,6 @@ DEFAULT_BACKEND_IMAGES: dict[str, str] = {
     "opencode": "ghcr.io/ke7/helix-evo-runner-opencode:latest",
 }
 
-BACKEND_AUTH_ENV: dict[str, tuple[str, ...]] = {
-    "claude": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
-    "cursor": ("CURSOR_API_KEY",),
-    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
-    "opencode": ("OPENCODE_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"),
-}
-
 BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {
     "claude": {
         "login": ["claude", "auth", "login", "--claudeai"],

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -62,7 +62,7 @@ DEFAULT_BACKEND_IMAGES: dict[str, str] = {
 }
 
 AGENT_LOGIN_IDENTITY_ENV: tuple[str, ...] = ("USER", "LOGNAME")
-"""Non-secret identity variables preserved for every agent CLI.
+"""Non-secret identity variables preserved for host/unsandboxed agent CLIs.
 
 Agent CLIs resolve stored interactive credentials independently. Claude Code
 on macOS, for example, needs ``USER`` to locate its Keychain entry even when

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -61,6 +61,17 @@ DEFAULT_BACKEND_IMAGES: dict[str, str] = {
     "opencode": "ghcr.io/ke7/helix-evo-runner-opencode:latest",
 }
 
+AGENT_LOGIN_IDENTITY_ENV: tuple[str, ...] = ("USER", "LOGNAME")
+"""Non-secret identity variables preserved for every agent CLI.
+
+Agent CLIs resolve stored interactive credentials independently. Claude Code
+on macOS, for example, needs ``USER`` to locate its Keychain entry even when
+``HOME`` is present. ``LOGNAME`` is harmless, conventional on Unix-like
+systems, and provides compatibility for CLIs that use that spelling instead.
+Keep this narrowly scoped to agent subprocesses: evaluator environments retain
+their existing strict allowlist.
+"""
+
 BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {
     "claude": {
         "login": ["claude", "auth", "login", "--claudeai"],

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -432,10 +432,11 @@ def sandbox_login(
 
     volume = sandbox_auth_volume_name(backend)
     print_info(f"Using Docker auth volume [cyan]{volume}[/cyan].")
-    if backend == "gemini":
+    if backend == "agy":
         print_warning(
-            "Gemini CLI does not expose a dedicated login subcommand; HELIX "
-            "starts the interactive Gemini CLI so you can complete its auth flow."
+            "Antigravity CLI does not expose a dedicated login subcommand; "
+            "HELIX starts the interactive Antigravity CLI so you can "
+            "complete its auth flow."
         )
     extra_hosts = _parse_extra_hosts(extra_hosts_list)
     result = run_sandbox_auth_command(
@@ -593,7 +594,7 @@ def sandbox_logout(
 @click.option(
     "--backend",
     default=None,
-    type=click.Choice(["claude", "codex", "cursor", "gemini", "opencode"]),
+    type=click.Choice(["agy", "claude", "codex", "cursor", "opencode"]),
     help="Override the mutation backend.",
 )
 @click.option("--model", default=None, help="Override the backend model.")
@@ -602,10 +603,10 @@ def sandbox_logout(
     default=None,
     help=(
         "Override backend reasoning-effort level. Forwarded as --effort to "
-        "the 'claude' backend (low|medium|high), as model_reasoning_effort "
-        "to the 'codex' backend, and as --variant to the 'opencode' backend; "
-        "ignored by cursor/gemini (a warning is emitted when set on a backend "
-        "that does not support it)."
+        "the 'agy' and 'claude' backends (low|medium|high), as "
+        "model_reasoning_effort to the 'codex' backend, and as --variant to "
+        "the 'opencode' backend; ignored by cursor (a warning is emitted "
+        "when set on a backend that does not support it)."
     ),
 )
 def evolve(

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -80,6 +80,10 @@ command = "uv run python evaluate.py"
 # after passthrough_env. Useful for repeatable run-local service endpoints.
 # ANTHROPIC_BASE_URL = "https://model-service.example.invalid/v1"
 # ANTHROPIC_API_KEY = "dummy"
+# A credential-shaped value here reaches the agent even under sandbox
+# auth = "volume". For some backends that value outranks the seeded login
+# (see the "Docker Sandboxing" section of README.md) — only set one if you
+# mean it to authenticate the agent, or know it won't.
 
 [evolution]
 max_generations = 20

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -81,9 +81,9 @@ command = "uv run python evaluate.py"
 # ANTHROPIC_BASE_URL = "https://model-service.example.invalid/v1"
 # ANTHROPIC_API_KEY = "dummy"
 # A credential-shaped value here reaches the agent even under sandbox
-# auth = "volume". For some backends that value outranks the seeded login
-# (see the "Docker Sandboxing" section of README.md) — only set one if you
-# mean it to authenticate the agent, or know it won't.
+# auth = "volume", and the backend CLI decides which credential wins. Set
+# one only if you intend it to authenticate the agent; see the "Docker
+# Sandboxing" section of README.md for what is known per backend.
 
 [evolution]
 max_generations = 20

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -98,8 +98,8 @@ enabled = false
 # image = "ghcr.io/ke7/helix-evo-runner-claude:latest"  # optional; defaults from agent.backend
 # network = "bridge"
 # skip_special_files = true  # skip FIFOs/sockets/devices during workspace sync
-# Agent containers mount a persistent Docker auth volume named
-# helix-auth-<backend>. Run `helix sandbox login <backend>` once per backend.
+# auth = "login"  # default: seed a private candidate volume from the login volume
+# auth = "env"    # explicit key only; also set auth_env_allow = ["API_KEY_NAME"]
 """
 
 _HELIX_DIR = ".helix"

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -73,6 +73,7 @@ command = "uv run python evaluate.py"
 # runner_image = "my-evaluator-runner:latest"
 # command = "python -m benchmark_server"
 # endpoint = "http://helix-evaluator:8080/evaluate"
+# passthrough_env = ["OPENAI_API_KEY"]  # sidecar-only host values
 
 [env]
 # Fixed non-secret env values injected into evaluator and agent subprocesses
@@ -98,7 +99,7 @@ enabled = false
 # image = "ghcr.io/ke7/helix-evo-runner-claude:latest"  # optional; defaults from agent.backend
 # network = "bridge"
 # skip_special_files = true  # skip FIFOs/sockets/devices during workspace sync
-# auth = "login"  # default: seed a private candidate volume from the login volume
+# auth = "volume"  # default: seed a private candidate volume from the login volume
 # auth = "env"    # explicit key only; also set auth_env_allow = ["API_KEY_NAME"]
 """
 

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -10,7 +10,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from helix.backends import (
     BackendName,
@@ -68,6 +68,13 @@ class EvaluatorSidecarConfig(BaseModel):
     healthcheck_command: str | None = None
     startup_timeout_seconds: int = 60
     internal_network: bool = True
+    passthrough_env: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Environment variable names passed only to the private evaluator "
+            "sidecar, never to mutation-agent containers."
+        ),
+    )
 
     @property
     def resolved_runner_image(self) -> str:
@@ -603,29 +610,14 @@ class SandboxConfig(BaseModel):
     preserve_backend_transcripts: bool = True
     transcript_artifact_dir: str = ".helix_artifacts/backend_transcripts"
     claude_transcript_root: str = "/home/node/.claude/projects/-workspace"
-    auth: Literal["login", "env"] = "login"
+    auth: Literal["volume", "env"] = "volume"
     auth_env_allow: list[str] = Field(default_factory=list)
 
-    @field_validator("auth", mode="before")
-    @classmethod
-    def reject_retired_volume_auth(cls, value: object) -> object:
-        if value == "volume":
-            raise ValueError(
-                'sandbox.auth = "volume" has been replaced by "login".\n'
-                "  auth = \"login\" reads the credential from helix-auth-<backend> "
-                "at candidate start, copies only the credential into a private "
-                "candidate store, and never mounts the shared login volume in an "
-                "agent container.\n"
-                "  Set sandbox.auth = \"login\"; do not use environment "
-                "credential transport."
-            )
-        return value
-
     def model_post_init(self, __context: object) -> None:
-        if self.auth == "login" and self.auth_env_allow:
+        if self.auth == "volume" and self.auth_env_allow:
             raise ValueError(
-                "sandbox.auth_env_allow is set but sandbox.auth = \"login\"; "
-                "login credential copying has no environment transport. Remove "
+                "sandbox.auth_env_allow is set but sandbox.auth = \"volume\"; "
+                "volume credential copying has no environment transport. Remove "
                 "auth_env_allow or set auth = \"env\"."
             )
         if self.auth == "env" and not self.auth_env_allow:
@@ -697,6 +689,16 @@ class HelixConfig(BaseModel):
                 raise ValueError(
                     "Docker sandboxing requires [evaluator.sidecar] with image, "
                     "command, and endpoint."
+                )
+        sidecar = self.evaluator.sidecar
+        if sidecar is not None:
+            shared = sorted(set(self.sandbox.auth_env_allow) & set(sidecar.passthrough_env))
+            if shared:
+                names = ", ".join(repr(name) for name in shared)
+                raise ValueError(
+                    f"{names} appears in both sandbox.auth_env_allow and "
+                    "evaluator.sidecar.passthrough_env. The agent and sidecar "
+                    "credential sets must be disjoint."
                 )
         _validate_agent_effort(self.agent)
 

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -10,7 +10,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from helix.backends import (
     BackendName,
@@ -603,6 +603,36 @@ class SandboxConfig(BaseModel):
     preserve_backend_transcripts: bool = True
     transcript_artifact_dir: str = ".helix_artifacts/backend_transcripts"
     claude_transcript_root: str = "/home/node/.claude/projects/-workspace"
+    auth: Literal["login", "env"] = "login"
+    auth_env_allow: list[str] = Field(default_factory=list)
+
+    @field_validator("auth", mode="before")
+    @classmethod
+    def reject_retired_volume_auth(cls, value: object) -> object:
+        if value == "volume":
+            raise ValueError(
+                'sandbox.auth = "volume" has been replaced by "login".\n'
+                "  auth = \"login\" reads the credential from helix-auth-<backend> "
+                "at candidate start, copies only the credential into a private "
+                "candidate store, and never mounts the shared login volume in an "
+                "agent container.\n"
+                "  Set sandbox.auth = \"login\"; do not use environment "
+                "credential transport."
+            )
+        return value
+
+    def model_post_init(self, __context: object) -> None:
+        if self.auth == "login" and self.auth_env_allow:
+            raise ValueError(
+                "sandbox.auth_env_allow is set but sandbox.auth = \"login\"; "
+                "login credential copying has no environment transport. Remove "
+                "auth_env_allow or set auth = \"env\"."
+            )
+        if self.auth == "env" and not self.auth_env_allow:
+            raise ValueError(
+                'sandbox.auth = "env" requires a non-empty '
+                "sandbox.auth_env_allow."
+            )
 
 
 class WorktreeConfig(BaseModel):

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -708,7 +708,7 @@ def _validate_agent_effort(agent: AgentConfig) -> None:
 
     Two cases are surfaced:
 
-    1. **Backend ignores the field** (``cursor`` / ``gemini``):
+    1. **Backend ignores the field** (``cursor``):
        ``effort`` is silently dropped by ``helix.mutator`` because those CLIs
        don't expose an equivalent flag.  Without a warning, users assume the
        knob is taking effect.

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -766,11 +766,25 @@ def _sandbox_agent_environment(
 ) -> dict[str, str]:
     """Build the deliberately small environment for a sandboxed agent.
 
-    Volume auth has no environment transport.  Env auth receives only a value
-    both named by ``auth_env_allow`` and explicitly supplied through ``[env]``
-    or ``passthrough_env``; an ambient host credential is never inferred.
+    The config-declared ``[env]`` (``fixed_env``) and ``passthrough_env``
+    values are applied in both auth modes — this is the same "read what the
+    config declares" transport the evaluator sidecar and the unsandboxed
+    agent already use, and it is what config.py's ``HelixConfig.env`` /
+    ``passthrough_env`` docstrings promise ("evaluator and agent
+    subprocesses"). Nothing here is inferred from ambient host state: a
+    value only reaches the agent because the caller explicitly named it in
+    ``passthrough_env`` or gave it a value in ``fixed_env``.
+
+    ``auth_env_allow`` is a separate, additional gate that applies only
+    under ``auth = "env"``: for names listed there, an ambient host value
+    may also be pulled in as the credential HELIX otherwise gets from the
+    login volume. It does not restrict the general ``fixed_env`` /
+    ``passthrough_env`` transport above — it only widens what a
+    caller-declared credential name is allowed to resolve to.
     """
-    env = _scrub_environment(passthrough_env=_agent_passthrough_env(None))
+    env = _scrub_environment(
+        passthrough_env=_agent_passthrough_env(passthrough_env), fixed_env=fixed_env
+    )
     if sandbox.auth != "env":
         return env
     configured = set(passthrough_env or []) | set((fixed_env or {}).keys())

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -728,7 +728,7 @@ def _sandbox_agent_environment(
 ) -> dict[str, str]:
     """Build the deliberately small environment for a sandboxed agent.
 
-    Login auth has no environment transport.  Env auth receives only a value
+    Volume auth has no environment transport.  Env auth receives only a value
     both named by ``auth_env_allow`` and explicitly supplied through ``[env]``
     or ``passthrough_env``; an ambient host credential is never inferred.
     """

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1462,15 +1462,15 @@ def _copy_local_claude_transcript(
             "backend": "claude",
             "session_id": session_id,
             "path": str(rel_path),
-            "source": "sandbox_auth_volume",
+            "source": "sandbox_transcript_bind",
             "available": True,
         }
-    if transcript_root == "sandbox_auth_volume":
+    if transcript_root == "sandbox_transcript_bind":
         return {
             "backend": "claude",
             "session_id": session_id,
             "path": str(rel_path),
-            "source": "sandbox_auth_volume",
+            "source": "sandbox_transcript_bind",
             "available": False,
             "reason": "transcript_not_found",
         }
@@ -1537,7 +1537,7 @@ def _collect_backend_transcript_artifacts(
         else BACKEND_TRANSCRIPT_ARTIFACT_DIR
     )
     transcript_root = (
-        "sandbox_auth_volume"
+        "sandbox_transcript_bind"
         if sandbox is not None and sandbox.enabled
         else sandbox.claude_transcript_root
         if sandbox is not None

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -721,15 +721,13 @@ def _write_mutation_prompt_artifact(worktree_path: str, prompt: str) -> str:
 
 
 def _agent_passthrough_env(passthrough_env: list[str] | None) -> list[str]:
-    """Return configured passthrough values plus safe login identity values.
+    """Return configured passthrough values plus the login-identity names.
 
-    Host/unsandboxed agents only: the login-identity names are keychain-shaped,
-    and a sandboxed agent has a tmpfs ``HOME`` and no keychain to unlock.
-
-    Stored-login resolution is a first-class agent authentication path, not a
-    feature users should have to repair by discovering an OS-specific variable.
-    Values named here are non-secret and apply only to agent CLIs; evaluator
-    subprocesses still receive their original strict environment.
+    Host and unsandboxed agents only. Those names are non-secret, and they
+    exist so that a stored interactive login resolves without the user having
+    to discover an OS-specific variable. A sandboxed agent needs neither: its
+    credential is a file under a tmpfs ``HOME``, not a keychain entry to
+    unlock. Evaluator subprocesses keep their original strict environment.
     """
     return list(dict.fromkeys([*AGENT_LOGIN_IDENTITY_ENV, *(passthrough_env or [])]))
 
@@ -769,21 +767,19 @@ def _sandbox_agent_environment(
 ) -> dict[str, str]:
     """Build the deliberately small environment for a sandboxed agent.
 
-    The config-declared ``[env]`` (``fixed_env``) and ``passthrough_env``
-    values are applied in both auth modes — this is the same "read what the
-    config declares" transport the evaluator sidecar and the unsandboxed
-    agent already use, and it is what config.py's ``HelixConfig.env`` /
-    ``passthrough_env`` docstrings promise ("evaluator and agent
-    subprocesses"). Nothing here is inferred from ambient host state: a
-    value only reaches the agent because the caller explicitly named it in
-    ``passthrough_env`` or gave it a value in ``fixed_env``.
+    Config-declared ``[env]`` (``fixed_env``) and ``passthrough_env`` values
+    apply in both auth modes, matching what those settings promise everywhere
+    else. Nothing here is inferred from ambient host state: a value reaches the
+    agent only because the caller named it in ``passthrough_env`` or gave it a
+    value in ``fixed_env``.
 
-    ``auth_env_allow`` is a separate, additional gate that applies only
-    under ``auth = "env"``: for names listed there, an ambient host value
-    may also be pulled in as the credential HELIX otherwise gets from the
-    login volume. It does not restrict the general ``fixed_env`` /
-    ``passthrough_env`` transport above — it only widens what a
-    caller-declared credential name is allowed to resolve to.
+    ``auth_env_allow`` is a separate, additional gate that applies only under
+    ``auth = "env"``. For a name listed there, an ambient host value may also
+    resolve as the credential that ``auth = "volume"`` would otherwise seed
+    from the login volume. It does not restrict the general ``fixed_env`` /
+    ``passthrough_env`` transport above; it only widens what an
+    already-declared credential name is allowed to resolve to. A name listed
+    in ``auth_env_allow`` alone never reaches the agent.
     """
     env = _scrub_environment(passthrough_env=passthrough_env, fixed_env=fixed_env)
     if sandbox.auth != "env":

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -10,7 +10,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
-from helix.backends import BACKEND_AUTH_ENV, backend_display_name
+from helix.backends import backend_display_name
 from helix.display import UsageStats
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, SandboxConfig
@@ -720,11 +720,30 @@ def _write_mutation_prompt_artifact(worktree_path: str, prompt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _add_backend_auth_env(env: dict[str, str], backend: str) -> None:
-    """Pass official headless auth env vars without requiring TOML config."""
-    for key in BACKEND_AUTH_ENV.get(backend, ()):
-        if key in os.environ and key not in env:
+def _sandbox_agent_environment(
+    *,
+    sandbox: SandboxConfig,
+    passthrough_env: list[str] | None,
+    fixed_env: dict[str, str] | None,
+) -> dict[str, str]:
+    """Build the deliberately small environment for a sandboxed agent.
+
+    Login auth has no environment transport.  Env auth receives only a value
+    both named by ``auth_env_allow`` and explicitly supplied through ``[env]``
+    or ``passthrough_env``; an ambient host credential is never inferred.
+    """
+    env = _scrub_environment()
+    if sandbox.auth != "env":
+        return env
+    configured = set(passthrough_env or []) | set((fixed_env or {}).keys())
+    for key in sandbox.auth_env_allow:
+        if key not in configured:
+            continue
+        if fixed_env is not None and key in fixed_env:
+            env[key] = str(fixed_env[key])
+        elif key in os.environ:
             env[key] = os.environ[key]
+    return env
 
 
 def _build_backend_args(
@@ -1595,10 +1614,15 @@ def invoke_claude_code(
         prompt_artifact_name,
     )
     cmd_str = shlex.join(args)
-    backend_env = _scrub_environment(
-        passthrough_env=passthrough_env, fixed_env=fixed_env
+    backend_env = (
+        _sandbox_agent_environment(
+            sandbox=sandbox,
+            passthrough_env=passthrough_env,
+            fixed_env=fixed_env,
+        )
+        if sandbox is not None and sandbox.enabled
+        else _scrub_environment(passthrough_env=passthrough_env, fixed_env=fixed_env)
     )
-    _add_backend_auth_env(backend_env, backend)
     if backend == "gemini":
         backend_env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"
     if backend == "opencode" and (sandbox is None or not sandbox.enabled):

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -761,7 +761,6 @@ def _agent_failure_suggestion(*, stdout: str, stderr: str, env: dict[str, str]) 
 
 def _sandbox_agent_environment(
     *,
-    sandbox: SandboxConfig,
     passthrough_env: list[str] | None,
     fixed_env: dict[str, str] | None,
 ) -> dict[str, str]:
@@ -773,26 +772,18 @@ def _sandbox_agent_environment(
     agent only because the caller named it in ``passthrough_env`` or gave it a
     value in ``fixed_env``.
 
-    ``auth_env_allow`` is a separate, additional gate that applies only under
-    ``auth = "env"``. For a name listed there, an ambient host value may also
-    resolve as the credential that ``auth = "volume"`` would otherwise seed
-    from the login volume. It does not restrict the general ``fixed_env`` /
-    ``passthrough_env`` transport above; it only widens what an
-    already-declared credential name is allowed to resolve to. A name listed
-    in ``auth_env_allow`` alone never reaches the agent.
+    ``auth_env_allow`` does not run through this function at all, and no code
+    path here checks membership in it. It is a declaration of intent, not an
+    enforcement mechanism: it exists so an operator can name, in one place,
+    which credential(s) ``auth = "env"`` is expected to supply, and so
+    :class:`~helix.config.SandboxConfig`'s ``model_post_init`` and
+    :class:`~helix.config.HelixConfig`'s disjointness check (against
+    ``evaluator.sidecar.passthrough_env``) have something to validate against.
+    Whether a name in ``auth_env_allow`` actually reaches the agent is decided
+    entirely by whether that same name also appears in ``passthrough_env`` or
+    ``[env]`` — the transport this docstring already describes above.
     """
-    env = _scrub_environment(passthrough_env=passthrough_env, fixed_env=fixed_env)
-    if sandbox.auth != "env":
-        return env
-    configured = set(passthrough_env or []) | set((fixed_env or {}).keys())
-    for key in sandbox.auth_env_allow:
-        if key not in configured:
-            continue
-        if fixed_env is not None and key in fixed_env:
-            env[key] = str(fixed_env[key])
-        elif key in os.environ:
-            env[key] = os.environ[key]
-    return env
+    return _scrub_environment(passthrough_env=passthrough_env, fixed_env=fixed_env)
 
 
 def _build_backend_args(
@@ -1665,7 +1656,6 @@ def invoke_claude_code(
     cmd_str = shlex.join(args)
     backend_env = (
         _sandbox_agent_environment(
-            sandbox=sandbox,
             passthrough_env=passthrough_env,
             fixed_env=fixed_env,
         )

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -10,7 +10,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
-from helix.backends import backend_display_name
+from helix.backends import AGENT_LOGIN_IDENTITY_ENV, backend_display_name
 from helix.display import UsageStats
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, SandboxConfig
@@ -720,6 +720,44 @@ def _write_mutation_prompt_artifact(worktree_path: str, prompt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _agent_passthrough_env(passthrough_env: list[str] | None) -> list[str]:
+    """Return configured passthrough values plus safe login identity values.
+
+    Stored-login resolution is a first-class agent authentication path, not a
+    feature users should have to repair by discovering an OS-specific variable.
+    Values named here are non-secret and apply only to agent CLIs; evaluator
+    subprocesses still receive their original strict environment.
+    """
+    return list(dict.fromkeys([*AGENT_LOGIN_IDENTITY_ENV, *(passthrough_env or [])]))
+
+
+def _looks_like_authentication_failure(stdout: str, stderr: str) -> bool:
+    """Return whether a backend failure appears to be an authentication error."""
+    text = f"{stdout}\n{stderr}".lower()
+    return any(
+        marker in text
+        for marker in (
+            "not logged in",
+            "please run /login",
+            "authentication failed",
+            "unauthenticated",
+            "not authenticated",
+        )
+    )
+
+
+def _agent_failure_suggestion(*, stdout: str, stderr: str, env: dict[str, str]) -> str:
+    """Describe the scrubbed environment when an agent authentication fails."""
+    if not _looks_like_authentication_failure(stdout, stderr):
+        return "Check stderr for rate limits, permission errors, or model availability."
+    names = ", ".join(sorted(env)) or "(none)"
+    return (
+        "Authentication failed. The agent environment after HELIX scrubbing "
+        f"contained these variable names (not values): {names}. "
+        "Confirm the selected backend's login is available to that environment."
+    )
+
+
 def _sandbox_agent_environment(
     *,
     sandbox: SandboxConfig,
@@ -732,7 +770,7 @@ def _sandbox_agent_environment(
     both named by ``auth_env_allow`` and explicitly supplied through ``[env]``
     or ``passthrough_env``; an ambient host credential is never inferred.
     """
-    env = _scrub_environment()
+    env = _scrub_environment(passthrough_env=_agent_passthrough_env(None))
     if sandbox.auth != "env":
         return env
     configured = set(passthrough_env or []) | set((fixed_env or {}).keys())
@@ -1621,7 +1659,9 @@ def invoke_claude_code(
             fixed_env=fixed_env,
         )
         if sandbox is not None and sandbox.enabled
-        else _scrub_environment(passthrough_env=passthrough_env, fixed_env=fixed_env)
+        else _scrub_environment(
+            passthrough_env=_agent_passthrough_env(passthrough_env), fixed_env=fixed_env
+        )
     )
     if backend == "gemini":
         backend_env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"
@@ -1762,7 +1802,11 @@ def invoke_claude_code(
             stdout=result.stdout,
             stderr=result.stderr,
             exit_code=result.returncode,
-            suggestion="Check stderr for rate limits, permission errors, or model availability.",
+            suggestion=_agent_failure_suggestion(
+                stdout=result.stdout,
+                stderr=result.stderr,
+                env=backend_env,
+            ),
         )
     finally:
         _write_backend_artifacts(

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1,4 +1,4 @@
-"""HELIX mutator: applies code mutations via agentic coding backends (claude, codex, cursor, gemini, opencode)."""
+"""HELIX mutator: applies code mutations via agentic coding backends (agy, claude, codex, cursor, opencode)."""
 
 from __future__ import annotations
 
@@ -97,7 +97,7 @@ def _turn_budget_section(max_turns: int | None) -> str:
       limit, and the resulting ``subtype="error_max_turns"`` response is
       detected at :func:`invoke_claude_code` and treated as partial
       success.
-    * ``codex`` / ``cursor`` / ``gemini`` / ``opencode`` — soft hint only.
+    * ``agy`` / ``codex`` / ``cursor`` / ``opencode`` — soft hint only.
       None of these CLIs expose an equivalent flag (verified against
       ``--help`` for the installed binaries), so the in-prompt request is
       the only signal the agent receives.  Whether the agent self-honors
@@ -786,6 +786,28 @@ def _build_backend_args(
     prompt_artifact_name: str,
 ) -> list[str]:
     backend = config.backend
+    if backend == "agy":
+        args = [
+            "agy",
+            "--dangerously-skip-permissions",
+            "--print",
+            "--output-format",
+            "json",
+        ]
+        if config.model:
+            args.extend(["--model", config.model])
+        if config.effort:
+            args.extend(["--effort", config.effort])
+        # Every other HELIX backend takes its prompt as a trailing positional
+        # argument (see the ``claude`` / ``codex`` / ``cursor`` / ``opencode``
+        # branches below); ``agy --help`` documents ``-p``/``--print`` and a
+        # ``--prompt`` alias but not the exact invocation grammar, and
+        # confirming it empirically would require an actual ``--print`` call,
+        # which is off-limits here. This follows the established convention;
+        # the first real dry run must confirm it before this is relied on.
+        args.append(_prompt_file_instruction(prompt_artifact_name))
+        return args
+
     if backend == "claude":
         args = [
             "claude",
@@ -841,18 +863,6 @@ def _build_backend_args(
             "--trust",
             "--workspace",
             worktree_path,
-        ]
-        if config.model:
-            args.extend(["--model", config.model])
-        args.append(_prompt_file_instruction(prompt_artifact_name))
-        return args
-
-    if backend == "gemini":
-        args = [
-            "gemini",
-            "--yolo",
-            "--output-format",
-            "stream-json",
         ]
         if config.model:
             args.extend(["--model", config.model])
@@ -947,12 +957,6 @@ def _parse_jsonl_output(
             parsed = json.loads(line)
         except json.JSONDecodeError:
             if strict:
-                # Gemini CLI may prepend advisory text such as MCP-health
-                # warnings before the JSON stream even when
-                # `--output-format stream-json` is requested.
-                if backend == "gemini":
-                    unparsable.append(line)
-                    continue
                 raise MutationError(
                     f"Failed to parse {backend_display_name(backend)} JSONL output line",
                     operation=f"{backend_display_name(backend)} invocation",
@@ -984,7 +988,7 @@ def _parse_backend_output(
     cmd_str: str,
     worktree_path: str,
 ) -> dict[str, Any]:
-    if backend == "claude":
+    if backend in {"agy", "claude"}:
         return _parse_json_object_output(
             result.stdout,
             backend=backend,
@@ -993,7 +997,7 @@ def _parse_backend_output(
             stderr=result.stderr,
             exit_code=result.returncode,
         )
-    if backend in {"codex", "cursor", "gemini", "opencode"}:
+    if backend in {"codex", "cursor", "opencode"}:
         return _parse_jsonl_output(
             result.stdout,
             backend=backend,
@@ -1340,36 +1344,6 @@ def _count_cursor_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
     return count, names
 
 
-def _count_gemini_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
-    """Count tool invocations from a Gemini stream-json stdout artifact.
-
-    Gemini emits ``tool_use`` events (correctly counted by
-    ``_normalise_usage_stats``) but stores the tool name in ``tool_name``
-    rather than ``name``, so ``tool_names`` remains empty after the initial
-    parse.  This function provides both the count and the names.
-    """
-    count = 0
-    names: list[str] = []
-    try:
-        for raw in path.read_text(encoding="utf-8").splitlines():
-            raw = raw.strip()
-            if not raw:
-                continue
-            try:
-                event = json.loads(raw)
-            except (json.JSONDecodeError, ValueError):
-                continue
-            if not isinstance(event, dict) or event.get("type") != "tool_use":
-                continue
-            count += 1
-            name = event.get("tool_name")
-            if isinstance(name, str) and name:
-                names.append(name)
-    except OSError:
-        return 0, []
-    return count, names
-
-
 def _count_opencode_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
     """Count tool invocations from an OpenCode ``--format json`` stdout artifact.
 
@@ -1402,11 +1376,17 @@ def _count_opencode_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
 
 
 # Dispatcher: maps backend name → per-backend counter function.
+#
+# ``agy`` has no entry yet: writing one correctly needs a real
+# ``--output-format json`` transcript sample, which requires an actual
+# ``--print`` call and is out of scope for this migration (see
+# ``docs/design/sandbox-auth-projection.md``). Until then it falls back to
+# ``_normalise_usage_stats``'s generic walk below, same as any backend
+# without a dedicated counter.
 _TRANSCRIPT_TOOL_COUNTERS: dict[str, Callable[[Path], tuple[int, list[str]]]] = {
     "claude": _count_claude_transcript_tool_events,
     "codex": _count_codex_stdout_tool_events,
     "cursor": _count_cursor_stdout_tool_events,
-    "gemini": _count_gemini_stdout_tool_events,
     "opencode": _count_opencode_stdout_tool_events,
 }
 
@@ -1658,8 +1638,6 @@ def invoke_claude_code(
             passthrough_env=_agent_passthrough_env(passthrough_env), fixed_env=fixed_env
         )
     )
-    if backend == "gemini":
-        backend_env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"
     if backend == "opencode" and (sandbox is None or not sandbox.enabled):
         # Per-candidate SQLite isolation for concurrent opencode subprocesses.
         #

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -723,6 +723,9 @@ def _write_mutation_prompt_artifact(worktree_path: str, prompt: str) -> str:
 def _agent_passthrough_env(passthrough_env: list[str] | None) -> list[str]:
     """Return configured passthrough values plus safe login identity values.
 
+    Host/unsandboxed agents only: the login-identity names are keychain-shaped,
+    and a sandboxed agent has a tmpfs ``HOME`` and no keychain to unlock.
+
     Stored-login resolution is a first-class agent authentication path, not a
     feature users should have to repair by discovering an OS-specific variable.
     Values named here are non-secret and apply only to agent CLIs; evaluator
@@ -782,9 +785,7 @@ def _sandbox_agent_environment(
     ``passthrough_env`` transport above — it only widens what a
     caller-declared credential name is allowed to resolve to.
     """
-    env = _scrub_environment(
-        passthrough_env=_agent_passthrough_env(passthrough_env), fixed_env=fixed_env
-    )
+    env = _scrub_environment(passthrough_env=passthrough_env, fixed_env=fixed_env)
     if sandbox.auth != "env":
         return env
     configured = set(passthrough_env or []) | set((fixed_env or {}).keys())

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -772,16 +772,10 @@ def _sandbox_agent_environment(
     agent only because the caller named it in ``passthrough_env`` or gave it a
     value in ``fixed_env``.
 
-    ``auth_env_allow`` does not run through this function at all, and no code
-    path here checks membership in it. It is a declaration of intent, not an
-    enforcement mechanism: it exists so an operator can name, in one place,
-    which credential(s) ``auth = "env"`` is expected to supply, and so
-    :class:`~helix.config.SandboxConfig`'s ``model_post_init`` and
-    :class:`~helix.config.HelixConfig`'s disjointness check (against
-    ``evaluator.sidecar.passthrough_env``) have something to validate against.
-    Whether a name in ``auth_env_allow`` actually reaches the agent is decided
-    entirely by whether that same name also appears in ``passthrough_env`` or
-    ``[env]`` — the transport this docstring already describes above.
+    ``auth_env_allow`` is deliberately absent: no code path here checks
+    membership in it. It is validated by :class:`~helix.config.SandboxConfig`
+    and :class:`~helix.config.HelixConfig` as a declaration of intent, and it
+    gates nothing at runtime.
     """
     return _scrub_environment(passthrough_env=passthrough_env, fixed_env=fixed_env)
 

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -255,15 +255,11 @@ def _extract_session_id_from_json_output(stdout: str) -> str | None:
     return None
 
 
-def _candidate_auth_volume_name(agent_backend: str) -> str:
-    return f"{_CANDIDATE_AUTH_PREFIX}{agent_backend}-{uuid.uuid4().hex}"
-
-
 def _create_candidate_auth_volume(agent_backend: str) -> CandidateAuthVolume:
     """Create a never-reused, labelled candidate credential volume."""
     if agent_backend not in AUTH_CREDENTIAL_MANIFEST:
         raise ValueError(f"No credential manifest for backend: {agent_backend}")
-    name = _candidate_auth_volume_name(agent_backend)
+    name = f"{_CANDIDATE_AUTH_PREFIX}{agent_backend}-{uuid.uuid4().hex}"
     existing = _run_docker(["docker", "volume", "inspect", name], check=False)
     # Only a real inspect payload counts as proof the name is taken: a zero
     # exit code with no JSON object is not evidence a volume exists.
@@ -1240,10 +1236,10 @@ def _docker_args(
         )
 
         # Pre-own whatever ancestor directories the mounts below would
-        # otherwise leave root-owned -- see F2/F3: under `auth = "env"` with
-        # transcripts on, nothing mounts at AUTH_MOUNT_DESTINATIONS["claude"]
-        # itself; under the default volume mode, opencode's destination is
-        # three levels deep and its own parents are never mounted at all.
+        # otherwise leave root-owned. Under `auth = "env"` with transcripts
+        # on, nothing mounts at AUTH_MOUNT_DESTINATIONS["claude"] itself;
+        # under the default volume mode, opencode's destination is three
+        # levels deep and its own parents are never mounted at all.
         args.extend(
             _synthesized_ancestor_tmpfs_args(
                 [d for d in (candidate_destination, transcript_destination) if d is not None]

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -16,7 +16,7 @@ import tempfile
 import threading
 import time
 import uuid
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Literal
 
 from helix.backends import BACKEND_AUTH_COMMANDS, DEFAULT_BACKEND_IMAGES
@@ -68,6 +68,14 @@ AUTH_MOUNT_DESTINATIONS: dict[str, str] = {
     "gemini": "/home/node/.gemini",
     "opencode": "/home/node/.local/share/opencode",
 }
+
+_AGENT_HOME = "/home/node"
+_AGENT_UID, _AGENT_GID = _RUNNER_UID_GID.split(":")
+
+# Claude's transcript bind always lands here -- three path components below
+# the agent's tmpfs $HOME, nested under (but never equal to)
+# AUTH_MOUNT_DESTINATIONS["claude"].
+_CLAUDE_TRANSCRIPT_MOUNT_DESTINATION = f"{_AGENT_HOME}/.claude/projects/-workspace"
 
 
 @dataclass(frozen=True)
@@ -1025,6 +1033,58 @@ def sandbox_auth_volume_name(agent_backend: str) -> str:
     return f"helix-auth-{agent_backend}"
 
 
+def _tmpfs_owned_by_agent(path: str) -> str:
+    """A ``--tmpfs`` value mounting *path* writable by the agent's uid/gid."""
+    return f"{path}:rw,uid={_AGENT_UID},gid={_AGENT_GID},mode=700"
+
+
+def _synthesized_ancestor_tmpfs_args(mount_destinations: list[str]) -> list[str]:
+    """``--tmpfs`` args pre-owning directories Docker would otherwise root-own.
+
+    Docker synthesises every directory between the agent's tmpfs ``$HOME`` and
+    a deeper ``-v`` mount destination itself -- as ``root:root 0755`` --
+    regardless of ``$HOME``'s own ownership. Any destination nested more than
+    one path component below ``$HOME`` (an ``AUTH_MOUNT_DESTINATIONS`` entry
+    such as opencode's, or Claude's transcript bind) therefore leaves an
+    intervening directory the uid-1000 agent cannot write into.
+
+    *mount_destinations* is every path this docker invocation will mount
+    directly under ``$HOME`` in this call -- derived by the caller from
+    ``AUTH_MOUNT_DESTINATIONS`` and the transcript bind, never hardcoded here.
+    For each, every ancestor directory strictly between ``$HOME`` and that
+    destination needs pre-owning, except one already nested under a
+    *different* entry in *mount_destinations*: that entry's own volume
+    (seeded and chowned by ``_seed_command``) or tmpfs already owns everything
+    beneath it, and stacking another tmpfs inside it would only shadow that
+    ownership rather than extend it.
+    """
+    home = PurePosixPath(_AGENT_HOME)
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for destination in mount_destinations:
+        ancestors: list[str] = []
+        current = PurePosixPath(destination).parent
+        while current != home:
+            current_str = str(current)
+            covered_by_another = any(
+                other != destination
+                and (current_str == other or current_str.startswith(other + "/"))
+                for other in mount_destinations
+            )
+            if covered_by_another:
+                break
+            ancestors.append(current_str)
+            current = current.parent
+        for path in reversed(ancestors):  # shallowest first
+            if path not in seen:
+                seen.add(path)
+                ordered.append(path)
+    args: list[str] = []
+    for path in ordered:
+        args.extend(["--tmpfs", _tmpfs_owned_by_agent(path)])
+    return args
+
+
 def _transcript_bind_dir(
     sandbox: SandboxConfig,
     workspace: Path,
@@ -1078,23 +1138,38 @@ def _docker_args(
     if scope == "agent":
         if agent_backend is None:
             raise ValueError("agent_backend is required for sandboxed agent commands")
-        args.extend(["--tmpfs", "/home/node:rw,uid=1000,gid=1000,mode=700"])
+        args.extend(["--tmpfs", _tmpfs_owned_by_agent(_AGENT_HOME)])
+
+        candidate_destination: str | None = None
         if sandbox.auth == "volume":
             if candidate_auth_volume is None:
                 raise ValueError("volume auth requires a candidate credential volume")
-            args.extend(
-                [
-                    "-v",
-                    f"{candidate_auth_volume.name}:"
-                    f"{AUTH_MOUNT_DESTINATIONS[agent_backend]}:rw",
-                ]
+            candidate_destination = AUTH_MOUNT_DESTINATIONS[agent_backend]
+
+        transcript_dir = _transcript_bind_dir(sandbox, workspace, scope, agent_backend)
+        transcript_destination = (
+            _CLAUDE_TRANSCRIPT_MOUNT_DESTINATION if transcript_dir is not None else None
+        )
+
+        # Pre-own whatever ancestor directories the mounts below would
+        # otherwise leave root-owned -- see F2/F3: under `auth = "env"` with
+        # transcripts on, nothing mounts at AUTH_MOUNT_DESTINATIONS["claude"]
+        # itself; under the default volume mode, opencode's destination is
+        # three levels deep and its own parents are never mounted at all.
+        args.extend(
+            _synthesized_ancestor_tmpfs_args(
+                [d for d in (candidate_destination, transcript_destination) if d is not None]
             )
-        if transcript_dir := _transcript_bind_dir(sandbox, workspace, scope, agent_backend):
+        )
+
+        if candidate_destination is not None:
+            assert candidate_auth_volume is not None
             args.extend(
-                [
-                    "-v",
-                    f"{transcript_dir}:/home/node/.claude/projects/-workspace:rw",
-                ]
+                ["-v", f"{candidate_auth_volume.name}:{candidate_destination}:rw"]
+            )
+        if transcript_dir is not None:
+            args.extend(
+                ["-v", f"{transcript_dir}:{_CLAUDE_TRANSCRIPT_MOUNT_DESTINATION}:rw"]
             )
 
     if sandbox.pids_limit is not None:

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -78,6 +78,24 @@ AUTH_MOUNT_DESTINATIONS: dict[str, str] = {
     "opencode": "/home/node/.local/share/opencode",
 }
 
+# Non-credential files HELIX writes into the candidate volume itself.
+#
+# A candidate mount replaces the whole directory the CLI reads its credential
+# from, so any sibling file that lives in that same directory disappears with
+# it. Where a CLI refuses to start without such a sibling, HELIX synthesises a
+# minimal one rather than copying the operator's own: the sibling is settings,
+# not a secret, it carries no grant, and copying it would drag unrelated
+# operator preferences into every candidate.
+AUTH_SYNTHESIZED_SIBLINGS: dict[str, tuple[tuple[str, str], ...]] = {
+    # Gemini stores its OAuth credential and its settings side by side in one
+    # directory. Without a selected auth method in that settings file the CLI
+    # refuses before it ever looks at the credential, so the candidate needs a
+    # settings file naming the method the copied credential was issued under.
+    "gemini": (
+        ("settings.json", '{"security": {"auth": {"selectedType": "oauth-personal"}}}'),
+    ),
+}
+
 _AGENT_HOME = "/home/node"
 _AGENT_UID, _AGENT_GID = _RUNNER_UID_GID.split(":")
 
@@ -343,6 +361,16 @@ def _seed_command(agent_backend: str) -> str:
         )
     )
     statements.extend(copy_statements)
+    # Siblings the candidate mount would otherwise shadow. Written before the
+    # chown below so the agent -- not root -- ends up owning them.
+    for name, contents in AUTH_SYNTHESIZED_SIBLINGS.get(agent_backend, ()):
+        destination = f"/destination/{name}"
+        statements.extend(
+            [
+                f"printf %s {shlex.quote(contents)} > {shlex.quote(destination)}",
+                f"chmod 600 {shlex.quote(destination)}",
+            ]
+        )
     # Claude's transcript bind is deliberately nested below the auth mount.
     # Pre-creating it as node avoids Docker synthesising a root-owned parent.
     if agent_backend == "claude":

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -247,6 +247,7 @@ def _seed_command(agent_backend: str) -> str:
     """Return a fixed allowlist-only copy command for the seed helper."""
     statements = ["set -eu", "umask 077"]
     source_paths: list[str] = []
+    copy_statements: list[str] = []
     for source, target in AUTH_CREDENTIAL_MANIFEST[agent_backend]:
         source_path = f"/source/{source}"
         target_path = f"/destination/{target}"
@@ -258,13 +259,18 @@ def _seed_command(agent_backend: str) -> str:
                 f"test -s {shlex.quote(source_path)}",
                 f"test $(wc -c < {shlex.quote(source_path)}) -le 1048576",
                 f"test $(stat -c %a {shlex.quote(source_path)}) = 600",
+            ]
+        )
+        copy_statements.extend(
+            [
                 f"mkdir -p {shlex.quote(str(Path(target_path).parent))}",
                 f"cp {shlex.quote(source_path)} {shlex.quote(target_path)}",
                 f"chmod 600 {shlex.quote(target_path)}",
             ]
         )
     # Every manifest entry is a JSON credential record. Parsing before copying
-    # fails closed on a malformed source without exposing its contents.
+    # fails closed on a malformed source without exposing its contents, and
+    # without ever writing it into the candidate volume.
     statements.append(
         "python -c "
         + shlex.quote(
@@ -275,6 +281,7 @@ def _seed_command(agent_backend: str) -> str:
         + " "
         + " ".join(shlex.quote(path) for path in source_paths)
     )
+    statements.extend(copy_statements)
     # Claude's transcript bind is deliberately nested below the auth mount.
     # Pre-creating it as node avoids Docker synthesising a root-owned parent.
     if agent_backend == "claude":

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -49,7 +49,6 @@ class CredentialCleanupError(RuntimeError):
 
 _CANDIDATE_AUTH_PREFIX = "helix-candidate-auth-"
 _CANDIDATE_AUTH_LABEL = "helix.auth.candidate"
-_SEED_IMAGE = "python:3.13-alpine"
 _RUNNER_UID_GID = "1000:1000"
 
 # Source paths are relative to the operator-facing login volume; targets are
@@ -284,8 +283,9 @@ def _seed_command(agent_backend: str) -> str:
     return "; ".join(statements)
 
 
-def _seed_candidate_auth_volume(volume: CandidateAuthVolume) -> None:
-    """Copy only declared credential files from the login volume to *volume*."""
+def _seed_candidate_auth_volume(volume: CandidateAuthVolume, image: str) -> None:
+    """Copy declared credential files from the login volume to *volume*, using
+    the caller-resolved, in-trust-boundary backend runner *image*."""
     args = [
         "docker",
         "run",
@@ -300,7 +300,7 @@ def _seed_candidate_auth_volume(volume: CandidateAuthVolume) -> None:
         f"{sandbox_auth_volume_name(volume.backend)}:/source:ro",
         "-v",
         f"{volume.name}:/destination:rw",
-        _SEED_IMAGE,
+        image,
         "sh",
         "-c",
         _seed_command(volume.backend),
@@ -1161,7 +1161,7 @@ def run_sandboxed_commands(
             if agent_backend is None:
                 raise ValueError("agent_backend is required for volume auth")
             candidate_auth_volume = _create_candidate_auth_volume(agent_backend)
-            _seed_candidate_auth_volume(candidate_auth_volume)
+            _seed_candidate_auth_volume(candidate_auth_volume, docker_image)
         sidecar_runtime = (
             current_evaluator_sidecar_runtime() if scope == "evaluator" else None
         )

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -35,6 +35,43 @@ HELIX_ARTIFACT_NAMES = {
 
 
 @dataclass(frozen=True)
+class CandidateAuthVolume:
+    """A credential-only volume created for exactly one agent candidate."""
+
+    name: str
+    backend: str
+    labels: tuple[tuple[str, str], ...]
+
+
+class CredentialCleanupError(RuntimeError):
+    """A candidate credential volume could not be removed safely."""
+
+
+_CANDIDATE_AUTH_PREFIX = "helix-candidate-auth-"
+_CANDIDATE_AUTH_LABEL = "helix.auth.candidate"
+_SEED_IMAGE = "python:3.13-alpine"
+_RUNNER_UID_GID = "1000:1000"
+
+# Source paths are relative to the operator-facing login volume; targets are
+# relative to the candidate-owned volume mounted at the destination below.
+AUTH_CREDENTIAL_MANIFEST: dict[str, tuple[tuple[str, str], ...]] = {
+    "claude": ((".claude/.credentials.json", ".credentials.json"),),
+    "codex": ((".codex/auth.json", "auth.json"),),
+    "cursor": ((".cursor/cli-config.json", "cli-config.json"),),
+    "gemini": ((".gemini/oauth_creds.json", "oauth_creds.json"),),
+    "opencode": ((".local/share/opencode/auth.json", "auth.json"),),
+}
+
+AUTH_MOUNT_DESTINATIONS: dict[str, str] = {
+    "claude": "/home/node/.claude",
+    "codex": "/home/node/.codex",
+    "cursor": "/home/node/.cursor",
+    "gemini": "/home/node/.gemini",
+    "opencode": "/home/node/.local/share/opencode",
+}
+
+
+@dataclass(frozen=True)
 class EvaluatorSidecarRuntime:
     network: str
     container_name: str
@@ -184,55 +221,115 @@ def _extract_session_id_from_json_output(stdout: str) -> str | None:
     return None
 
 
-def _copy_claude_transcript_from_auth_volume(
-    *,
-    workspace: Path,
-    image: str,
-    agent_backend: str | None,
-    sandbox: SandboxConfig,
-    stdout: str,
-) -> None:
-    if agent_backend != "claude" or not sandbox.preserve_backend_transcripts:
-        return
-    session_id = _extract_session_id_from_json_output(stdout)
-    if not session_id:
-        return
-    rel_dir = Path(sandbox.transcript_artifact_dir) / "claude"
-    rel_file = rel_dir / f"{session_id}.jsonl"
-    source = Path(sandbox.claude_transcript_root) / f"{session_id}.jsonl"
-    rel_file_str = str(rel_file).lstrip("/")
-    command = (
-        "set -eu; "
-        f"src={shlex.quote(str(source))}; "
-        f"dst={shlex.quote('/workspace/' + rel_file_str)}; "
-        '[ -f "$src" ] || exit 0; '
-        'mkdir -p "$(dirname "$dst")"; '
-        'cp "$src" "$dst"'
+def _candidate_auth_volume_name(agent_backend: str) -> str:
+    return f"{_CANDIDATE_AUTH_PREFIX}{agent_backend}-{uuid.uuid4().hex}"
+
+
+def _create_candidate_auth_volume(agent_backend: str) -> CandidateAuthVolume:
+    """Create a never-reused, labelled candidate credential volume."""
+    if agent_backend not in AUTH_CREDENTIAL_MANIFEST:
+        raise ValueError(f"No credential manifest for backend: {agent_backend}")
+    name = _candidate_auth_volume_name(agent_backend)
+    existing = _run_docker(["docker", "volume", "inspect", name], check=False)
+    # Docker prints a JSON object on a real successful inspect.  The non-empty
+    # condition keeps lightweight command fakes from masquerading as a daemon.
+    if existing.returncode == 0 and '"Name"' in (existing.stdout or ""):
+        raise RuntimeError(f"refusing to reuse existing candidate auth volume {name}")
+    labels = ((_CANDIDATE_AUTH_LABEL, "true"), ("helix.auth.backend", agent_backend))
+    args = ["docker", "volume", "create"]
+    for key, value in labels:
+        args.extend(["--label", f"{key}={value}"])
+    args.append(name)
+    _run_docker(args)
+    return CandidateAuthVolume(name=name, backend=agent_backend, labels=labels)
+
+
+def _seed_command(agent_backend: str) -> str:
+    """Return a fixed allowlist-only copy command for the seed helper."""
+    statements = ["set -eu", "umask 077"]
+    source_paths: list[str] = []
+    for source, target in AUTH_CREDENTIAL_MANIFEST[agent_backend]:
+        source_path = f"/source/{source}"
+        target_path = f"/destination/{target}"
+        source_paths.append(source_path)
+        statements.extend(
+            [
+                f"test -f {shlex.quote(source_path)}",
+                f"test ! -L {shlex.quote(source_path)}",
+                f"test -s {shlex.quote(source_path)}",
+                f"test $(wc -c < {shlex.quote(source_path)}) -le 1048576",
+                f"test $(stat -c %a {shlex.quote(source_path)}) = 600",
+                f"mkdir -p {shlex.quote(str(Path(target_path).parent))}",
+                f"cp {shlex.quote(source_path)} {shlex.quote(target_path)}",
+                f"chmod 600 {shlex.quote(target_path)}",
+            ]
+        )
+    # Every manifest entry is a JSON credential record. Parsing before copying
+    # fails closed on a malformed source without exposing its contents.
+    statements.append(
+        "python -c "
+        + shlex.quote(
+            "import json, pathlib, sys; "
+            "records=[json.loads(pathlib.Path(item).read_text()) for item in sys.argv[1:]]; "
+            "assert all(isinstance(record, dict) and record for record in records)"
+        )
+        + " "
+        + " ".join(shlex.quote(path) for path in source_paths)
     )
+    # Claude's transcript bind is deliberately nested below the auth mount.
+    # Pre-creating it as node avoids Docker synthesising a root-owned parent.
+    if agent_backend == "claude":
+        statements.append("mkdir -p /destination/projects/-workspace")
+    statements.append(f"chown -R {_RUNNER_UID_GID} /destination")
+    return "; ".join(statements)
+
+
+def _seed_candidate_auth_volume(volume: CandidateAuthVolume) -> None:
+    """Copy only declared credential files from the login volume to *volume*."""
     args = [
         "docker",
         "run",
         "--rm",
-        "--workdir",
-        "/workspace",
         "--user",
-        "node",
+        "root",
         "--network",
         "none",
         "--security-opt",
         "no-new-privileges",
         "-v",
-        f"{workspace}:/workspace:rw",
+        f"{sandbox_auth_volume_name(volume.backend)}:/source:ro",
         "-v",
-        f"{sandbox_auth_volume_name(agent_backend)}:/home/node:ro",
-        "-e",
-        "HOME=/home/node",
-        image,
+        f"{volume.name}:/destination:rw",
+        _SEED_IMAGE,
         "sh",
         "-c",
-        command,
+        _seed_command(volume.backend),
     ]
-    _run_docker(args, check=False)
+    try:
+        _run_docker(args)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"credential seed failed for backend {volume.backend}; agent was not started"
+        ) from exc
+
+
+def _remove_candidate_auth_volume(volume: CandidateAuthVolume) -> None:
+    """Remove only a volume HELIX created and labelled as candidate-owned."""
+    labels = dict(volume.labels)
+    if (
+        not volume.name.startswith(_CANDIDATE_AUTH_PREFIX)
+        or volume.name.startswith("helix-auth-")
+        or labels.get(_CANDIDATE_AUTH_LABEL) != "true"
+    ):
+        raise CredentialCleanupError(
+            f"refusing credential cleanup for unsafe volume identifier {volume.name!r}"
+        )
+    result = _run_docker(["docker", "volume", "rm", volume.name], check=False)
+    if result.returncode != 0:
+        raise CredentialCleanupError(
+            "credential cleanup failed; remove candidate volume manually: "
+            f"docker volume rm {volume.name}"
+        )
 
 
 def _matches_omitted_path(path: Path, omitted: set[Path]) -> bool:
@@ -922,6 +1019,7 @@ def _docker_args(
     scope: Literal["agent", "evaluator"],
     image: str,
     agent_backend: str | None,
+    candidate_auth_volume: CandidateAuthVolume | None = None,
     network: str | None = None,
     container_name: str | None = None,
 ) -> list[str]:
@@ -945,7 +1043,28 @@ def _docker_args(
     if scope == "agent":
         if agent_backend is None:
             raise ValueError("agent_backend is required for sandboxed agent commands")
-        args.extend(["-v", f"{sandbox_auth_volume_name(agent_backend)}:/home/node:rw"])
+        args.extend(["--tmpfs", "/home/node:rw,uid=1000,gid=1000,mode=700"])
+        if sandbox.auth == "login":
+            if candidate_auth_volume is None:
+                raise ValueError("login auth requires a candidate credential volume")
+            args.extend(
+                [
+                    "-v",
+                    f"{candidate_auth_volume.name}:"
+                    f"{AUTH_MOUNT_DESTINATIONS[agent_backend]}:rw",
+                ]
+            )
+        if agent_backend == "claude" and sandbox.preserve_backend_transcripts:
+            transcript_dir = (
+                workspace / sandbox.transcript_artifact_dir / "claude"
+            )
+            transcript_dir.mkdir(parents=True, exist_ok=True)
+            args.extend(
+                [
+                    "-v",
+                    f"{transcript_dir}:/home/node/.claude/projects/-workspace:rw",
+                ]
+            )
 
     if sandbox.pids_limit is not None:
         args.extend(["--pids-limit", str(sandbox.pids_limit)])
@@ -967,6 +1086,8 @@ def _docker_args(
     container_env["PATH"] = (
         "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     )
+    if scope == "agent" and agent_backend == "opencode":
+        container_env["XDG_DATA_HOME"] = "/home/node/.local/share"
 
     for key, value in container_env.items():
         args.extend(["-e", f"{key}={value}"])
@@ -998,6 +1119,7 @@ def run_sandboxed_commands(
     if docker_image is None:
         raise ValueError("sandbox image must be provided")
     tmp_path = Path(tempfile.mkdtemp(prefix="helix-sandbox-"))
+    candidate_auth_volume: CandidateAuthVolume | None = None
     try:
         workspace = tmp_path / "workspace"
         omit_paths = (
@@ -1013,6 +1135,11 @@ def run_sandboxed_commands(
         )
         _init_synthetic_git_repo(workspace)
         _docker_chown_workspace(workspace, docker_image, "node:node")
+        if scope == "agent" and sandbox.auth == "login":
+            if agent_backend is None:
+                raise ValueError("agent_backend is required for login auth")
+            candidate_auth_volume = _create_candidate_auth_volume(agent_backend)
+            _seed_candidate_auth_volume(candidate_auth_volume)
         sidecar_runtime = (
             current_evaluator_sidecar_runtime() if scope == "evaluator" else None
         )
@@ -1031,6 +1158,7 @@ def run_sandboxed_commands(
                     scope,
                     docker_image,
                     agent_backend,
+                    candidate_auth_volume,
                     sidecar_runtime.network if sidecar_runtime is not None else None,
                     container_name=container_name,
                 )
@@ -1045,14 +1173,6 @@ def run_sandboxed_commands(
                     )
                 finally:
                     _run_docker(["docker", "rm", "-f", container_name], check=False)
-                if scope == "agent":
-                    _copy_claude_transcript_from_auth_volume(
-                        workspace=workspace,
-                        image=docker_image,
-                        agent_backend=agent_backend,
-                        sandbox=sandbox,
-                        stdout=results[-1].stdout or "",
-                    )
         finally:
             if host_owner := _host_owner():
                 _docker_chown_workspace(workspace, docker_image, host_owner)
@@ -1069,7 +1189,11 @@ def run_sandboxed_commands(
                 _sync_back_backend_transcripts(workspace, source)
         return results
     finally:
-        _safe_rmtree(tmp_path, docker_image=docker_image)
+        try:
+            if candidate_auth_volume is not None:
+                _remove_candidate_auth_volume(candidate_auth_volume)
+        finally:
+            _safe_rmtree(tmp_path, docker_image=docker_image)
 
 
 def run_sandboxed_command(

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -251,6 +251,37 @@ def _create_candidate_auth_volume(agent_backend: str) -> CandidateAuthVolume:
     return CandidateAuthVolume(name=name, backend=agent_backend, labels=labels)
 
 
+# Exit codes the seed helper uses to name *why* it refused, so the operator
+# gets a cause instead of a bare failure. They are chosen above the range a
+# shell uses for its own errors and are never surfaced to the operator
+# directly -- ``_SEED_FAILURE_CAUSES`` turns them into a sentence.
+_SEED_EXIT_NO_CREDENTIAL = 10
+_SEED_EXIT_UNSAFE_CREDENTIAL = 11
+_SEED_EXIT_UNREADABLE_CREDENTIAL = 12
+
+_SEED_FAILURE_CAUSES: dict[int, str] = {
+    _SEED_EXIT_NO_CREDENTIAL: (
+        "the {backend} login volume holds no credential -- signing in on the "
+        "host does not sign the sandbox in. Run: helix sandbox login {backend}"
+    ),
+    _SEED_EXIT_UNSAFE_CREDENTIAL: (
+        "the credential in the {backend} login volume is not a private, "
+        "regular, reasonably sized file, so HELIX refused to copy it. Sign "
+        "the sandbox in again: helix sandbox login {backend}"
+    ),
+    _SEED_EXIT_UNREADABLE_CREDENTIAL: (
+        "the credential in the {backend} login volume is not a readable "
+        "credential record. Sign the sandbox in again: "
+        "helix sandbox login {backend}"
+    ),
+}
+
+
+def _guarded(condition: str, exit_code: int) -> str:
+    """A shell statement that exits with *exit_code* when *condition* fails."""
+    return f"{{ {condition}; }} || exit {exit_code}"
+
+
 def _seed_command(agent_backend: str) -> str:
     """Return a fixed allowlist-only copy command for the seed helper."""
     statements = ["set -eu", "umask 077"]
@@ -260,19 +291,29 @@ def _seed_command(agent_backend: str) -> str:
         source_path = f"/source/{source}"
         target_path = f"/destination/{target}"
         source_paths.append(source_path)
+        quoted = shlex.quote(source_path)
         statements.extend(
             [
-                f"test -f {shlex.quote(source_path)}",
-                f"test ! -L {shlex.quote(source_path)}",
-                f"test -s {shlex.quote(source_path)}",
-                f"test $(wc -c < {shlex.quote(source_path)}) -le 1048576",
-                f"test $(stat -c %a {shlex.quote(source_path)}) = 600",
+                # An absent or empty source is the everyday case: nobody has
+                # signed this backend's sandbox in yet, or it was signed out.
+                _guarded(
+                    f"test -f {quoted} && test -s {quoted}",
+                    _SEED_EXIT_NO_CREDENTIAL,
+                ),
+                # A source that exists but fails a safety guard is a different
+                # problem, and needs a different sentence.
+                _guarded(
+                    f"test ! -L {quoted} "
+                    f"&& test $(wc -c < {quoted}) -le 1048576 "
+                    f"&& test $(stat -c %a {quoted}) = 600",
+                    _SEED_EXIT_UNSAFE_CREDENTIAL,
+                ),
             ]
         )
         copy_statements.extend(
             [
                 f"mkdir -p {shlex.quote(str(Path(target_path).parent))}",
-                f"cp {shlex.quote(source_path)} {shlex.quote(target_path)}",
+                f"cp {quoted} {shlex.quote(target_path)}",
                 f"chmod 600 {shlex.quote(target_path)}",
             ]
         )
@@ -280,14 +321,17 @@ def _seed_command(agent_backend: str) -> str:
     # fails closed on a malformed source without exposing its contents, and
     # without ever writing it into the candidate volume.
     statements.append(
-        "python -c "
-        + shlex.quote(
-            "import json, pathlib, sys; "
-            "records=[json.loads(pathlib.Path(item).read_text()) for item in sys.argv[1:]]; "
-            "assert all(isinstance(record, dict) and record for record in records)"
+        _guarded(
+            "python -c "
+            + shlex.quote(
+                "import json, pathlib, sys; "
+                "records=[json.loads(pathlib.Path(item).read_text()) for item in sys.argv[1:]]; "
+                "assert all(isinstance(record, dict) and record for record in records)"
+            )
+            + " "
+            + " ".join(shlex.quote(path) for path in source_paths),
+            _SEED_EXIT_UNREADABLE_CREDENTIAL,
         )
-        + " "
-        + " ".join(shlex.quote(path) for path in source_paths)
     )
     statements.extend(copy_statements)
     # Claude's transcript bind is deliberately nested below the auth mount.
@@ -327,8 +371,15 @@ def _seed_candidate_auth_volume(volume: CandidateAuthVolume, image: str) -> None
     try:
         _run_docker(args)
     except subprocess.CalledProcessError as exc:
+        cause = _SEED_FAILURE_CAUSES.get(exc.returncode)
+        detail = (
+            cause.format(backend=volume.backend)
+            if cause is not None
+            else "the seed helper exited without naming a cause"
+        )
         raise RuntimeError(
-            f"credential seed failed for backend {volume.backend}; agent was not started"
+            f"credential seed failed for backend {volume.backend}; "
+            f"agent was not started: {detail}"
         ) from exc
 
 

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -54,6 +54,14 @@ _RUNNER_UID_GID = "1000:1000"
 # Source paths are relative to the operator-facing login volume; targets are
 # relative to the candidate-owned volume mounted at the destination below.
 AUTH_CREDENTIAL_MANIFEST: dict[str, tuple[tuple[str, str], ...]] = {
+    # Traced with ``strace -f -e trace=openat`` on a real, unauthenticated
+    # Linux binary: the CLI falls back to a plaintext token file at this path
+    # whenever no OS keyring is reachable (always true inside a container),
+    # logging "Using file-based token storage because no D-Bus session bus
+    # detected". Distinct from ``~/.gemini/config``, which the CLI's own
+    # embedded docs describe as shared with the separate, legacy gemini-cli
+    # tooling.
+    "agy": ((".gemini/antigravity-cli/antigravity-oauth-token", "antigravity-oauth-token"),),
     "claude": ((".claude/.credentials.json", ".credentials.json"),),
     "codex": ((".codex/auth.json", "auth.json"),),
     # Cursor's credential store and its settings store are different
@@ -66,15 +74,19 @@ AUTH_CREDENTIAL_MANIFEST: dict[str, tuple[tuple[str, str], ...]] = {
     # so with neither variable set the CLI reads and writes exactly
     # ``$HOME/.config/cursor/auth.json``.
     "cursor": ((".config/cursor/auth.json", "auth.json"),),
-    "gemini": ((".gemini/oauth_creds.json", "oauth_creds.json"),),
     "opencode": ((".local/share/opencode/auth.json", "auth.json"),),
 }
 
 AUTH_MOUNT_DESTINATIONS: dict[str, str] = {
+    # One path component deeper than a bare ``~/.gemini`` -- the CLI's own
+    # private state directory sits under the shared ``.gemini`` root.
+    # ``_synthesized_ancestor_tmpfs_args`` walks ancestors between $HOME and
+    # this destination and pre-owns ``/home/node/.gemini`` automatically; see
+    # its docstring and the confirmation in this backend's tests.
+    "agy": "/home/node/.gemini/antigravity-cli",
     "claude": "/home/node/.claude",
     "codex": "/home/node/.codex",
     "cursor": "/home/node/.config/cursor",
-    "gemini": "/home/node/.gemini",
     "opencode": "/home/node/.local/share/opencode",
 }
 
@@ -87,13 +99,20 @@ AUTH_MOUNT_DESTINATIONS: dict[str, str] = {
 # not a secret, it carries no grant, and copying it would drag unrelated
 # operator preferences into every candidate.
 AUTH_SYNTHESIZED_SIBLINGS: dict[str, tuple[tuple[str, str], ...]] = {
-    # Gemini stores its OAuth credential and its settings side by side in one
-    # directory. Without a selected auth method in that settings file the CLI
-    # refuses before it ever looks at the credential, so the candidate needs a
-    # settings file naming the method the copied credential was issued under.
-    "gemini": (
-        ("settings.json", '{"security": {"auth": {"selectedType": "oauth-personal"}}}'),
-    ),
+    # No backend currently needs a synthesized sibling.
+    #
+    # ``agy``'s credential file is known (see AUTH_CREDENTIAL_MANIFEST above)
+    # but its exact JSON shape is not: probing the traced path with a
+    # synthetic blob shows the CLI opens it and then fails with
+    # "unknown auth method:" rather than "not logged in", meaning the file
+    # likely carries (or is paired with a settings field naming) an explicit
+    # auth-method discriminator -- the same shape of requirement gemini's own
+    # credential had, previously handled by an entry here. HELIX's seed
+    # mechanism only ever copies the credential file opaquely (see
+    # ``_seed_command`` below), so this is safe to leave unresolved: the
+    # first real ``helix sandbox login agy`` will reveal the exact shape and
+    # whether an entry here turns out to be needed. This dict already
+    # defaults to ``()`` for any backend not listed, so omitting one is safe.
 }
 
 _AGENT_HOME = "/home/node"

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -978,7 +978,10 @@ def start_evaluator_sidecar(
         args.extend(
             _build_add_host_args(add_host_gateway=False, extra_hosts=extra_hosts)
         )
-        for key in passthrough_env or []:
+        sidecar_env_names = list(
+            dict.fromkeys([*(passthrough_env or []), *sidecar.passthrough_env])
+        )
+        for key in sidecar_env_names:
             if key in os.environ:
                 args.extend(["-e", f"{key}={os.environ[key]}"])
         for key, value in (fixed_env or {}).items():
@@ -1044,9 +1047,9 @@ def _docker_args(
         if agent_backend is None:
             raise ValueError("agent_backend is required for sandboxed agent commands")
         args.extend(["--tmpfs", "/home/node:rw,uid=1000,gid=1000,mode=700"])
-        if sandbox.auth == "login":
+        if sandbox.auth == "volume":
             if candidate_auth_volume is None:
-                raise ValueError("login auth requires a candidate credential volume")
+                raise ValueError("volume auth requires a candidate credential volume")
             args.extend(
                 [
                     "-v",
@@ -1135,9 +1138,9 @@ def run_sandboxed_commands(
         )
         _init_synthetic_git_repo(workspace)
         _docker_chown_workspace(workspace, docker_image, "node:node")
-        if scope == "agent" and sandbox.auth == "login":
+        if scope == "agent" and sandbox.auth == "volume":
             if agent_backend is None:
-                raise ValueError("agent_backend is required for login auth")
+                raise ValueError("agent_backend is required for volume auth")
             candidate_auth_volume = _create_candidate_auth_volume(agent_backend)
             _seed_candidate_auth_volume(candidate_auth_volume)
         sidecar_runtime = (

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -230,8 +230,8 @@ def _create_candidate_auth_volume(agent_backend: str) -> CandidateAuthVolume:
         raise ValueError(f"No credential manifest for backend: {agent_backend}")
     name = _candidate_auth_volume_name(agent_backend)
     existing = _run_docker(["docker", "volume", "inspect", name], check=False)
-    # Docker prints a JSON object on a real successful inspect.  The non-empty
-    # condition keeps lightweight command fakes from masquerading as a daemon.
+    # Only a real inspect payload counts as proof the name is taken: a zero
+    # exit code with no JSON object is not evidence a volume exists.
     if existing.returncode == 0 and '"Name"' in (existing.stdout or ""):
         raise RuntimeError(f"refusing to reuse existing candidate auth volume {name}")
     labels = ((_CANDIDATE_AUTH_LABEL, "true"), ("helix.auth.backend", agent_backend))
@@ -284,8 +284,12 @@ def _seed_command(agent_backend: str) -> str:
 
 
 def _seed_candidate_auth_volume(volume: CandidateAuthVolume, image: str) -> None:
-    """Copy declared credential files from the login volume to *volume*, using
-    the caller-resolved, in-trust-boundary backend runner *image*."""
+    """Copy the manifest's credential files from the login volume to *volume*.
+
+    *image* is the backend's own runner image, resolved by the caller. The seed
+    helper must run inside the trust boundary HELIX already accepts for that
+    backend; it must never introduce a third-party image of its own.
+    """
     args = [
         "docker",
         "run",

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -1014,6 +1014,27 @@ def sandbox_auth_volume_name(agent_backend: str) -> str:
     return f"helix-auth-{agent_backend}"
 
 
+def _transcript_bind_dir(
+    sandbox: SandboxConfig,
+    workspace: Path,
+    scope: Literal["agent", "evaluator"],
+    agent_backend: str | None,
+) -> Path | None:
+    """Host path bind-mounted over claude's in-container transcript directory.
+
+    ``None`` when this run has no such bind. The directory must be created
+    before the workspace is chowned to ``node:node`` so that chown covers it;
+    creating it afterwards fails on native Linux whenever the host UID is not
+    1000, and silently produces a bind directory the container user cannot
+    write when the host is root.
+    """
+    if scope != "agent" or agent_backend != "claude":
+        return None
+    if not sandbox.preserve_backend_transcripts:
+        return None
+    return workspace / sandbox.transcript_artifact_dir / "claude"
+
+
 def _docker_args(
     command: list[str],
     env: dict[str, str],
@@ -1057,11 +1078,7 @@ def _docker_args(
                     f"{AUTH_MOUNT_DESTINATIONS[agent_backend]}:rw",
                 ]
             )
-        if agent_backend == "claude" and sandbox.preserve_backend_transcripts:
-            transcript_dir = (
-                workspace / sandbox.transcript_artifact_dir / "claude"
-            )
-            transcript_dir.mkdir(parents=True, exist_ok=True)
+        if transcript_dir := _transcript_bind_dir(sandbox, workspace, scope, agent_backend):
             args.extend(
                 [
                     "-v",
@@ -1137,6 +1154,8 @@ def run_sandboxed_commands(
             omit_paths=omit_paths,
         )
         _init_synthetic_git_repo(workspace)
+        if transcript_dir := _transcript_bind_dir(sandbox, workspace, scope, agent_backend):
+            transcript_dir.mkdir(parents=True, exist_ok=True)
         _docker_chown_workspace(workspace, docker_image, "node:node")
         if scope == "agent" and sandbox.auth == "volume":
             if agent_backend is None:

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -56,7 +56,16 @@ _RUNNER_UID_GID = "1000:1000"
 AUTH_CREDENTIAL_MANIFEST: dict[str, tuple[tuple[str, str], ...]] = {
     "claude": ((".claude/.credentials.json", ".credentials.json"),),
     "codex": ((".codex/auth.json", "auth.json"),),
-    "cursor": ((".cursor/cli-config.json", "cli-config.json"),),
+    # Cursor's credential store and its settings store are different
+    # directories on Linux. The CLI resolves its settings directory as
+    # ``$CURSOR_CONFIG_DIR``, else ``$XDG_CONFIG_HOME/cursor``, else
+    # ``$HOME/.cursor`` -- that is where ``cli-config.json`` (editor, display,
+    # permissions, model) lives, and it holds no credential. The credential
+    # goes through a separate resolver that on Linux always joins
+    # ``$XDG_CONFIG_HOME`` (else ``$HOME/.config``) with the application name,
+    # so with neither variable set the CLI reads and writes exactly
+    # ``$HOME/.config/cursor/auth.json``.
+    "cursor": ((".config/cursor/auth.json", "auth.json"),),
     "gemini": ((".gemini/oauth_creds.json", "oauth_creds.json"),),
     "opencode": ((".local/share/opencode/auth.json", "auth.json"),),
 }
@@ -64,7 +73,7 @@ AUTH_CREDENTIAL_MANIFEST: dict[str, tuple[tuple[str, str], ...]] = {
 AUTH_MOUNT_DESTINATIONS: dict[str, str] = {
     "claude": "/home/node/.claude",
     "codex": "/home/node/.codex",
-    "cursor": "/home/node/.cursor",
+    "cursor": "/home/node/.config/cursor",
     "gemini": "/home/node/.gemini",
     "opencode": "/home/node/.local/share/opencode",
 }

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -1,0 +1,384 @@
+"""Real-Docker proof that per-candidate auth volumes actually isolate credentials.
+
+``tests/unit/test_sandbox.py`` proves HELIX's auth-volume design *by
+construction*: it patches ``helix.sandbox.subprocess.run`` and inspects the
+argv HELIX builds, so no container ever runs and no volume is ever created.
+That is necessary but not sufficient -- the credential-rotation incident this
+design exists to prevent was an *observed* runtime failure (a shared
+credential mutated in place under concurrent use), not a static argv defect.
+
+This module closes that gap using a real Docker daemon and HELIX's own
+volume-creation/seeding functions (``_create_candidate_auth_volume``,
+``_seed_candidate_auth_volume``, ``run_sandboxed_command``) -- never a
+hand-rolled reimplementation of the copy/mount logic under test.
+
+Credential safety
+------------------
+Every credential used here is synthetic (``fake-not-a-real-token``, shaped
+like ``AUTH_CREDENTIAL_MANIFEST["claude"]`` expects). The tests never read,
+mount, or reference an operator's real ``~/.claude`` et al., and never touch
+the real ``helix-auth-<backend>`` volumes: ``helix.sandbox.sandbox_auth_volume_name``
+is monkeypatched for the duration of each test to point at a throwaway
+``helix-test-synthetic-login-*`` volume instead. That is the sole seam
+touched; every other code path under test runs unmodified.
+
+Convention: follows ``docker_integration`` (see ``pyproject.toml`` markers)
+and the ``_require_docker_fixture``-style skip used historically for
+Docker-gated tests in this repo -- skip cleanly when the daemon or fixture
+image is unavailable rather than fail CI/a laptop without Docker.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+import helix.sandbox as sandbox_module
+from helix.backends import DEFAULT_BACKEND_IMAGES
+from helix.config import SandboxConfig
+from helix.sandbox import (
+    AUTH_CREDENTIAL_MANIFEST,
+    AUTH_MOUNT_DESTINATIONS,
+    CandidateAuthVolume,
+    _create_candidate_auth_volume,
+    _remove_candidate_auth_volume,
+    _run_docker,
+    _seed_candidate_auth_volume,
+    _SEED_IMAGE,
+    run_sandboxed_command,
+)
+
+
+pytestmark = pytest.mark.docker_integration
+
+_BACKEND = "claude"
+_FIXTURE_IMAGE = os.environ.get("HELIX_DOCKER_TEST_IMAGE", DEFAULT_BACKEND_IMAGES[_BACKEND])
+_REAL_LOGIN_VOLUME_NAME = f"helix-auth-{_BACKEND}"  # never created/read/written below
+
+_SOURCE_REL, _TARGET_REL = AUTH_CREDENTIAL_MANIFEST[_BACKEND][0]
+_MOUNT_DEST = AUTH_MOUNT_DESTINATIONS[_BACKEND]
+
+_FAKE_CREDENTIAL = json.dumps(
+    {
+        "claudeAiOauth": {
+            "accessToken": "fake-not-a-real-token",
+            "refreshToken": "fake",
+            "expiresAt": 9999999999,
+            "scopes": ["user:inference"],
+        }
+    }
+)
+_ROTATED_CREDENTIAL = json.dumps(
+    {
+        "claudeAiOauth": {
+            "accessToken": "fake-rotated-token-from-candidate-a",
+            "refreshToken": "fake-rotated",
+            "expiresAt": 9999999999,
+            "scopes": ["user:inference"],
+        }
+    }
+)
+
+
+def _docker(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", *args], check=check, capture_output=True, text=True, timeout=30
+    )
+
+
+def _require_docker_fixture() -> None:
+    try:
+        daemon = _docker("info")
+        image = _docker("image", "inspect", _FIXTURE_IMAGE)
+    except (OSError, subprocess.SubprocessError) as exc:
+        pytest.skip(f"Docker daemon unavailable: {exc}")
+    if daemon.returncode != 0:
+        pytest.skip(f"Docker daemon unavailable: {daemon.stderr.strip()}")
+    if image.returncode != 0:
+        pytest.skip(f"fixture image {_FIXTURE_IMAGE!r} is not installed locally")
+
+
+def _diagnostic_docker_args(
+    volume_name: str, mount: str, script: str, *, writable: bool
+) -> list[str]:
+    mode = "rw" if writable else "ro"
+    return [
+        "docker",
+        "run",
+        "--rm",
+        "--user",
+        "root",
+        "--network",
+        "none",
+        "--security-opt",
+        "no-new-privileges",
+        "-v",
+        f"{volume_name}:{mount}:{mode}",
+        _SEED_IMAGE,
+        "sh",
+        "-c",
+        script,
+    ]
+
+
+def _make_synthetic_login_volume(backend: str, credential_json: str) -> str:
+    """Create a throwaway, HELIX-shaped login volume holding a fake credential.
+
+    This mimics the *shape* the real login volume has after ``claude auth
+    login`` (manifest-declared relative path, mode 0600, uid/gid 1000) but is
+    a brand-new randomly-named volume -- it is never ``helix-auth-<backend>``
+    and never derived from any real credential.
+    """
+    name = f"helix-test-synthetic-login-{backend}-{uuid.uuid4().hex}"
+    _run_docker(["docker", "volume", "create", name])
+    container_path = f"/home/node/{_SOURCE_REL}"
+    parent = str(Path(container_path).parent)
+    script = (
+        f"set -eu; mkdir -p {shlex.quote(parent)}; "
+        f"printf '%s' {shlex.quote(credential_json)} > {shlex.quote(container_path)}; "
+        f"chmod 600 {shlex.quote(container_path)}; "
+        "chown -R 1000:1000 /home/node"
+    )
+    _run_docker(_diagnostic_docker_args(name, "/home/node", script, writable=True))
+    return name
+
+
+def _read_credential(volume_name: str, rel_path: str, *, mount: str = "/check") -> tuple[str, str]:
+    """Return ``(file content, "mode uid:gid")`` read from inside *volume_name*."""
+    path = f"{mount}/{rel_path}"
+    script = (
+        f"cat {shlex.quote(path)}; "
+        "printf '\\n===MODE===\\n'; "
+        f"stat -c '%a %u:%g' {shlex.quote(path)}"
+    )
+    result = _run_docker(_diagnostic_docker_args(volume_name, mount, script, writable=False))
+    content, mode = result.stdout.split("\n===MODE===\n")
+    return content, mode.strip()
+
+
+def _write_credential(volume_name: str, rel_path: str, content: str, *, mount: str = "/check") -> None:
+    path = f"{mount}/{rel_path}"
+    script = f"printf '%s' {shlex.quote(content)} > {shlex.quote(path)}"
+    _run_docker(_diagnostic_docker_args(volume_name, mount, script, writable=True))
+
+
+def _list_top_level(volume_name: str, *, mount: str = "/check") -> set[str]:
+    result = _run_docker(
+        _diagnostic_docker_args(volume_name, mount, f"ls -a {mount}", writable=False)
+    )
+    return {entry for entry in result.stdout.split() if entry not in {".", ".."}}
+
+
+def _volume_exists(name: str) -> bool:
+    return _docker("volume", "inspect", name).returncode == 0
+
+
+def _force_remove_volume(name: str) -> None:
+    _docker("volume", "rm", "-f", name)
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_test_volumes():
+    """Belt-and-braces cleanup: remove any stray test-created volumes.
+
+    Scoped to prefixes HELIX itself only ever assigns to throwaway
+    credential volumes (``helix-candidate-auth-``) or that this test module
+    invents for its synthetic login fixture (``helix-test-synthetic-login-``).
+    Neither prefix can collide with a real ``helix-auth-<backend>`` volume.
+    """
+    yield
+    listing = _docker("volume", "ls", "--format", "{{.Name}}")
+    for name in listing.stdout.splitlines():
+        if name.startswith("helix-candidate-auth-") or name.startswith(
+            "helix-test-synthetic-login-"
+        ):
+            _force_remove_volume(name)
+
+
+# --------------------------------------------------------------------------
+# TEST 1 -- runtime isolation via HELIX's own volume-creation/seeding code
+# --------------------------------------------------------------------------
+
+
+def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_docker_fixture()
+
+    login_volume = _make_synthetic_login_volume(_BACKEND, _FAKE_CREDENTIAL)
+
+    # The only seam we touch: redirect the seeding step's *source* volume
+    # away from the real "helix-auth-claude" toward our synthetic fixture.
+    # `_seed_candidate_auth_volume` looks this up by calling
+    # `sandbox_auth_volume_name(volume.backend)` from `helix.sandbox`'s own
+    # module globals, so patching the module attribute here also redirects
+    # the call made from inside `_seed_candidate_auth_volume` itself.
+    monkeypatch.setattr(sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume)
+
+    candidate_a: CandidateAuthVolume | None = None
+    candidate_b: CandidateAuthVolume | None = None
+    try:
+        # 1 & 2: real HELIX volume-creation + seeding code, called directly.
+        candidate_a = _create_candidate_auth_volume(_BACKEND)
+        candidate_b = _create_candidate_auth_volume(_BACKEND)
+        assert candidate_a.name != candidate_b.name
+        assert candidate_a.name != login_volume
+        assert candidate_b.name != login_volume
+        assert _REAL_LOGIN_VOLUME_NAME not in (candidate_a.name, candidate_b.name, login_volume)
+
+        _seed_candidate_auth_volume(candidate_a)
+        _seed_candidate_auth_volume(candidate_b)
+
+        # 3: both candidates contain the credential, mode 0600, owned 1000:1000.
+        content_a, mode_a = _read_credential(candidate_a.name, _TARGET_REL)
+        content_b, mode_b = _read_credential(candidate_b.name, _TARGET_REL)
+        assert content_a == _FAKE_CREDENTIAL
+        assert content_b == _FAKE_CREDENTIAL
+        assert mode_a == "600 1000:1000"
+        assert mode_b == "600 1000:1000"
+
+        # 4: THE assertion that matters most. Write a different "rotated"
+        # credential into candidate A's own copy (simulating a backend
+        # refreshing its token in place, exactly as observed in the
+        # incident), then assert candidate B is byte-unchanged.
+        _write_credential(candidate_a.name, _TARGET_REL, _ROTATED_CREDENTIAL)
+        rotated_content_a, _ = _read_credential(candidate_a.name, _TARGET_REL)
+        assert rotated_content_a == _ROTATED_CREDENTIAL
+
+        unaffected_content_b, unaffected_mode_b = _read_credential(candidate_b.name, _TARGET_REL)
+        assert unaffected_content_b == _FAKE_CREDENTIAL, (
+            "candidate B's credential changed after candidate A rotated its "
+            "own copy -- this is exactly the shared-volume rotation incident "
+            "this design exists to prevent"
+        )
+        assert unaffected_mode_b == "600 1000:1000"
+
+        # The synthetic login volume itself is also untouched by A's write.
+        login_content, _ = _read_credential(login_volume, _SOURCE_REL, mount="/home/node")
+        assert login_content == _FAKE_CREDENTIAL
+
+        # 5: candidate volumes only contain the manifest-declared targets --
+        # no trace of the login volume's own nested layout leaks through.
+        top_level_a = _list_top_level(candidate_a.name)
+        top_level_b = _list_top_level(candidate_b.name)
+        assert ".claude" not in top_level_a  # source's directory name, not the target's
+        assert ".claude" not in top_level_b
+        assert top_level_a == {".credentials.json", "projects"}
+        assert top_level_b == {".credentials.json", "projects"}
+
+        login_mountpoint = _docker(
+            "volume", "inspect", "-f", "{{.Mountpoint}}", login_volume
+        ).stdout.strip()
+        for candidate in (candidate_a, candidate_b):
+            candidate_mountpoint = _docker(
+                "volume", "inspect", "-f", "{{.Mountpoint}}", candidate.name
+            ).stdout.strip()
+            assert candidate_mountpoint != login_mountpoint
+    finally:
+        _force_remove_volume(login_volume)
+
+    # 6: cleanup actually destroys the candidate volumes (real Docker check).
+    assert _volume_exists(candidate_a.name)
+    assert _volume_exists(candidate_b.name)
+    _remove_candidate_auth_volume(candidate_a)
+    _remove_candidate_auth_volume(candidate_b)
+    assert not _volume_exists(candidate_a.name)
+    assert not _volume_exists(candidate_b.name)
+
+
+# --------------------------------------------------------------------------
+# TEST 2 -- E2E through HELIX's real sandbox entry point
+# --------------------------------------------------------------------------
+
+
+def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _require_docker_fixture()
+
+    login_volume = _make_synthetic_login_volume(_BACKEND, _FAKE_CREDENTIAL)
+    monkeypatch.setattr(sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume)
+
+    observed_docker_args: list[list[str]] = []
+    original_docker_args = sandbox_module._docker_args
+
+    def _spy(*args: object, **kwargs: object) -> list[str]:
+        built = original_docker_args(*args, **kwargs)  # type: ignore[arg-type]
+        observed_docker_args.append(built)
+        return built
+
+    monkeypatch.setattr(sandbox_module, "_docker_args", _spy)
+
+    source = tmp_path / "candidate"
+    source.mkdir()
+    dest_path = f"{_MOUNT_DEST}/{_TARGET_REL}"
+
+    # A harmless command that never calls a model or any backend CLI: it only
+    # reads the seeded credential and process environment, then writes a
+    # "rotated" value the way a real refresh would -- purely local file I/O.
+    command = [
+        "sh",
+        "-c",
+        (
+            f"cat {shlex.quote(dest_path)}; echo; "
+            f"echo MODE:$(stat -c '%a %u:%g' {shlex.quote(dest_path)}); "
+            "echo HOME_ENV:$HOME; "
+            "if mount | grep -q \" on /home/node type tmpfs\"; then "
+            "echo HOME_MOUNT:tmpfs; else echo HOME_MOUNT:not-tmpfs; fi; "
+            f"printf '%s' {shlex.quote(_ROTATED_CREDENTIAL)} > {shlex.quote(dest_path)}"
+        ),
+    ]
+
+    result = run_sandboxed_command(
+        command,
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
+        scope="agent",
+        sync_back=False,
+        image=_FIXTURE_IMAGE,
+        agent_backend=_BACKEND,
+    )
+
+    try:
+        assert result.returncode == 0, f"sandboxed command failed: {result.stderr}"
+        lines = result.stdout.splitlines()
+        assert lines[0] == _FAKE_CREDENTIAL, "seeded credential not present/readable at mount dest"
+        assert lines[1] == "MODE:600 1000:1000", "credential not owned/moded correctly in container"
+        assert lines[2] == "HOME_ENV:/home/node"
+        assert lines[3] == "HOME_MOUNT:tmpfs", "HOME is not the private per-container tmpfs"
+
+        # The agent container's own argv never mentions the login volume, by
+        # name or by our monkeypatched stand-in -- it only ever sees a
+        # `helix-candidate-auth-*` volume.
+        agent_call = next(
+            call for call in observed_docker_args if call[:2] == ["docker", "run"]
+        )
+        assert not any(login_volume in item for item in agent_call)
+        assert not any(_REAL_LOGIN_VOLUME_NAME in item for item in agent_call)
+        mount_arg = next(
+            item for item in agent_call if item.endswith(f":{_MOUNT_DEST}:rw")
+        )
+        candidate_volume_in_argv = mount_arg.split(":", 1)[0]
+        assert candidate_volume_in_argv.startswith("helix-candidate-auth-claude-")
+
+        # The candidate volume the agent actually used is gone once
+        # `run_sandboxed_command` returns (its own cleanup path ran).
+        assert not _volume_exists(candidate_volume_in_argv)
+
+        # THE assertion that matters most, replayed through the real E2E
+        # entry point: the in-container "rotation" write landed on the
+        # candidate's private copy, not on the synthetic login volume.
+        login_content, _ = _read_credential(login_volume, _SOURCE_REL, mount="/home/node")
+        assert login_content == _FAKE_CREDENTIAL, (
+            "the login volume was mutated by a write made inside the agent "
+            "container -- credentials are not isolated"
+        )
+    finally:
+        _force_remove_volume(login_volume)

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -33,21 +33,21 @@ is monkeypatched for the duration of each test to point at a throwaway
 touched; every other code path under test runs unmodified.
 
 Credential shape: ``claude``'s login-volume shape (``claudeAiOauth`` with an
-OAuth token pair) and ``cursor``'s (an access/refresh token pair) are
-reflected in the fake fixtures below. Neither was obtained by reading an
-operator's credential file -- which the paragraph above forbids; each was read
-out of the shipped runner image's own CLI bundle, where the code that writes
-the file states the shape directly. The on-disk shapes of ``codex``'s
-``auth.json``, ``gemini``'s ``oauth_creds.json``, and ``opencode``'s
-``auth.json`` are deliberately not reproduced; those three get a minimal,
-valid, non-empty JSON object (see ``_fake_credential`` below) instead.
-Everything the isolation tests assert -- byte-for-byte isolation across
-candidate volumes, mode and ownership, manifest-only contents, and that a
-write to one candidate reaches neither another candidate nor the login volume
--- depends on the manifest's source/target *paths* and on file *bytes*
-surviving unchanged, not on any credential's internal schema. The shape
-matters only to the backend-specific test at the end of this module, which
-hands a real CLI the seeded record and reads what it says about it.
+OAuth token pair), ``cursor``'s (an access/refresh token pair), and
+``gemini``'s (an OAuth token record) are reflected in the fake fixtures below.
+None was obtained by reading an operator's credential file -- which the
+paragraph above forbids; each was read out of the shipped runner image's own
+CLI bundle, where the code that writes the file states the shape directly. The
+on-disk shapes of ``codex``'s ``auth.json`` and ``opencode``'s ``auth.json``
+are deliberately not reproduced; those two get a minimal, valid, non-empty
+JSON object (see ``_fake_credential`` below) instead. Everything the isolation
+tests assert -- byte-for-byte isolation across candidate volumes, mode and
+ownership, manifest-only contents, and that a write to one candidate reaches
+neither another candidate nor the login volume -- depends on the manifest's
+source/target *paths* and on file *bytes* surviving unchanged, not on any
+credential's internal schema. The shape matters only to the two
+backend-specific tests at the end of this module, which hand a real CLI the
+seeded record and read what it says about it.
 
 These tests carry the ``docker_integration`` marker (see ``pyproject.toml``)
 and skip when the daemon or a fixture image is unavailable, so a machine
@@ -72,6 +72,7 @@ from helix.config import SandboxConfig
 from helix.sandbox import (
     AUTH_CREDENTIAL_MANIFEST,
     AUTH_MOUNT_DESTINATIONS,
+    AUTH_SYNTHESIZED_SIBLINGS,
     CandidateAuthVolume,
     _create_candidate_auth_volume,
     _remove_candidate_auth_volume,
@@ -124,6 +125,17 @@ def _fake_credential(backend: str) -> str:
                 "apiKey": None,
             }
         )
+    if backend == "gemini":
+        # The CLI's credential cache stores an OAuth token record.
+        return json.dumps(
+            {
+                "access_token": _SYNTHETIC_TOKEN,
+                "refresh_token": f"{_SYNTHETIC_TOKEN}-refresh",
+                "scope": "https://www.googleapis.com/auth/cloud-platform",
+                "token_type": "Bearer",
+                "expiry_date": 4102444800000,
+            }
+        )
     return json.dumps(
         {
             "synthetic_credential": True,
@@ -136,9 +148,10 @@ def _fake_credential(backend: str) -> str:
 
 def _rotated_credential(backend: str) -> str:
     """A synthetic "rotated" value simulating an in-place token refresh."""
-    if backend == "cursor":
+    if backend in {"cursor", "gemini"}:
         rotated = json.loads(_fake_credential(backend))
-        rotated["accessToken"] = f"{_SYNTHETIC_TOKEN}-rotated-by-candidate-a"
+        key = "accessToken" if backend == "cursor" else "access_token"
+        rotated[key] = f"{_SYNTHETIC_TOKEN}-rotated-by-candidate-a"
         return json.dumps(rotated)
     if backend == "claude":
         return json.dumps(
@@ -431,9 +444,15 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
         assert source_top_component not in top_level_a  # source's directory name, not the target's
         assert source_top_component not in top_level_b
         expected_top_level = {target for _, target in AUTH_CREDENTIAL_MANIFEST[backend]}
+        # Siblings the seed helper writes itself, because the candidate mount
+        # would otherwise shadow them (gemini's settings file today).
+        expected_top_level |= {
+            name for name, _ in AUTH_SYNTHESIZED_SIBLINGS.get(backend, ())
+        }
         # claude's transcript bind is deliberately pre-created by the seed
         # helper (see `_seed_command`'s claude special case in sandbox.py);
-        # every other backend's candidate volume holds only its credential.
+        # every other backend's candidate volume holds only its credential
+        # and whatever sibling the line above accounts for.
         if backend == "claude":
             expected_top_level.add("projects")
         assert top_level_a == expected_top_level
@@ -913,5 +932,112 @@ def test_cursor_cli_reads_the_credential_from_the_path_helix_mounts_it_at(
             )
         finally:
             _force_remove_volume(settings_login_volume)
+    finally:
+        _force_remove_volume(login_volume)
+
+
+# --------------------------------------------------------------------------
+# TEST 7 -- the gemini CLI gets past its auth-method gate
+#
+# Without a settings file naming an auth method, the CLI refuses before it
+# ever opens the credential. The candidate mount replaces the directory that
+# settings file lives in, so HELIX writes a minimal one into the candidate
+# volume; this proves it clears the gate.
+#
+# "The refusal is absent" is not on its own evidence of anything -- an empty
+# candidate volume would satisfy it too. So this asserts the CLI got far
+# enough to *read* the credential from the mounted path, using the line the
+# CLI emits only from inside the branch it takes when a cached credential was
+# found and parsed, and pairs that with a control run that suppresses the
+# synthesized sibling and shows the refusal returning.
+# --------------------------------------------------------------------------
+
+
+_GEMINI_AUTH_METHOD_REFUSAL = "Please set an Auth method"
+# Emitted only from the branch the CLI takes when it has loaded a cached
+# credential and is trying to use it; absent when no credential was found.
+_GEMINI_CREDENTIAL_WAS_READ = "Cached credentials are not valid"
+
+
+def test_gemini_cli_clears_its_auth_method_gate_and_reads_the_seeded_credential(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = "gemini"
+    fixture_image = _fixture_image(backend)
+    _require_docker_fixture(fixture_image)
+
+    source_rel, target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
+    destination = AUTH_MOUNT_DESTINATIONS[backend]
+    sibling_name, sibling_contents = AUTH_SYNTHESIZED_SIBLINGS[backend][0]
+    credential = _fake_credential(backend)
+
+    def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        workspace = tmp_path / f"candidate-{uuid.uuid4().hex[:8]}"
+        workspace.mkdir()
+        return run_sandboxed_command(
+            command,
+            cwd=workspace,
+            env={},
+            sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
+            scope="agent",
+            sync_back=False,
+            image=fixture_image,
+            agent_backend=backend,
+        )
+
+    login_volume = _make_synthetic_login_volume(
+        backend, credential, source_rel, image=fixture_image
+    )
+    monkeypatch.setattr(
+        sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume
+    )
+
+    try:
+        # 1. Credential and sibling are both at the exact paths the CLI reads,
+        #    private and owned by the agent.
+        credential_path = f"{destination}/{target_rel}"
+        sibling_path = f"{destination}/{sibling_name}"
+        probe = _run(
+            [
+                "sh",
+                "-c",
+                (
+                    f"cat {shlex.quote(credential_path)}; echo; "
+                    f"echo MODE:$(stat -c '%a %u:%g' {shlex.quote(credential_path)}); "
+                    f"cat {shlex.quote(sibling_path)}; echo; "
+                    f"echo SIBLING_MODE:$(stat -c '%a %u:%g' {shlex.quote(sibling_path)})"
+                ),
+            ]
+        )
+        assert probe.returncode == 0, probe.stderr
+        probe_lines = probe.stdout.splitlines()
+        assert probe_lines[0] == credential
+        assert probe_lines[1] == "MODE:600 1000:1000"
+        assert probe_lines[2] == sibling_contents
+        assert probe_lines[3] == "SIBLING_MODE:600 1000:1000"
+
+        # 2. The CLI clears the gate and goes on to read the credential.
+        run = _run(["gemini", "--debug", "-p", "hello"])
+        combined = f"{run.stdout}\n{run.stderr}"
+        assert _GEMINI_AUTH_METHOD_REFUSAL not in combined, (
+            f"the auth-method gate is still closed: {combined!r}"
+        )
+        assert _GEMINI_CREDENTIAL_WAS_READ in combined, (
+            "the CLI never got as far as loading a credential -- clearing the "
+            f"gate alone proves nothing: {combined!r}"
+        )
+
+        # 3. The control. With the sibling suppressed, the same command hits
+        #    the refusal again and never reaches the credential, so step 2 is
+        #    not satisfied by an empty candidate volume.
+        monkeypatch.setitem(sandbox_module.AUTH_SYNTHESIZED_SIBLINGS, backend, ())
+        control = _run(["gemini", "--debug", "-p", "hello"])
+        control_combined = f"{control.stdout}\n{control.stderr}"
+        assert _GEMINI_AUTH_METHOD_REFUSAL in control_combined, (
+            "the auth-method refusal did not return without the synthesized "
+            f"settings sibling: {control_combined!r}"
+        )
+        assert _GEMINI_CREDENTIAL_WAS_READ not in control_combined
     finally:
         _force_remove_volume(login_volume)

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -1,34 +1,30 @@
 """Real-Docker proof that per-candidate auth volumes actually isolate credentials.
 
-``tests/unit/test_sandbox.py`` proves HELIX's auth-volume design *by
-construction*: it patches ``helix.sandbox.subprocess.run`` and inspects the
-argv HELIX builds, so no container ever runs and no volume is ever created.
-That is necessary but not sufficient -- the credential-rotation incident this
-design exists to prevent was an *observed* runtime failure (a shared
-credential mutated in place under concurrent use), not a static argv defect.
+``tests/unit/test_sandbox.py`` covers the same design by construction: it
+patches ``helix.sandbox.subprocess.run`` and inspects the argv HELIX builds, so
+no container ever runs and no volume is ever created. This module covers the
+runtime behaviour instead -- a shared credential mutated in place under
+concurrent use is a runtime failure, not a static argv defect -- using a real
+Docker daemon and HELIX's own volume-creation and seeding functions
+(``_create_candidate_auth_volume``, ``_seed_candidate_auth_volume``,
+``run_sandboxed_command``), never a hand-rolled reimplementation of the
+copy/mount logic under test.
 
-This module closes that gap using a real Docker daemon and HELIX's own
-volume-creation/seeding functions (``_create_candidate_auth_volume``,
-``_seed_candidate_auth_volume``, ``run_sandboxed_command``) -- never a
-hand-rolled reimplementation of the copy/mount logic under test.
-
-Both tests below are parametrized over *every* backend key in
-``helix.sandbox.AUTH_CREDENTIAL_MANIFEST`` -- not just ``claude`` -- because
-each backend's manifest entry (a distinct source path, target filename, and
-mount destination) is a place the copy/mount logic can fail independently.
-This resolves review finding #5 against
-``docs/design/sandbox-auth-projection.md``: that document marks cursor,
-gemini, and opencode as UNVERIFIED and states that a backend is not enabled
-for ``auth = "volume"`` until its manifest is confirmed by a real test. The
-parametrization is driven directly off ``AUTH_CREDENTIAL_MANIFEST`` (backend
-list) and ``AUTH_MOUNT_DESTINATIONS`` (looked up by key, never copied into a
-second hardcoded list), so a future manifest entry is covered automatically
-and a backend present in one dict but missing from the other fails with a
-loud ``KeyError`` rather than being silently skipped.
+Both tests are parametrized over *every* backend key in
+``helix.sandbox.AUTH_CREDENTIAL_MANIFEST``, not just ``claude``, because each
+backend's manifest entry (a distinct source path, target filename, and mount
+destination) is a place the copy/mount logic can fail independently. A backend
+is not enabled for ``auth = "volume"`` until a real test confirms its manifest,
+so this parametrization is the gate, not a convenience. It is driven directly
+off ``AUTH_CREDENTIAL_MANIFEST`` (backend list) and ``AUTH_MOUNT_DESTINATIONS``
+(looked up by key, never copied into a second hardcoded list), so a new
+manifest entry is covered automatically and a backend present in one dict but
+missing from the other fails with a loud ``KeyError`` rather than being
+silently skipped.
 
 Credential safety
 ------------------
-Every credential used here is synthetic. The tests never read, mount, or
+Every credential used here is synthetic. These tests never read, mount, or
 reference an operator's real ``~/.claude``, ``~/.codex``, ``~/.cursor``,
 ``~/.gemini``, or ``~/.local/share/opencode``, and never touch the real
 ``helix-auth-<backend>`` volumes: ``helix.sandbox.sandbox_auth_volume_name``
@@ -36,29 +32,25 @@ is monkeypatched for the duration of each test to point at a throwaway
 ``helix-test-synthetic-login-*`` volume instead. That is the sole seam
 touched; every other code path under test runs unmodified.
 
-Credential shape: only ``claude``'s real login-volume shape
-(``claudeAiOauth`` with an OAuth token pair) is reflected in the fake
-fixture below, matching what earlier claude-only auth-volume work already
-established. The real on-disk shape of ``codex``'s ``auth.json``,
-``cursor``'s ``cli-config.json``, ``gemini``'s ``oauth_creds.json``, and
-``opencode``'s ``auth.json`` was **not** determined for this change -- doing
-so would require reading an operator's real credential file, which is
-exactly what this module must never do. Those four backends instead get a
-minimal, valid, non-empty JSON object (``_GENERIC_SYNTHETIC_SHAPE`` below).
-This is a deliberate substitution, not an oversight: everything these tests
-assert -- byte-for-byte isolation across candidate volumes, mode/ownership,
-manifest-only contents, and that a write to one candidate never reaches
-another candidate or the login volume -- depends on the manifest's
-source/target *paths* and on file *bytes* being preserved unchanged, not on
-the credential JSON's internal schema. A schema-accurate fixture would not
-change what byte-isolation demonstrates; it would only matter for a test
-that also validates backend-specific JSON semantics, which none of these
-do.
+Credential shape: only ``claude``'s login-volume shape (``claudeAiOauth`` with
+an OAuth token pair) is reflected in the fake fixture below. The on-disk shapes
+of ``codex``'s ``auth.json``, ``cursor``'s ``cli-config.json``, ``gemini``'s
+``oauth_creds.json``, and ``opencode``'s ``auth.json`` are deliberately not
+reproduced, because determining them would mean reading an operator's real
+credential file -- which the paragraph above forbids. Those four backends get a
+minimal, valid, non-empty JSON object (``_GENERIC_SYNTHETIC_SHAPE`` below)
+instead. Everything these tests assert -- byte-for-byte isolation across
+candidate volumes, mode and ownership, manifest-only contents, and that a write
+to one candidate reaches neither another candidate nor the login volume --
+depends on the manifest's source/target *paths* and on file *bytes* surviving
+unchanged, not on any credential's internal schema. A schema-accurate fixture
+would only matter for a test that also validated backend-specific JSON
+semantics, which none of these do.
 
-Convention: follows ``docker_integration`` (see ``pyproject.toml`` markers)
-and the ``_require_docker_fixture``-style skip used historically for
-Docker-gated tests in this repo -- skip cleanly when the daemon or fixture
-image is unavailable rather than fail CI/a laptop without Docker.
+These tests carry the ``docker_integration`` marker (see ``pyproject.toml``)
+and skip when the daemon or a fixture image is unavailable, so a machine
+without Docker is not a failure. Set ``HELIX_DOCKER_TESTS_STRICT=1``, as CI
+does, to turn every such skip into a failure.
 """
 
 from __future__ import annotations
@@ -93,10 +85,9 @@ pytestmark = pytest.mark.docker_integration
 # which backends these tests cover. Sorted only for stable, readable test IDs.
 _BACKENDS = sorted(AUTH_CREDENTIAL_MANIFEST)
 
-# ``claude``'s real login-volume shape (verified, not read from an operator
-# credential -- this shape is already established by prior claude-only auth
-# work). Every other backend's real shape is unknown here by design; see the
-# module docstring's "Credential shape" section.
+# Every backend other than ``claude`` gets this placeholder rather than a
+# shape-accurate fixture; see the module docstring's "Credential shape"
+# section for why that is a safety requirement, not an omission.
 _GENERIC_SYNTHETIC_SHAPE_NOTE = (
     "real on-disk shape unknown -- placeholder for byte-isolation testing only, "
     "see test_sandbox_auth_isolation_docker.py module docstring"
@@ -104,7 +95,7 @@ _GENERIC_SYNTHETIC_SHAPE_NOTE = (
 
 
 def _fake_credential(backend: str) -> str:
-    """A synthetic, backend-shaped-where-known seed credential. All fake."""
+    """A synthetic seed credential -- backend-shaped only for ``claude``."""
     if backend == "claude":
         return json.dumps(
             {
@@ -171,9 +162,9 @@ def _docker(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]
 def _require_docker_fixture(image: str) -> None:
     """Skip when Docker or the fixture image is unavailable.
 
-    Set ``HELIX_DOCKER_TESTS_STRICT=1`` to turn every skip into a failure.
-    CI sets it: a Docker job that silently skips every test still reports
-    green, which is worse than not running it at all.
+    Set ``HELIX_DOCKER_TESTS_STRICT=1`` to turn every skip into a failure. CI
+    sets it, because a Docker job that silently skips every test still reports
+    green -- which is worse than not running the job at all.
     """
     strict = os.environ.get("HELIX_DOCKER_TESTS_STRICT") == "1"
 
@@ -380,10 +371,9 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
         assert mode_a == "600 1000:1000"
         assert mode_b == "600 1000:1000"
 
-        # 4: THE assertion that matters most. Write a different "rotated"
-        # credential into candidate A's own copy (simulating a backend
-        # refreshing its token in place, exactly as observed in the
-        # incident), then assert candidate B is byte-unchanged.
+        # 4: the central assertion. Write a different "rotated" credential
+        # into candidate A's own copy -- what a backend does when it refreshes
+        # a token in place -- then assert candidate B is byte-unchanged.
         _write_credential(candidate_a.name, target_rel, rotated_credential, image=fixture_image)
         rotated_content_a, _ = _read_credential(candidate_a.name, target_rel, image=fixture_image)
         assert rotated_content_a == rotated_credential
@@ -393,8 +383,7 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
         )
         assert unaffected_content_b == fake_credential, (
             "candidate B's credential changed after candidate A rotated its "
-            "own copy -- this is exactly the shared-volume rotation incident "
-            "this design exists to prevent"
+            "own copy -- candidate auth volumes are not isolated"
         )
         assert unaffected_mode_b == "600 1000:1000"
 
@@ -534,9 +523,9 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
         # `run_sandboxed_command` returns (its own cleanup path ran).
         assert not _volume_exists(candidate_volume_in_argv)
 
-        # THE assertion that matters most, replayed through the real E2E
-        # entry point: the in-container "rotation" write landed on the
-        # candidate's private copy, not on the synthetic login volume.
+        # The central assertion, replayed through the real end-to-end entry
+        # point: the in-container "rotation" write landed on the candidate's
+        # private copy, not on the synthetic login volume.
         login_content, _ = _read_credential(
             login_volume, source_rel, mount="/home/node", image=fixture_image
         )

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -32,20 +32,22 @@ is monkeypatched for the duration of each test to point at a throwaway
 ``helix-test-synthetic-login-*`` volume instead. That is the sole seam
 touched; every other code path under test runs unmodified.
 
-Credential shape: only ``claude``'s login-volume shape (``claudeAiOauth`` with
-an OAuth token pair) is reflected in the fake fixture below. The on-disk shapes
-of ``codex``'s ``auth.json``, ``cursor``'s ``cli-config.json``, ``gemini``'s
-``oauth_creds.json``, and ``opencode``'s ``auth.json`` are deliberately not
-reproduced, because determining them would mean reading an operator's real
-credential file -- which the paragraph above forbids. Those four backends get a
-minimal, valid, non-empty JSON object (see ``_fake_credential`` below)
-instead. Everything these tests assert -- byte-for-byte isolation across
-candidate volumes, mode and ownership, manifest-only contents, and that a write
-to one candidate reaches neither another candidate nor the login volume --
-depends on the manifest's source/target *paths* and on file *bytes* surviving
-unchanged, not on any credential's internal schema. A schema-accurate fixture
-would only matter for a test that also validated backend-specific JSON
-semantics, which none of these do.
+Credential shape: ``claude``'s login-volume shape (``claudeAiOauth`` with an
+OAuth token pair) and ``cursor``'s (an access/refresh token pair) are
+reflected in the fake fixtures below. Neither was obtained by reading an
+operator's credential file -- which the paragraph above forbids; each was read
+out of the shipped runner image's own CLI bundle, where the code that writes
+the file states the shape directly. The on-disk shapes of ``codex``'s
+``auth.json``, ``gemini``'s ``oauth_creds.json``, and ``opencode``'s
+``auth.json`` are deliberately not reproduced; those three get a minimal,
+valid, non-empty JSON object (see ``_fake_credential`` below) instead.
+Everything the isolation tests assert -- byte-for-byte isolation across
+candidate volumes, mode and ownership, manifest-only contents, and that a
+write to one candidate reaches neither another candidate nor the login volume
+-- depends on the manifest's source/target *paths* and on file *bytes*
+surviving unchanged, not on any credential's internal schema. The shape
+matters only to the backend-specific test at the end of this module, which
+hands a real CLI the seeded record and reads what it says about it.
 
 These tests carry the ``docker_integration`` marker (see ``pyproject.toml``)
 and skip when the daemon or a fixture image is unavailable, so a machine
@@ -94,8 +96,14 @@ _GENERIC_SYNTHETIC_SHAPE_NOTE = (
 )
 
 
+# Shapes taken from the code inside each shipped runner image's CLI bundle
+# that writes the file, never from an operator's credential. Every token value
+# below is a fixed placeholder that no service ever issued.
+_SYNTHETIC_TOKEN = "synthetic-not-a-real-token"
+
+
 def _fake_credential(backend: str) -> str:
-    """A synthetic seed credential -- backend-shaped only for ``claude``."""
+    """A synthetic seed credential, backend-shaped where the shape is known."""
     if backend == "claude":
         return json.dumps(
             {
@@ -105,6 +113,15 @@ def _fake_credential(backend: str) -> str:
                     "expiresAt": 9999999999,
                     "scopes": ["user:inference"],
                 }
+            }
+        )
+    if backend == "cursor":
+        # The CLI's credential writer stores exactly these keys.
+        return json.dumps(
+            {
+                "accessToken": _SYNTHETIC_TOKEN,
+                "refreshToken": f"{_SYNTHETIC_TOKEN}-refresh",
+                "apiKey": None,
             }
         )
     return json.dumps(
@@ -119,6 +136,10 @@ def _fake_credential(backend: str) -> str:
 
 def _rotated_credential(backend: str) -> str:
     """A synthetic "rotated" value simulating an in-place token refresh."""
+    if backend == "cursor":
+        rotated = json.loads(_fake_credential(backend))
+        rotated["accessToken"] = f"{_SYNTHETIC_TOKEN}-rotated-by-candidate-a"
+        return json.dumps(rotated)
     if backend == "claude":
         return json.dumps(
             {
@@ -763,5 +784,134 @@ def test_empty_login_volume_names_its_cause_and_the_command_that_fixes_it(
         assert "not a private, regular" not in message
         # No agent container was created.
         assert observed_docker_args == []
+    finally:
+        _force_remove_volume(login_volume)
+
+
+# --------------------------------------------------------------------------
+# TEST 6 -- the cursor CLI reads the credential from the path we mount it at
+#
+# `cursor-agent status` grades a *local parse*: it reads the credential the
+# CLI's own resolver points at and reports whether an access/refresh pair is
+# there. Under `--network none` it cannot and does not check the grant with
+# any service, so this test establishes that HELIX mounts the credential
+# where the CLI looks -- not that any grant is valid.
+#
+# The negative half matters as much as the positive half. A test that only
+# asserted "the signed-out message is absent" would pass just as well if no
+# credential reached the container at all, so this asserts the credential is
+# present at the exact path the CLI reads, asserts the CLI reports the
+# signed-in message positively, and runs the CLI a second time against the
+# directory the manifest used to point at to show the check can tell the two
+# apart.
+# --------------------------------------------------------------------------
+
+
+_CURSOR_SIGNED_IN = "Login successful!"
+_CURSOR_SIGNED_OUT = "Not logged in"
+
+# What the manifest said before it was read out of the CLI bundle: the
+# settings file, in the settings directory. Kept here only as the control
+# arm of the test below.
+_CURSOR_SETTINGS_ENTRY = (".cursor/cli-config.json", "cli-config.json")
+_CURSOR_SETTINGS_DESTINATION = "/home/node/.cursor"
+
+
+def test_cursor_cli_reads_the_credential_from_the_path_helix_mounts_it_at(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = "cursor"
+    fixture_image = _fixture_image(backend)
+    _require_docker_fixture(fixture_image)
+
+    source_rel, target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
+    destination = AUTH_MOUNT_DESTINATIONS[backend]
+    credential = _fake_credential(backend)
+
+    def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        workspace = tmp_path / f"candidate-{uuid.uuid4().hex[:8]}"
+        workspace.mkdir()
+        return run_sandboxed_command(
+            command,
+            cwd=workspace,
+            env={},
+            sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
+            scope="agent",
+            sync_back=False,
+            image=fixture_image,
+            agent_backend=backend,
+        )
+
+    login_volume = _make_synthetic_login_volume(
+        backend, credential, source_rel, image=fixture_image
+    )
+    monkeypatch.setattr(
+        sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume
+    )
+
+    try:
+        # 1. The credential is at the exact path, mode, and ownership the CLI
+        #    needs -- asserted directly, not inferred from the CLI's verdict.
+        credential_path = f"{destination}/{target_rel}"
+        probe = _run(
+            [
+                "sh",
+                "-c",
+                (
+                    f"cat {shlex.quote(credential_path)}; echo; "
+                    f"echo MODE:$(stat -c '%a %u:%g' {shlex.quote(credential_path)}); "
+                    # The corrected destination sits two components below the
+                    # tmpfs $HOME, so Docker would synthesise its parent as
+                    # root-owned unless HELIX pre-owns it.
+                    "echo PARENT:$(stat -c '%a %u:%g' /home/node/.config)"
+                ),
+            ]
+        )
+        assert probe.returncode == 0, probe.stderr
+        probe_lines = probe.stdout.splitlines()
+        assert probe_lines[0] == credential, "credential is not readable at the mount destination"
+        assert probe_lines[1] == "MODE:600 1000:1000"
+        assert probe_lines[2] == "PARENT:700 1000:1000", (
+            "the credential directory's parent is not owned by the agent -- "
+            "Docker synthesised it as root"
+        )
+
+        # 2. The CLI itself, handed that credential, reports signed in.
+        status = _run(["cursor-agent", "status"])
+        assert _CURSOR_SIGNED_IN in status.stdout, (
+            f"cursor-agent did not find the seeded credential: {status.stdout!r} "
+            f"{status.stderr!r}"
+        )
+        assert _CURSOR_SIGNED_OUT not in status.stdout
+
+        # 3. The control. Point HELIX at the CLI's *settings* file in the
+        #    settings directory -- the pre-correction manifest -- and the same
+        #    check reports signed out, so step 2 is not vacuous.
+        settings_login_volume = _make_synthetic_login_volume(
+            backend,
+            json.dumps({"version": 1, "editor": {"vimMode": False}}),
+            _CURSOR_SETTINGS_ENTRY[0],
+            image=fixture_image,
+        )
+        monkeypatch.setattr(
+            sandbox_module,
+            "sandbox_auth_volume_name",
+            lambda _backend: settings_login_volume,
+        )
+        monkeypatch.setitem(
+            sandbox_module.AUTH_CREDENTIAL_MANIFEST, backend, (_CURSOR_SETTINGS_ENTRY,)
+        )
+        monkeypatch.setitem(
+            sandbox_module.AUTH_MOUNT_DESTINATIONS, backend, _CURSOR_SETTINGS_DESTINATION
+        )
+        try:
+            control = _run(["cursor-agent", "status"])
+            assert _CURSOR_SIGNED_OUT in control.stdout, (
+                "the settings file was accepted as a credential -- this check "
+                f"cannot tell the two apart: {control.stdout!r}"
+            )
+        finally:
+            _force_remove_volume(settings_login_volume)
     finally:
         _force_remove_volume(login_volume)

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -612,8 +612,13 @@ def test_wrong_mode_credential_fails_closed_before_any_agent_container(
                 agent_backend=backend,
             )
 
-        assert "credential seed failed" in str(excinfo.value)
-        assert secret_marker not in str(excinfo.value)
+        message = str(excinfo.value)
+        assert "credential seed failed" in message
+        # The message names *this* cause, not the generic one and not the
+        # cause of a different guard.
+        assert "not a private, regular" in message
+        assert "holds no credential" not in message
+        assert secret_marker not in message
         assert secret_marker not in repr(excinfo.value)
         cause = excinfo.value.__cause__
         if isinstance(cause, subprocess.CalledProcessError):
@@ -680,14 +685,83 @@ def test_malformed_json_credential_fails_closed_before_any_agent_container(
                 agent_backend=backend,
             )
 
-        assert "credential seed failed" in str(excinfo.value)
-        assert secret_marker not in str(excinfo.value)
+        message = str(excinfo.value)
+        assert "credential seed failed" in message
+        assert "not a readable credential record" in message
+        assert "holds no credential" not in message
+        assert secret_marker not in message
         assert secret_marker not in repr(excinfo.value)
         cause = excinfo.value.__cause__
         if isinstance(cause, subprocess.CalledProcessError):
             assert secret_marker not in (cause.stdout or "")
             assert secret_marker not in (cause.stderr or "")
 
+        assert observed_docker_args == []
+    finally:
+        _force_remove_volume(login_volume)
+
+
+# --------------------------------------------------------------------------
+# TEST 5 -- an empty login volume names itself
+#
+# The most likely real-world seeding failure is not a corrupt credential: it
+# is a login volume nobody has signed in yet. Signing in on the host does not
+# sign the sandbox in, and the two are easy to confuse, so the error has to
+# say which one is missing and how to fix it.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_empty_login_volume_names_its_cause_and_the_command_that_fixes_it(
+    backend: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_image = _fixture_image(backend)
+    _require_docker_fixture(fixture_image)
+
+    # A login volume that exists but holds no credential at all -- exactly
+    # what a never-signed-in or signed-out backend looks like.
+    login_volume = f"helix-test-synthetic-login-{backend}-{uuid.uuid4().hex}"
+    _run_docker(["docker", "volume", "create", login_volume])
+    monkeypatch.setattr(
+        sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume
+    )
+
+    observed_docker_args: list[list[str]] = []
+    original_docker_args = sandbox_module._docker_args
+
+    def _spy(*args: object, **kwargs: object) -> list[str]:
+        built = original_docker_args(*args, **kwargs)  # type: ignore[arg-type]
+        observed_docker_args.append(built)
+        return built
+
+    monkeypatch.setattr(sandbox_module, "_docker_args", _spy)
+
+    source = tmp_path / "candidate"
+    source.mkdir()
+
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            run_sandboxed_command(
+                ["sh", "-c", "echo should-not-run"],
+                cwd=source,
+                env={},
+                sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
+                scope="agent",
+                sync_back=False,
+                image=fixture_image,
+                agent_backend=backend,
+            )
+
+        message = str(excinfo.value)
+        # The failure must name *this* cause, and must not be confusable with
+        # the malformed or wrong-mode cases the tests above cover.
+        assert "holds no credential" in message
+        assert f"helix sandbox login {backend}" in message
+        assert "not a readable credential record" not in message
+        assert "not a private, regular" not in message
+        # No agent container was created.
         assert observed_docker_args == []
     finally:
         _force_remove_volume(login_volume)

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -32,22 +32,12 @@ is monkeypatched for the duration of each test to point at a throwaway
 ``helix-test-synthetic-login-*`` volume instead. That is the sole seam
 touched; every other code path under test runs unmodified.
 
-Credential shape: ``claude``'s login-volume shape (``claudeAiOauth`` with an
-OAuth token pair), ``cursor``'s (an access/refresh token pair), and
-``gemini``'s (an OAuth token record) are reflected in the fake fixtures below.
-None was obtained by reading an operator's credential file -- which the
-paragraph above forbids; each was read out of the shipped runner image's own
-CLI bundle, where the code that writes the file states the shape directly. The
-on-disk shapes of ``codex``'s ``auth.json`` and ``opencode``'s ``auth.json``
-are deliberately not reproduced; those two get a minimal, valid, non-empty
-JSON object (see ``_fake_credential`` below) instead. Everything the isolation
-tests assert -- byte-for-byte isolation across candidate volumes, mode and
-ownership, manifest-only contents, and that a write to one candidate reaches
-neither another candidate nor the login volume -- depends on the manifest's
-source/target *paths* and on file *bytes* surviving unchanged, not on any
-credential's internal schema. The shape matters only to the two
-backend-specific tests at the end of this module, which hand a real CLI the
-seeded record and read what it says about it.
+Credential shape: ``claude``, ``cursor``, and ``gemini`` get shape-accurate
+fixtures; ``codex`` and ``opencode`` deliberately get a minimal valid JSON
+object instead (see ``_fake_credential``). The isolation tests assert only
+paths, bytes, mode, and ownership, so they need no schema at all -- the shape
+matters solely to the two backend-specific tests at the end of this module,
+which hand a real CLI the seeded record and read what it says about it.
 
 These tests carry the ``docker_integration`` marker (see ``pyproject.toml``)
 and skip when the daemon or a fixture image is unavailable, so a machine
@@ -62,6 +52,7 @@ import os
 import shlex
 import subprocess
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -175,16 +166,9 @@ def _rotated_credential(backend: str) -> str:
 
 
 def _fixture_image(backend: str) -> str:
-    """Resolve the runner image for *backend*, honoring test-only overrides."""
-    per_backend_override = os.environ.get(f"HELIX_DOCKER_TEST_IMAGE_{backend.upper()}")
-    if per_backend_override:
-        return per_backend_override
-    # Legacy single-backend override, kept for anyone still setting it locally.
-    if backend == "claude":
-        legacy_override = os.environ.get("HELIX_DOCKER_TEST_IMAGE")
-        if legacy_override:
-            return legacy_override
-    return DEFAULT_BACKEND_IMAGES[backend]
+    """Resolve the runner image for *backend*, honoring a test-only override."""
+    override = os.environ.get(f"HELIX_DOCKER_TEST_IMAGE_{backend.upper()}")
+    return override or DEFAULT_BACKEND_IMAGES[backend]
 
 
 def _docker(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
@@ -318,6 +302,25 @@ def _list_top_level(volume_name: str, *, mount: str = "/check", image: str) -> s
         )
     )
     return {entry for entry in result.stdout.split() if entry not in {".", ".."}}
+
+
+def _spy_on_docker_args(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    """Record every argv ``_docker_args`` builds, without changing what it builds.
+
+    An empty list afterwards means no container was ever described, let alone
+    created -- which is how the fail-closed tests prove the seed step aborted
+    before the agent.
+    """
+    observed: list[list[str]] = []
+    original = sandbox_module._docker_args
+
+    def _spy(*args: object, **kwargs: object) -> list[str]:
+        built = original(*args, **kwargs)  # type: ignore[arg-type]
+        observed.append(built)
+        return built
+
+    monkeypatch.setattr(sandbox_module, "_docker_args", _spy)
+    return observed
 
 
 def _volume_exists(name: str) -> bool:
@@ -503,15 +506,7 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
     )
     monkeypatch.setattr(sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume)
 
-    observed_docker_args: list[list[str]] = []
-    original_docker_args = sandbox_module._docker_args
-
-    def _spy(*args: object, **kwargs: object) -> list[str]:
-        built = original_docker_args(*args, **kwargs)  # type: ignore[arg-type]
-        observed_docker_args.append(built)
-        return built
-
-    monkeypatch.setattr(sandbox_module, "_docker_args", _spy)
+    observed_docker_args = _spy_on_docker_args(monkeypatch)
 
     source = tmp_path / "candidate"
     source.mkdir()
@@ -587,196 +582,93 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
 
 
 # --------------------------------------------------------------------------
-# TEST 3 & 4 -- fail-closed guards on malformed source material
+# TESTS 3-5 -- fail-closed guards, one arm per refusal cause
 #
 # ADR verification requirement 4: "Missing, malformed, oversized, or
 # wrong-mode source material must prevent the agent from starting with a
-# stable, redacted error. This is mandatory." Neither guard has real-Docker
-# coverage: `_seed_command`'s checks run inside the seed helper container, so
-# a unit test that only inspects argv (as `tests/unit/test_sandbox.py` does
-# for the rest of this module) never actually exercises them.
-# --------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("backend", _BACKENDS)
-def test_wrong_mode_credential_fails_closed_before_any_agent_container(
-    backend: str,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A credential source at the wrong mode must fail closed, not silently.
-
-    ADR verification requirement 4 names "wrong-mode source material" as one
-    of the cases that "must prevent the agent from starting with a stable,
-    redacted error. This is mandatory." `_seed_command` enforces this with
-    ``test $(stat -c %a <source>) = 600``; this test proves that guard
-    actually runs against a real Docker daemon, not just that the argv
-    contains the check.
-    """
-    fixture_image = _fixture_image(backend)
-    _require_docker_fixture(fixture_image)
-
-    source_rel, _target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
-    secret_marker = f"SECRET-MARKER-{uuid.uuid4().hex}"
-    credential = json.dumps({"marker": secret_marker, "backend": backend})
-
-    # 0644, not the required 0600 -- the guard `_seed_command` enforces.
-    login_volume = _make_synthetic_login_volume(
-        backend, credential, source_rel, image=fixture_image, mode="644"
-    )
-    monkeypatch.setattr(sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume)
-
-    observed_docker_args: list[list[str]] = []
-    original_docker_args = sandbox_module._docker_args
-
-    def _spy(*args: object, **kwargs: object) -> list[str]:
-        built = original_docker_args(*args, **kwargs)  # type: ignore[arg-type]
-        observed_docker_args.append(built)
-        return built
-
-    monkeypatch.setattr(sandbox_module, "_docker_args", _spy)
-
-    source = tmp_path / "candidate"
-    source.mkdir()
-
-    try:
-        with pytest.raises(RuntimeError) as excinfo:
-            run_sandboxed_command(
-                ["sh", "-c", "echo should-not-run"],
-                cwd=source,
-                env={},
-                sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
-                scope="agent",
-                sync_back=False,
-                image=fixture_image,
-                agent_backend=backend,
-            )
-
-        message = str(excinfo.value)
-        assert "credential seed failed" in message
-        # The message names *this* cause, not the generic one and not the
-        # cause of a different guard.
-        assert "not a private, regular" in message
-        assert "holds no credential" not in message
-        assert secret_marker not in message
-        assert secret_marker not in repr(excinfo.value)
-        cause = excinfo.value.__cause__
-        if isinstance(cause, subprocess.CalledProcessError):
-            assert secret_marker not in (cause.stdout or "")
-            assert secret_marker not in (cause.stderr or "")
-
-        # The seed step raised before `run_sandboxed_commands`'s command loop
-        # ever reaches `_docker_args` -- no agent container was created.
-        assert observed_docker_args == []
-    finally:
-        _force_remove_volume(login_volume)
-
-
-@pytest.mark.parametrize("backend", _BACKENDS)
-def test_malformed_json_credential_fails_closed_before_any_agent_container(
-    backend: str,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Non-JSON credential content must fail closed, not silently.
-
-    ADR verification requirement 4 names "malformed source material" as one
-    of the cases that "must prevent the agent from starting with a stable,
-    redacted error. This is mandatory." `_seed_command` enforces this with a
-    ``python -c`` step that parses every manifest entry as JSON; this test
-    proves that guard actually runs against a real Docker daemon.
-    """
-    fixture_image = _fixture_image(backend)
-    _require_docker_fixture(fixture_image)
-
-    source_rel, _target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
-    secret_marker = f"SECRET-MARKER-{uuid.uuid4().hex}"
-    non_json_content = f"not-json-at-all::{secret_marker}"
-
-    # Correct mode, but content that fails `python -c ... json.loads(...)`.
-    login_volume = _make_synthetic_login_volume(
-        backend, non_json_content, source_rel, image=fixture_image, mode="600"
-    )
-    monkeypatch.setattr(sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume)
-
-    observed_docker_args: list[list[str]] = []
-    original_docker_args = sandbox_module._docker_args
-
-    def _spy(*args: object, **kwargs: object) -> list[str]:
-        built = original_docker_args(*args, **kwargs)  # type: ignore[arg-type]
-        observed_docker_args.append(built)
-        return built
-
-    monkeypatch.setattr(sandbox_module, "_docker_args", _spy)
-
-    source = tmp_path / "candidate"
-    source.mkdir()
-
-    try:
-        with pytest.raises(RuntimeError) as excinfo:
-            run_sandboxed_command(
-                ["sh", "-c", "echo should-not-run"],
-                cwd=source,
-                env={},
-                sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
-                scope="agent",
-                sync_back=False,
-                image=fixture_image,
-                agent_backend=backend,
-            )
-
-        message = str(excinfo.value)
-        assert "credential seed failed" in message
-        assert "not a readable credential record" in message
-        assert "holds no credential" not in message
-        assert secret_marker not in message
-        assert secret_marker not in repr(excinfo.value)
-        cause = excinfo.value.__cause__
-        if isinstance(cause, subprocess.CalledProcessError):
-            assert secret_marker not in (cause.stdout or "")
-            assert secret_marker not in (cause.stderr or "")
-
-        assert observed_docker_args == []
-    finally:
-        _force_remove_volume(login_volume)
-
-
-# --------------------------------------------------------------------------
-# TEST 5 -- an empty login volume names itself
+# stable, redacted error. This is mandatory." None of these guards has any
+# other real-Docker coverage: `_seed_command`'s checks run inside the seed
+# helper container, so a unit test that only inspects argv (as
+# `tests/unit/test_sandbox.py` does for the rest of this module) proves the
+# check is in the script, never that it fires.
 #
-# The most likely real-world seeding failure is not a corrupt credential: it
-# is a login volume nobody has signed in yet. Signing in on the host does not
-# sign the sandbox in, and the two are easy to confuse, so the error has to
-# say which one is missing and how to fix it.
+# The most likely real-world failure is not a corrupt credential but a login
+# volume nobody has signed in yet. Signing in on the host does not sign the
+# sandbox in, and the two are easy to confuse, so each arm asserts that the
+# message names *its own* cause and none of the others.
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
-def test_empty_login_volume_names_its_cause_and_the_command_that_fixes_it(
-    backend: str,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    fixture_image = _fixture_image(backend)
-    _require_docker_fixture(fixture_image)
+@dataclass(frozen=True)
+class _SeedRefusal:
+    """One way the seed step must refuse, and the sentence it must produce."""
 
+    mode: str
+    content: str | None  # None -> no credential file at all
+    says: str
+    never_says: tuple[str, ...]
+    names_the_fix: bool
+
+
+_SEED_REFUSALS: dict[str, _SeedRefusal] = {
+    # 0644, not the required 0600 -- `_seed_command`'s stat guard.
+    "wrong_mode": _SeedRefusal(
+        mode="644",
+        content='{"marker": "%s"}',
+        says="not a private, regular",
+        never_says=("holds no credential", "not a readable credential record"),
+        names_the_fix=True,
+    ),
+    # Correct mode, content that fails `_seed_command`'s json.loads step.
+    "malformed_json": _SeedRefusal(
+        mode="600",
+        content="not-json-at-all::%s",
+        says="not a readable credential record",
+        never_says=("holds no credential", "not a private, regular"),
+        names_the_fix=True,
+    ),
     # A login volume that exists but holds no credential at all -- exactly
     # what a never-signed-in or signed-out backend looks like.
-    login_volume = f"helix-test-synthetic-login-{backend}-{uuid.uuid4().hex}"
-    _run_docker(["docker", "volume", "create", login_volume])
+    "empty_login_volume": _SeedRefusal(
+        mode="600",
+        content=None,
+        says="holds no credential",
+        never_says=("not a readable credential record", "not a private, regular"),
+        names_the_fix=True,
+    ),
+}
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize("cause", sorted(_SEED_REFUSALS), ids=sorted(_SEED_REFUSALS))
+def test_seed_refusal_fails_closed_and_names_its_own_cause(
+    backend: str,
+    cause: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    refusal = _SEED_REFUSALS[cause]
+    fixture_image = _fixture_image(backend)
+    _require_docker_fixture(fixture_image)
+
+    source_rel, _target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
+    secret_marker = f"SECRET-MARKER-{uuid.uuid4().hex}"
+
+    if refusal.content is None:
+        login_volume = f"helix-test-synthetic-login-{backend}-{uuid.uuid4().hex}"
+        _run_docker(["docker", "volume", "create", login_volume])
+    else:
+        login_volume = _make_synthetic_login_volume(
+            backend,
+            refusal.content % secret_marker,
+            source_rel,
+            image=fixture_image,
+            mode=refusal.mode,
+        )
     monkeypatch.setattr(
         sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume
     )
-
-    observed_docker_args: list[list[str]] = []
-    original_docker_args = sandbox_module._docker_args
-
-    def _spy(*args: object, **kwargs: object) -> list[str]:
-        built = original_docker_args(*args, **kwargs)  # type: ignore[arg-type]
-        observed_docker_args.append(built)
-        return built
-
-    monkeypatch.setattr(sandbox_module, "_docker_args", _spy)
+    observed_docker_args = _spy_on_docker_args(monkeypatch)
 
     source = tmp_path / "candidate"
     source.mkdir()
@@ -795,13 +687,27 @@ def test_empty_login_volume_names_its_cause_and_the_command_that_fixes_it(
             )
 
         message = str(excinfo.value)
-        # The failure must name *this* cause, and must not be confusable with
-        # the malformed or wrong-mode cases the tests above cover.
-        assert "holds no credential" in message
-        assert f"helix sandbox login {backend}" in message
-        assert "not a readable credential record" not in message
-        assert "not a private, regular" not in message
-        # No agent container was created.
+        assert "credential seed failed" in message
+        # The message names *this* cause, and cannot be confused with any of
+        # the other refusals this matrix covers.
+        assert refusal.says in message
+        for other in refusal.never_says:
+            assert other not in message
+        if refusal.names_the_fix:
+            assert f"helix sandbox login {backend}" in message
+
+        # Nothing that touched the credential may echo it back, on the
+        # exception or on the CalledProcessError it wraps.
+        if refusal.content is not None:
+            assert secret_marker not in message
+            assert secret_marker not in repr(excinfo.value)
+            inner = excinfo.value.__cause__
+            if isinstance(inner, subprocess.CalledProcessError):
+                assert secret_marker not in (inner.stdout or "")
+                assert secret_marker not in (inner.stderr or "")
+
+        # The seed step raised before `run_sandboxed_commands`'s command loop
+        # ever reaches `_docker_args` -- no agent container was created.
         assert observed_docker_args == []
     finally:
         _force_remove_volume(login_volume)

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -12,15 +12,48 @@ volume-creation/seeding functions (``_create_candidate_auth_volume``,
 ``_seed_candidate_auth_volume``, ``run_sandboxed_command``) -- never a
 hand-rolled reimplementation of the copy/mount logic under test.
 
+Both tests below are parametrized over *every* backend key in
+``helix.sandbox.AUTH_CREDENTIAL_MANIFEST`` -- not just ``claude`` -- because
+each backend's manifest entry (a distinct source path, target filename, and
+mount destination) is a place the copy/mount logic can fail independently.
+This resolves review finding #5 against
+``docs/design/sandbox-auth-projection.md``: that document marks cursor,
+gemini, and opencode as UNVERIFIED and states that a backend is not enabled
+for ``auth = "volume"`` until its manifest is confirmed by a real test. The
+parametrization is driven directly off ``AUTH_CREDENTIAL_MANIFEST`` (backend
+list) and ``AUTH_MOUNT_DESTINATIONS`` (looked up by key, never copied into a
+second hardcoded list), so a future manifest entry is covered automatically
+and a backend present in one dict but missing from the other fails with a
+loud ``KeyError`` rather than being silently skipped.
+
 Credential safety
 ------------------
-Every credential used here is synthetic (``fake-not-a-real-token``, shaped
-like ``AUTH_CREDENTIAL_MANIFEST["claude"]`` expects). The tests never read,
-mount, or reference an operator's real ``~/.claude`` et al., and never touch
-the real ``helix-auth-<backend>`` volumes: ``helix.sandbox.sandbox_auth_volume_name``
+Every credential used here is synthetic. The tests never read, mount, or
+reference an operator's real ``~/.claude``, ``~/.codex``, ``~/.cursor``,
+``~/.gemini``, or ``~/.local/share/opencode``, and never touch the real
+``helix-auth-<backend>`` volumes: ``helix.sandbox.sandbox_auth_volume_name``
 is monkeypatched for the duration of each test to point at a throwaway
 ``helix-test-synthetic-login-*`` volume instead. That is the sole seam
 touched; every other code path under test runs unmodified.
+
+Credential shape: only ``claude``'s real login-volume shape
+(``claudeAiOauth`` with an OAuth token pair) is reflected in the fake
+fixture below, matching what earlier claude-only auth-volume work already
+established. The real on-disk shape of ``codex``'s ``auth.json``,
+``cursor``'s ``cli-config.json``, ``gemini``'s ``oauth_creds.json``, and
+``opencode``'s ``auth.json`` was **not** determined for this change -- doing
+so would require reading an operator's real credential file, which is
+exactly what this module must never do. Those four backends instead get a
+minimal, valid, non-empty JSON object (``_GENERIC_SYNTHETIC_SHAPE`` below).
+This is a deliberate substitution, not an oversight: everything these tests
+assert -- byte-for-byte isolation across candidate volumes, mode/ownership,
+manifest-only contents, and that a write to one candidate never reaches
+another candidate or the login volume -- depends on the manifest's
+source/target *paths* and on file *bytes* being preserved unchanged, not on
+the credential JSON's internal schema. A schema-accurate fixture would not
+change what byte-isolation demonstrates; it would only matter for a test
+that also validates backend-specific JSON semantics, which none of these
+do.
 
 Convention: follows ``docker_integration`` (see ``pyproject.toml`` markers)
 and the ``_require_docker_fixture``-style skip used historically for
@@ -57,33 +90,77 @@ from helix.sandbox import (
 
 pytestmark = pytest.mark.docker_integration
 
-_BACKEND = "claude"
-_FIXTURE_IMAGE = os.environ.get("HELIX_DOCKER_TEST_IMAGE", DEFAULT_BACKEND_IMAGES[_BACKEND])
-_REAL_LOGIN_VOLUME_NAME = f"helix-auth-{_BACKEND}"  # never created/read/written below
+# Every backend HELIX's manifest declares -- the sole source of truth for
+# which backends these tests cover. Sorted only for stable, readable test IDs.
+_BACKENDS = sorted(AUTH_CREDENTIAL_MANIFEST)
 
-_SOURCE_REL, _TARGET_REL = AUTH_CREDENTIAL_MANIFEST[_BACKEND][0]
-_MOUNT_DEST = AUTH_MOUNT_DESTINATIONS[_BACKEND]
+# ``claude``'s real login-volume shape (verified, not read from an operator
+# credential -- this shape is already established by prior claude-only auth
+# work). Every other backend's real shape is unknown here by design; see the
+# module docstring's "Credential shape" section.
+_GENERIC_SYNTHETIC_SHAPE_NOTE = (
+    "real on-disk shape unknown -- placeholder for byte-isolation testing only, "
+    "see test_sandbox_auth_isolation_docker.py module docstring"
+)
 
-_FAKE_CREDENTIAL = json.dumps(
-    {
-        "claudeAiOauth": {
-            "accessToken": "fake-not-a-real-token",
-            "refreshToken": "fake",
-            "expiresAt": 9999999999,
-            "scopes": ["user:inference"],
+
+def _fake_credential(backend: str) -> str:
+    """A synthetic, backend-shaped-where-known seed credential. All fake."""
+    if backend == "claude":
+        return json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "fake-not-a-real-token",
+                    "refreshToken": "fake",
+                    "expiresAt": 9999999999,
+                    "scopes": ["user:inference"],
+                }
+            }
+        )
+    return json.dumps(
+        {
+            "synthetic_credential": True,
+            "backend": backend,
+            "state": "seed",
+            "note": _GENERIC_SYNTHETIC_SHAPE_NOTE,
         }
-    }
-)
-_ROTATED_CREDENTIAL = json.dumps(
-    {
-        "claudeAiOauth": {
-            "accessToken": "fake-rotated-token-from-candidate-a",
-            "refreshToken": "fake-rotated",
-            "expiresAt": 9999999999,
-            "scopes": ["user:inference"],
+    )
+
+
+def _rotated_credential(backend: str) -> str:
+    """A synthetic "rotated" value simulating an in-place token refresh."""
+    if backend == "claude":
+        return json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "fake-rotated-token-from-candidate-a",
+                    "refreshToken": "fake-rotated",
+                    "expiresAt": 9999999999,
+                    "scopes": ["user:inference"],
+                }
+            }
+        )
+    return json.dumps(
+        {
+            "synthetic_credential": True,
+            "backend": backend,
+            "state": "rotated-by-candidate-a",
+            "note": _GENERIC_SYNTHETIC_SHAPE_NOTE,
         }
-    }
-)
+    )
+
+
+def _fixture_image(backend: str) -> str:
+    """Resolve the runner image for *backend*, honoring test-only overrides."""
+    per_backend_override = os.environ.get(f"HELIX_DOCKER_TEST_IMAGE_{backend.upper()}")
+    if per_backend_override:
+        return per_backend_override
+    # Legacy single-backend override, kept for anyone still setting it locally.
+    if backend == "claude":
+        legacy_override = os.environ.get("HELIX_DOCKER_TEST_IMAGE")
+        if legacy_override:
+            return legacy_override
+    return DEFAULT_BACKEND_IMAGES[backend]
 
 
 def _docker(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
@@ -92,16 +169,16 @@ def _docker(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]
     )
 
 
-def _require_docker_fixture() -> None:
+def _require_docker_fixture(image: str) -> None:
     try:
         daemon = _docker("info")
-        image = _docker("image", "inspect", _FIXTURE_IMAGE)
+        inspected = _docker("image", "inspect", image)
     except (OSError, subprocess.SubprocessError) as exc:
         pytest.skip(f"Docker daemon unavailable: {exc}")
     if daemon.returncode != 0:
         pytest.skip(f"Docker daemon unavailable: {daemon.stderr.strip()}")
-    if image.returncode != 0:
-        pytest.skip(f"fixture image {_FIXTURE_IMAGE!r} is not installed locally")
+    if inspected.returncode != 0:
+        pytest.skip(f"fixture image {image!r} is not installed locally")
 
 
 def _diagnostic_docker_args(
@@ -127,17 +204,17 @@ def _diagnostic_docker_args(
     ]
 
 
-def _make_synthetic_login_volume(backend: str, credential_json: str) -> str:
+def _make_synthetic_login_volume(backend: str, credential_json: str, source_rel: str) -> str:
     """Create a throwaway, HELIX-shaped login volume holding a fake credential.
 
-    This mimics the *shape* the real login volume has after ``claude auth
-    login`` (manifest-declared relative path, mode 0600, uid/gid 1000) but is
-    a brand-new randomly-named volume -- it is never ``helix-auth-<backend>``
+    This mimics the *shape* the real login volume has after a real login (a
+    manifest-declared relative path, mode 0600, uid/gid 1000) but is a
+    brand-new randomly-named volume -- it is never ``helix-auth-<backend>``
     and never derived from any real credential.
     """
     name = f"helix-test-synthetic-login-{backend}-{uuid.uuid4().hex}"
     _run_docker(["docker", "volume", "create", name])
-    container_path = f"/home/node/{_SOURCE_REL}"
+    container_path = f"/home/node/{source_rel}"
     parent = str(Path(container_path).parent)
     script = (
         f"set -eu; mkdir -p {shlex.quote(parent)}; "
@@ -202,19 +279,43 @@ def _no_leaked_test_volumes():
 
 
 # --------------------------------------------------------------------------
+# Manifest/destination parity -- makes drift between the two dicts loud.
+# --------------------------------------------------------------------------
+
+
+def test_auth_manifest_and_mount_destinations_cover_the_same_backends() -> None:
+    """Every manifest backend has a mount destination and vice versa.
+
+    The parametrized tests below look up ``AUTH_MOUNT_DESTINATIONS[backend]``
+    directly (never a second hardcoded backend list), so a missing entry
+    already fails those tests loudly with a ``KeyError`` at setup time. This
+    assertion makes that guarantee explicit and independent of Docker.
+    """
+    assert set(AUTH_CREDENTIAL_MANIFEST) == set(AUTH_MOUNT_DESTINATIONS)
+
+
+# --------------------------------------------------------------------------
 # TEST 1 -- runtime isolation via HELIX's own volume-creation/seeding code
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("backend", _BACKENDS)
 def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
+    backend: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _require_docker_fixture()
+    fixture_image = _fixture_image(backend)
+    _require_docker_fixture(fixture_image)
 
-    login_volume = _make_synthetic_login_volume(_BACKEND, _FAKE_CREDENTIAL)
+    real_login_volume_name = f"helix-auth-{backend}"  # never created/read/written below
+    source_rel, target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
+    fake_credential = _fake_credential(backend)
+    rotated_credential = _rotated_credential(backend)
+
+    login_volume = _make_synthetic_login_volume(backend, fake_credential, source_rel)
 
     # The only seam we touch: redirect the seeding step's *source* volume
-    # away from the real "helix-auth-claude" toward our synthetic fixture.
+    # away from the real "helix-auth-<backend>" toward our synthetic fixture.
     # `_seed_candidate_auth_volume` looks this up by calling
     # `sandbox_auth_volume_name(volume.backend)` from `helix.sandbox`'s own
     # module globals, so patching the module attribute here also redirects
@@ -225,21 +326,21 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
     candidate_b: CandidateAuthVolume | None = None
     try:
         # 1 & 2: real HELIX volume-creation + seeding code, called directly.
-        candidate_a = _create_candidate_auth_volume(_BACKEND)
-        candidate_b = _create_candidate_auth_volume(_BACKEND)
+        candidate_a = _create_candidate_auth_volume(backend)
+        candidate_b = _create_candidate_auth_volume(backend)
         assert candidate_a.name != candidate_b.name
         assert candidate_a.name != login_volume
         assert candidate_b.name != login_volume
-        assert _REAL_LOGIN_VOLUME_NAME not in (candidate_a.name, candidate_b.name, login_volume)
+        assert real_login_volume_name not in (candidate_a.name, candidate_b.name, login_volume)
 
         _seed_candidate_auth_volume(candidate_a)
         _seed_candidate_auth_volume(candidate_b)
 
         # 3: both candidates contain the credential, mode 0600, owned 1000:1000.
-        content_a, mode_a = _read_credential(candidate_a.name, _TARGET_REL)
-        content_b, mode_b = _read_credential(candidate_b.name, _TARGET_REL)
-        assert content_a == _FAKE_CREDENTIAL
-        assert content_b == _FAKE_CREDENTIAL
+        content_a, mode_a = _read_credential(candidate_a.name, target_rel)
+        content_b, mode_b = _read_credential(candidate_b.name, target_rel)
+        assert content_a == fake_credential
+        assert content_b == fake_credential
         assert mode_a == "600 1000:1000"
         assert mode_b == "600 1000:1000"
 
@@ -247,12 +348,12 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
         # credential into candidate A's own copy (simulating a backend
         # refreshing its token in place, exactly as observed in the
         # incident), then assert candidate B is byte-unchanged.
-        _write_credential(candidate_a.name, _TARGET_REL, _ROTATED_CREDENTIAL)
-        rotated_content_a, _ = _read_credential(candidate_a.name, _TARGET_REL)
-        assert rotated_content_a == _ROTATED_CREDENTIAL
+        _write_credential(candidate_a.name, target_rel, rotated_credential)
+        rotated_content_a, _ = _read_credential(candidate_a.name, target_rel)
+        assert rotated_content_a == rotated_credential
 
-        unaffected_content_b, unaffected_mode_b = _read_credential(candidate_b.name, _TARGET_REL)
-        assert unaffected_content_b == _FAKE_CREDENTIAL, (
+        unaffected_content_b, unaffected_mode_b = _read_credential(candidate_b.name, target_rel)
+        assert unaffected_content_b == fake_credential, (
             "candidate B's credential changed after candidate A rotated its "
             "own copy -- this is exactly the shared-volume rotation incident "
             "this design exists to prevent"
@@ -260,17 +361,24 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
         assert unaffected_mode_b == "600 1000:1000"
 
         # The synthetic login volume itself is also untouched by A's write.
-        login_content, _ = _read_credential(login_volume, _SOURCE_REL, mount="/home/node")
-        assert login_content == _FAKE_CREDENTIAL
+        login_content, _ = _read_credential(login_volume, source_rel, mount="/home/node")
+        assert login_content == fake_credential
 
         # 5: candidate volumes only contain the manifest-declared targets --
         # no trace of the login volume's own nested layout leaks through.
         top_level_a = _list_top_level(candidate_a.name)
         top_level_b = _list_top_level(candidate_b.name)
-        assert ".claude" not in top_level_a  # source's directory name, not the target's
-        assert ".claude" not in top_level_b
-        assert top_level_a == {".credentials.json", "projects"}
-        assert top_level_b == {".credentials.json", "projects"}
+        source_top_component = source_rel.split("/", 1)[0]
+        assert source_top_component not in top_level_a  # source's directory name, not the target's
+        assert source_top_component not in top_level_b
+        expected_top_level = {target for _, target in AUTH_CREDENTIAL_MANIFEST[backend]}
+        # claude's transcript bind is deliberately pre-created by the seed
+        # helper (see `_seed_command`'s claude special case in sandbox.py);
+        # every other backend's candidate volume holds only its credential.
+        if backend == "claude":
+            expected_top_level.add("projects")
+        assert top_level_a == expected_top_level
+        assert top_level_b == expected_top_level
 
         login_mountpoint = _docker(
             "volume", "inspect", "-f", "{{.Mountpoint}}", login_volume
@@ -297,12 +405,22 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("backend", _BACKENDS)
 def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    backend: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _require_docker_fixture()
+    fixture_image = _fixture_image(backend)
+    _require_docker_fixture(fixture_image)
 
-    login_volume = _make_synthetic_login_volume(_BACKEND, _FAKE_CREDENTIAL)
+    real_login_volume_name = f"helix-auth-{backend}"
+    source_rel, target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
+    mount_dest = AUTH_MOUNT_DESTINATIONS[backend]
+    fake_credential = _fake_credential(backend)
+    rotated_credential = _rotated_credential(backend)
+
+    login_volume = _make_synthetic_login_volume(backend, fake_credential, source_rel)
     monkeypatch.setattr(sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume)
 
     observed_docker_args: list[list[str]] = []
@@ -317,7 +435,7 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
 
     source = tmp_path / "candidate"
     source.mkdir()
-    dest_path = f"{_MOUNT_DEST}/{_TARGET_REL}"
+    dest_path = f"{mount_dest}/{target_rel}"
 
     # A harmless command that never calls a model or any backend CLI: it only
     # reads the seeded credential and process environment, then writes a
@@ -331,7 +449,7 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
             "echo HOME_ENV:$HOME; "
             "if mount | grep -q \" on /home/node type tmpfs\"; then "
             "echo HOME_MOUNT:tmpfs; else echo HOME_MOUNT:not-tmpfs; fi; "
-            f"printf '%s' {shlex.quote(_ROTATED_CREDENTIAL)} > {shlex.quote(dest_path)}"
+            f"printf '%s' {shlex.quote(rotated_credential)} > {shlex.quote(dest_path)}"
         ),
     ]
 
@@ -342,14 +460,16 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
         sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
         scope="agent",
         sync_back=False,
-        image=_FIXTURE_IMAGE,
-        agent_backend=_BACKEND,
+        image=fixture_image,
+        agent_backend=backend,
     )
 
     try:
-        assert result.returncode == 0, f"sandboxed command failed: {result.stderr}"
+        assert result.returncode == 0, (
+            f"sandboxed command failed for backend {backend!r}: {result.stderr}"
+        )
         lines = result.stdout.splitlines()
-        assert lines[0] == _FAKE_CREDENTIAL, "seeded credential not present/readable at mount dest"
+        assert lines[0] == fake_credential, "seeded credential not present/readable at mount dest"
         assert lines[1] == "MODE:600 1000:1000", "credential not owned/moded correctly in container"
         assert lines[2] == "HOME_ENV:/home/node"
         assert lines[3] == "HOME_MOUNT:tmpfs", "HOME is not the private per-container tmpfs"
@@ -361,12 +481,12 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
             call for call in observed_docker_args if call[:2] == ["docker", "run"]
         )
         assert not any(login_volume in item for item in agent_call)
-        assert not any(_REAL_LOGIN_VOLUME_NAME in item for item in agent_call)
+        assert not any(real_login_volume_name in item for item in agent_call)
         mount_arg = next(
-            item for item in agent_call if item.endswith(f":{_MOUNT_DEST}:rw")
+            item for item in agent_call if item.endswith(f":{mount_dest}:rw")
         )
         candidate_volume_in_argv = mount_arg.split(":", 1)[0]
-        assert candidate_volume_in_argv.startswith("helix-candidate-auth-claude-")
+        assert candidate_volume_in_argv.startswith(f"helix-candidate-auth-{backend}-")
 
         # The candidate volume the agent actually used is gone once
         # `run_sandboxed_command` returns (its own cleanup path ran).
@@ -375,8 +495,8 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
         # THE assertion that matters most, replayed through the real E2E
         # entry point: the in-container "rotation" write landed on the
         # candidate's private copy, not on the synthetic login volume.
-        login_content, _ = _read_credential(login_volume, _SOURCE_REL, mount="/home/node")
-        assert login_content == _FAKE_CREDENTIAL, (
+        login_content, _ = _read_credential(login_volume, source_rel, mount="/home/node")
+        assert login_content == fake_credential, (
             "the login volume was mutated by a write made inside the agent "
             "container -- credentials are not isolated"
         )

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -38,7 +38,7 @@ of ``codex``'s ``auth.json``, ``cursor``'s ``cli-config.json``, ``gemini``'s
 ``oauth_creds.json``, and ``opencode``'s ``auth.json`` are deliberately not
 reproduced, because determining them would mean reading an operator's real
 credential file -- which the paragraph above forbids. Those four backends get a
-minimal, valid, non-empty JSON object (``_GENERIC_SYNTHETIC_SHAPE`` below)
+minimal, valid, non-empty JSON object (see ``_fake_credential`` below)
 instead. Everything these tests assert -- byte-for-byte isolation across
 candidate volumes, mode and ownership, manifest-only contents, and that a write
 to one candidate reaches neither another candidate nor the login volume --

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -170,15 +170,30 @@ def _docker(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]
 
 
 def _require_docker_fixture(image: str) -> None:
+    """Skip when Docker or the fixture image is unavailable.
+
+    Set ``HELIX_DOCKER_TESTS_STRICT=1`` to turn every skip into a failure.
+    CI sets it: a Docker job that silently skips every test still reports
+    green, which is worse than not running it at all.
+    """
+    strict = os.environ.get("HELIX_DOCKER_TESTS_STRICT") == "1"
+
+    def _bail(reason: str) -> None:
+        if strict:
+            pytest.fail(f"{reason} [HELIX_DOCKER_TESTS_STRICT=1 forbids skipping]")
+        pytest.skip(reason)
+
     try:
         daemon = _docker("info")
         inspected = _docker("image", "inspect", image)
     except (OSError, subprocess.SubprocessError) as exc:
-        pytest.skip(f"Docker daemon unavailable: {exc}")
+        _bail(f"Docker daemon unavailable: {exc}")
+        return
     if daemon.returncode != 0:
-        pytest.skip(f"Docker daemon unavailable: {daemon.stderr.strip()}")
+        _bail(f"Docker daemon unavailable: {daemon.stderr.strip()}")
+        return
     if inspected.returncode != 0:
-        pytest.skip(f"fixture image {image!r} is not installed locally")
+        _bail(f"fixture image {image!r} is not installed locally")
 
 
 def _diagnostic_docker_args(

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -216,14 +216,23 @@ def _diagnostic_docker_args(
 
 
 def _make_synthetic_login_volume(
-    backend: str, credential_json: str, source_rel: str, *, image: str
+    backend: str,
+    credential_json: str,
+    source_rel: str,
+    *,
+    image: str,
+    mode: str = "600",
 ) -> str:
     """Create a throwaway, HELIX-shaped login volume holding a fake credential.
 
     This mimics the *shape* the real login volume has after a real login (a
-    manifest-declared relative path, mode 0600, uid/gid 1000) but is a
-    brand-new randomly-named volume -- it is never ``helix-auth-<backend>``
-    and never derived from any real credential.
+    manifest-declared relative path, mode 0600 by default, uid/gid 1000) but
+    is a brand-new randomly-named volume -- it is never
+    ``helix-auth-<backend>`` and never derived from any real credential.
+
+    *mode* defaults to the real login volume's own mode, ``600``. Tests
+    exercising ``_seed_command``'s wrong-mode guard (ADR verification
+    requirement 4) pass a different value deliberately.
     """
     name = f"helix-test-synthetic-login-{backend}-{uuid.uuid4().hex}"
     _run_docker(["docker", "volume", "create", name])
@@ -232,7 +241,7 @@ def _make_synthetic_login_volume(
     script = (
         f"set -eu; mkdir -p {shlex.quote(parent)}; "
         f"printf '%s' {shlex.quote(credential_json)} > {shlex.quote(container_path)}; "
-        f"chmod 600 {shlex.quote(container_path)}; "
+        f"chmod {shlex.quote(mode)} {shlex.quote(container_path)}; "
         "chown -R 1000:1000 /home/node"
     )
     _run_docker(
@@ -533,5 +542,152 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
             "the login volume was mutated by a write made inside the agent "
             "container -- credentials are not isolated"
         )
+    finally:
+        _force_remove_volume(login_volume)
+
+
+# --------------------------------------------------------------------------
+# TEST 3 & 4 -- fail-closed guards on malformed source material
+#
+# ADR verification requirement 4: "Missing, malformed, oversized, or
+# wrong-mode source material must prevent the agent from starting with a
+# stable, redacted error. This is mandatory." Neither guard has real-Docker
+# coverage: `_seed_command`'s checks run inside the seed helper container, so
+# a unit test that only inspects argv (as `tests/unit/test_sandbox.py` does
+# for the rest of this module) never actually exercises them.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_wrong_mode_credential_fails_closed_before_any_agent_container(
+    backend: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A credential source at the wrong mode must fail closed, not silently.
+
+    ADR verification requirement 4 names "wrong-mode source material" as one
+    of the cases that "must prevent the agent from starting with a stable,
+    redacted error. This is mandatory." `_seed_command` enforces this with
+    ``test $(stat -c %a <source>) = 600``; this test proves that guard
+    actually runs against a real Docker daemon, not just that the argv
+    contains the check.
+    """
+    fixture_image = _fixture_image(backend)
+    _require_docker_fixture(fixture_image)
+
+    source_rel, _target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
+    secret_marker = f"SECRET-MARKER-{uuid.uuid4().hex}"
+    credential = json.dumps({"marker": secret_marker, "backend": backend})
+
+    # 0644, not the required 0600 -- the guard `_seed_command` enforces.
+    login_volume = _make_synthetic_login_volume(
+        backend, credential, source_rel, image=fixture_image, mode="644"
+    )
+    monkeypatch.setattr(sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume)
+
+    observed_docker_args: list[list[str]] = []
+    original_docker_args = sandbox_module._docker_args
+
+    def _spy(*args: object, **kwargs: object) -> list[str]:
+        built = original_docker_args(*args, **kwargs)  # type: ignore[arg-type]
+        observed_docker_args.append(built)
+        return built
+
+    monkeypatch.setattr(sandbox_module, "_docker_args", _spy)
+
+    source = tmp_path / "candidate"
+    source.mkdir()
+
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            run_sandboxed_command(
+                ["sh", "-c", "echo should-not-run"],
+                cwd=source,
+                env={},
+                sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
+                scope="agent",
+                sync_back=False,
+                image=fixture_image,
+                agent_backend=backend,
+            )
+
+        assert "credential seed failed" in str(excinfo.value)
+        assert secret_marker not in str(excinfo.value)
+        assert secret_marker not in repr(excinfo.value)
+        cause = excinfo.value.__cause__
+        if isinstance(cause, subprocess.CalledProcessError):
+            assert secret_marker not in (cause.stdout or "")
+            assert secret_marker not in (cause.stderr or "")
+
+        # The seed step raised before `run_sandboxed_commands`'s command loop
+        # ever reaches `_docker_args` -- no agent container was created.
+        assert observed_docker_args == []
+    finally:
+        _force_remove_volume(login_volume)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_malformed_json_credential_fails_closed_before_any_agent_container(
+    backend: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-JSON credential content must fail closed, not silently.
+
+    ADR verification requirement 4 names "malformed source material" as one
+    of the cases that "must prevent the agent from starting with a stable,
+    redacted error. This is mandatory." `_seed_command` enforces this with a
+    ``python -c`` step that parses every manifest entry as JSON; this test
+    proves that guard actually runs against a real Docker daemon.
+    """
+    fixture_image = _fixture_image(backend)
+    _require_docker_fixture(fixture_image)
+
+    source_rel, _target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
+    secret_marker = f"SECRET-MARKER-{uuid.uuid4().hex}"
+    non_json_content = f"not-json-at-all::{secret_marker}"
+
+    # Correct mode, but content that fails `python -c ... json.loads(...)`.
+    login_volume = _make_synthetic_login_volume(
+        backend, non_json_content, source_rel, image=fixture_image, mode="600"
+    )
+    monkeypatch.setattr(sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume)
+
+    observed_docker_args: list[list[str]] = []
+    original_docker_args = sandbox_module._docker_args
+
+    def _spy(*args: object, **kwargs: object) -> list[str]:
+        built = original_docker_args(*args, **kwargs)  # type: ignore[arg-type]
+        observed_docker_args.append(built)
+        return built
+
+    monkeypatch.setattr(sandbox_module, "_docker_args", _spy)
+
+    source = tmp_path / "candidate"
+    source.mkdir()
+
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            run_sandboxed_command(
+                ["sh", "-c", "echo should-not-run"],
+                cwd=source,
+                env={},
+                sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
+                scope="agent",
+                sync_back=False,
+                image=fixture_image,
+                agent_backend=backend,
+            )
+
+        assert "credential seed failed" in str(excinfo.value)
+        assert secret_marker not in str(excinfo.value)
+        assert secret_marker not in repr(excinfo.value)
+        cause = excinfo.value.__cause__
+        if isinstance(cause, subprocess.CalledProcessError):
+            assert secret_marker not in (cause.stdout or "")
+            assert secret_marker not in (cause.stderr or "")
+
+        assert observed_docker_args == []
     finally:
         _force_remove_volume(login_volume)

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -333,20 +333,66 @@ def _force_remove_volume(name: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _no_leaked_test_volumes():
-    """Belt-and-braces cleanup: remove any stray test-created volumes.
+def _no_leaked_test_volumes(monkeypatch: pytest.MonkeyPatch):
+    """Belt-and-braces cleanup: remove exactly the volumes this test process created.
 
-    Scoped to prefixes HELIX itself only ever assigns to throwaway
-    credential volumes (``helix-candidate-auth-``) or that this test module
-    invents for its synthetic login fixture (``helix-test-synthetic-login-``).
-    Neither prefix can collide with a real ``helix-auth-<backend>`` volume.
+    ``helix-candidate-auth-`` is not a test-only prefix -- it is the real
+    production prefix ``_create_candidate_auth_volume`` in
+    ``src/helix/sandbox.py`` assigns to *every* live candidate's credential
+    volume, test-made or not. (An earlier version of this docstring reasoned
+    that neither cleanup prefix "can collide with a real
+    ``helix-auth-<backend>`` volume" -- true, but irrelevant: the volume this
+    fixture must not touch is a real *candidate* volume, i.e. one sharing
+    this exact prefix, not a real *login* volume under a different one.) A
+    sweep that force-removes anything starting with that prefix after every
+    test would delete another, concurrently running HELIX process's
+    in-flight candidate volumes right along with this test's own -- pulling
+    a live run's credentials out from under it mid-mutation, not just
+    cleaning up a leaked test artifact. So cleanup here never sweeps that
+    namespace by prefix. Instead it wraps ``_create_candidate_auth_volume``
+    at both places this suite calls it -- this test module's own direct
+    calls, and the internal call ``run_sandboxed_command`` makes inside
+    ``helix.sandbox`` -- to record the exact name of every candidate volume
+    this test process itself asked Docker to create, and removes only those
+    names.
+
+    ``helix-test-synthetic-login-`` is different: production code never
+    assigns that prefix to anything, so no real HELIX workload can ever hold
+    a volume under it -- only this test module's own fixtures do, always
+    with a random uuid suffix. A prefix sweep there cannot delete a live
+    run's credentials, so it stays a sweep: a cheap, robust fallback for a
+    login volume some other test in this process leaked, without needing
+    name-for-name tracking for it too.
     """
+    created_candidate_volumes: list[str] = []
+    original_create_candidate_auth_volume = sandbox_module._create_candidate_auth_volume
+
+    def _tracking_create_candidate_auth_volume(agent_backend: str) -> CandidateAuthVolume:
+        volume = original_create_candidate_auth_volume(agent_backend)
+        created_candidate_volumes.append(volume.name)
+        return volume
+
+    # Patched in two places on purpose -- see the docstring. Both bindings
+    # point at the same underlying function; either call path left
+    # unpatched would create a real, untracked candidate volume.
+    monkeypatch.setattr(
+        sandbox_module,
+        "_create_candidate_auth_volume",
+        _tracking_create_candidate_auth_volume,
+    )
+    monkeypatch.setitem(
+        globals(), "_create_candidate_auth_volume", _tracking_create_candidate_auth_volume
+    )
+
     yield
+
+    for name in created_candidate_volumes:
+        if _volume_exists(name):
+            _force_remove_volume(name)
+
     listing = _docker("volume", "ls", "--format", "{{.Name}}")
     for name in listing.stdout.splitlines():
-        if name.startswith("helix-candidate-auth-") or name.startswith(
-            "helix-test-synthetic-login-"
-        ):
+        if name.startswith("helix-test-synthetic-login-"):
             _force_remove_volume(name)
 
 

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -32,12 +32,18 @@ is monkeypatched for the duration of each test to point at a throwaway
 ``helix-test-synthetic-login-*`` volume instead. That is the sole seam
 touched; every other code path under test runs unmodified.
 
-Credential shape: ``claude``, ``cursor``, and ``gemini`` get shape-accurate
-fixtures; ``codex`` and ``opencode`` deliberately get a minimal valid JSON
-object instead (see ``_fake_credential``). The isolation tests assert only
-paths, bytes, mode, and ownership, so they need no schema at all -- the shape
-matters solely to the two backend-specific tests at the end of this module,
-which hand a real CLI the seeded record and read what it says about it.
+Credential shape: ``claude`` and ``cursor`` get shape-accurate fixtures;
+``codex``, ``opencode``, and ``agy`` deliberately get a minimal valid JSON
+object instead (see ``_fake_credential``). For ``agy`` this is not a matter of
+convenience: a synthetic OAuth-token-shaped blob is known to be insufficient
+on its own (the real CLI reports "unknown auth method:" rather than accepting
+it, see ``AUTH_SYNTHESIZED_SIBLINGS`` in ``src/helix/sandbox.py``), and this
+module never invokes ``agy`` against a prompt (no ``--print``, ever). Cursor
+gets a dedicated backend-specific test below this generic isolation coverage
+because a real, network-isolated CLI call was possible to write honestly for
+it; agy does not have one yet for the same reason its shape is unconfirmed.
+The isolation tests below assert only paths, bytes, mode, and ownership, so
+they need no schema at all.
 
 These tests carry the ``docker_integration`` marker (see ``pyproject.toml``)
 and skip when the daemon or a fixture image is unavailable, so a machine
@@ -116,17 +122,12 @@ def _fake_credential(backend: str) -> str:
                 "apiKey": None,
             }
         )
-    if backend == "gemini":
-        # The CLI's credential cache stores an OAuth token record.
-        return json.dumps(
-            {
-                "access_token": _SYNTHETIC_TOKEN,
-                "refresh_token": f"{_SYNTHETIC_TOKEN}-refresh",
-                "scope": "https://www.googleapis.com/auth/cloud-platform",
-                "token_type": "Bearer",
-                "expiry_date": 4102444800000,
-            }
-        )
+    # agy: the traced credential's exact JSON shape is unconfirmed (see
+    # AUTH_SYNTHESIZED_SIBLINGS in src/helix/sandbox.py) -- a synthetic
+    # OAuth-token-shaped blob is known to be *insufficient* (the real CLI
+    # fails with "unknown auth method:" rather than accepting it), so agy
+    # deliberately falls through to the generic shape below rather than
+    # claiming a shape that isn't actually confirmed to work.
     return json.dumps(
         {
             "synthetic_credential": True,
@@ -139,7 +140,7 @@ def _fake_credential(backend: str) -> str:
 
 def _rotated_credential(backend: str) -> str:
     """A synthetic "rotated" value simulating an in-place token refresh."""
-    if backend in {"cursor", "gemini"}:
+    if backend in {"cursor"}:
         rotated = json.loads(_fake_credential(backend))
         key = "accessToken" if backend == "cursor" else "access_token"
         rotated[key] = f"{_SYNTHETIC_TOKEN}-rotated-by-candidate-a"
@@ -448,7 +449,9 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
         assert source_top_component not in top_level_b
         expected_top_level = {target for _, target in AUTH_CREDENTIAL_MANIFEST[backend]}
         # Siblings the seed helper writes itself, because the candidate mount
-        # would otherwise shadow them (gemini's settings file today).
+        # would otherwise shadow them. No current backend has one (see
+        # AUTH_SYNTHESIZED_SIBLINGS in src/helix/sandbox.py); this loop still
+        # covers one automatically if a future backend needs it.
         expected_top_level |= {
             name for name, _ in AUTH_SYNTHESIZED_SIBLINGS.get(backend, ())
         }
@@ -841,109 +844,3 @@ def test_cursor_cli_reads_the_credential_from_the_path_helix_mounts_it_at(
     finally:
         _force_remove_volume(login_volume)
 
-
-# --------------------------------------------------------------------------
-# TEST 7 -- the gemini CLI gets past its auth-method gate
-#
-# Without a settings file naming an auth method, the CLI refuses before it
-# ever opens the credential. The candidate mount replaces the directory that
-# settings file lives in, so HELIX writes a minimal one into the candidate
-# volume; this proves it clears the gate.
-#
-# "The refusal is absent" is not on its own evidence of anything -- an empty
-# candidate volume would satisfy it too. So this asserts the CLI got far
-# enough to *read* the credential from the mounted path, using the line the
-# CLI emits only from inside the branch it takes when a cached credential was
-# found and parsed, and pairs that with a control run that suppresses the
-# synthesized sibling and shows the refusal returning.
-# --------------------------------------------------------------------------
-
-
-_GEMINI_AUTH_METHOD_REFUSAL = "Please set an Auth method"
-# Emitted only from the branch the CLI takes when it has loaded a cached
-# credential and is trying to use it; absent when no credential was found.
-_GEMINI_CREDENTIAL_WAS_READ = "Cached credentials are not valid"
-
-
-def test_gemini_cli_clears_its_auth_method_gate_and_reads_the_seeded_credential(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    backend = "gemini"
-    fixture_image = _fixture_image(backend)
-    _require_docker_fixture(fixture_image)
-
-    source_rel, target_rel = AUTH_CREDENTIAL_MANIFEST[backend][0]
-    destination = AUTH_MOUNT_DESTINATIONS[backend]
-    sibling_name, sibling_contents = AUTH_SYNTHESIZED_SIBLINGS[backend][0]
-    credential = _fake_credential(backend)
-
-    def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
-        workspace = tmp_path / f"candidate-{uuid.uuid4().hex[:8]}"
-        workspace.mkdir()
-        return run_sandboxed_command(
-            command,
-            cwd=workspace,
-            env={},
-            sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
-            scope="agent",
-            sync_back=False,
-            image=fixture_image,
-            agent_backend=backend,
-        )
-
-    login_volume = _make_synthetic_login_volume(
-        backend, credential, source_rel, image=fixture_image
-    )
-    monkeypatch.setattr(
-        sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume
-    )
-
-    try:
-        # 1. Credential and sibling are both at the exact paths the CLI reads,
-        #    private and owned by the agent.
-        credential_path = f"{destination}/{target_rel}"
-        sibling_path = f"{destination}/{sibling_name}"
-        probe = _run(
-            [
-                "sh",
-                "-c",
-                (
-                    f"cat {shlex.quote(credential_path)}; echo; "
-                    f"echo MODE:$(stat -c '%a %u:%g' {shlex.quote(credential_path)}); "
-                    f"cat {shlex.quote(sibling_path)}; echo; "
-                    f"echo SIBLING_MODE:$(stat -c '%a %u:%g' {shlex.quote(sibling_path)})"
-                ),
-            ]
-        )
-        assert probe.returncode == 0, probe.stderr
-        probe_lines = probe.stdout.splitlines()
-        assert probe_lines[0] == credential
-        assert probe_lines[1] == "MODE:600 1000:1000"
-        assert probe_lines[2] == sibling_contents
-        assert probe_lines[3] == "SIBLING_MODE:600 1000:1000"
-
-        # 2. The CLI clears the gate and goes on to read the credential.
-        run = _run(["gemini", "--debug", "-p", "hello"])
-        combined = f"{run.stdout}\n{run.stderr}"
-        assert _GEMINI_AUTH_METHOD_REFUSAL not in combined, (
-            f"the auth-method gate is still closed: {combined!r}"
-        )
-        assert _GEMINI_CREDENTIAL_WAS_READ in combined, (
-            "the CLI never got as far as loading a credential -- clearing the "
-            f"gate alone proves nothing: {combined!r}"
-        )
-
-        # 3. The control. With the sibling suppressed, the same command hits
-        #    the refusal again and never reaches the credential, so step 2 is
-        #    not satisfied by an empty candidate volume.
-        monkeypatch.setitem(sandbox_module.AUTH_SYNTHESIZED_SIBLINGS, backend, ())
-        control = _run(["gemini", "--debug", "-p", "hello"])
-        control_combined = f"{control.stdout}\n{control.stderr}"
-        assert _GEMINI_AUTH_METHOD_REFUSAL in control_combined, (
-            "the auth-method refusal did not return without the synthesized "
-            f"settings sibling: {control_combined!r}"
-        )
-        assert _GEMINI_CREDENTIAL_WAS_READ not in control_combined
-    finally:
-        _force_remove_volume(login_volume)

--- a/tests/integration/test_sandbox_auth_isolation_docker.py
+++ b/tests/integration/test_sandbox_auth_isolation_docker.py
@@ -83,7 +83,6 @@ from helix.sandbox import (
     _remove_candidate_auth_volume,
     _run_docker,
     _seed_candidate_auth_volume,
-    _SEED_IMAGE,
     run_sandboxed_command,
 )
 
@@ -197,8 +196,14 @@ def _require_docker_fixture(image: str) -> None:
 
 
 def _diagnostic_docker_args(
-    volume_name: str, mount: str, script: str, *, writable: bool
+    volume_name: str, mount: str, script: str, *, writable: bool, image: str
 ) -> list[str]:
+    """Build argv for a throwaway inspection container.
+
+    *image* is always one of the already-pulled backend runner images (see
+    ``_fixture_image``) -- these diagnostics never pull a separate
+    third-party image just to poke at a volume.
+    """
     mode = "rw" if writable else "ro"
     return [
         "docker",
@@ -212,14 +217,16 @@ def _diagnostic_docker_args(
         "no-new-privileges",
         "-v",
         f"{volume_name}:{mount}:{mode}",
-        _SEED_IMAGE,
+        image,
         "sh",
         "-c",
         script,
     ]
 
 
-def _make_synthetic_login_volume(backend: str, credential_json: str, source_rel: str) -> str:
+def _make_synthetic_login_volume(
+    backend: str, credential_json: str, source_rel: str, *, image: str
+) -> str:
     """Create a throwaway, HELIX-shaped login volume holding a fake credential.
 
     This mimics the *shape* the real login volume has after a real login (a
@@ -237,11 +244,15 @@ def _make_synthetic_login_volume(backend: str, credential_json: str, source_rel:
         f"chmod 600 {shlex.quote(container_path)}; "
         "chown -R 1000:1000 /home/node"
     )
-    _run_docker(_diagnostic_docker_args(name, "/home/node", script, writable=True))
+    _run_docker(
+        _diagnostic_docker_args(name, "/home/node", script, writable=True, image=image)
+    )
     return name
 
 
-def _read_credential(volume_name: str, rel_path: str, *, mount: str = "/check") -> tuple[str, str]:
+def _read_credential(
+    volume_name: str, rel_path: str, *, mount: str = "/check", image: str
+) -> tuple[str, str]:
     """Return ``(file content, "mode uid:gid")`` read from inside *volume_name*."""
     path = f"{mount}/{rel_path}"
     script = (
@@ -249,20 +260,28 @@ def _read_credential(volume_name: str, rel_path: str, *, mount: str = "/check") 
         "printf '\\n===MODE===\\n'; "
         f"stat -c '%a %u:%g' {shlex.quote(path)}"
     )
-    result = _run_docker(_diagnostic_docker_args(volume_name, mount, script, writable=False))
+    result = _run_docker(
+        _diagnostic_docker_args(volume_name, mount, script, writable=False, image=image)
+    )
     content, mode = result.stdout.split("\n===MODE===\n")
     return content, mode.strip()
 
 
-def _write_credential(volume_name: str, rel_path: str, content: str, *, mount: str = "/check") -> None:
+def _write_credential(
+    volume_name: str, rel_path: str, content: str, *, mount: str = "/check", image: str
+) -> None:
     path = f"{mount}/{rel_path}"
     script = f"printf '%s' {shlex.quote(content)} > {shlex.quote(path)}"
-    _run_docker(_diagnostic_docker_args(volume_name, mount, script, writable=True))
+    _run_docker(
+        _diagnostic_docker_args(volume_name, mount, script, writable=True, image=image)
+    )
 
 
-def _list_top_level(volume_name: str, *, mount: str = "/check") -> set[str]:
+def _list_top_level(volume_name: str, *, mount: str = "/check", image: str) -> set[str]:
     result = _run_docker(
-        _diagnostic_docker_args(volume_name, mount, f"ls -a {mount}", writable=False)
+        _diagnostic_docker_args(
+            volume_name, mount, f"ls -a {mount}", writable=False, image=image
+        )
     )
     return {entry for entry in result.stdout.split() if entry not in {".", ".."}}
 
@@ -327,7 +346,9 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
     fake_credential = _fake_credential(backend)
     rotated_credential = _rotated_credential(backend)
 
-    login_volume = _make_synthetic_login_volume(backend, fake_credential, source_rel)
+    login_volume = _make_synthetic_login_volume(
+        backend, fake_credential, source_rel, image=fixture_image
+    )
 
     # The only seam we touch: redirect the seeding step's *source* volume
     # away from the real "helix-auth-<backend>" toward our synthetic fixture.
@@ -348,12 +369,12 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
         assert candidate_b.name != login_volume
         assert real_login_volume_name not in (candidate_a.name, candidate_b.name, login_volume)
 
-        _seed_candidate_auth_volume(candidate_a)
-        _seed_candidate_auth_volume(candidate_b)
+        _seed_candidate_auth_volume(candidate_a, fixture_image)
+        _seed_candidate_auth_volume(candidate_b, fixture_image)
 
         # 3: both candidates contain the credential, mode 0600, owned 1000:1000.
-        content_a, mode_a = _read_credential(candidate_a.name, target_rel)
-        content_b, mode_b = _read_credential(candidate_b.name, target_rel)
+        content_a, mode_a = _read_credential(candidate_a.name, target_rel, image=fixture_image)
+        content_b, mode_b = _read_credential(candidate_b.name, target_rel, image=fixture_image)
         assert content_a == fake_credential
         assert content_b == fake_credential
         assert mode_a == "600 1000:1000"
@@ -363,11 +384,13 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
         # credential into candidate A's own copy (simulating a backend
         # refreshing its token in place, exactly as observed in the
         # incident), then assert candidate B is byte-unchanged.
-        _write_credential(candidate_a.name, target_rel, rotated_credential)
-        rotated_content_a, _ = _read_credential(candidate_a.name, target_rel)
+        _write_credential(candidate_a.name, target_rel, rotated_credential, image=fixture_image)
+        rotated_content_a, _ = _read_credential(candidate_a.name, target_rel, image=fixture_image)
         assert rotated_content_a == rotated_credential
 
-        unaffected_content_b, unaffected_mode_b = _read_credential(candidate_b.name, target_rel)
+        unaffected_content_b, unaffected_mode_b = _read_credential(
+            candidate_b.name, target_rel, image=fixture_image
+        )
         assert unaffected_content_b == fake_credential, (
             "candidate B's credential changed after candidate A rotated its "
             "own copy -- this is exactly the shared-volume rotation incident "
@@ -376,13 +399,15 @@ def test_candidate_auth_volumes_isolate_synthetic_credential_under_rotation(
         assert unaffected_mode_b == "600 1000:1000"
 
         # The synthetic login volume itself is also untouched by A's write.
-        login_content, _ = _read_credential(login_volume, source_rel, mount="/home/node")
+        login_content, _ = _read_credential(
+            login_volume, source_rel, mount="/home/node", image=fixture_image
+        )
         assert login_content == fake_credential
 
         # 5: candidate volumes only contain the manifest-declared targets --
         # no trace of the login volume's own nested layout leaks through.
-        top_level_a = _list_top_level(candidate_a.name)
-        top_level_b = _list_top_level(candidate_b.name)
+        top_level_a = _list_top_level(candidate_a.name, image=fixture_image)
+        top_level_b = _list_top_level(candidate_b.name, image=fixture_image)
         source_top_component = source_rel.split("/", 1)[0]
         assert source_top_component not in top_level_a  # source's directory name, not the target's
         assert source_top_component not in top_level_b
@@ -435,7 +460,9 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
     fake_credential = _fake_credential(backend)
     rotated_credential = _rotated_credential(backend)
 
-    login_volume = _make_synthetic_login_volume(backend, fake_credential, source_rel)
+    login_volume = _make_synthetic_login_volume(
+        backend, fake_credential, source_rel, image=fixture_image
+    )
     monkeypatch.setattr(sandbox_module, "sandbox_auth_volume_name", lambda _backend: login_volume)
 
     observed_docker_args: list[list[str]] = []
@@ -510,7 +537,9 @@ def test_e2e_sandboxed_agent_command_sees_isolated_seeded_credential(
         # THE assertion that matters most, replayed through the real E2E
         # entry point: the in-container "rotation" write landed on the
         # candidate's private copy, not on the synthetic login volume.
-        login_content, _ = _read_credential(login_volume, source_rel, mount="/home/node")
+        login_content, _ = _read_credential(
+            login_volume, source_rel, mount="/home/node", image=fixture_image
+        )
         assert login_content == fake_credential, (
             "the login volume was mutated by a write made inside the agent "
             "container -- credentials are not isolated"

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -29,10 +29,10 @@ from helix.trace import TRACE, EventType
 # ``invoke_claude_code`` actually dispatched to the requested backend CLI
 # (rather than short-circuiting via the differential-testing override).
 _BACKEND_EXECUTABLE = {
+    "agy": "agy",
     "claude": "claude",
     "codex": "codex",
     "cursor": "cursor",
-    "gemini": "gemini",
     "opencode": "opencode",
 }
 
@@ -196,21 +196,6 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
             id="cursor",
         ),
         pytest.param(
-            "gemini",
-            "\n".join(
-                [
-                    "MCP advisory preamble tolerated by the Gemini parser.",
-                    '{"type":"init","session_id":"gemini-session"}',
-                    (
-                        '{"type":"result","usageMetadata":{"prompt_tokens":14,'
-                        '"completion_tokens":10},"cost":0.34}'
-                    ),
-                ]
-            ),
-            (14, 10, 0.34),
-            id="gemini",
-        ),
-        pytest.param(
             "opencode",
             "\n".join(
                 [
@@ -223,6 +208,24 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
             ),
             (15, 11, 0.35),
             id="opencode",
+        ),
+        pytest.param(
+            # agy's confirmed dispatch is the same single-JSON-object branch
+            # claude uses (see _parse_backend_output); its real field names
+            # are not yet confirmed (needs a real --print run, out of scope
+            # for this migration), so this envelope is illustrative -- it
+            # exercises the generic _normalise_usage_stats walk, not a
+            # verified agy transcript shape.
+            "agy",
+            json.dumps(
+                {
+                    "session_id": "agy-session",
+                    "usage": {"input_tokens": 16, "output_tokens": 12},
+                    "total_cost_usd": 0.36,
+                }
+            ),
+            (16, 12, 0.36),
+            id="agy",
         ),
     ],
 )
@@ -345,26 +348,6 @@ def test_backend_usage_parsing_charges_llm_budget(
             id="cursor",
         ),
         pytest.param(
-            "gemini",
-            "\n".join(
-                [
-                    '{"type":"init","session_id":"gemini-session"}',
-                    (
-                        '{"type":"result","usageMetadata":{"prompt_tokens":14,'
-                        '"completion_tokens":10,"cachedTokens":23},'
-                        '"thoughts":8,"cost":0.34}'
-                    ),
-                ]
-            ),
-            {
-                "input_tokens": 14,
-                "output_tokens": 10,
-                "cached_input_tokens": 23,
-                "reasoning_tokens": 8,
-            },
-            id="gemini",
-        ),
-        pytest.param(
             "opencode",
             "\n".join(
                 [
@@ -382,6 +365,30 @@ def test_backend_usage_parsing_charges_llm_budget(
                 "reasoning_tokens": 9,
             },
             id="opencode",
+        ),
+        pytest.param(
+            # Illustrative envelope on agy's confirmed dispatch path (the
+            # same single-JSON-object branch claude uses); real field names
+            # are not yet confirmed, see the "agy" case above.
+            "agy",
+            json.dumps(
+                {
+                    "session_id": "agy-session",
+                    "usage": {
+                        "input_tokens": 16,
+                        "output_tokens": 12,
+                        "cached_input_tokens": 25,
+                        "reasoning_tokens": 10,
+                    },
+                }
+            ),
+            {
+                "input_tokens": 16,
+                "output_tokens": 12,
+                "cached_input_tokens": 25,
+                "reasoning_tokens": 10,
+            },
+            id="agy",
         ),
     ],
 )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -292,13 +292,21 @@ class TestAgentEffortValidation:
             )
         assert [w for w in recwarn.list if issubclass(w.category, UserWarning)] == []
 
-    def test_effort_warns_on_ignoring_backend_gemini(self, recwarn):
+    def test_effort_accepts_valid_value_on_agy(self, recwarn):
+        for value in ("low", "medium", "high"):
+            HelixConfig(
+                **self._base_kwargs(),
+                agent=AgentConfig(backend="agy", effort=value),
+            )
+        assert [w for w in recwarn.list if issubclass(w.category, UserWarning)] == []
+
+    def test_effort_warns_on_unknown_value_for_agy(self, recwarn):
         HelixConfig(
             **self._base_kwargs(),
-            agent=AgentConfig(backend="gemini", effort="high"),
+            agent=AgentConfig(backend="agy", effort="extreme"),
         )
         warnings = [str(w.message) for w in recwarn.list if w.category is UserWarning]
-        assert any("does not propagate" in w for w in warnings), warnings
+        assert any("not a recognized value" in w and "extreme" in w for w in warnings), warnings
 
     def test_effort_warns_on_ignoring_backend_cursor(self, recwarn):
         HelixConfig(
@@ -347,7 +355,7 @@ class TestAgentEffortValidation:
         with pytest.warns(UserWarning, match="does not propagate"):
             HelixConfig(
                 **self._base_kwargs(),
-                agent=AgentConfig(backend="gemini", effort="high"),
+                agent=AgentConfig(backend="cursor", effort="high"),
             )
 
     def test_every_backend_has_effort_metadata(self):

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -452,12 +452,12 @@ class TestSandboxConfig:
             # Inline comment after unquoted value (POSIX/foreman convention).
             "OPENAI_API_KEY=plain-key   # this is a trailing comment\n"
             # Hash inside a quoted value must be preserved verbatim.
-            'GEMINI_API_KEY="gem#key#with#hashes"\n'
+            'SERVICE_API_KEY="quoted#key#with#hashes"\n'
         )
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("CURSOR_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("SERVICE_API_KEY", raising=False)
         monkeypatch.setenv("EXISTING", "from-shell")
 
         load_config(toml)
@@ -468,7 +468,7 @@ class TestSandboxConfig:
         # Trailing inline comment must be stripped from unquoted values.
         assert os.environ["OPENAI_API_KEY"] == "plain-key"
         # Embedded ``#`` inside a quoted value must be preserved.
-        assert os.environ["GEMINI_API_KEY"] == "gem#key#with#hashes"
+        assert os.environ["SERVICE_API_KEY"] == "quoted#key#with#hashes"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -300,6 +300,24 @@ class TestSandboxConfig:
         assert cfg.transcript_artifact_dir == ".helix_artifacts/backend_transcripts"
         assert cfg.claude_transcript_root == "/home/node/.claude/projects/-workspace"
 
+    def test_login_auth_is_the_default_and_rejects_env_allowlist(self):
+        cfg = SandboxConfig(enabled=True)
+        assert cfg.auth == "login"
+        with pytest.raises(ValueError, match="login credential copying has no environment"):
+            SandboxConfig(enabled=True, auth_env_allow=["ANTHROPIC_API_KEY"])
+
+    def test_env_auth_requires_an_explicit_allowlist(self):
+        with pytest.raises(ValueError, match="requires a non-empty"):
+            SandboxConfig(enabled=True, auth="env")
+        cfg = SandboxConfig(
+            enabled=True, auth="env", auth_env_allow=["ANTHROPIC_API_KEY"]
+        )
+        assert cfg.auth_env_allow == ["ANTHROPIC_API_KEY"]
+
+    def test_retired_volume_auth_has_a_migration_error(self):
+        with pytest.raises(ValueError, match='has been replaced by "login"'):
+            SandboxConfig(enabled=True, auth="volume")  # type: ignore[arg-type]
+
     def test_sandboxed_evaluator_requires_sidecar(self):
         with pytest.raises(ValueError, match=r"\[evaluator.sidecar\]"):
             HelixConfig(

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 
 from helix.config import (
     DatasetConfig,
+    EvaluatorConfig,
     EvaluatorSidecarConfig,
     EvolutionConfig,
     HelixConfig,
@@ -300,10 +301,10 @@ class TestSandboxConfig:
         assert cfg.transcript_artifact_dir == ".helix_artifacts/backend_transcripts"
         assert cfg.claude_transcript_root == "/home/node/.claude/projects/-workspace"
 
-    def test_login_auth_is_the_default_and_rejects_env_allowlist(self):
+    def test_volume_auth_is_the_default_and_rejects_env_allowlist(self):
         cfg = SandboxConfig(enabled=True)
-        assert cfg.auth == "login"
-        with pytest.raises(ValueError, match="login credential copying has no environment"):
+        assert cfg.auth == "volume"
+        with pytest.raises(ValueError, match="volume credential copying has no environment"):
             SandboxConfig(enabled=True, auth_env_allow=["ANTHROPIC_API_KEY"])
 
     def test_env_auth_requires_an_explicit_allowlist(self):
@@ -314,9 +315,34 @@ class TestSandboxConfig:
         )
         assert cfg.auth_env_allow == ["ANTHROPIC_API_KEY"]
 
-    def test_retired_volume_auth_has_a_migration_error(self):
-        with pytest.raises(ValueError, match='has been replaced by "login"'):
-            SandboxConfig(enabled=True, auth="volume")  # type: ignore[arg-type]
+    def test_sidecar_accepts_its_own_passthrough_environment(self):
+        sidecar = EvaluatorSidecarConfig(
+            image="eval:latest",
+            command="python -m server",
+            endpoint="http://helix-evaluator:8080/evaluate",
+            passthrough_env=["OPENAI_API_KEY"],
+        )
+        assert sidecar.passthrough_env == ["OPENAI_API_KEY"]
+
+    def test_agent_and_sidecar_credential_sets_must_be_disjoint(self):
+        with pytest.raises(ValueError, match="credential sets must be disjoint"):
+            HelixConfig(
+                objective="Test",
+                evaluator=EvaluatorConfig(
+                    command="python /runner/evaluate.py",
+                    sidecar=EvaluatorSidecarConfig(
+                        image="eval:latest",
+                        command="python -m server",
+                        endpoint="http://helix-evaluator:8080/evaluate",
+                        passthrough_env=["OPENAI_API_KEY"],
+                    ),
+                ),
+                sandbox=SandboxConfig(
+                    enabled=True,
+                    auth="env",
+                    auth_env_allow=["OPENAI_API_KEY"],
+                ),
+            )
 
     def test_sandboxed_evaluator_requires_sidecar(self):
         with pytest.raises(ValueError, match=r"\[evaluator.sidecar\]"):

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from helix.population import Candidate, EvalResult
+from helix.backends import AGENT_LOGIN_IDENTITY_ENV
 from helix.config import AgentConfig, HelixConfig, EvaluatorConfig, SandboxConfig
 from helix.executor import _scrub_environment
 from helix.mutator import (
@@ -1179,19 +1180,21 @@ class TestInvokeClaudeCode:
 
         assert "ANTHROPIC_API_KEY" not in mock_run.call_args.kwargs["env"]
 
-    def test_login_identity_reaches_only_the_agent(
+    def test_login_identity_reaches_only_the_host_agent(
         self, tmp_path: Path, mocker, monkeypatch
     ):
-        """Stored agent logins need identity; evaluator environments remain strict."""
-        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
+        """Stored agent logins need identity; evaluator environments remain strict.
+
+        Host/unsandboxed path only -- see
+        ``test_login_identity_does_not_reach_a_sandboxed_agent``.
+        """
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
         monkeypatch.setenv("USER", "login-user")
         monkeypatch.setenv("LOGNAME", "login-logname")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-secret")
 
-        invoke_claude_code(
-            str(tmp_path), "prompt", AgentConfig(), sandbox=SandboxConfig(enabled=True)
-        )
+        invoke_claude_code(str(tmp_path), "prompt", AgentConfig())
 
         agent_env = mock_run.call_args.kwargs["env"]
         assert agent_env["USER"] == "login-user"
@@ -1202,13 +1205,43 @@ class TestInvokeClaudeCode:
         assert "LOGNAME" not in evaluator_env
 
     @pytest.mark.parametrize(
+        "sandbox",
+        [
+            SandboxConfig(enabled=True, auth="volume"),
+            SandboxConfig(
+                enabled=True, auth="env", auth_env_allow=["HELIX_TEST_CREDENTIAL"]
+            ),
+        ],
+        ids=["volume", "env"],
+    )
+    def test_login_identity_does_not_reach_a_sandboxed_agent(
+        self, tmp_path: Path, mocker, monkeypatch, sandbox
+    ):
+        """Host login identity must not be injected into the container.
+
+        The sandbox runs ``--user node`` with ``/home/node`` on a tmpfs, so the
+        host's login identity describes nobody inside the container. See
+        ``helix.mutator._agent_passthrough_env``, which is host-path only.
+        """
+        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+        for name in AGENT_LOGIN_IDENTITY_ENV:
+            monkeypatch.setenv(name, f"host-{name.lower()}")
+
+        invoke_claude_code(str(tmp_path), "prompt", AgentConfig(), sandbox=sandbox)
+
+        agent_env = mock_run.call_args.kwargs["env"]
+        leaked = sorted(n for n in AGENT_LOGIN_IDENTITY_ENV if n in agent_env)
+        assert leaked == []
+
+    @pytest.mark.parametrize(
         ("passthrough_env", "fixed_env", "expected_key"),
         [
             (None, {"ANTHROPIC_API_KEY": "configured-in-env"}, "configured-in-env"),
             (["ANTHROPIC_API_KEY"], None, "configured-by-passthrough"),
         ],
     )
-    def test_sandbox_env_auth_requires_explicit_credential_and_preserves_identity(
+    def test_sandbox_env_auth_requires_explicit_credential_without_login_identity(
         self,
         tmp_path: Path,
         mocker,
@@ -1235,7 +1268,7 @@ class TestInvokeClaudeCode:
 
         env = mock_run.call_args.kwargs["env"]
         assert env["ANTHROPIC_API_KEY"] == expected_key
-        assert env["USER"] == "login-user"
+        assert "USER" not in env
 
     def test_authentication_failure_reports_environment_names_not_values(
         self, tmp_path: Path, mocker, monkeypatch

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1310,16 +1310,13 @@ class TestInvokeClaudeCode:
 
     # -- Positive sandbox-path coverage -----------------------------------
     #
-    # The tests above (and every other sandbox test in this class) assert
-    # what must NOT reach a sandboxed agent. None of them exercise the
-    # SANDBOXED path with a configured ``[env]``/``passthrough_env`` value
-    # and assert it actually arrives — the exact promise documented in
-    # config.py's ``HelixConfig.env``/``passthrough_env`` docstrings ("...
-    # into evaluator and agent subprocesses") and in the ``helix init``
-    # template. These four tests close that gap: fixed_env and
-    # passthrough_env, under both sandbox.auth = "volume" and
-    # sandbox.auth = "env". They use the init template's own documented
-    # example value, ANTHROPIC_BASE_URL = "https://model-service.example.invalid/v1".
+    # The tests above pin what must NOT reach a sandboxed agent. The four
+    # below pin the other half of the contract: a value the configuration
+    # declares MUST arrive, which is what ``HelixConfig.env`` /
+    # ``passthrough_env`` promise ("into evaluator and agent subprocesses")
+    # and what the ``helix init`` template tells users to expect. Both
+    # transports (fixed_env, passthrough_env) under both auth modes, using
+    # the init template's own example value.
 
     def test_sandbox_volume_auth_forwards_configured_fixed_env(self, mocker):
         """[env]-configured values must reach the sandboxed agent under auth='volume'."""

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -11,6 +11,7 @@ import pytest
 
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, EvaluatorConfig, SandboxConfig
+from helix.executor import _scrub_environment
 from helix.mutator import (
     MutationError,
     BACKEND_RESULT_ARTIFACT_NAME,
@@ -1177,6 +1178,82 @@ class TestInvokeClaudeCode:
         )
 
         assert "ANTHROPIC_API_KEY" not in mock_run.call_args.kwargs["env"]
+
+    def test_login_identity_reaches_only_the_agent(
+        self, tmp_path: Path, mocker, monkeypatch
+    ):
+        """Stored agent logins need identity; evaluator environments remain strict."""
+        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+        monkeypatch.setenv("USER", "login-user")
+        monkeypatch.setenv("LOGNAME", "login-logname")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-secret")
+
+        invoke_claude_code(
+            str(tmp_path), "prompt", AgentConfig(), sandbox=SandboxConfig(enabled=True)
+        )
+
+        agent_env = mock_run.call_args.kwargs["env"]
+        assert agent_env["USER"] == "login-user"
+        assert agent_env["LOGNAME"] == "login-logname"
+        assert "ANTHROPIC_API_KEY" not in agent_env
+        evaluator_env = _scrub_environment()
+        assert "USER" not in evaluator_env
+        assert "LOGNAME" not in evaluator_env
+
+    @pytest.mark.parametrize(
+        ("passthrough_env", "fixed_env", "expected_key"),
+        [
+            (None, {"ANTHROPIC_API_KEY": "configured-in-env"}, "configured-in-env"),
+            (["ANTHROPIC_API_KEY"], None, "configured-by-passthrough"),
+        ],
+    )
+    def test_sandbox_env_auth_requires_explicit_credential_and_preserves_identity(
+        self,
+        tmp_path: Path,
+        mocker,
+        monkeypatch,
+        passthrough_env,
+        fixed_env,
+        expected_key,
+    ):
+        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+        monkeypatch.setenv("USER", "login-user")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "configured-by-passthrough")
+
+        invoke_claude_code(
+            str(tmp_path),
+            "prompt",
+            AgentConfig(),
+            passthrough_env=passthrough_env,
+            fixed_env=fixed_env,
+            sandbox=SandboxConfig(
+                enabled=True, auth="env", auth_env_allow=["ANTHROPIC_API_KEY"]
+            ),
+        )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env["ANTHROPIC_API_KEY"] == expected_key
+        assert env["USER"] == "login-user"
+
+    def test_authentication_failure_reports_environment_names_not_values(
+        self, tmp_path: Path, mocker, monkeypatch
+    ):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout="", stderr="Not logged in · Please run /login", returncode=1
+        )
+        monkeypatch.setenv("USER", "login-user")
+        monkeypatch.setenv("LOGNAME", "login-logname")
+
+        with pytest.raises(MutationError) as exc_info:
+            invoke_claude_code(str(tmp_path), "prompt", AgentConfig())
+
+        suggestion = exc_info.value.suggestion
+        assert "environment after HELIX scrubbing contained" in suggestion
+        assert "USER" in suggestion and "LOGNAME" in suggestion
+        assert "login-user" not in suggestion
 
     def test_fixed_env_is_passed_to_backend_subprocess(self, mocker, monkeypatch):
         mock_run = mocker.patch("helix.mutator.subprocess.run")

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1143,9 +1143,18 @@ class TestInvokeClaudeCode:
             == "ghcr.io/ke7/helix-evo-runner-claude:latest"
         )
 
-    def test_sandbox_env_auth_forwards_only_explicitly_allowed_key(
+    def test_sandbox_env_auth_excludes_key_not_named_in_passthrough_env(
         self, mocker, monkeypatch
     ):
+        """Agent-env membership is decided by passthrough_env, not auth_env_allow.
+
+        ``AMBIENT_API_KEY`` is listed in ``auth_env_allow`` here, on top of
+        having an ambient host value, and it still does not reach the agent:
+        it was never named in ``passthrough_env``. ``auth_env_allow`` is a
+        declaration of intent enforced by ``SandboxConfig`` / ``HelixConfig``
+        validation, not a runtime filter -- see
+        ``helix.mutator._sandbox_agent_environment``.
+        """
         mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
         mock_run.return_value = MagicMock(
             stdout='{"type":"system","subtype":"init","session_id":"sess_123"}\n',
@@ -1161,7 +1170,9 @@ class TestInvokeClaudeCode:
             AgentConfig(backend="cursor"),
             passthrough_env=["CURSOR_API_KEY"],
             sandbox=SandboxConfig(
-                enabled=True, auth="env", auth_env_allow=["CURSOR_API_KEY"]
+                enabled=True,
+                auth="env",
+                auth_env_allow=["CURSOR_API_KEY", "AMBIENT_API_KEY"],
             ),
         )
 

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1321,99 +1321,48 @@ class TestInvokeClaudeCode:
 
     # -- Positive sandbox-path coverage -----------------------------------
     #
-    # The tests above pin what must NOT reach a sandboxed agent. The four
-    # below pin the other half of the contract: a value the configuration
+    # The tests above pin what must NOT reach a sandboxed agent. The matrix
+    # below pins the other half of the contract: a value the configuration
     # declares MUST arrive, which is what ``HelixConfig.env`` /
     # ``passthrough_env`` promise ("into evaluator and agent subprocesses")
     # and what the ``helix init`` template tells users to expect. Both
-    # transports (fixed_env, passthrough_env) under both auth modes, using
-    # the init template's own example value.
+    # transports under both auth modes, using the init template's own example
+    # value. Under ``auth = "env"`` the allowlist deliberately names an
+    # UNRELATED key: ``auth_env_allow`` gates the ambient-credential path,
+    # not general user-declared configuration.
 
-    def test_sandbox_volume_auth_forwards_configured_fixed_env(self, mocker):
-        """[env]-configured values must reach the sandboxed agent under auth='volume'."""
-        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
-        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+    _CONFIGURED_URL = "https://model-service.example.invalid/v1"
 
-        invoke_claude_code(
-            "/tmp/wt",
-            "prompt",
-            AgentConfig(),
-            fixed_env={"ANTHROPIC_BASE_URL": "https://model-service.example.invalid/v1"},
-            sandbox=SandboxConfig(enabled=True, auth="volume"),
-        )
-
-        env = mock_run.call_args.kwargs["env"]
-        assert env["ANTHROPIC_BASE_URL"] == "https://model-service.example.invalid/v1"
-
-    def test_sandbox_volume_auth_forwards_configured_passthrough_env(
-        self, mocker, monkeypatch
-    ):
-        """passthrough_env-named values must reach the sandboxed agent under auth='volume'."""
-        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
-        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
-        monkeypatch.setenv(
-            "ANTHROPIC_BASE_URL", "https://model-service.example.invalid/v1"
-        )
-
-        invoke_claude_code(
-            "/tmp/wt",
-            "prompt",
-            AgentConfig(),
-            passthrough_env=["ANTHROPIC_BASE_URL"],
-            sandbox=SandboxConfig(enabled=True, auth="volume"),
-        )
-
-        env = mock_run.call_args.kwargs["env"]
-        assert env["ANTHROPIC_BASE_URL"] == "https://model-service.example.invalid/v1"
-
-    def test_sandbox_env_auth_forwards_configured_fixed_env(self, mocker):
-        """[env]-configured values must reach the sandboxed agent under auth='env',
-
-        even when the key is not also listed in sandbox.auth_env_allow —
-        auth_env_allow gates the ambient-credential path, not general
-        user-declared configuration.
-        """
-        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
-        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
-
-        invoke_claude_code(
-            "/tmp/wt",
-            "prompt",
-            AgentConfig(),
-            fixed_env={"ANTHROPIC_BASE_URL": "https://model-service.example.invalid/v1"},
-            sandbox=SandboxConfig(
+    @pytest.mark.parametrize(
+        "sandbox",
+        [
+            SandboxConfig(enabled=True, auth="volume"),
+            SandboxConfig(
                 enabled=True, auth="env", auth_env_allow=["UNRELATED_CREDENTIAL"]
             ),
-        )
-
-        env = mock_run.call_args.kwargs["env"]
-        assert env["ANTHROPIC_BASE_URL"] == "https://model-service.example.invalid/v1"
-
-    def test_sandbox_env_auth_forwards_configured_passthrough_env(
-        self, mocker, monkeypatch
+        ],
+        ids=["volume", "env"],
+    )
+    @pytest.mark.parametrize("transport", ["fixed_env", "passthrough_env"])
+    def test_sandboxed_agent_receives_configured_env(
+        self, mocker, monkeypatch, sandbox, transport
     ):
-        """passthrough_env-named values must reach the sandboxed agent under auth='env',
-
-        even when the key is not also listed in sandbox.auth_env_allow.
-        """
+        """Configured [env]/passthrough_env values must reach a sandboxed agent."""
         mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
-        monkeypatch.setenv(
-            "ANTHROPIC_BASE_URL", "https://model-service.example.invalid/v1"
-        )
+        kwargs: dict[str, object] = {}
+        if transport == "fixed_env":
+            kwargs["fixed_env"] = {"ANTHROPIC_BASE_URL": self._CONFIGURED_URL}
+        else:
+            monkeypatch.setenv("ANTHROPIC_BASE_URL", self._CONFIGURED_URL)
+            kwargs["passthrough_env"] = ["ANTHROPIC_BASE_URL"]
 
         invoke_claude_code(
-            "/tmp/wt",
-            "prompt",
-            AgentConfig(),
-            passthrough_env=["ANTHROPIC_BASE_URL"],
-            sandbox=SandboxConfig(
-                enabled=True, auth="env", auth_env_allow=["UNRELATED_CREDENTIAL"]
-            ),
+            "/tmp/wt", "prompt", AgentConfig(), sandbox=sandbox, **kwargs
         )
 
         env = mock_run.call_args.kwargs["env"]
-        assert env["ANTHROPIC_BASE_URL"] == "https://model-service.example.invalid/v1"
+        assert env["ANTHROPIC_BASE_URL"] == self._CONFIGURED_URL
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1167,7 +1167,7 @@ class TestInvokeClaudeCode:
         assert env["CURSOR_API_KEY"] == "explicit-key"
         assert "AMBIENT_API_KEY" not in env
 
-    def test_sandbox_login_auth_does_not_forward_ambient_key(self, mocker, monkeypatch):
+    def test_sandbox_volume_auth_does_not_forward_ambient_key(self, mocker, monkeypatch):
         mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -706,6 +706,42 @@ class TestInvokeClaudeCode:
         assert ".agent_task_prompt.md" in args_list[-1]
         assert "input" not in call_args[1]
 
+    def test_agy_cli_args_include_required_flags(self, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"session_id":"sess_123"}', stderr="", returncode=0
+        )
+        config = AgentConfig(backend="agy", model="test-model", effort="high")
+
+        result, _ = invoke_claude_code("/tmp/wt", "the prompt", config)
+
+        args_list = mock_run.call_args[0][0]
+        assert args_list[0] == "agy"
+        assert "--dangerously-skip-permissions" in args_list
+        assert "--print" in args_list
+        assert "--output-format" in args_list
+        assert "json" in args_list
+        assert "--model" in args_list
+        assert "test-model" in args_list
+        assert "--effort" in args_list
+        assert "high" in args_list
+        assert "--sandbox" not in args_list
+        assert "the prompt" not in args_list
+        assert ".agent_task_prompt.md" in args_list[-1]
+        assert "input" not in mock_run.call_args[1]
+        assert result["session_id"] == "sess_123"
+
+    def test_agy_cli_args_omit_optional_flags_when_unset(self, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+        config = AgentConfig(backend="agy")
+
+        invoke_claude_code("/tmp/wt", "the prompt", config)
+
+        args_list = mock_run.call_args[0][0]
+        assert "--model" not in args_list
+        assert "--effort" not in args_list
+
     def test_uses_correct_cwd(self, mocker):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
@@ -894,29 +930,6 @@ class TestInvokeClaudeCode:
                 id="cursor",
             ),
             pytest.param(
-                "gemini",
-                "\n".join(
-                    [
-                        "MCP advisory preamble tolerated by the Gemini parser.",
-                        '{"type":"init","session_id":"gemini-session"}',
-                        (
-                            '{"type":"result","stats":{"input_tokens":14,'
-                            '"output_tokens":10,"cached":23,"input":14,'
-                            '"models":{"gemini":{"total_tokens":47,'
-                            '"input_tokens":14,"output_tokens":10,'
-                            '"cached":23,"input":14}}}}'
-                        ),
-                    ]
-                ),
-                {
-                    "input_tokens": 14,
-                    "output_tokens": 10,
-                    "cached_input_tokens": 23,
-                    "session_id": "gemini-session",
-                },
-                id="gemini",
-            ),
-            pytest.param(
                 "opencode",
                 "\n".join(
                     [
@@ -1049,30 +1062,9 @@ class TestInvokeClaudeCode:
         assert payload["transcript_artifacts"][0]["available"] is False
         assert payload["transcript_artifacts"][0]["reason"] == "transcript_not_found"
 
-    def test_gemini_tolerates_text_preamble_before_json_stream(self, mocker):
-        mock_run = mocker.patch("helix.mutator.subprocess.run")
-        mock_run.return_value = MagicMock(
-            stdout=(
-                "MCP issues detected. Run /mcp list for status.\n"
-                '{"type":"init","session_id":"sess_123"}\n'
-                '{"type":"result","status":"success","stats":{"input_tokens":10,"output_tokens":2}}\n'
-            ),
-            stderr="",
-            returncode=0,
-        )
-        config = AgentConfig(backend="gemini")
-
-        result, _ = invoke_claude_code("/tmp/wt", "prompt", config)
-
-        assert result["events"][0]["type"] == "init"
-        assert result["unparsable_lines"] == [
-            "MCP issues detected. Run /mcp list for status."
-        ]
-
     @pytest.mark.parametrize(
         ("backend", "expected_prefix", "expected_flags"),
         [
-            ("gemini", ["gemini"], ["--yolo", "--output-format", "stream-json"]),
             (
                 "opencode",
                 ["opencode", "run"],
@@ -1080,7 +1072,7 @@ class TestInvokeClaudeCode:
             ),
         ],
     )
-    def test_gemini_and_opencode_cli_args(
+    def test_opencode_cli_args(
         self, mocker, backend, expected_prefix, expected_flags
     ):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
@@ -1830,54 +1822,6 @@ class TestCountCursorStdoutToolEvents:
         assert names == []
 
 
-class TestCountGeminiStdoutToolEvents:
-    """Tests for ``_count_gemini_stdout_tool_events``."""
-
-    def test_counts_tool_use_and_extracts_tool_name(self, tmp_path: Path) -> None:
-        from helix.mutator import _count_gemini_stdout_tool_events
-
-        stdout = tmp_path / "stdout.jsonl"
-        stdout.write_text(
-            json.dumps(
-                {
-                    "type": "tool_use",
-                    "tool_name": "read_file",
-                    "tool_id": "t1",
-                }
-            )
-            + "\n"
-            + json.dumps(
-                {
-                    "type": "tool_result",
-                    "tool_id": "t1",
-                    "content": "...",
-                }
-            )
-            + "\n"  # tool_result → skip (not tool_use)
-            + json.dumps(
-                {
-                    "type": "tool_use",
-                    "tool_name": "write_file",
-                    "tool_id": "t2",
-                }
-            )
-            + "\n"
-        )
-
-        count, names = _count_gemini_stdout_tool_events(stdout)
-
-        assert count == 2
-        assert names == ["read_file", "write_file"]
-
-    def test_missing_file_returns_zero(self, tmp_path: Path) -> None:
-        from helix.mutator import _count_gemini_stdout_tool_events
-
-        count, names = _count_gemini_stdout_tool_events(tmp_path / "nope.jsonl")
-
-        assert count == 0
-        assert names == []
-
-
 class TestCountOpencodeStdoutToolEvents:
     """Tests for ``_count_opencode_stdout_tool_events``."""
 
@@ -1968,18 +1912,22 @@ class TestCountTranscriptToolEventsDispatcher:
         assert count == 1
         assert names == ["Read"]
 
-    def test_dispatches_to_gemini_counter(self, tmp_path: Path) -> None:
+    def test_agy_has_no_dedicated_counter_yet(self, tmp_path: Path) -> None:
+        """agy has no dedicated per-field counter (needs a real transcript sample
+        to write correctly, see ``_TRANSCRIPT_TOOL_COUNTERS``), so it falls back
+        to the dispatcher's unknown-backend behavior even for an existing file.
+        ``_normalise_usage_stats``'s generic walk still produces best-effort
+        stats independently of this counter.
+        """
         from helix.mutator import _count_transcript_tool_events
 
-        stdout = tmp_path / "stdout.jsonl"
-        stdout.write_text(
-            json.dumps({"type": "tool_use", "tool_name": "grep"}) + "\n"
-        )
+        stdout = tmp_path / "stdout.json"
+        stdout.write_text(json.dumps({"type": "tool_use", "tool_name": "grep"}))
 
-        count, names = _count_transcript_tool_events(stdout, "gemini")
+        count, names = _count_transcript_tool_events(stdout, "agy")
 
-        assert count == 1
-        assert names == ["grep"]
+        assert count == 0
+        assert names == []
 
 
 class TestTranscriptToolPatchesUsageInArtifact:
@@ -2130,11 +2078,11 @@ class TestOpenCodeSubprocessIsolation:
     def test_opencode_isolation_not_applied_to_other_backends(
         self, tmp_path: Path, mocker
     ):
-        """XDG_DATA_HOME must NOT be injected for claude/codex/cursor/gemini."""
+        """XDG_DATA_HOME must NOT be injected for agy/claude/codex/cursor."""
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
 
-        for backend in ("claude", "codex", "cursor", "gemini"):
+        for backend in ("agy", "claude", "codex", "cursor"):
             invoke_claude_code(
                 str(tmp_path), "prompt", AgentConfig(backend=backend)
             )

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1275,6 +1275,105 @@ class TestInvokeClaudeCode:
         assert env["ANTHROPIC_BASE_URL"] == "https://model-service.example.invalid/v1"
         assert env["ANTHROPIC_API_KEY"] == "dummy"
 
+    # -- Positive sandbox-path coverage -----------------------------------
+    #
+    # The tests above (and every other sandbox test in this class) assert
+    # what must NOT reach a sandboxed agent. None of them exercise the
+    # SANDBOXED path with a configured ``[env]``/``passthrough_env`` value
+    # and assert it actually arrives — the exact promise documented in
+    # config.py's ``HelixConfig.env``/``passthrough_env`` docstrings ("...
+    # into evaluator and agent subprocesses") and in the ``helix init``
+    # template. These four tests close that gap: fixed_env and
+    # passthrough_env, under both sandbox.auth = "volume" and
+    # sandbox.auth = "env". They use the init template's own documented
+    # example value, ANTHROPIC_BASE_URL = "https://model-service.example.invalid/v1".
+
+    def test_sandbox_volume_auth_forwards_configured_fixed_env(self, mocker):
+        """[env]-configured values must reach the sandboxed agent under auth='volume'."""
+        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+
+        invoke_claude_code(
+            "/tmp/wt",
+            "prompt",
+            AgentConfig(),
+            fixed_env={"ANTHROPIC_BASE_URL": "https://model-service.example.invalid/v1"},
+            sandbox=SandboxConfig(enabled=True, auth="volume"),
+        )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env["ANTHROPIC_BASE_URL"] == "https://model-service.example.invalid/v1"
+
+    def test_sandbox_volume_auth_forwards_configured_passthrough_env(
+        self, mocker, monkeypatch
+    ):
+        """passthrough_env-named values must reach the sandboxed agent under auth='volume'."""
+        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+        monkeypatch.setenv(
+            "ANTHROPIC_BASE_URL", "https://model-service.example.invalid/v1"
+        )
+
+        invoke_claude_code(
+            "/tmp/wt",
+            "prompt",
+            AgentConfig(),
+            passthrough_env=["ANTHROPIC_BASE_URL"],
+            sandbox=SandboxConfig(enabled=True, auth="volume"),
+        )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env["ANTHROPIC_BASE_URL"] == "https://model-service.example.invalid/v1"
+
+    def test_sandbox_env_auth_forwards_configured_fixed_env(self, mocker):
+        """[env]-configured values must reach the sandboxed agent under auth='env',
+
+        even when the key is not also listed in sandbox.auth_env_allow —
+        auth_env_allow gates the ambient-credential path, not general
+        user-declared configuration.
+        """
+        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+
+        invoke_claude_code(
+            "/tmp/wt",
+            "prompt",
+            AgentConfig(),
+            fixed_env={"ANTHROPIC_BASE_URL": "https://model-service.example.invalid/v1"},
+            sandbox=SandboxConfig(
+                enabled=True, auth="env", auth_env_allow=["UNRELATED_CREDENTIAL"]
+            ),
+        )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env["ANTHROPIC_BASE_URL"] == "https://model-service.example.invalid/v1"
+
+    def test_sandbox_env_auth_forwards_configured_passthrough_env(
+        self, mocker, monkeypatch
+    ):
+        """passthrough_env-named values must reach the sandboxed agent under auth='env',
+
+        even when the key is not also listed in sandbox.auth_env_allow.
+        """
+        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+        monkeypatch.setenv(
+            "ANTHROPIC_BASE_URL", "https://model-service.example.invalid/v1"
+        )
+
+        invoke_claude_code(
+            "/tmp/wt",
+            "prompt",
+            AgentConfig(),
+            passthrough_env=["ANTHROPIC_BASE_URL"],
+            sandbox=SandboxConfig(
+                enabled=True, auth="env", auth_env_allow=["UNRELATED_CREDENTIAL"]
+            ),
+        )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env["ANTHROPIC_BASE_URL"] == "https://model-service.example.invalid/v1"
+
 
 # ---------------------------------------------------------------------------
 # Tests: mutate

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1141,18 +1141,42 @@ class TestInvokeClaudeCode:
             == "ghcr.io/ke7/helix-evo-runner-claude:latest"
         )
 
-    def test_backend_auth_env_is_passed_automatically(self, mocker, monkeypatch):
-        mock_run = mocker.patch("helix.mutator.subprocess.run")
+    def test_sandbox_env_auth_forwards_only_explicitly_allowed_key(
+        self, mocker, monkeypatch
+    ):
+        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
         mock_run.return_value = MagicMock(
             stdout='{"type":"system","subtype":"init","session_id":"sess_123"}\n',
             stderr="",
             returncode=0,
         )
-        monkeypatch.setenv("CURSOR_API_KEY", "cursor-key")
+        monkeypatch.setenv("CURSOR_API_KEY", "explicit-key")
+        monkeypatch.setenv("AMBIENT_API_KEY", "must-not-travel")
 
-        invoke_claude_code("/tmp/wt", "prompt", AgentConfig(backend="cursor"))
+        invoke_claude_code(
+            "/tmp/wt",
+            "prompt",
+            AgentConfig(backend="cursor"),
+            passthrough_env=["CURSOR_API_KEY"],
+            sandbox=SandboxConfig(
+                enabled=True, auth="env", auth_env_allow=["CURSOR_API_KEY"]
+            ),
+        )
 
-        assert mock_run.call_args.kwargs["env"]["CURSOR_API_KEY"] == "cursor-key"
+        env = mock_run.call_args.kwargs["env"]
+        assert env["CURSOR_API_KEY"] == "explicit-key"
+        assert "AMBIENT_API_KEY" not in env
+
+    def test_sandbox_login_auth_does_not_forward_ambient_key(self, mocker, monkeypatch):
+        mock_run = mocker.patch("helix.mutator.run_sandboxed_command")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+
+        invoke_claude_code(
+            "/tmp/wt", "prompt", AgentConfig(), sandbox=SandboxConfig(enabled=True)
+        )
+
+        assert "ANTHROPIC_API_KEY" not in mock_run.call_args.kwargs["env"]
 
     def test_fixed_env_is_passed_to_backend_subprocess(self, mocker, monkeypatch):
         mock_run = mocker.patch("helix.mutator.subprocess.run")

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1308,6 +1308,22 @@ def test_cursor_manifest_points_at_the_credential_not_the_settings_file() -> Non
     assert sandbox_module.AUTH_MOUNT_DESTINATIONS["cursor"] == "/home/node/.config/cursor"
 
 
+def test_every_synthesized_sibling_belongs_to_a_manifest_backend() -> None:
+    """A sibling for a backend with no manifest entry would never be written."""
+    assert set(sandbox_module.AUTH_SYNTHESIZED_SIBLINGS) <= set(
+        sandbox_module.AUTH_CREDENTIAL_MANIFEST
+    )
+
+
+def test_synthesized_siblings_never_collide_with_a_manifest_target() -> None:
+    """A sibling must not overwrite the credential the seed helper just copied."""
+    for backend, siblings in sandbox_module.AUTH_SYNTHESIZED_SIBLINGS.items():
+        targets = {
+            target for _, target in sandbox_module.AUTH_CREDENTIAL_MANIFEST[backend]
+        }
+        assert not targets & {name for name, _ in siblings}
+
+
 # --------------------------------------------------------------------------
 # Ancestor pre-ownership
 # --------------------------------------------------------------------------
@@ -1381,9 +1397,32 @@ def test_cursor_volume_auth_argv_pre_owns_the_credential_directory_parent(
     )
     assert parent_index < mount_index
 
+
 # --------------------------------------------------------------------------
-# Seed helper: named failure causes
+# Seed helper: synthesized siblings and named failure causes
 # --------------------------------------------------------------------------
+
+
+def test_seed_command_writes_synthesized_siblings_before_the_chown() -> None:
+    """A sibling written after the chown stays root-owned and unreadable.
+
+    The agent runs as uid 1000; the seed helper runs as root. Anything it
+    creates after ``chown -R`` never gets handed over, and the CLI then fails
+    on a permission error instead of starting.
+    """
+    command = sandbox_module._seed_command("gemini")
+    name, contents = sandbox_module.AUTH_SYNTHESIZED_SIBLINGS["gemini"][0]
+    assert f"/destination/{name}" in command
+    assert contents in command
+    assert command.index(f"/destination/{name}") < command.index("chown -R")
+    assert command.rstrip().endswith("chown -R 1000:1000 /destination")
+
+
+def test_seed_command_omits_sibling_synthesis_for_backends_without_one() -> None:
+    for backend in sandbox_module.AUTH_CREDENTIAL_MANIFEST:
+        if backend in sandbox_module.AUTH_SYNTHESIZED_SIBLINGS:
+            continue
+        assert "settings.json" not in sandbox_module._seed_command(backend)
 
 
 def test_seed_command_gives_each_refusal_its_own_exit_code() -> None:

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -12,7 +12,6 @@ import helix.sandbox as sandbox_module
 
 from helix.config import EvaluatorSidecarConfig, SandboxConfig
 from helix.sandbox import (
-    _SEED_IMAGE,
     EvaluatorSidecarRuntime,
     _healthcheck_docker_args,
     current_evaluator_sidecar_runtime,
@@ -210,7 +209,14 @@ def test_volume_auth_seeds_a_private_allowlisted_volume_and_never_mounts_source(
         agent_backend="codex",
     )
 
-    seed = next(call for call in calls if _SEED_IMAGE in call)
+    # The seed helper is the container that mounts the login volume
+    # read-only at /source; it now runs in the same backend runner image as
+    # the agent it is seeding for, so the mount (not the image) identifies
+    # it uniquely.
+    seed = next(
+        call for call in calls if any(item.endswith(":/source:ro") for item in call)
+    )
+    assert "helix-test:latest" in seed
     agent = next(call for call in calls if _is_agent_container(call))
     candidate_mount = next(
         item

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -11,6 +12,7 @@ import helix.sandbox as sandbox_module
 
 from helix.config import EvaluatorSidecarConfig, SandboxConfig
 from helix.sandbox import (
+    _SEED_IMAGE,
     EvaluatorSidecarRuntime,
     _healthcheck_docker_args,
     current_evaluator_sidecar_runtime,
@@ -50,6 +52,14 @@ def _is_workspace_permission_relax(args: list[str]) -> bool:
     )
 
 
+def _is_agent_container(args: list[str]) -> bool:
+    return (
+        args[:2] == ["docker", "run"]
+        and "--user" in args
+        and args[args.index("--user") + 1] == "node"
+    )
+
+
 def test_resolve_sandbox_image_defaults_from_backend():
     cfg = SandboxConfig(enabled=True)
     assert (
@@ -79,7 +89,7 @@ def test_resolve_sandbox_image_honors_override():
     assert resolve_sandbox_image(cfg, "claude") == "custom:latest"
 
 
-def test_docker_command_mounts_only_workspace_and_auth_volume(tmp_path: Path, mocker):
+def test_docker_command_mounts_private_home_and_candidate_auth_volume(tmp_path: Path, mocker):
     source = tmp_path / "candidate"
     source.mkdir()
     (source / "main.py").write_text("print('hi')\n")
@@ -133,7 +143,14 @@ def test_docker_command_mounts_only_workspace_and_auth_volume(tmp_path: Path, mo
     assert "helix-test:latest" in docker_call
     assert "-e" in docker_call
     assert "HOME=/home/node" in docker_call
-    assert "helix-auth-codex:/home/node:rw" in docker_call
+    assert "--tmpfs" in docker_call
+    assert "/home/node:rw,uid=1000,gid=1000,mode=700" in docker_call
+    assert not any("helix-auth-codex" in item for item in docker_call)
+    assert any(
+        item.startswith("helix-candidate-auth-codex-")
+        and item.endswith(":/home/node/.codex:rw")
+        for item in docker_call
+    )
     assert f"{tmp_path}:" not in joined
     assert "/workspace:rw" in joined
     chown_calls = [call for call in calls if _is_workspace_chown(call)]
@@ -168,6 +185,109 @@ def test_evaluator_scope_does_not_mount_agent_auth(tmp_path: Path, mocker):
         if call.args[0][:2] == ["docker", "run"]
     )
     assert "helix-auth-codex:/home/node:rw" not in docker_call
+
+
+def test_login_auth_seeds_a_private_allowlisted_volume_and_never_mounts_source(
+    tmp_path: Path, mocker
+):
+    source = tmp_path / "candidate"
+    source.mkdir()
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    run_sandboxed_command(
+        ["codex", "exec", "prompt"],
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True),
+        scope="agent",
+        sync_back=False,
+        image="helix-test:latest",
+        agent_backend="codex",
+    )
+
+    seed = next(call for call in calls if _SEED_IMAGE in call)
+    agent = next(call for call in calls if _is_agent_container(call))
+    candidate_mount = next(
+        item
+        for item in agent
+        if item.startswith("helix-candidate-auth-codex-")
+    )
+    assert "helix-auth-codex:/source:ro" in seed
+    assert "cp /source/.codex/auth.json /destination/auth.json" in seed[-1]
+    assert "cp -R" not in seed[-1]
+    assert "helix-auth-codex" not in " ".join(agent)
+    assert candidate_mount.endswith(":/home/node/.codex:rw")
+    assert any(
+        call[:3] == ["docker", "volume", "rm"]
+        and call[-1] == candidate_mount.split(":", 1)[0]
+        for call in calls
+    )
+
+
+def test_parallel_login_candidates_use_distinct_private_auth_volumes(tmp_path: Path, mocker):
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+
+    def run_one(index: int) -> None:
+        source = tmp_path / f"candidate-{index}"
+        source.mkdir()
+        run_sandboxed_command(
+            ["codex", "exec", "prompt"],
+            cwd=source,
+            env={},
+            sandbox=SandboxConfig(enabled=True),
+            scope="agent",
+            sync_back=False,
+            image="helix-test:latest",
+            agent_backend="codex",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(run_one, range(2)))
+
+    agent_mounts = {
+        item.split(":", 1)[0]
+        for call in calls
+        if _is_agent_container(call)
+        for item in call
+        if item.startswith("helix-candidate-auth-codex-")
+    }
+    assert len(agent_mounts) == 2
+    assert all("helix-auth-codex" not in " ".join(call) for call in calls if _is_agent_container(call))
+
+
+def test_candidate_volume_cleanup_failure_is_loud_and_actionable(tmp_path: Path, mocker):
+    source = tmp_path / "candidate"
+    source.mkdir()
+
+    def fake_run(args, **kwargs):
+        if args[:3] == ["docker", "volume", "rm"]:
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="busy")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    with pytest.raises(RuntimeError, match="credential cleanup failed") as exc:
+        run_sandboxed_command(
+            ["codex", "exec", "prompt"],
+            cwd=source,
+            env={},
+            sandbox=SandboxConfig(enabled=True),
+            scope="agent",
+            sync_back=False,
+            image="helix-test:latest",
+            agent_backend="codex",
+        )
+    assert "docker volume rm helix-candidate-auth-codex-" in str(exc.value)
 
 
 def test_sidecar_runtime_switches_evaluator_to_private_network(tmp_path: Path, mocker):
@@ -329,11 +449,12 @@ def test_agent_syncs_changes_back_but_excludes_git_and_artifacts(
     (source / "helix.toml").write_text("[evaluator.sidecar]\nendpoint = 'private'\n")
 
     def fake_run(args, **kwargs):
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
             assert not (workspace / ".env").exists()
             assert not (workspace / ".helix").exists()
-            assert not (workspace / ".helix_artifacts").exists()
+            # Claude's nested transcript bind creates this candidate-local
+            # host directory before the agent starts.
             assert not (workspace / "helix.toml").exists()
             (workspace / "keep.py").write_text("new\n")
             (workspace / "delete.py").unlink()
@@ -342,7 +463,7 @@ def test_agent_syncs_changes_back_but_excludes_git_and_artifacts(
             (workspace / ".env.local").write_text("NEW_SECRET=value\n")
             (workspace / ".helix").mkdir()
             (workspace / ".helix" / "state.json").write_text("tampered\n")
-            (workspace / ".helix_artifacts").mkdir()
+            (workspace / ".helix_artifacts").mkdir(exist_ok=True)
             (workspace / ".helix_artifacts" / "new.txt").write_text("new artifact\n")
             (workspace / ".helix_backend_stdout.txt").write_text("artifact\n")
         return subprocess.CompletedProcess(args, 0, stdout="{}", stderr="")
@@ -371,7 +492,7 @@ def test_agent_syncs_changes_back_but_excludes_git_and_artifacts(
     assert (source / ".helix" / "state.json").read_text() == "{}\n"
     assert (source / ".helix_artifacts" / "old.txt").read_text() == "old artifact\n"
     assert not (source / ".helix_artifacts" / "new.txt").exists()
-    assert not (source / ".helix_artifacts" / "backend_transcripts").exists()
+    assert (source / ".helix_artifacts" / "backend_transcripts").exists()
     assert not (source / ".env.local").exists()
     assert not (source / ".git").exists()
     assert not (source / ".helix_backend_stdout.txt").exists()
@@ -395,7 +516,7 @@ def test_agent_sync_tolerates_inaccessible_workspace_paths(
 
     def fake_run(args, **kwargs):
         nonlocal workspace_ready
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
             (workspace / "keep.py").write_text("new\n")
             workspace_ready = True
@@ -419,7 +540,7 @@ def test_agent_sync_tolerates_inaccessible_workspace_paths(
     assert (source / ".gitignore").read_text() == "*.tmp\n"
 
 
-def test_agent_copies_claude_transcript_from_auth_volume(tmp_path: Path, mocker):
+def test_agent_transcript_bind_does_not_remount_login_volume(tmp_path: Path, mocker):
     source = tmp_path / "candidate"
     source.mkdir()
     (source / "main.py").write_text("old\n")
@@ -428,20 +549,18 @@ def test_agent_copies_claude_transcript_from_auth_volume(tmp_path: Path, mocker)
 
     def fake_run(args, **kwargs):
         calls.append(args)
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
-            if args[-3:] and args[-3] == "sh" and "sess_123.jsonl" in args[-1]:
-                transcript = (
-                    workspace
-                    / ".helix_artifacts"
-                    / "backend_transcripts"
-                    / "claude"
-                    / "sess_123.jsonl"
-                )
-                transcript.parent.mkdir(parents=True)
-                transcript.write_text('{"message":"saved"}\n')
-            else:
-                (workspace / "main.py").write_text("new\n")
+            (workspace / "main.py").write_text("new\n")
+            transcript = (
+                workspace
+                / ".helix_artifacts"
+                / "backend_transcripts"
+                / "claude"
+                / "sess_123.jsonl"
+            )
+            transcript.parent.mkdir(parents=True, exist_ok=True)
+            transcript.write_text('{"message":"saved"}\n')
         return subprocess.CompletedProcess(
             args,
             0,
@@ -472,12 +591,9 @@ def test_agent_copies_claude_transcript_from_auth_volume(tmp_path: Path, mocker)
         / "sess_123.jsonl"
     )
     assert transcript.read_text() == '{"message":"saved"}\n'
-    copy_call = next(
-        call
-        for call in calls
-        if call[:2] == ["docker", "run"] and "sess_123.jsonl" in " ".join(call)
-    )
-    assert "helix-auth-claude:/home/node:ro" in copy_call
+    agent_calls = [call for call in calls if _is_agent_container(call)]
+    assert len(agent_calls) == 1
+    assert not any("helix-auth-claude" in item for call in agent_calls for item in call)
 
 
 def test_agent_sync_tolerates_inaccessible_backend_transcripts(
@@ -500,7 +616,7 @@ def test_agent_sync_tolerates_inaccessible_backend_transcripts(
 
     def fake_run(args, **kwargs):
         nonlocal workspace_root
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace_root = Path(args[args.index("-v") + 1].split(":", 1)[0])
             (workspace_root / "main.py").write_text("new\n")
             blocked = workspace_root / ".helix_artifacts" / "backend_transcripts"
@@ -543,8 +659,7 @@ def test_agent_sync_recovers_rootless_workspace_permissions(tmp_path: Path, mock
         nonlocal workspace_root
         calls.append(args)
         if (
-            args[:2] == ["docker", "run"]
-            and not _is_workspace_chown(args)
+            _is_agent_container(args)
             and not _is_workspace_permission_relax(args)
         ):
             workspace_root = Path(args[args.index("-v") + 1].split(":", 1)[0])
@@ -595,8 +710,7 @@ def test_agent_sync_skips_relax_when_host_owner_available(tmp_path: Path, mocker
     def fake_run(args, **kwargs):
         calls.append(args)
         if (
-            args[:2] == ["docker", "run"]
-            and not _is_workspace_chown(args)
+            _is_agent_container(args)
             and not _is_workspace_permission_relax(args)
         ):
             workspace_root = Path(args[args.index("-v") + 1].split(":", 1)[0])
@@ -668,7 +782,7 @@ def test_agent_sync_back_honors_omitted_paths(tmp_path: Path, mocker):
     (source / "private" / "token.txt").write_text("host secret\n")
 
     def fake_run(args, **kwargs):
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
             assert not (workspace / "private" / "token.txt").exists()
             (workspace / "main.py").write_text("new\n")
@@ -698,7 +812,7 @@ def test_agent_sync_back_does_not_create_omitted_paths(tmp_path: Path, mocker):
     source.mkdir()
 
     def fake_run(args, **kwargs):
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
             (workspace / "private").mkdir()
             (workspace / "private" / "token.txt").write_text("agent secret\n")
@@ -728,7 +842,7 @@ def test_agent_sync_skips_special_files_by_default(tmp_path: Path, mocker):
     source.mkdir()
 
     def fake_run(args, **kwargs):
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
             os.mkfifo(workspace / "agent.pipe")
             (workspace / "regular.txt").write_text("ok\n")
@@ -762,7 +876,7 @@ def test_sync_preserves_existing_host_special_files_when_skipped(
     os.mkfifo(source / "existing.pipe")
 
     def fake_run(args, **kwargs):
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
             assert not (workspace / "existing.pipe").exists()
             (workspace / "regular.txt").write_text("ok\n")
@@ -794,7 +908,7 @@ def test_special_file_skip_can_be_disabled(tmp_path: Path, mocker):
     source.mkdir()
 
     def fake_run(args, **kwargs):
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
             os.mkfifo(workspace / "agent.pipe")
         return subprocess.CompletedProcess(args, 0, stdout="{}", stderr="")
@@ -821,7 +935,7 @@ def test_evaluator_does_not_sync_changes_back(tmp_path: Path, mocker):
     (source / "helix_batch.json").write_text('["0"]\n')
 
     def fake_run(args, **kwargs):
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
             assert (workspace / "helix_batch.json").read_text() == '["0"]\n'
             (workspace / "main.py").write_text("mutated\n")
@@ -852,7 +966,7 @@ def test_sandboxed_command_sequence_reuses_workspace(tmp_path: Path, mocker):
     seen_workspaces: list[Path] = []
 
     def fake_run(args, **kwargs):
-        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+        if _is_agent_container(args):
             workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
             seen_workspaces.append(workspace)
             if args[-1] == "write":

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1285,3 +1285,78 @@ class TestDockerEnvRedaction:
         result = sandbox_module._run_docker(args, check=False)
 
         assert result.stderr == traceback_text
+
+
+# --------------------------------------------------------------------------
+# Seed helper: named failure causes
+# --------------------------------------------------------------------------
+
+
+def test_seed_command_gives_each_refusal_its_own_exit_code() -> None:
+    """Distinct causes must be distinguishable from outside the container.
+
+    The seed helper runs where its stderr cannot be shown to the operator
+    without risking rendering credential content, so the cause travels out as
+    an exit code and is turned into a sentence on this side.
+    """
+    command = sandbox_module._seed_command("cursor")
+    for exit_code in (
+        sandbox_module._SEED_EXIT_NO_CREDENTIAL,
+        sandbox_module._SEED_EXIT_UNSAFE_CREDENTIAL,
+        sandbox_module._SEED_EXIT_UNREADABLE_CREDENTIAL,
+    ):
+        assert f"|| exit {exit_code}" in command
+    assert set(sandbox_module._SEED_FAILURE_CAUSES) == {
+        sandbox_module._SEED_EXIT_NO_CREDENTIAL,
+        sandbox_module._SEED_EXIT_UNSAFE_CREDENTIAL,
+        sandbox_module._SEED_EXIT_UNREADABLE_CREDENTIAL,
+    }
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "expected"),
+    [
+        (10, "holds no credential"),
+        (11, "not a private, regular"),
+        (12, "not a readable credential record"),
+    ],
+)
+def test_seed_failure_names_its_cause_and_the_command_that_fixes_it(
+    exit_code: int, expected: str, mocker
+) -> None:
+    mocker.patch.object(
+        sandbox_module,
+        "_run_docker",
+        side_effect=subprocess.CalledProcessError(exit_code, ["docker", "run"]),
+    )
+    volume = sandbox_module.CandidateAuthVolume(
+        name="helix-candidate-auth-gemini-deadbeef",
+        backend="gemini",
+        labels=(("helix.auth.candidate", "true"),),
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        sandbox_module._seed_candidate_auth_volume(volume, "helix-test:latest")
+    message = str(excinfo.value)
+    assert "credential seed failed for backend gemini" in message
+    assert expected in message
+    assert "helix sandbox login gemini" in message
+
+
+def test_unrecognised_seed_failure_still_says_the_agent_did_not_start(mocker) -> None:
+    """A failure that is not one of the named guards must not claim to be one."""
+    mocker.patch.object(
+        sandbox_module,
+        "_run_docker",
+        side_effect=subprocess.CalledProcessError(125, ["docker", "run"]),
+    )
+    volume = sandbox_module.CandidateAuthVolume(
+        name="helix-candidate-auth-codex-deadbeef",
+        backend="codex",
+        labels=(("helix.auth.candidate", "true"),),
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        sandbox_module._seed_candidate_auth_volume(volume, "helix-test:latest")
+    message = str(excinfo.value)
+    assert "agent was not started" in message
+    assert "without naming a cause" in message
+    assert "helix sandbox login" not in message

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -209,10 +209,10 @@ def test_volume_auth_seeds_a_private_allowlisted_volume_and_never_mounts_source(
         agent_backend="codex",
     )
 
-    # The seed helper is the container that mounts the login volume
-    # read-only at /source; it now runs in the same backend runner image as
-    # the agent it is seeding for, so the mount (not the image) identifies
-    # it uniquely.
+    # The seed helper runs in the same backend runner image as the agent it
+    # seeds for, so the image cannot distinguish the two containers. What
+    # identifies the helper is its read-only /source mount of the login
+    # volume -- the one mount no agent container is ever allowed to have.
     seed = next(
         call for call in calls if any(item.endswith(":/source:ro") for item in call)
     )

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -74,12 +74,12 @@ def test_resolve_sandbox_image_defaults_from_backend():
         == "ghcr.io/ke7/helix-evo-runner-cursor:latest"
     )
     assert (
-        resolve_sandbox_image(cfg, "gemini")
-        == "ghcr.io/ke7/helix-evo-runner-gemini:latest"
-    )
-    assert (
         resolve_sandbox_image(cfg, "opencode")
         == "ghcr.io/ke7/helix-evo-runner-opencode:latest"
+    )
+    assert (
+        resolve_sandbox_image(cfg, "agy")
+        == "ghcr.io/ke7/helix-evo-runner-agy:latest"
     )
 
 
@@ -1141,16 +1141,51 @@ def test_sandbox_auth_codex_login_uses_device_auth_flow():
     assert args[-3:] == ["codex", "login", "--device-auth"]
 
 
-def test_sandbox_auth_gemini_login_skips_workspace_trust_prompt():
+def test_sandbox_auth_agy_login_uses_bare_interactive_launch():
+    # agy has no dedicated login subcommand; the login flow is the same bare
+    # interactive launch as opencode's below.
     args = sandbox_auth_docker_args(
-        "gemini",
-        image="helix-gemini:latest",
+        "agy",
+        image="helix-agy:latest",
         action="login",
         interactive=True,
     )
 
-    assert "helix-auth-gemini:/home/node:rw" in args
-    assert args[-2:] == ["gemini", "--skip-trust"]
+    assert "helix-auth-agy:/home/node:rw" in args
+    assert args[-1:] == ["agy"]
+
+
+def test_sandbox_auth_agy_status_uses_credential_file_probe():
+    # ``agy models`` exits 0 even when logged out, so status is a file probe
+    # against the traced credential path, matching claude's pattern above.
+    args = sandbox_auth_docker_args(
+        "agy",
+        image="helix-agy:latest",
+        action="status",
+    )
+
+    assert "helix-auth-agy:/home/node:rw" in args
+    assert args[-3:-1] == ["sh", "-lc"]
+    script = args[-1]
+    assert (
+        'test -s "${HOME:-/home/node}/.gemini/antigravity-cli/antigravity-oauth-token"'
+        in script
+    )
+
+
+def test_sandbox_auth_agy_logout_only_removes_its_own_state_directory():
+    # ~/.gemini is shared with legacy gemini-cli state; logout must not
+    # blanket-remove it.
+    args = sandbox_auth_docker_args(
+        "agy",
+        image="helix-agy:latest",
+        action="logout",
+    )
+
+    assert args[-3:-1] == ["sh", "-lc"]
+    script = args[-1]
+    assert '"${HOME:-/home/node}/.gemini/antigravity-cli"' in script
+    assert script.count(".gemini") == 1
 
 
 def test_sandbox_auth_opencode_login_uses_full_setup_tui():
@@ -1337,12 +1372,19 @@ def test_ancestor_tmpfs_pre_owns_the_cursor_credential_directory_parent() -> Non
     # A destination one component below $HOME needs nothing -- $HOME's own
     # tmpfs already owns it.
     assert sandbox_module._synthesized_ancestor_tmpfs_args(["/home/node/.cursor"]) == []
-    assert (
-        sandbox_module._synthesized_ancestor_tmpfs_args(
-            [sandbox_module.AUTH_MOUNT_DESTINATIONS["gemini"]]
-        )
-        == []
-    )
+
+
+def test_ancestor_tmpfs_pre_owns_the_agy_credential_directory_parent() -> None:
+    """Agy's destination is two components below $HOME, same shape as Cursor's.
+
+    ``AUTH_MOUNT_DESTINATIONS["agy"]`` is one level deeper than a bare
+    ``~/.gemini`` (it is ``~/.gemini/antigravity-cli``), so the generic
+    ancestor helper must pre-own ``/home/node/.gemini`` itself -- no
+    agy-specific tmpfs rule is needed.
+    """
+    assert sandbox_module._synthesized_ancestor_tmpfs_args(
+        [sandbox_module.AUTH_MOUNT_DESTINATIONS["agy"]]
+    ) == ["--tmpfs", "/home/node/.gemini:rw,uid=1000,gid=1000,mode=700"]
 
 
 def test_cursor_volume_auth_argv_pre_owns_the_credential_directory_parent(
@@ -1397,15 +1439,25 @@ def test_cursor_volume_auth_argv_pre_owns_the_credential_directory_parent(
 # --------------------------------------------------------------------------
 
 
-def test_seed_command_writes_synthesized_siblings_before_the_chown() -> None:
+def test_seed_command_writes_synthesized_siblings_before_the_chown(monkeypatch) -> None:
     """A sibling written after the chown stays root-owned and unreadable.
 
     The agent runs as uid 1000; the seed helper runs as root. Anything it
     creates after ``chown -R`` never gets handed over, and the CLI then fails
     on a permission error instead of starting.
+
+    No current backend needs a synthesized sibling (see
+    ``AUTH_SYNTHESIZED_SIBLINGS``), so this test exercises the generic
+    mechanism directly via monkeypatch rather than depending on a real
+    backend having one.
     """
-    command = sandbox_module._seed_command("gemini")
-    name, contents = sandbox_module.AUTH_SYNTHESIZED_SIBLINGS["gemini"][0]
+    monkeypatch.setitem(
+        sandbox_module.AUTH_SYNTHESIZED_SIBLINGS,
+        "cursor",
+        (("settings.json", '{"auth": "test-only"}'),),
+    )
+    command = sandbox_module._seed_command("cursor")
+    name, contents = sandbox_module.AUTH_SYNTHESIZED_SIBLINGS["cursor"][0]
     assert f"/destination/{name}" in command
     assert contents in command
     assert command.index(f"/destination/{name}") < command.index("chown -R")
@@ -1457,16 +1509,16 @@ def test_seed_failure_names_its_cause_and_the_command_that_fixes_it(
         side_effect=subprocess.CalledProcessError(exit_code, ["docker", "run"]),
     )
     volume = sandbox_module.CandidateAuthVolume(
-        name="helix-candidate-auth-gemini-deadbeef",
-        backend="gemini",
+        name="helix-candidate-auth-agy-deadbeef",
+        backend="agy",
         labels=(("helix.auth.candidate", "true"),),
     )
     with pytest.raises(RuntimeError) as excinfo:
         sandbox_module._seed_candidate_auth_volume(volume, "helix-test:latest")
     message = str(excinfo.value)
-    assert "credential seed failed for backend gemini" in message
+    assert "credential seed failed for backend agy" in message
     assert expected in message
-    assert "helix sandbox login gemini" in message
+    assert "helix sandbox login agy" in message
 
 
 def test_unrecognised_seed_failure_still_says_the_agent_did_not_start(mocker) -> None:

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -629,6 +629,62 @@ def test_agent_transcript_bind_does_not_remount_login_volume(tmp_path: Path, moc
     assert not any("helix-auth-claude" in item for call in agent_calls for item in call)
 
 
+def test_transcript_bind_dir_exists_before_first_node_chown(tmp_path: Path, mocker):
+    """Pins the ordering fixed by b3a2352: the transcript bind dir must exist
+    before the first ``node:node`` chown, or the chown never covers it.
+
+    ``_transcript_bind_dir``'s docstring explains why -- creating the
+    directory afterwards fails on native Linux whenever the host UID is not
+    1000, and silently produces a bind directory the container user cannot
+    write when the host is root. Nothing before this test asserted the call
+    sequence: a refactor moving ``transcript_dir.mkdir()`` back into
+    ``_docker_args`` leaves every other unit test green.
+    """
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "main.py").write_text("print('hi')\n")
+
+    call_sequence: list[str] = []
+    transcript_dir_existed_at_first_node_chown: list[bool] = []
+
+    def fake_run(args, **kwargs):
+        if _is_workspace_chown_only(args) and "node:node" in args:
+            call_sequence.append("node_chown")
+            if len(call_sequence) == 1:
+                workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
+                transcript_dir = (
+                    workspace / ".helix_artifacts" / "backend_transcripts" / "claude"
+                )
+                transcript_dir_existed_at_first_node_chown.append(
+                    transcript_dir.exists()
+                )
+        elif _is_agent_container(args):
+            call_sequence.append("agent")
+        return subprocess.CompletedProcess(
+            args, 0, stdout='{"type":"result","session_id":"sess_1"}\n', stderr=""
+        )
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+
+    run_sandboxed_command(
+        ["claude", "-p", "prompt"],
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True),
+        scope="agent",
+        sync_back=False,
+        image="helix-test:latest",
+        agent_backend="claude",
+    )
+
+    # The first node:node chown ran (proves the ordering was actually
+    # exercised, not vacuously skipped), and the transcript dir already
+    # existed on disk at that exact moment.
+    assert call_sequence[0] == "node_chown"
+    assert transcript_dir_existed_at_first_node_chown == [True]
+
+
 def test_agent_sync_tolerates_inaccessible_backend_transcripts(
     tmp_path: Path, mocker, monkeypatch
 ):

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -187,7 +187,7 @@ def test_evaluator_scope_does_not_mount_agent_auth(tmp_path: Path, mocker):
     assert "helix-auth-codex:/home/node:rw" not in docker_call
 
 
-def test_login_auth_seeds_a_private_allowlisted_volume_and_never_mounts_source(
+def test_volume_auth_seeds_a_private_allowlisted_volume_and_never_mounts_source(
     tmp_path: Path, mocker
 ):
     source = tmp_path / "candidate"
@@ -229,7 +229,7 @@ def test_login_auth_seeds_a_private_allowlisted_volume_and_never_mounts_source(
     )
 
 
-def test_parallel_login_candidates_use_distinct_private_auth_volumes(tmp_path: Path, mocker):
+def test_parallel_volume_candidates_use_distinct_private_auth_volumes(tmp_path: Path, mocker):
     calls: list[list[str]] = []
 
     def fake_run(args, **kwargs):
@@ -432,6 +432,33 @@ def test_start_evaluator_sidecar_injects_fixed_env(mocker):
 
     docker_run = next(call for call in calls if call[:3] == ["docker", "run", "-d"])
     assert "EVALUATOR_BASE_URL=https://model-service.example.invalid/v1" in docker_run
+
+
+def test_start_evaluator_sidecar_injects_its_own_passthrough_env(mocker, monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run_docker(args, *, check=True):
+        calls.append(args)
+        if args[:2] == ["docker", "inspect"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="true running\n", stderr=""
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox._run_docker", side_effect=fake_run_docker)
+    monkeypatch.setenv("OPENAI_API_KEY", "sidecar-only-test-key")
+    sidecar = EvaluatorSidecarConfig(
+        image="eval-service:latest",
+        command="python -m server",
+        endpoint="http://helix-evaluator:8080/evaluate",
+        passthrough_env=["OPENAI_API_KEY"],
+    )
+
+    with start_evaluator_sidecar(sidecar):
+        pass
+
+    docker_run = next(call for call in calls if call[:3] == ["docker", "run", "-d"])
+    assert "OPENAI_API_KEY=sidecar-only-test-key" in docker_run
 
 
 def test_agent_syncs_changes_back_but_excludes_git_and_artifacts(

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -630,15 +630,12 @@ def test_agent_transcript_bind_does_not_remount_login_volume(tmp_path: Path, moc
 
 
 def test_transcript_bind_dir_exists_before_first_node_chown(tmp_path: Path, mocker):
-    """Pins the ordering fixed by b3a2352: the transcript bind dir must exist
-    before the first ``node:node`` chown, or the chown never covers it.
+    """The transcript bind dir must exist before the first ``node:node`` chown.
 
-    ``_transcript_bind_dir``'s docstring explains why -- creating the
-    directory afterwards fails on native Linux whenever the host UID is not
-    1000, and silently produces a bind directory the container user cannot
-    write when the host is root. Nothing before this test asserted the call
-    sequence: a refactor moving ``transcript_dir.mkdir()`` back into
-    ``_docker_args`` leaves every other unit test green.
+    ``_transcript_bind_dir``'s docstring says what breaks otherwise. Nothing
+    else asserts the call *sequence*: a refactor moving
+    ``transcript_dir.mkdir()`` back into ``_docker_args`` leaves every other
+    unit test green.
     """
     source = tmp_path / "candidate"
     source.mkdir()
@@ -1295,12 +1292,9 @@ class TestDockerEnvRedaction:
 def test_cursor_manifest_points_at_the_credential_not_the_settings_file() -> None:
     """Cursor's settings directory and its credential directory differ.
 
-    The CLI resolves its settings directory (holding ``cli-config.json``:
-    editor, display, permission, and model preferences, and no credential)
-    separately from its credential path, which on Linux is always
-    ``$XDG_CONFIG_HOME``, else ``$HOME/.config``, joined with the application
-    name. Seeding a candidate from the settings file leaves the CLI reporting
-    itself signed out, which is what this manifest previously did.
+    ``AUTH_CREDENTIAL_MANIFEST``'s own comment records the two resolvers.
+    Seeding a candidate from the settings file leaves the CLI reporting itself
+    signed out, so both halves of this pair are load-bearing.
     """
     assert sandbox_module.AUTH_CREDENTIAL_MANIFEST["cursor"] == (
         (".config/cursor/auth.json", "auth.json"),

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1288,6 +1288,100 @@ class TestDockerEnvRedaction:
 
 
 # --------------------------------------------------------------------------
+# Credential manifest shape
+# --------------------------------------------------------------------------
+
+
+def test_cursor_manifest_points_at_the_credential_not_the_settings_file() -> None:
+    """Cursor's settings directory and its credential directory differ.
+
+    The CLI resolves its settings directory (holding ``cli-config.json``:
+    editor, display, permission, and model preferences, and no credential)
+    separately from its credential path, which on Linux is always
+    ``$XDG_CONFIG_HOME``, else ``$HOME/.config``, joined with the application
+    name. Seeding a candidate from the settings file leaves the CLI reporting
+    itself signed out, which is what this manifest previously did.
+    """
+    assert sandbox_module.AUTH_CREDENTIAL_MANIFEST["cursor"] == (
+        (".config/cursor/auth.json", "auth.json"),
+    )
+    assert sandbox_module.AUTH_MOUNT_DESTINATIONS["cursor"] == "/home/node/.config/cursor"
+
+
+# --------------------------------------------------------------------------
+# Ancestor pre-ownership
+# --------------------------------------------------------------------------
+
+
+def test_ancestor_tmpfs_pre_owns_the_cursor_credential_directory_parent() -> None:
+    """Cursor's destination is two components below $HOME, so its parent needs owning.
+
+    Docker synthesises every directory between the agent's tmpfs ``$HOME`` and
+    a deeper ``-v`` destination as ``root:root``, whatever ``$HOME`` itself is
+    owned by. The generic ancestor helper derives that from the destination
+    alone, so no backend needs a rule of its own.
+    """
+    assert sandbox_module._synthesized_ancestor_tmpfs_args(
+        [sandbox_module.AUTH_MOUNT_DESTINATIONS["cursor"]]
+    ) == ["--tmpfs", "/home/node/.config:rw,uid=1000,gid=1000,mode=700"]
+    # A destination one component below $HOME needs nothing -- $HOME's own
+    # tmpfs already owns it.
+    assert sandbox_module._synthesized_ancestor_tmpfs_args(["/home/node/.cursor"]) == []
+    assert (
+        sandbox_module._synthesized_ancestor_tmpfs_args(
+            [sandbox_module.AUTH_MOUNT_DESTINATIONS["gemini"]]
+        )
+        == []
+    )
+
+
+def test_cursor_volume_auth_argv_pre_owns_the_credential_directory_parent(
+    tmp_path: Path, mocker
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch.object(sandbox_module.subprocess, "run", side_effect=fake_run)
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "file.txt").write_text("x")
+
+    run_sandboxed_command(
+        ["cursor-agent", "status"],
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True, auth="volume", network="none"),
+        scope="agent",
+        sync_back=False,
+        image="helix-test:latest",
+        agent_backend="cursor",
+    )
+
+    agent_call = next(
+        call
+        for call in calls
+        if call[:2] == ["docker", "run"]
+        and any(item.endswith(":/home/node/.config/cursor:rw") for item in call)
+    )
+    tmpfs_values = [
+        agent_call[index + 1]
+        for index, item in enumerate(agent_call)
+        if item == "--tmpfs"
+    ]
+    assert "/home/node/.config:rw,uid=1000,gid=1000,mode=700" in tmpfs_values
+    # The parent tmpfs must be declared before the volume that lands inside it.
+    parent_index = agent_call.index("/home/node/.config:rw,uid=1000,gid=1000,mode=700")
+    mount_index = next(
+        index
+        for index, item in enumerate(agent_call)
+        if item.endswith(":/home/node/.config/cursor:rw")
+    )
+    assert parent_index < mount_index
+
+# --------------------------------------------------------------------------
 # Seed helper: named failure causes
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

This PR does two things together, because the second was built directly on the first's per-candidate auth design and reuses its manifest:

- **Isolates sandbox login credentials per candidate.** `sandbox.auth = "volume"` now seeds a private, per-candidate Docker volume from an allowlist of credential files in the operator's `helix-auth-<backend>` login volume; no agent container ever mounts that shared volume. Both concurrent and sequential candidates get disjoint writable auth state, and the candidate volume is removed after the candidate finishes.
- **Removes the `gemini` mutation backend and replaces it with `agy`** (Google's Antigravity CLI). **This is breaking**: `agent.backend = "gemini"` is now rejected. `gemini`'s runner image, Dockerfile, sandbox auth manifest entry, and CI matrix rows are removed outright, not deprecated; see the `CHANGELOG.md` entry for the migration note. **This must land together with the pending `0.2.1` → `0.3.0` version bump.**

Also folded in: seeding Cursor from the credential file its CLI actually reads rather than its settings file, sidecar-only host values through `evaluator.sidecar.passthrough_env` kept disjoint from agent credentials, confining `USER`/`LOGNAME` to the unsandboxed path, naming the cause when a credential seed refuses (including the everyday case — nobody has signed in yet), and having CI's `docker-integration` job build its own fixture images from this checkout's Dockerfiles instead of pulling published `:latest` tags.

## Real-grant verification

Four of the five backends are now confirmed end to end against a real grant, not a synthetic record. Each was seeded from its real, already-authenticated login volume through HELIX's own candidate-volume path (`run_sandboxed_command(..., scope="agent", auth="volume")` → volume creation → seeding → the agent's own Docker argv → cleanup), then checked from inside the candidate container with the backend's own free, no-spend status command:

| Backend | Status command | Result |
| --- | --- | --- |
| Claude | `claude auth status --text` | exit 0, `Login method: Claude Max account` |
| Codex | `codex login status` | exit 0, `Logged in using ChatGPT` |
| Cursor | `cursor-agent status` | exit 0, signed-in confirmation naming the account |
| OpenCode | `auth list` | exit 0, `1 credentials` |

These checks ran under Docker's amd64-on-arm64 emulation (no arm64 runner image exists yet); all four still passed, and HELIX's CI already runs these images as amd64, so the confirmed path is the one that ships.

**`agy`'s manifest entry is derived, not verified.** Its credential path was traced with `strace` against a real, unauthenticated Linux binary, but its login volume holds no credential yet, so nothing has been seeded or probed, and the credential file's JSON shape is still unknown. It ships enabled anyway, the same as every other manifest entry — see `docs/design/sandbox-auth-projection.md` for why that's a documentation standard, not a code gate, and for the mechanism a missing/invalid credential actually hits (a closed-by-default seed failure naming the cause and pointing at `helix sandbox login <backend>`).

Also folds in and supersedes the now-closed backend-swap PR (#66), which is why this diff includes the `agy` migration rather than only credential isolation.

## Verification
- `uv sync --extra dev`
- `uv run python -m pytest` — 982 passed
- `HELIX_DOCKER_TESTS_STRICT=1 uv run python -m pytest tests/integration/ -m docker_integration -q -rs` — 27 passed, 0 skipped (one fewer than this table's historical 28: `gemini`'s dedicated auth-method-gate test was removed with no direct replacement, since exercising `agy`'s equivalent live would require a `--print` call this work's hard limits forbid)
- `uv run ruff check src/ tests/` — clean
- `uv run mypy --strict src/helix/` — clean
- Diff: +2935/-396 lines across 24 files

