### PR TITLE
Reuse validation-stage results and retain rejected candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ the source of truth. During evolution HELIX sets `HELIX_SPLIT` (`train` or `val`
 so evaluator-owned datasets can switch behavior by phase, mirroring GEPA's
 `trainset` / `valset` duality.
 
-When `evolution.val_stage_size` is positive and `dataset.val_size` is set, accepted mutation proposals first evaluate the deterministic first-N validation ids, then evaluate only the remaining ids and compose the per-id results. This is valid only when each per-id score and objective is independent of the requested id set; do not enable it for batch-relative metrics, cross-example normalization, shared warm-up, or objectives derived from a batch-global judge. Stage-only results are never added to the frontier; HELIX persists only the composed full-val result for Pareto ranking and resume stability. Feedback and judge artifacts remain per invocation, so they are partitioned between the stage and tail calls.
+When `evolution.val_stage_size` is positive and `dataset.val_size` is set, accepted mutation proposals first evaluate the deterministic first-N validation ids, then evaluate only the remaining ids and compose the per-id results. This is valid only when each per-id score and objective is independent of the requested id set; do not enable it for batch-relative metrics, cross-example normalization, shared warm-up, or objectives derived from a batch-global judge. Stage-only results are never added to the frontier; HELIX persists only the composed full-val result for Pareto ranking and resume stability. An evaluator may treat `HELIX_EVALUATION_PHASE=val_stage` as a score-only call and defer feedback or candidate-level judge artifacts until the promoted tail/full call.
 
 ### Evaluator Integrity
 

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ the source of truth. During evolution HELIX sets `HELIX_SPLIT` (`train` or `val`
 so evaluator-owned datasets can switch behavior by phase, mirroring GEPA's
 `trainset` / `valset` duality.
 
-When `evolution.val_stage_size` is positive and `dataset.val_size` is set, accepted mutation proposals first evaluate the deterministic first-N validation ids, then evaluate only the remaining ids and compose the per-id results. This is valid only when each per-id score and objective is independent of the requested id set; do not enable it for batch-relative metrics, cross-example normalization, shared warm-up, or objectives derived from a batch-global judge. Stage-only results are never added to the frontier; HELIX persists only the composed full-val result for Pareto ranking and resume stability. An evaluator may treat `HELIX_EVALUATION_PHASE=val_stage` as a score-only call and defer feedback or candidate-level judge artifacts until the promoted tail/full call.
+When `evolution.val_stage_size` is positive and `dataset.val_size` is set, accepted mutation proposals first evaluate the deterministic first-N validation ids, then evaluate only the remaining ids and compose the per-id results. This is valid only when each per-id score and objective is independent of the requested id set; do not enable it for batch-relative metrics, cross-example normalization, shared warm-up, or objectives derived from an aggregate metric. Stage-only results are never added to the frontier; HELIX persists only the composed full-val result for Pareto ranking and resume stability. An evaluator may treat `HELIX_EVALUATION_PHASE=val_stage` as a score-only call and defer feedback or other non-score side effects until the promoted tail/full call.
 
 ### Evaluator Integrity
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ num_parallel_proposals = 1       # parallel mutations per generation
 minibatch_size = 3               # train-set minibatch size for reflective mutation
 cache_evaluation = true          # reuse per-instance evaluator results
 acceptance_criterion = "strict_improvement"
-val_stage_size = 0               # optional first-N val gate before full val
+val_stage_size = 0               # optional first-N val gate; passing results carry into the tail
 frontier_type = "instance"       # Pareto dimensionality (GEPA FrontierType parity):
                                  # "instance" | "objective" | "hybrid" | "cartesian".
                                  # The four modes mirror GEPA optimize_anything;
@@ -683,7 +683,7 @@ the source of truth. During evolution HELIX sets `HELIX_SPLIT` (`train` or `val`
 so evaluator-owned datasets can switch behavior by phase, mirroring GEPA's
 `trainset` / `valset` duality.
 
-When `evolution.val_stage_size` is set to a positive value and `dataset.val_size` is also set, accepted mutation proposals run a deterministic first-N validation stage before the full validation sweep. Stage-only results are never added to the frontier; HELIX still persists only full-val results for Pareto ranking and resume stability.
+When `evolution.val_stage_size` is positive and `dataset.val_size` is set, accepted mutation proposals first evaluate the deterministic first-N validation ids, then evaluate only the remaining ids and compose the per-id results. This is valid only when each per-id score and objective is independent of the requested id set; do not enable it for batch-relative metrics, cross-example normalization, shared warm-up, or objectives derived from a batch-global judge. Stage-only results are never added to the frontier; HELIX persists only the composed full-val result for Pareto ranking and resume stability. Feedback and judge artifacts remain per invocation, so they are partitioned between the stage and tail calls.
 
 ### Evaluator Integrity
 

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -409,20 +409,14 @@ class EvolutionConfig(BaseModel):
     retain_rejected_worktrees: bool = Field(
         default=False,
         description=(
-            "Whether to retain candidates rejected by the validation-stage "
-            "gate. Regardless of this setting, their identity, lineage, and "
-            "scores are saved in .helix/lineage.json and .helix/attempts/, "
-            "so the run can be reconstructed without candidate worktrees. "
-            "When enabled, each rejected candidate's complete worktree at "
-            "the point of rejection and its live "
-            "helix/<id> ref are kept; that ref keeps its snapshot commit "
-            "reachable. When disabled (the default), HELIX removes the "
-            "worktree and ref, making the commit eventually garbage-collectable, "
-            "so the rejected candidate's contents cannot be inspected even "
-            "though its rejection and scores remain. Retaining consumes one "
-            "full candidate repository per validation-stage rejection; size "
-            "depends on the project and evaluator. Run helix clean to reclaim "
-            "retained worktrees."
+            "Whether to keep the worktree of a candidate rejected by the "
+            "validation-stage gate, for inspecting what it changed. Either "
+            "way its identity, lineage, and scores are recorded in "
+            ".helix/lineage.json and .helix/attempts/. When disabled (the "
+            "default), the worktree and its helix/<id> ref are removed and "
+            "the candidate's contents become unrecoverable. Retaining costs "
+            "one full candidate repository per rejection; run helix clean to "
+            "reclaim them."
         ),
     )
     batch_sampler: Literal["epoch_shuffled", "stratified"] = Field(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -402,7 +402,7 @@ class EvolutionConfig(BaseModel):
             "stage is composed with a later call for the remaining ids. Use "
             "only when per-id scores/objectives are independent of the id "
             "set; do not use with batch-relative scores, cross-example "
-            "normalization, shared warm-up, or a batch-global judge used as "
+            "normalization, shared warm-up, or an aggregate metric used as "
             "an objective. Disabled when unset or 0."
         ),
     )
@@ -413,8 +413,8 @@ class EvolutionConfig(BaseModel):
             "gate. Regardless of this setting, their identity, lineage, and "
             "scores are saved in .helix/lineage.json and .helix/attempts/, "
             "so the run can be reconstructed without candidate worktrees. "
-            "When enabled, each rejected candidate's complete worktree—the "
-            "mutation plus whatever artifacts the evaluator wrote—and its live "
+            "When enabled, each rejected candidate's complete worktree at "
+            "the point of rejection and its live "
             "helix/<id> ref are kept; that ref keeps its snapshot commit "
             "reachable. When disabled (the default), HELIX removes the "
             "worktree and ref, making the commit eventually garbage-collectable, "

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -398,8 +398,12 @@ class EvolutionConfig(BaseModel):
         default=None,
         description=(
             "Optional deterministic first-N validation stage that runs after "
-            "the train minibatch gate and before full validation. Disabled "
-            "when unset or 0."
+            "the train minibatch gate and before full validation. A passing "
+            "stage is composed with a later call for the remaining ids. Use "
+            "only when per-id scores/objectives are independent of the id "
+            "set; do not use with batch-relative scores, cross-example "
+            "normalization, shared warm-up, or a batch-global judge used as "
+            "an objective. Disabled when unset or 0."
         ),
     )
     batch_sampler: Literal["epoch_shuffled", "stratified"] = Field(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -406,6 +406,25 @@ class EvolutionConfig(BaseModel):
             "an objective. Disabled when unset or 0."
         ),
     )
+    retain_rejected_worktrees: bool = Field(
+        default=False,
+        description=(
+            "Whether to retain candidates rejected by the validation-stage "
+            "gate. Regardless of this setting, their identity, lineage, and "
+            "scores are saved in .helix/lineage.json and .helix/attempts/, "
+            "so the run can be reconstructed without candidate worktrees. "
+            "When enabled, each rejected candidate's complete worktree—the "
+            "mutation plus whatever artifacts the evaluator wrote—and its live "
+            "helix/<id> ref are kept; that ref keeps its snapshot commit "
+            "reachable. When disabled (the default), HELIX removes the "
+            "worktree and ref, making the commit eventually garbage-collectable, "
+            "so the rejected candidate's contents cannot be inspected even "
+            "though its rejection and scores remain. Retaining consumes one "
+            "full candidate repository per validation-stage rejection; size "
+            "depends on the project and evaluator. Run helix clean to reclaim "
+            "retained worktrees."
+        ),
+    )
     batch_sampler: Literal["epoch_shuffled", "stratified"] = Field(
         default="epoch_shuffled",
         description=(

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -880,6 +880,7 @@ def _cached_evaluate_batch(
     GEPA parity: line-for-line mirror of GEPA's ``cached_evaluate_full`` in
     ``core/state.py``, which delegates to
     ``EvaluationCache.evaluate_with_cache_full`` (also ``core/state.py``).
+
     Flow:
 
       1. ``cache.get_batch(candidate, example_ids)`` partitions into
@@ -1144,6 +1145,42 @@ def _stage_val_example_ids(
 def _scores_for_example_ids(result: EvalResult, example_ids: list[str]) -> list[float]:
     """Return per-id scores in a stable order for acceptance comparisons."""
     return [float(result.instance_scores.get(eid, 0.0)) for eid in example_ids]
+
+
+def _merge_partitioned_evaluations(
+    candidate: Candidate,
+    requested_ids: list[str],
+    carried: EvalResult,
+    carried_ids: list[str],
+    fresh: EvalResult,
+    fresh_ids: list[str],
+) -> EvalResult:
+    """Merge stage and tail results from one live candidate lifecycle."""
+    assert set(carried_ids).isdisjoint(fresh_ids)
+    assert set(requested_ids) == set(carried_ids) | set(fresh_ids)
+
+    def by_id(result: EvalResult, ids: list[str], attr: str) -> dict[str, dict[str, Any]]:
+        values = getattr(result, attr)
+        if values is None:
+            return {}
+        assert len(values) == len(ids)
+        return dict(zip(ids, values, strict=True))
+
+    carried_obj = by_id(carried, carried_ids, "objective_scores")
+    fresh_obj = by_id(fresh, fresh_ids, "objective_scores")
+    carried_side = by_id(carried, carried_ids, "per_example_side_info")
+    fresh_side = by_id(fresh, fresh_ids, "per_example_side_info")
+    all_scores = carried.instance_scores | fresh.instance_scores
+    all_obj = carried_obj | fresh_obj
+    all_side = carried_side | fresh_side
+    return EvalResult(
+        candidate_id=candidate.id,
+        scores={},
+        asi={},
+        instance_scores={eid: all_scores[eid] for eid in requested_ids},
+        objective_scores=[all_obj.get(eid, {}) for eid in requested_ids] if all_obj else None,
+        per_example_side_info=[all_side.get(eid, {}) for eid in requested_ids] if all_side else None,
+    )
 
 
 def _has_example_scores(result: EvalResult | None, example_ids: list[str]) -> bool:
@@ -1647,7 +1684,16 @@ def run_evolution(
     project_root: Path,
     base_dir: Path,
 ) -> HelixResult:
-    """Run the HELIX evolutionary loop."""
+    """Run the HELIX evolutionary loop.
+
+    When ``config.evolution.val_stage_size`` is positive, an accepted staged
+    validation result is carried into final validation: the evaluator receives
+    only the remaining validation ids and HELIX composes both per-id results.
+    Enable it only for evaluators whose per-id scores and objectives do not
+    depend on the complete id set (for example, no batch-relative metric,
+    cross-example normalization, shared warm-up, or an aggregate metric used
+    as an objective).
+    """
     # Mirror GEPA's ``optimize`` (``api.py``): at least one stopping condition is required.
     # Without this, perfect-skip + always-perfect data + no effective bound =
     # a run that terminates only by the OS.  In HELIX, max_generations (loop
@@ -3008,10 +3054,11 @@ def _run_evolution_impl(
                 use_val_stage_gate = _has_example_scores(
                     _parent_frontier_result, stage_val_example_ids
                 )
+                stage_result: EvalResult | None = None
                 if stage_val_example_ids and use_val_stage_gate:
                     set_phase(HelixPhase.VAL_EVALUATION)
                     stage_result, _n = _cached_evaluate_batch(
-                        child, list(stage_val_example_ids), minibatch_cache,
+                        child, list(stage_val_example_ids), None,
                         config, "val", project_root,
                     )
                     stage_result.candidate_id = child.id
@@ -3075,19 +3122,37 @@ def _run_evolution_impl(
                     )
 
                 # --- Val evaluation -------------------------------------------
-                # UNCHANGED: run full val eval sequentially after gating.
                 set_phase(HelixPhase.VAL_EVALUATION)
-                val_result = _run_full_val_eval(
-                    child,
-                    state,
-                    full_val_example_ids=full_val_example_ids,
-                    minibatch_cache=minibatch_cache,
-                    eval_cache=eval_cache,
-                    config=config,
-                    project_root=project_root,
-                    source_batch="mutation_full_val_batch",
-                    source_single="mutation_full_val",
-                )
+                if stage_result is not None:
+                    stage_ids = list(stage_val_example_ids)
+                    stage_id_set = set(stage_ids)
+                    tail_ids = [eid for eid in full_val_example_ids if eid not in stage_id_set]
+                    if not tail_ids:
+                        val_result = stage_result
+                    else:
+                        tail_result, tail_evals = _cached_evaluate_batch(
+                            child, tail_ids, None, config, "val", project_root,
+                        )
+                        budget_api.charge_evaluation(
+                            state, num_actual_examples=tail_evals, candidate_id=child.id,
+                            split="val", source="mutation_full_val_batch",
+                        )
+                        val_result = _merge_partitioned_evaluations(
+                            child, list(full_val_example_ids), stage_result, stage_ids,
+                            tail_result, tail_ids,
+                        )
+                else:
+                    val_result = _run_full_val_eval(
+                        child,
+                        state,
+                        full_val_example_ids=full_val_example_ids,
+                        minibatch_cache=minibatch_cache,
+                        eval_cache=eval_cache,
+                        config=config,
+                        project_root=project_root,
+                        source_batch="mutation_full_val_batch",
+                        source_single="mutation_full_val",
+                    )
                 _last_eval_result = val_result
 
                 if budget_api.budget_exhausted(state, config):

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -874,6 +874,7 @@ def _cached_evaluate_batch(
     config: HelixConfig,
     split: str,
     project_root: Path,
+    evaluation_phase: str | None = None,
 ) -> tuple[EvalResult, int]:
     """Evaluate ``candidate`` on ``example_ids`` with per-example caching.
 
@@ -910,6 +911,7 @@ def _cached_evaluate_batch(
                 config,
                 split=split,
                 instance_ids=example_ids,
+                evaluation_phase=evaluation_phase,
             )
         return result, len(example_ids)
 
@@ -957,6 +959,7 @@ def _cached_evaluate_batch(
                 config,
                 split=split,
                 instance_ids=batch,
+                evaluation_phase=evaluation_phase,
             )
         # HELIX does not track rollout outputs per-example; store ``None``
         # per slot (the cache's ``RolloutOutput`` type parameter is
@@ -3059,7 +3062,7 @@ def _run_evolution_impl(
                     set_phase(HelixPhase.VAL_EVALUATION)
                     stage_result, _n = _cached_evaluate_batch(
                         child, list(stage_val_example_ids), None,
-                        config, "val", project_root,
+                        config, "val", project_root, evaluation_phase="val_stage",
                     )
                     stage_result.candidate_id = child.id
                     _last_eval_result = stage_result

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -3103,13 +3103,24 @@ def _run_evolution_impl(
                             decision="reject_stage", example_ids=list(stage_val_example_ids),
                             score=float(sum(_stage_after)),
                         )
-                        print_warning(
-                            f"Val stage: {child.id} rejected on first "
-                            f"{len(stage_val_example_ids)} val ids "
-                            f"(sum {sum(_stage_after):.4f} vs parent "
-                            f"{sum(_stage_before):.4f}) -- removing."
-                        )
-                        _safe_remove_worktree(child, label="val-stage-rejected candidate")
+                        if config.evolution.retain_rejected_worktrees:
+                            print_warning(
+                                f"Val stage: {child.id} rejected on first "
+                                f"{len(stage_val_example_ids)} val ids "
+                                f"(sum {sum(_stage_after):.4f} vs parent "
+                                f"{sum(_stage_before):.4f}) -- retaining worktree "
+                                f"for review."
+                            )
+                        else:
+                            print_warning(
+                                f"Val stage: {child.id} rejected on first "
+                                f"{len(stage_val_example_ids)} val ids "
+                                f"(sum {sum(_stage_after):.4f} vs parent "
+                                f"{sum(_stage_before):.4f}) -- removing."
+                            )
+                            _safe_remove_worktree(
+                                child, label="val-stage-rejected candidate"
+                            )
                         del candidates[child.id]
                         return
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -1158,7 +1158,12 @@ def _merge_partitioned_evaluations(
     fresh: EvalResult,
     fresh_ids: list[str],
 ) -> EvalResult:
-    """Merge stage and tail results from one live candidate lifecycle."""
+    """Compose staged and tail results into one result over *requested_ids*.
+
+    Per-id scores are carried across unchanged, so both halves must come from
+    the same candidate and the evaluator's per-id scores must not depend on
+    which ids were requested.
+    """
     assert set(carried_ids).isdisjoint(fresh_ids)
     assert set(requested_ids) == set(carried_ids) | set(fresh_ids)
 

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -187,6 +187,7 @@ def run_evaluator(
     config: HelixConfig,
     split: str = "val",
     instance_ids: list[str] | None = None,
+    evaluation_phase: str | None = None,
 ) -> EvalResult:
     """Run the evaluator for a single candidate.
 
@@ -199,6 +200,8 @@ def run_evaluator(
             the evaluator via HELIX_INSTANCE_IDS. The positional id list
             in helix_batch.json is the source of truth for the returned
             instance_scores. None → evaluate the whole split.
+        evaluation_phase: Optional lifecycle hint for evaluators that need
+            to defer non-score side effects during a staged validation call.
 
     Returns:
         EvalResult with scores and instance_scores.
@@ -245,6 +248,8 @@ def run_evaluator(
         passthrough_env=config.passthrough_env,
         fixed_env=config.env,
     )
+    if evaluation_phase is not None:
+        env["HELIX_EVALUATION_PHASE"] = evaluation_phase
     helix_log_name = f".helix_asi_log_{uuid.uuid4().hex}.jsonl"
     helix_log_path = Path(candidate.worktree_path) / helix_log_name
     # Absolute path inside the sidecar — the evaluator command may run

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -151,6 +151,7 @@ class TestLoadConfig:
         assert cfg.evolution.max_evaluations == -1
         assert cfg.evolution.merge_enabled is False  # GEPA parity: off by default
         assert cfg.evolution.max_merge_invocations == 5
+        assert cfg.evolution.retain_rejected_worktrees is False
 
         # AgentConfig defaults
         assert cfg.agent.backend == "claude"

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -119,6 +119,7 @@ def _make_minibatch_config(
     num_parallel_proposals: int = 1,
     cache_evaluation: bool = True,
     acceptance_criterion: str = "strict_improvement",
+    retain_rejected_worktrees: bool = False,
     max_workers: int | None = None,
 ) -> HelixConfig:
     evo_kwargs: dict[str, Any] = dict(
@@ -130,6 +131,7 @@ def _make_minibatch_config(
         cache_evaluation=cache_evaluation,
         acceptance_criterion=acceptance_criterion,
         val_stage_size=val_stage_size,
+        retain_rejected_worktrees=retain_rejected_worktrees,
         frontier_type="instance",
     )
     if max_workers is not None:
@@ -570,6 +572,7 @@ class TestMinibatchGateIntegration:
             val_stage_size=2,
             max_generations=1,
             max_evaluations=100,
+            retain_rejected_worktrees=True,
         )
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
@@ -585,8 +588,11 @@ class TestMinibatchGateIntegration:
         # example_ids should be the val stage ids (first val_stage_size=2 val ids).
         assert attempt["attempt"]["example_ids"] is not None
         assert len(attempt["attempt"]["example_ids"]) == 2
-        # Verify worktree cleaned up.
-        assert all_mocks["remove_worktree"].called
+        all_mocks["remove_worktree"].assert_not_called()
+        assert any(
+            "-- retaining worktree for review." in str(call.args[0])
+            for call in all_mocks["print_warning"].call_args_list
+        )
 
     def test_accepted_proposal_triggers_full_val_eval(
         self, tmp_path: Path, all_mocks: dict[str, Any]
@@ -678,7 +684,13 @@ class TestMinibatchGateIntegration:
 
         assert child_val_calls == [["0", "1"]]
         assert all_mocks["_save_evaluation"].call_count == 1
-        assert all_mocks["remove_worktree"].called
+        all_mocks["remove_worktree"].assert_called_once()
+        removed_candidate = all_mocks["remove_worktree"].call_args.args[0]
+        assert removed_candidate.id == "g1-s1"
+        assert any(
+            "-- removing." in str(call.args[0])
+            for call in all_mocks["print_warning"].call_args_list
+        )
 
     def test_stage_pass_promotes_to_partition_carry_without_cache(
         self, tmp_path: Path, all_mocks: dict[str, Any]

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -689,7 +689,7 @@ class TestMinibatchGateIntegration:
         all_mocks["create_seed_worktree"].return_value = seed
         all_mocks["mutate"].return_value = _make_candidate("g1-s1")
 
-        child_val_calls: list[list[str]] = []
+        child_val_calls: list[tuple[list[str], str | None]] = []
 
         def run_eval(
             candidate: Candidate,
@@ -699,7 +699,7 @@ class TestMinibatchGateIntegration:
             **kwargs: Any,
         ) -> EvalResult:
             if split == "val" and instance_ids is not None and candidate.id == "g1-s1":
-                child_val_calls.append(list(instance_ids))
+                child_val_calls.append((list(instance_ids), kwargs.get("evaluation_phase")))
             if split == "val" and instance_ids == ["0", "1", "2", "3"] and candidate.id == seed.id:
                 return _make_result(candidate.id, {"0": 0.2, "1": 0.2, "2": 0.2, "3": 0.2})
             if split == "train" and instance_ids is not None:
@@ -725,7 +725,7 @@ class TestMinibatchGateIntegration:
         )
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
-        assert child_val_calls == [["0", "1"], ["2", "3"]]
+        assert child_val_calls == [(["0", "1"], "val_stage"), (["2", "3"], None)]
         assert all_mocks["_save_evaluation"].call_count == 2
         saved_child_result = all_mocks["_save_evaluation"].call_args_list[-1].args[1]
         assert saved_child_result.candidate_id == "g1-s1"

--- a/tests/unit/test_evolution_minibatch.py
+++ b/tests/unit/test_evolution_minibatch.py
@@ -26,6 +26,7 @@ from helix.config import (
 from helix.evolution import (
     HelixDataLoader,
     _make_data_loader,
+    _merge_partitioned_evaluations,
     _reconcile_incomplete_attempts_on_resume,
     run_evolution,
 )
@@ -679,10 +680,10 @@ class TestMinibatchGateIntegration:
         assert all_mocks["_save_evaluation"].call_count == 1
         assert all_mocks["remove_worktree"].called
 
-    def test_stage_pass_promotes_to_full_val_with_cache_reuse(
+    def test_stage_pass_promotes_to_partition_carry_without_cache(
         self, tmp_path: Path, all_mocks: dict[str, Any]
     ) -> None:
-        """Stage pass should only full-eval the uncached remainder and persist full val."""
+        """Stage pass evaluates only the tail even when caching is disabled."""
         train_path = _write_train_jsonl(tmp_path, n=4)
         seed = _make_candidate("g0-s0")
         all_mocks["create_seed_worktree"].return_value = seed
@@ -720,7 +721,7 @@ class TestMinibatchGateIntegration:
             val_stage_size=2,
             max_generations=1,
             max_evaluations=100,
-            cache_evaluation=True,
+            cache_evaluation=False,
         )
         run_evolution(config, tmp_path, tmp_path / ".helix")
 
@@ -2944,3 +2945,31 @@ class TestAtomicProposalWorker:
             assert snapped is None or snapped.id != child.id, (
                 f"snapshot_candidate must not be called for tampered child {child.id}"
             )
+
+
+def test_merge_partitioned_evaluations_preserves_id_alignment() -> None:
+    candidate = _make_candidate("g1-s1")
+    stage = EvalResult(
+        candidate_id=candidate.id, scores={}, asi={},
+        instance_scores={"0": 0.8, "1": 0.7},
+        objective_scores=[{"quality": 0.8}, {"quality": 0.7}],
+        per_example_side_info=[{"judge": "stage-0"}, {"judge": "stage-1"}],
+    )
+    tail = EvalResult(
+        candidate_id=candidate.id, scores={}, asi={},
+        instance_scores={"2": 0.6},
+        objective_scores=[{"quality": 0.6}],
+        per_example_side_info=[{"judge": "tail-2"}],
+    )
+
+    merged = _merge_partitioned_evaluations(
+        candidate, ["2", "0", "1"], stage, ["0", "1"], tail, ["2"]
+    )
+
+    assert merged.instance_scores == {"2": 0.6, "0": 0.8, "1": 0.7}
+    assert merged.objective_scores == [
+        {"quality": 0.6}, {"quality": 0.8}, {"quality": 0.7}
+    ]
+    assert merged.per_example_side_info == [
+        {"judge": "tail-2"}, {"judge": "stage-0"}, {"judge": "stage-1"}
+    ]


### PR DESCRIPTION
## What

With `evolution.val_stage_size`, an accepted validation-stage result is carried into final validation: Helix evaluates only the remaining IDs and `_merge_partitioned_evaluations` composes the partitions. `run_evaluator` marks the stage call with `HELIX_EVALUATION_PHASE=val_stage`. Rejected stage candidates keep attempt metadata while their worktrees are removed by default.

## Why

Avoid evaluating the staged validation IDs twice while preserving one complete per-ID validation result.

## Review focus

Check that partition composition preserves requested-ID order across instance scores, objective scores, and per-example side info; evaluators must be safe to run on a subset.

## Validation

`uv run pytest tests/unit/test_config.py tests/unit/test_evolution_minibatch.py -q` — 84 passed in 2.02s. Diff: +184/−35 lines.
