### PR TITLE
Fix backend usage parsing

### DIFF
--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1057,6 +1057,8 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> UsageStats:
                     "cache_creation_input_tokens",
                     "cacheCreationInputTokens",
                     "cacheCreation",
+                    "cache_write_input_tokens",
+                    "cacheWriteTokens",
                 ),
             ),
             (
@@ -1064,10 +1066,20 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> UsageStats:
                 (
                     "cache_read_input_tokens",
                     "cacheReadInputTokens",
+                    "cacheReadTokens",
                     "cacheRead",
                 ),
             ),
-            ("reasoning_tokens", ("reasoning_tokens", "reasoningTokens", "thoughts")),
+            (
+                "reasoning_tokens",
+                (
+                    "reasoning_tokens",
+                    "reasoningTokens",
+                    "reasoning_output_tokens",
+                    "thoughts",
+                    "reasoning",
+                ),
+            ),
             (
                 "cost_usd",
                 ("cost_usd", "costUsd", "total_cost_usd", "totalCostUsd", "total"),
@@ -1103,6 +1115,21 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> UsageStats:
             coerced = _coerce_number(value)
             if coerced is not None:
                 _d["cost_usd"] = coerced
+
+        # OpenCode emits cache accounting as ``tokens.cache.{read,write}``.
+        # Keep this contextual rather than treating generic ``read``/``write``
+        # fields elsewhere in a transcript as token counts.
+        cache = node.get("cache")
+        if isinstance(cache, dict):
+            for key, field in (
+                ("cache_creation_input_tokens", "write"),
+                ("cache_read_input_tokens", "read"),
+            ):
+                if key in _d:
+                    continue
+                value = _coerce_number(cache.get(field))
+                if value is not None:
+                    _d[key] = value
 
     if tool_event_count and "tool_event_count" not in _d:
         _d["tool_event_count"] = tool_event_count

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -850,9 +850,9 @@ class TestInvokeClaudeCode:
                     [
                         '{"type":"session.started","session_id":"codex-session"}',
                         (
-                            '{"type":"turn","usage":{"prompt_tokens":12,'
-                            '"completion_tokens":8,"cached_input_tokens":21,'
-                            '"reasoning_tokens":6,"total_cost_usd":0.32}}'
+                            '{"type":"turn.completed","usage":{"input_tokens":12,'
+                            '"cached_input_tokens":21,"cache_write_input_tokens":3,'
+                            '"output_tokens":8,"reasoning_output_tokens":6}}'
                         ),
                     ]
                 ),
@@ -860,8 +860,8 @@ class TestInvokeClaudeCode:
                     "input_tokens": 12,
                     "output_tokens": 8,
                     "cached_input_tokens": 21,
+                    "cache_creation_input_tokens": 3,
                     "reasoning_tokens": 6,
-                    "cost_usd": 0.32,
                     "session_id": "codex-session",
                 },
                 id="codex",
@@ -873,7 +873,8 @@ class TestInvokeClaudeCode:
                         '{"type":"system","sessionId":"cursor-session"}',
                         (
                             '{"type":"assistant","usage":{"inputTokens":13,'
-                            '"outputTokens":9,"cachedTokens":22,'
+                            '"outputTokens":9,"cacheReadTokens":22,'
+                            '"cacheWriteTokens":5,'
                             '"reasoningTokens":7,"costUsd":0.33}}'
                         ),
                     ]
@@ -881,7 +882,8 @@ class TestInvokeClaudeCode:
                 {
                     "input_tokens": 13,
                     "output_tokens": 9,
-                    "cached_input_tokens": 22,
+                    "cache_creation_input_tokens": 5,
+                    "cache_read_input_tokens": 22,
                     "reasoning_tokens": 7,
                     "cost_usd": 0.33,
                     "session_id": "cursor-session",
@@ -895,9 +897,11 @@ class TestInvokeClaudeCode:
                         "MCP advisory preamble tolerated by the Gemini parser.",
                         '{"type":"init","session_id":"gemini-session"}',
                         (
-                            '{"type":"result","usageMetadata":{"prompt_tokens":14,'
-                            '"completion_tokens":10,"cachedTokens":23},'
-                            '"thoughts":8,"cost":0.34}'
+                            '{"type":"result","stats":{"input_tokens":14,'
+                            '"output_tokens":10,"cached":23,"input":14,'
+                            '"models":{"gemini":{"total_tokens":47,'
+                            '"input_tokens":14,"output_tokens":10,'
+                            '"cached":23,"input":14}}}}'
                         ),
                     ]
                 ),
@@ -905,8 +909,6 @@ class TestInvokeClaudeCode:
                     "input_tokens": 14,
                     "output_tokens": 10,
                     "cached_input_tokens": 23,
-                    "reasoning_tokens": 8,
-                    "cost_usd": 0.34,
                     "session_id": "gemini-session",
                 },
                 id="gemini",
@@ -918,14 +920,16 @@ class TestInvokeClaudeCode:
                         '{"type":"step_start","sessionID":"opencode-session"}',
                         (
                             '{"type":"step_finish","part":{"tokens":{"input":15,'
-                            '"output":11,"cached":24,"thoughts":9},"cost":0.35}}'
+                            '"output":11,"reasoning":9,'
+                            '"cache":{"read":24,"write":4}},"cost":0.35}}'
                         ),
                     ]
                 ),
                 {
                     "input_tokens": 15,
                     "output_tokens": 11,
-                    "cached_input_tokens": 24,
+                    "cache_creation_input_tokens": 4,
+                    "cache_read_input_tokens": 24,
                     "reasoning_tokens": 9,
                     "cost_usd": 0.35,
                     "session_id": "opencode-session",
@@ -961,6 +965,31 @@ class TestInvokeClaudeCode:
                 assert payload["usage"][key] == pytest.approx(value)
             else:
                 assert payload["usage"][key] == value
+
+    def test_usage_normalization_keeps_legacy_aliases(self):
+        from helix.mutator import _normalise_usage_stats
+
+        usage = _normalise_usage_stats(
+            {
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 2,
+                    "cachedTokens": 3,
+                    "cacheCreationInputTokens": 4,
+                    "cacheReadInputTokens": 5,
+                    "reasoningTokens": 6,
+                    "totalCostUsd": 0.07,
+                }
+            }
+        )
+
+        assert usage.input_tokens == 1
+        assert usage.output_tokens == 2
+        assert usage.cached_input_tokens == 3
+        assert usage.cache_creation_input_tokens == 4
+        assert usage.cache_read_input_tokens == 5
+        assert usage.reasoning_tokens == 6
+        assert usage.cost_usd == pytest.approx(0.07)
 
     def test_claude_backend_artifacts_copy_local_transcript(
         self, tmp_path: Path, mocker, monkeypatch


### PR DESCRIPTION
## Summary

Fix usage normalization so HELIX captures backend fields that were present in
backend output but silently fell through to zero. This is a compatibility-only
parser change: canonical HELIX field names are unchanged and existing aliases
keep their precedence.

## Defect and test evidence

A Codex-backed raw stream can emit `reasoning_output_tokens` while HELIX's
previous alias table does not recognize that spelling, causing the persisted
`reasoning_tokens` value to remain zero. The unit test now includes a synthetic
`turn.completed` fixture covering that field and `cache_write_input_tokens`.
It verifies that both are normalized to HELIX's existing canonical fields.

## Backend coverage

| Backend | Fields covered by HELIX | Source of truth |
| --- | --- | --- |
| Claude | Existing `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`, and `total_cost_usd`; existing reasoning aliases remain. | Anthropic's [prompt-caching field reference](https://github.com/anthropics/skills/blob/main/skills/claude-api/shared/prompt-caching.md) and [Claude Code CLI output-format reference](https://code.claude.com/docs/en/cli-usage). |
| Codex | Existing input/output/cache-read aliases plus `cache_write_input_tokens` and `reasoning_output_tokens`. | [Codex usage type](https://github.com/openai/codex/blob/main/codex-rs/tui/src/token_usage.rs). |
| Cursor | Existing input/output/reasoning/cost aliases plus `cacheReadTokens` and `cacheWriteTokens`. | Cursor Support's [CLI usage explanation](https://forum.cursor.com/t/discrepancies-between-cursor-cli-usage-and-billing/164471/7). |
| Gemini | Existing stream-JSON `stats` aliases: `input_tokens`, `output_tokens`, `cached`, and `input`. | [Gemini CLI headless-mode reference](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/headless.md) and [stream JSON formatter](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/output/stream-json-formatter.ts). |
| OpenCode | Existing input/output/cost aliases plus `reasoning` and contextual `tokens.cache.read` / `tokens.cache.write`. | [OpenCode session token schema](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/session.ts) and [JSON run emitter](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/cli/cmd/run.ts). |

## Compatibility notes

- Gemini aliases are retained for backward compatibility. Upstream status and
  documentation were checked on 2026-08-15; no Gemini-specific parser behavior
  is changed by this PR.
- The existing `cacheRead` fallback appears in both `cached_input_tokens` and
  `cache_read_input_tokens`. It predates this patch and is retained for
  compatibility; the new aliases do not broaden or reorder that ambiguous
  fallback.

## Validation

- `uv run pytest tests/unit/ -q` — 867 passed
- `uv run mypy --strict src/helix/` — passed
- `uv run ruff check src/helix tests/unit` — passed