### PR TITLE
feat(evolution): pluggable candidate-selection strategies

### DIFF
--- a/src/helix/candidate_selector.py
+++ b/src/helix/candidate_selector.py
@@ -24,34 +24,42 @@ score arrays off ``GEPAState``:
   array ``ParetoCandidateSelector`` passes into
   ``select_program_candidate_from_pareto_front``.
 
-At the upstream commit this was implemented against, both properties
-happen to be computed with the identical formula (mean of each program's
-validation subscores) — but a ``TODO`` on ``program_full_scores_val_set``
-notes it "should be using the val_evaluation_policy instead", so the two
-are documented as expected to diverge and must not be treated as
-interchangeable by name alone.
+Both properties are computed by the *identical* expression — a list
+comprehension over ``get_program_average_val_subset(program_idx)[0]``,
+which returns ``sum(scores.values()) / num_samples``. So both upstream
+arrays are **means**, and the correct HELIX analogue for both is
+``EvalResult.aggregate_score()`` (HELIX's own docstring: "mean of
+instance scores"), never ``EvalResult.sum_score()``.
 
-HELIX maps each upstream array to the existing HELIX quantity that already
-plays its role, rather than assuming they're the same array:
+Both properties carry ``TODO`` comments about routing through the
+``val_evaluation_policy`` instead. Those TODOs are about *where the
+number should come from*, not a signal that the two arrays are expected
+to diverge into different aggregation functions — and in any case a
+speculative future divergence is not a licence to substitute a sum for
+a mean today. If upstream ever does split them, this mapping should be
+re-derived from the new definitions rather than guessed.
 
-* ``per_program_tracked_scores`` feeds *both* the Pareto dominance-removal
-  sort key and the top-k ranking upstream. HELIX's own ``ParetoFrontier``
-  already uses ``EvalResult.sum_score()`` for exactly that role (see the
-  "GEPA parity (W1)" comments on ``ParetoFrontier.get_non_dominated`` and
-  ``select_parent`` in ``population.py``). So ``top_k_pareto`` here uses
-  ``sum_score()`` for both its ranking *and* its empty-mapping fallback —
-  matching upstream's reuse of the same local ``scores`` variable for both
-  roles inside ``TopKParetoCandidateSelector.select_candidate_idx``.
-* ``program_full_scores_val_set`` is upstream's "how good is this program
-  overall" figure. The closest existing HELIX quantity, both by name and
-  by mean-based semantics, is ``EvalResult.aggregate_score()`` (HELIX's own
-  docstring: "mean of instance scores"). ``current_best`` and
-  ``epsilon_greedy``'s greedy branch use ``aggregate_score()``.
+Accordingly every strategy in this module reads the mean:
 
-This split is deliberately exercised by
-``tests/unit/test_candidate_selector.py::TestScoreQuantityMapping``, which
-constructs a pool where ``sum_score()`` and ``aggregate_score()`` argmax
-disagree and asserts each strategy resolves to the quantity above.
+* ``current_best`` and ``epsilon_greedy``'s greedy branch use
+  ``aggregate_score()`` for ``program_full_scores_val_set``.
+* ``top_k_pareto`` uses ``aggregate_score()`` for its top-k ranking, its
+  filtered-front dominance-removal sort key, and its empty-mapping
+  fallback — the three places upstream's
+  ``TopKParetoCandidateSelector.select_candidate_idx`` reuses its single
+  local ``scores = state.per_program_tracked_scores`` variable.
+
+Sum-vs-mean only diverges when candidates have unequal numbers of scored
+instances, which HELIX permits; ``tests/unit/test_candidate_selector.py``
+— ``TestTopKPareto.test_ranking_uses_mean_not_sum_when_cardinality_differs``
+pins the disagreeing case.
+
+Pre-existing divergence (NOT addressed here): ``ParetoFrontier.select_parent``
+and ``get_non_dominated`` in ``population.py`` pass ``sum_score()`` into
+``_remove_dominated_programs`` under a "GEPA parity (W1)" comment. Upstream's
+``ParetoCandidateSelector`` passes the mean array, so that comment does not
+hold; it is deliberately left untouched by this module because the default
+``"pareto"`` path must stay behaviourally identical. Tracked separately.
 
 Determinism
 -----------
@@ -85,13 +93,16 @@ CandidateSelectionStrategy = Literal[
 
 
 def _aggregate_score_or_floor(result: EvalResult | None) -> float:
-    """HELIX analog of upstream's ``program_full_scores_val_set`` entry."""
+    """HELIX analog of an entry in either upstream per-program score array.
+
+    Upstream's ``program_full_scores_val_set`` and
+    ``per_program_tracked_scores`` are the same mean-valued expression (see
+    the module docstring), so one helper serves both. The ``-inf`` floor for
+    an unevaluated candidate matches upstream's
+    ``get_program_average_val_subset``, which returns ``float("-inf")`` when a
+    program has no recorded subscores.
+    """
     return result.aggregate_score() if result is not None else float("-inf")
-
-
-def _sum_score_or_floor(result: EvalResult | None) -> float:
-    """HELIX analog of upstream's ``per_program_tracked_scores`` entry."""
-    return result.sum_score() if result is not None else float("-inf")
 
 
 def _first_argmax(
@@ -159,24 +170,23 @@ def select_epsilon_greedy(
 def select_top_k_pareto(
     frontier: ParetoFrontier, rng: random.Random, k: int
 ) -> Candidate:
-    """Pareto draw restricted to the top-``k`` candidates by ``sum_score()``.
+    """Pareto draw restricted to the top-``k`` candidates by ``aggregate_score()``.
 
     GEPA parity: ``TopKParetoCandidateSelector.select_candidate_idx``:
 
-    1. Rank all evaluated candidates by score (HELIX: ``sum_score()``,
-       see module docstring) descending; ties keep discovery order (a
-       stable sort over an already discovery-ordered id list, matching
-       upstream's stable ``sorted(range(len(scores)), ...)`` over program
-       indices).
+    1. Rank all evaluated candidates by score (HELIX: ``aggregate_score()``,
+       the mean — see module docstring) descending; ties keep discovery
+       order (a stable sort over an already discovery-ordered id list,
+       matching upstream's stable ``sorted(range(len(scores)), ...)`` over
+       program indices).
     2. Intersect the top-k id set into every per-key frontier front
        (:meth:`ParetoFrontier.active_frontier_snapshot`); drop any key
        whose intersection is empty.
     3. If EVERY key's intersection is empty, fall back to a direct argmax
-       over the SAME ``sum_score()`` array used for ranking — upstream's
-       fallback reuses its local ``scores`` variable verbatim, not the
-       ``program_full_scores_val_set``/``aggregate_score()`` quantity
-       ``current_best`` uses. That fallback is load-bearing: replicate it
-       exactly, including which score array it reads.
+       over the SAME mean array used for ranking — upstream's fallback
+       reuses its local ``scores`` variable verbatim. Because both upstream
+       score arrays are the same mean expression, this is also the same
+       quantity ``current_best`` uses.
     4. Otherwise, run the identical dominance-removal + frequency-weighted
        draw :meth:`ParetoFrontier.select_parent` uses, over the filtered
        mapping (reusing :meth:`ParetoFrontier._remove_dominated_programs`,
@@ -197,7 +207,7 @@ def select_top_k_pareto(
 
     ordered_ids = list(frontier.candidates.keys())
     scores = {
-        cid: _sum_score_or_floor(frontier.get_result(cid)) for cid in ordered_ids
+        cid: _aggregate_score_or_floor(frontier.get_result(cid)) for cid in ordered_ids
     }
     ranked = sorted(ordered_ids, key=lambda cid: scores[cid], reverse=True)
     top_k_ids = set(ranked[:k])
@@ -209,7 +219,7 @@ def select_top_k_pareto(
             filtered_mapping[key] = filtered
 
     if not filtered_mapping:
-        return _first_argmax(frontier, _sum_score_or_floor)
+        return _first_argmax(frontier, _aggregate_score_or_floor)
 
     _, cleaned = ParetoFrontier._remove_dominated_programs(filtered_mapping, scores)
     program_frequency: dict[str, int] = {}
@@ -225,7 +235,7 @@ def select_top_k_pareto(
         # non-"instance" path) — guarded so an algorithm change fails
         # loudly here instead of surfacing as an opaque IndexError from
         # ``rng.choice([])``.
-        return _first_argmax(frontier, _sum_score_or_floor)
+        return _first_argmax(frontier, _aggregate_score_or_floor)
     return frontier.candidates[rng.choice(sampling_list)]
 
 
@@ -254,45 +264,3 @@ def select_candidate(
         assert top_k is not None
         return select_top_k_pareto(frontier, rng, top_k)
     raise ValueError(f"Unknown candidate_selection_strategy: {strategy!r}")
-
-
-def select_parents(
-    strategy: CandidateSelectionStrategy,
-    frontier: ParetoFrontier,
-    rng: random.Random,
-    p: int,
-    *,
-    epsilon: float | None = None,
-    top_k: int | None = None,
-) -> list[Candidate]:
-    """Batch seam: draw ``p`` parents, one independent :func:`select_candidate`
-    call each.
-
-    GEPA parity check: upstream's own ``CandidateSelector`` Protocol is
-    scalar (``select_candidate_idx(self, state) -> int``,
-    ``gepa.proposer.reflective_mutation.base``), and every upstream sampling
-    strategy — including ``PxNSampling(p, n)``, the direct analog of
-    HELIX's ``num_parallel_proposals * mutations_per_parent`` — draws its
-    P parents with a plain ``for _ in range(self.p):
-    candidate_selector.select_candidate_idx(state)`` loop
-    (``gepa.strategies.proposal_sampling``). So this default — looping the
-    existing scalar draw ``p`` times — isn't new behaviour; it's the same
-    loop GEPA already runs today, exposed as a batch-shaped HELIX API.
-
-    This exists purely as a seam: a future JOINT allocation strategy (e.g.
-    systematic/low-variance resampling over the frontier's per-key
-    frequency weights, so P parallel draws stop collapsing onto one
-    candidate) can replace this default without HELIX callers needing to
-    change how they call candidate selection. Deliberately NOT implemented
-    here — every strategy above still draws independently with
-    replacement, exactly as upstream GEPA does; see this module's
-    docstring on distinctness. ``evolution.py``'s proposal loop is not
-    migrated to call this: it already performs the equivalent "p
-    sequential scalar draws" inline, interleaved with per-slot budget and
-    minibatch-sampling logic that a batch call can't express without a
-    larger, out-of-scope restructure.
-    """
-    return [
-        select_candidate(strategy, frontier, rng, epsilon=epsilon, top_k=top_k)
-        for _ in range(p)
-    ]

--- a/src/helix/candidate_selector.py
+++ b/src/helix/candidate_selector.py
@@ -22,11 +22,11 @@ including one with a negative mean.
 
 Determinism
 -----------
-Selection draws from the caller's seeded ``random.Random``, so a run repeats
-within a process. It does not repeat across processes: the ``pareto`` and
-``top_k_pareto`` paths iterate ``set[str]`` fronts and CPython salts ``str``
-hashing per process, so ties can break differently under a different
-``PYTHONHASHSEED``. ``current_best`` draws no randomness and is unaffected.
+Selection draws from the caller's seeded ``random.Random``. The
+``top_k_pareto`` path orders its frontier ids before ties reach that RNG, so
+it repeats across processes. The legacy ``pareto`` path is unchanged and can
+iterate ``set[str]`` fronts whose string hashes are salted per process.
+``current_best`` draws no randomness and is unaffected.
 
 Limits
 ------
@@ -37,7 +37,7 @@ proposal may draw the same parent.
 from __future__ import annotations
 
 import random
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from typing import Literal
 
 from helix.population import Candidate, EvalResult, ParetoFrontier
@@ -45,6 +45,19 @@ from helix.population import Candidate, EvalResult, ParetoFrontier
 CandidateSelectionStrategy = Literal[
     "pareto", "current_best", "epsilon_greedy", "top_k_pareto"
 ]
+
+
+class _SortedCandidateIds(set[str]):
+    """Set with deterministic iteration for the selector-only Pareto path.
+
+    ``ParetoFrontier._remove_dominated_programs`` accepts sets and iterates
+    them while resolving score ties. Keeping this ordered-set behavior local
+    lets ``top_k_pareto`` be reproducible without changing the legacy
+    ``pareto`` selection path in :mod:`helix.population`.
+    """
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(sorted(super().__iter__()))
 
 
 def _aggregate_score_or_floor(result: EvalResult | None) -> float:
@@ -161,7 +174,7 @@ def select_top_k_pareto(
 
     filtered_mapping: dict[str, set[str]] = {}
     for key, ids in frontier.active_frontier_snapshot().items():
-        filtered = set(ids) & top_k_ids
+        filtered = _SortedCandidateIds(cid for cid in ids if cid in top_k_ids)
         if filtered:
             filtered_mapping[key] = filtered
 
@@ -171,7 +184,7 @@ def select_top_k_pareto(
     _, cleaned = ParetoFrontier._remove_dominated_programs(filtered_mapping, scores)
     program_frequency: dict[str, int] = {}
     for front in cleaned.values():
-        for cid in front:
+        for cid in sorted(front):
             program_frequency[cid] = program_frequency.get(cid, 0) + 1
     sampling_list = [
         cid for cid, freq in program_frequency.items() for _ in range(freq)

--- a/src/helix/candidate_selector.py
+++ b/src/helix/candidate_selector.py
@@ -1,101 +1,37 @@
-"""Pluggable candidate-selection strategies (GEPA parity).
+"""Candidate-selection strategies: choosing which candidate to mutate next.
 
-Upstream attribution: ``gepa.strategies.candidate_selector``
-(``ParetoCandidateSelector``, ``CurrentBestCandidateSelector``,
-``EpsilonGreedyCandidateSelector``, ``TopKParetoCandidateSelector`` —
-gepa-ai/gepa on GitHub).  Naming credit only; see this repo's PR hygiene
-rules against upstream ``file:line`` citations.
+Ports the three strategies GEPA implements as ``CurrentBestCandidateSelector``,
+``EpsilonGreedyCandidateSelector``, and ``TopKParetoCandidateSelector`` in
+``gepa.strategies.candidate_selector`` (gepa-ai/gepa). HELIX's own ``"pareto"``
+strategy is unchanged: :func:`select_candidate` delegates it to
+:meth:`helix.population.ParetoFrontier.select_parent`, which ranks by
+``sum_score()``. Which strategy runs is set by
+``config.evolution.candidate_selection_strategy``.
 
-HELIX already had the ``"pareto"`` strategy as
-:meth:`helix.population.ParetoFrontier.select_parent`.  This module adds
-the other three GEPA-parity strategies plus a single :func:`select_candidate`
-dispatcher that ``evolution.py`` calls instead of ``frontier.select_parent()``
-directly, keyed off ``config.evolution.candidate_selection_strategy``.
+Ranking
+-------
+The three ported strategies rank by ``EvalResult.aggregate_score()`` — the mean
+of a candidate's instance scores — never ``sum_score()``. Both per-program score
+arrays upstream ranks on are means, so the mean is the faithful analogue
+everywhere here. The two quantities disagree whenever candidates carry unequal
+numbers of scored instances, which HELIX permits, so this is not a free choice.
 
-Score-quantity mapping
------------------------
-Upstream's four selectors read one of two differently-named per-program
-score arrays off ``GEPAState``:
-
-* ``program_full_scores_val_set`` — read by ``CurrentBestCandidateSelector``
-  and ``EpsilonGreedyCandidateSelector`` via ``idxmax(...)``.
-* ``per_program_tracked_scores`` — read by ``TopKParetoCandidateSelector``
-  for its top-k ranking *and* its empty-mapping fallback, and is the same
-  array ``ParetoCandidateSelector`` passes into
-  ``select_program_candidate_from_pareto_front``.
-
-Both properties are computed by the *identical* expression — a list
-comprehension over ``get_program_average_val_subset(program_idx)[0]``,
-which returns ``sum(scores.values()) / num_samples``. So both upstream
-arrays are **means**, and the correct HELIX analogue for both is
-``EvalResult.aggregate_score()`` (HELIX's own docstring: "mean of
-instance scores"), never ``EvalResult.sum_score()``.
-
-Both properties carry ``TODO`` comments about routing through the
-``val_evaluation_policy`` instead. Those TODOs are about *where the
-number should come from*, not a signal that the two arrays are expected
-to diverge into different aggregation functions — and in any case a
-speculative future divergence is not a licence to substitute a sum for
-a mean today. If upstream ever does split them, this mapping should be
-re-derived from the new definitions rather than guessed.
-
-Accordingly every strategy in this module reads the mean:
-
-* ``current_best`` and ``epsilon_greedy``'s greedy branch use
-  ``aggregate_score()`` for ``program_full_scores_val_set``.
-* ``top_k_pareto`` uses ``aggregate_score()`` for its top-k ranking, its
-  filtered-front dominance-removal sort key, and its empty-mapping
-  fallback — the three places upstream's
-  ``TopKParetoCandidateSelector.select_candidate_idx`` reuses its single
-  local ``scores = state.per_program_tracked_scores`` variable.
-
-Sum-vs-mean only diverges when candidates have unequal numbers of scored
-instances, which HELIX permits; ``tests/unit/test_candidate_selector.py``
-— ``TestTopKPareto.test_ranking_uses_mean_not_sum_when_cardinality_differs``
-pins the disagreeing case.
-
-Empty-score floor
-------------------
-``EvalResult.aggregate_score()`` returns ``0.0`` for a result with empty
-``instance_scores`` (deliberately left unchanged — other callers such as
-reporting and serialization legitimately want ``0.0``). Upstream's
-``get_program_average_val_subset`` instead returns ``float("-inf")`` for a
-program with no recorded subscores, so an unscored candidate must rank
-BELOW every scored candidate, not above negative-but-finite ones.
-:func:`_aggregate_score_or_floor` applies that ``-inf`` floor at the
-selection site — for both an absent result and a present-but-empty one.
-
-Pre-existing divergence (NOT addressed here): ``ParetoFrontier.select_parent``
-and ``get_non_dominated`` in ``population.py`` pass ``sum_score()`` into
-``_remove_dominated_programs`` under a "GEPA parity (W1)" comment. Upstream's
-``ParetoCandidateSelector`` passes the mean array, so that comment does not
-hold; it is deliberately left untouched by this module because the default
-``"pareto"`` path must stay behaviourally identical. Tracked separately.
+A candidate with no instance scores floors to ``-inf``
+(:func:`_aggregate_score_or_floor`) and so ranks below every scored candidate,
+including one with a negative mean.
 
 Determinism
 -----------
-Every strategy takes the SAME ``random.Random`` instance the caller already
-threads through ``ParetoFrontier`` (see ``evolution.py``'s ``rng =
-random.Random(config.rng_seed)``), so within a single process a seeded run
-draws the same sequence from that ``rng`` on repeated invocations.
-This is NOT a claim of cross-process/end-to-end reproducibility: both
-``pareto`` (via ``ParetoFrontier.select_parent``) and ``top_k_pareto``'s
-dominance-removal path iterate ``set[str]`` candidate-id fronts, and
-CPython salts ``str`` hashing per process, so tie-broken outcomes can
-differ across ``PYTHONHASHSEED`` values even with an identical ``rng``
-seed. ``current_best`` never touches ``rng`` — GEPA parity, ``idxmax``
-is a pure argmax. Its tie-break is defined explicitly
-(see :func:`_first_argmax`) rather than left to dict/set iteration order,
-and does not read any ``set[str]`` front, so it is unaffected by the
-``PYTHONHASHSEED`` caveat above.
+Selection draws from the caller's seeded ``random.Random``, so a run repeats
+within a process. It does not repeat across processes: the ``pareto`` and
+``top_k_pareto`` paths iterate ``set[str]`` fronts and CPython salts ``str``
+hashing per process, so ties can break differently under a different
+``PYTHONHASHSEED``. ``current_best`` draws no randomness and is unaffected.
 
-Anti-collapse / distinctness
------------------------------
-This module deliberately does NOT implement any minimum-distinct-parents
-or anti-collapse guarantee (e.g. forcing P>1 proposals to sample >=2
-distinct parents). That is a separate, still-open design question tracked
-elsewhere. :func:`select_candidate` is a single seam a future distinctness
-layer could wrap without touching the four strategies themselves.
+Limits
+------
+No distinctness guarantee: with more than one proposal per iteration, every
+proposal may draw the same parent.
 """
 
 from __future__ import annotations
@@ -112,18 +48,13 @@ CandidateSelectionStrategy = Literal[
 
 
 def _aggregate_score_or_floor(result: EvalResult | None) -> float:
-    """HELIX analog of an entry in either upstream per-program score array.
+    """Mean instance score, floored to ``-inf`` when there is nothing to average.
 
-    Upstream's ``program_full_scores_val_set`` and
-    ``per_program_tracked_scores`` are the same mean-valued expression (see
-    the module docstring), so one helper serves both. The ``-inf`` floor
-    matches upstream's ``get_program_average_val_subset``, which returns
-    ``float("-inf")`` when a program has no recorded subscores — that is
-    the case both for an absent result (``result is None``) AND for a
-    present result with empty ``instance_scores`` (an evaluated-but-scoreless
-    candidate). ``EvalResult.aggregate_score()`` itself returns ``0.0`` for
-    the empty case (other callers legitimately want that), so the floor is
-    applied here, at the selection site, rather than in ``aggregate_score``.
+    Matches upstream's ``get_program_average_val_subset``, which yields
+    ``float("-inf")`` for a program with no recorded subscores. Both an absent
+    result and a present-but-scoreless one floor. ``aggregate_score()`` returns
+    ``0.0`` for the scoreless case and other callers want that, so the floor
+    belongs here at the selection site, not in ``aggregate_score``.
     """
     if result is None or not result.instance_scores:
         return float("-inf")
@@ -134,23 +65,17 @@ def _first_argmax(
     frontier: ParetoFrontier,
     score_of: Callable[[EvalResult | None], float],
 ) -> Candidate:
-    """GEPA ``idxmax`` parity: first occurrence of the max score wins ties.
+    """Highest-scoring candidate; ties go to the earliest discovered.
 
-    ``idxmax`` is ``lst.index(max(lst))`` over a list indexed by upstream's
-    append-only ``program_candidates`` (discovery order). HELIX's
-    ``ParetoFrontier._candidates`` dict is populated the same way — every
-    ``add()`` call only ever inserts, never reorders — so Python's
-    insertion-order-preserving dict iteration reproduces "first-discovered
-    candidate among the tied leaders" exactly: scan in discovery order, only
-    displace the running leader on a STRICT improvement — EXCEPT the very
-    first candidate is always taken unconditionally (``best_id is None``).
-    That unconditional first pick matters once ``-inf`` is a reachable
-    score (see :func:`_aggregate_score_or_floor`): an all-unscored pool
-    ties every candidate at ``-inf``, and ``-inf > -inf`` is False, so a
-    pure strict-improvement scan would leave ``best_id`` unset. Upstream's
-    ``idxmax`` is ``lst.index(max(lst))``, which always returns the first
-    index even when every value ties — so unconditionally taking the first
-    candidate is what reproduces that, not a special case for it.
+    ``ParetoFrontier`` only ever inserts into ``_candidates``, so iterating it
+    walks discovery order. Scanning that order and displacing the leader only
+    on a strict improvement reproduces GEPA's ``idxmax``
+    (``lst.index(max(lst))`` over its append-only ``program_candidates``).
+
+    The first candidate is taken unconditionally rather than on a strict
+    improvement, because ``-inf`` is a reachable score: an all-unscored pool
+    ties every candidate at ``-inf``, and ``-inf > -inf`` is False, so a pure
+    strict-improvement scan would leave ``best_id`` unset.
     """
     best_id: str | None = None
     best_score = float("-inf")
@@ -166,8 +91,8 @@ def _first_argmax(
 def select_current_best(frontier: ParetoFrontier) -> Candidate:
     """Deterministic argmax over aggregate validation score.
 
-    GEPA parity: ``CurrentBestCandidateSelector.select_candidate_idx`` ->
-    ``idxmax(state.program_full_scores_val_set)``. No randomness consumed.
+    GEPA parity: ``CurrentBestCandidateSelector.select_candidate_idx``.
+    Consumes no randomness.
     """
     if len(frontier) == 0:
         raise ValueError(
@@ -181,13 +106,11 @@ def select_epsilon_greedy(
 ) -> Candidate:
     """With probability ``epsilon``, pick uniformly from the whole pool.
 
-    GEPA parity: ``EpsilonGreedyCandidateSelector.select_candidate_idx``.
-    The random draw is over the FULL evaluated pool
-    (``rng.randint(0, len(program_candidates) - 1)``), not the Pareto
-    frontier — deliberately not routed through
-    :func:`select_current_best`'s frontier-only machinery. The greedy
-    branch always delegates to :func:`select_current_best` and consumes no
-    extra randomness, matching upstream's ``else: return idxmax(...)``.
+    GEPA parity: ``EpsilonGreedyCandidateSelector.select_candidate_idx``. The
+    exploration draw covers every evaluated candidate, not just the Pareto
+    frontier, so a candidate dominated on every key can still be picked. The
+    greedy branch delegates to :func:`select_current_best` and draws no
+    randomness beyond the coin flip.
     """
     if len(frontier) == 0:
         raise ValueError(
@@ -202,43 +125,27 @@ def select_epsilon_greedy(
 def select_top_k_pareto(
     frontier: ParetoFrontier, rng: random.Random, k: int
 ) -> Candidate:
-    """Pareto draw restricted to the top-``k`` candidates by ``aggregate_score()``.
+    """Pareto draw restricted to the top-``k`` candidates by mean score.
 
-    GEPA parity: ``TopKParetoCandidateSelector.select_candidate_idx``:
+    GEPA parity: ``TopKParetoCandidateSelector.select_candidate_idx``.
 
-    1. Rank all evaluated candidates by score (HELIX: ``aggregate_score()``,
-       the mean — see module docstring) descending; ties keep discovery
-       order (a stable sort over an already discovery-ordered id list,
-       matching upstream's stable ``sorted(range(len(scores)), ...)`` over
-       program indices).
-    2. Intersect the top-k id set into every per-key frontier front
-       (:meth:`ParetoFrontier.active_frontier_snapshot`); drop any key
-       whose intersection is empty.
-    3. If EVERY key's intersection is empty, fall back to a direct argmax
-       over the SAME mean array used for ranking — upstream's fallback
-       reuses its local ``scores`` variable verbatim. Because both upstream
-       score arrays are the same mean expression, this is also the same
-       quantity ``current_best`` uses.
-    4. Otherwise, run the identical dominance-removal + frequency-weighted
-       draw :meth:`ParetoFrontier.select_parent` uses, over the filtered
-       mapping (reusing :meth:`ParetoFrontier._remove_dominated_programs`,
-       the same canonical implementation, rather than re-deriving it).
+    1. Rank every evaluated candidate by ``aggregate_score()`` descending;
+       ties keep discovery order, via a stable sort over a discovery-ordered
+       id list.
+    2. Intersect the top-k ids into each per-key front from
+       :meth:`ParetoFrontier.active_frontier_snapshot`, dropping keys whose
+       intersection comes out empty.
+    3. If every key empties, fall back to an argmax over the same mean scores
+       used for the ranking.
+    4. Otherwise strip dominated candidates with
+       :meth:`ParetoFrontier._remove_dominated_programs` and draw from the
+       survivors weighted by how many fronts each appears on.
 
-    When ``k`` covers the whole pool, the top-k intersection can never
-    remove anything from any front — it is mathematically a no-op on the
-    *membership* side — but there is no shortcut back to
-    :meth:`ParetoFrontier.select_parent`: that method feeds ``sum_score()``
-    into dominance removal, whereas every other read in this function uses
-    the mean (``aggregate_score()``, see module docstring). Those two
-    quantities only coincide when every candidate has the same number of
-    scored instances, which HELIX does not guarantee. So ``k >= len(frontier)``
-    is handled by simply letting the normal path run to completion with the
-    full candidate set as its top-k slice: same mean mapping feeds the
-    ranking, :meth:`ParetoFrontier._remove_dominated_programs`, and the
-    empty-filter fallback, all three. The result is "Pareto frontier over
-    the full mapping, ranked and dominance-checked by MEAN" — deliberately
-    NOT identical to the legacy ``"pareto"`` strategy, which uses sums (see
-    the module docstring's "Pre-existing divergence" section).
+    ``k >= len(frontier)`` makes step 2 a no-op on membership, but the full
+    path still runs. :meth:`ParetoFrontier.select_parent` is the tempting
+    shortcut and is not equivalent: it feeds ``sum_score()`` into dominance
+    removal, which selects a different candidate whenever candidates carry
+    unequal numbers of scored instances.
     """
     if len(frontier) == 0:
         raise ValueError(
@@ -270,11 +177,9 @@ def select_top_k_pareto(
         cid for cid, freq in program_frequency.items() for _ in range(freq)
     ]
     if not sampling_list:
-        # Unreachable given a non-empty filtered_mapping (the same
-        # invariant ``ParetoFrontier.select_parent`` relies on for its own
-        # non-"instance" path) — guarded so an algorithm change fails
-        # loudly here instead of surfacing as an opaque IndexError from
-        # ``rng.choice([])``.
+        # Unreachable while filtered_mapping is non-empty. Guarded so that a
+        # future change to dominance removal degrades to an argmax instead of
+        # an opaque IndexError out of rng.choice([]).
         return _first_argmax(frontier, _aggregate_score_or_floor)
     return frontier.candidates[rng.choice(sampling_list)]
 
@@ -289,9 +194,10 @@ def select_candidate(
 ) -> Candidate:
     """Dispatch to the configured candidate-selection strategy.
 
-    ``epsilon``/``top_k`` are only read for their matching strategy; HELIX's
-    config layer (``EvolutionConfig.model_post_init``) already guarantees
-    they're set when required, so the asserts here are pure type narrowing.
+    ``"pareto"`` delegates to :meth:`ParetoFrontier.select_parent` unchanged.
+    ``epsilon`` and ``top_k`` are read only by the strategy that owns them;
+    ``EvolutionConfig.model_post_init`` already rejects a config missing the
+    one it needs, so the asserts narrow types rather than validate input.
     """
     if strategy == "pareto":
         return frontier.select_parent()

--- a/src/helix/candidate_selector.py
+++ b/src/helix/candidate_selector.py
@@ -54,6 +54,17 @@ instances, which HELIX permits; ``tests/unit/test_candidate_selector.py``
 — ``TestTopKPareto.test_ranking_uses_mean_not_sum_when_cardinality_differs``
 pins the disagreeing case.
 
+Empty-score floor
+------------------
+``EvalResult.aggregate_score()`` returns ``0.0`` for a result with empty
+``instance_scores`` (deliberately left unchanged — other callers such as
+reporting and serialization legitimately want ``0.0``). Upstream's
+``get_program_average_val_subset`` instead returns ``float("-inf")`` for a
+program with no recorded subscores, so an unscored candidate must rank
+BELOW every scored candidate, not above negative-but-finite ones.
+:func:`_aggregate_score_or_floor` applies that ``-inf`` floor at the
+selection site — for both an absent result and a present-but-empty one.
+
 Pre-existing divergence (NOT addressed here): ``ParetoFrontier.select_parent``
 and ``get_non_dominated`` in ``population.py`` pass ``sum_score()`` into
 ``_remove_dominated_programs`` under a "GEPA parity (W1)" comment. Upstream's
@@ -105,12 +116,18 @@ def _aggregate_score_or_floor(result: EvalResult | None) -> float:
 
     Upstream's ``program_full_scores_val_set`` and
     ``per_program_tracked_scores`` are the same mean-valued expression (see
-    the module docstring), so one helper serves both. The ``-inf`` floor for
-    an unevaluated candidate matches upstream's
-    ``get_program_average_val_subset``, which returns ``float("-inf")`` when a
-    program has no recorded subscores.
+    the module docstring), so one helper serves both. The ``-inf`` floor
+    matches upstream's ``get_program_average_val_subset``, which returns
+    ``float("-inf")`` when a program has no recorded subscores — that is
+    the case both for an absent result (``result is None``) AND for a
+    present result with empty ``instance_scores`` (an evaluated-but-scoreless
+    candidate). ``EvalResult.aggregate_score()`` itself returns ``0.0`` for
+    the empty case (other callers legitimately want that), so the floor is
+    applied here, at the selection site, rather than in ``aggregate_score``.
     """
-    return result.aggregate_score() if result is not None else float("-inf")
+    if result is None or not result.instance_scores:
+        return float("-inf")
+    return result.aggregate_score()
 
 
 def _first_argmax(
@@ -124,15 +141,22 @@ def _first_argmax(
     ``ParetoFrontier._candidates`` dict is populated the same way — every
     ``add()`` call only ever inserts, never reorders — so Python's
     insertion-order-preserving dict iteration reproduces "first-discovered
-    candidate among the tied leaders" exactly: scan in discovery order,
-    keep only STRICT improvements, so an earlier candidate is never
-    displaced by a later one with an equal score.
+    candidate among the tied leaders" exactly: scan in discovery order, only
+    displace the running leader on a STRICT improvement — EXCEPT the very
+    first candidate is always taken unconditionally (``best_id is None``).
+    That unconditional first pick matters once ``-inf`` is a reachable
+    score (see :func:`_aggregate_score_or_floor`): an all-unscored pool
+    ties every candidate at ``-inf``, and ``-inf > -inf`` is False, so a
+    pure strict-improvement scan would leave ``best_id`` unset. Upstream's
+    ``idxmax`` is ``lst.index(max(lst))``, which always returns the first
+    index even when every value ties — so unconditionally taking the first
+    candidate is what reproduces that, not a special case for it.
     """
     best_id: str | None = None
     best_score = float("-inf")
     for cid in frontier.candidates:
         score = score_of(frontier.get_result(cid))
-        if score > best_score:
+        if best_id is None or score > best_score:
             best_score = score
             best_id = cid
     assert best_id is not None  # caller guarantees a non-empty frontier

--- a/src/helix/candidate_selector.py
+++ b/src/helix/candidate_selector.py
@@ -65,10 +65,18 @@ Determinism
 -----------
 Every strategy takes the SAME ``random.Random`` instance the caller already
 threads through ``ParetoFrontier`` (see ``evolution.py``'s ``rng =
-random.Random(config.rng_seed)``), so a seeded run stays reproducible
-end-to-end. ``current_best`` never touches ``rng`` — GEPA parity, ``idxmax``
-is a pure argmax. Its tie-break is defined explicitly (see
-:func:`_first_argmax`) rather than left to dict/set iteration order.
+random.Random(config.rng_seed)``), so within a single process a seeded run
+draws the same sequence from that ``rng`` on repeated invocations.
+This is NOT a claim of cross-process/end-to-end reproducibility: both
+``pareto`` (via ``ParetoFrontier.select_parent``) and ``top_k_pareto``'s
+dominance-removal path iterate ``set[str]`` candidate-id fronts, and
+CPython salts ``str`` hashing per process, so tie-broken outcomes can
+differ across ``PYTHONHASHSEED`` values even with an identical ``rng``
+seed. ``current_best`` never touches ``rng`` — GEPA parity, ``idxmax``
+is a pure argmax. Its tie-break is defined explicitly
+(see :func:`_first_argmax`) rather than left to dict/set iteration order,
+and does not read any ``set[str]`` front, so it is unaffected by the
+``PYTHONHASHSEED`` caveat above.
 
 Anti-collapse / distinctness
 -----------------------------
@@ -193,17 +201,25 @@ def select_top_k_pareto(
        the same canonical implementation, rather than re-deriving it).
 
     When ``k`` covers the whole pool, the top-k intersection can never
-    remove anything — it is mathematically a no-op — so this degrades
-    directly to :meth:`ParetoFrontier.select_parent` (byte-for-byte
-    ``"pareto"`` behaviour) instead of re-deriving an equivalent result
-    through a differently-ordered mapping.
+    remove anything from any front — it is mathematically a no-op on the
+    *membership* side — but there is no shortcut back to
+    :meth:`ParetoFrontier.select_parent`: that method feeds ``sum_score()``
+    into dominance removal, whereas every other read in this function uses
+    the mean (``aggregate_score()``, see module docstring). Those two
+    quantities only coincide when every candidate has the same number of
+    scored instances, which HELIX does not guarantee. So ``k >= len(frontier)``
+    is handled by simply letting the normal path run to completion with the
+    full candidate set as its top-k slice: same mean mapping feeds the
+    ranking, :meth:`ParetoFrontier._remove_dominated_programs`, and the
+    empty-filter fallback, all three. The result is "Pareto frontier over
+    the full mapping, ranked and dominance-checked by MEAN" — deliberately
+    NOT identical to the legacy ``"pareto"`` strategy, which uses sums (see
+    the module docstring's "Pre-existing divergence" section).
     """
     if len(frontier) == 0:
         raise ValueError(
             "Frontier is empty — cannot select a top-k-pareto candidate."
         )
-    if k >= len(frontier):
-        return frontier.select_parent()
 
     ordered_ids = list(frontier.candidates.keys())
     scores = {

--- a/src/helix/candidate_selector.py
+++ b/src/helix/candidate_selector.py
@@ -1,0 +1,298 @@
+"""Pluggable candidate-selection strategies (GEPA parity).
+
+Upstream attribution: ``gepa.strategies.candidate_selector``
+(``ParetoCandidateSelector``, ``CurrentBestCandidateSelector``,
+``EpsilonGreedyCandidateSelector``, ``TopKParetoCandidateSelector`` —
+gepa-ai/gepa on GitHub).  Naming credit only; see this repo's PR hygiene
+rules against upstream ``file:line`` citations.
+
+HELIX already had the ``"pareto"`` strategy as
+:meth:`helix.population.ParetoFrontier.select_parent`.  This module adds
+the other three GEPA-parity strategies plus a single :func:`select_candidate`
+dispatcher that ``evolution.py`` calls instead of ``frontier.select_parent()``
+directly, keyed off ``config.evolution.candidate_selection_strategy``.
+
+Score-quantity mapping
+-----------------------
+Upstream's four selectors read one of two differently-named per-program
+score arrays off ``GEPAState``:
+
+* ``program_full_scores_val_set`` — read by ``CurrentBestCandidateSelector``
+  and ``EpsilonGreedyCandidateSelector`` via ``idxmax(...)``.
+* ``per_program_tracked_scores`` — read by ``TopKParetoCandidateSelector``
+  for its top-k ranking *and* its empty-mapping fallback, and is the same
+  array ``ParetoCandidateSelector`` passes into
+  ``select_program_candidate_from_pareto_front``.
+
+At the upstream commit this was implemented against, both properties
+happen to be computed with the identical formula (mean of each program's
+validation subscores) — but a ``TODO`` on ``program_full_scores_val_set``
+notes it "should be using the val_evaluation_policy instead", so the two
+are documented as expected to diverge and must not be treated as
+interchangeable by name alone.
+
+HELIX maps each upstream array to the existing HELIX quantity that already
+plays its role, rather than assuming they're the same array:
+
+* ``per_program_tracked_scores`` feeds *both* the Pareto dominance-removal
+  sort key and the top-k ranking upstream. HELIX's own ``ParetoFrontier``
+  already uses ``EvalResult.sum_score()`` for exactly that role (see the
+  "GEPA parity (W1)" comments on ``ParetoFrontier.get_non_dominated`` and
+  ``select_parent`` in ``population.py``). So ``top_k_pareto`` here uses
+  ``sum_score()`` for both its ranking *and* its empty-mapping fallback —
+  matching upstream's reuse of the same local ``scores`` variable for both
+  roles inside ``TopKParetoCandidateSelector.select_candidate_idx``.
+* ``program_full_scores_val_set`` is upstream's "how good is this program
+  overall" figure. The closest existing HELIX quantity, both by name and
+  by mean-based semantics, is ``EvalResult.aggregate_score()`` (HELIX's own
+  docstring: "mean of instance scores"). ``current_best`` and
+  ``epsilon_greedy``'s greedy branch use ``aggregate_score()``.
+
+This split is deliberately exercised by
+``tests/unit/test_candidate_selector.py::TestScoreQuantityMapping``, which
+constructs a pool where ``sum_score()`` and ``aggregate_score()`` argmax
+disagree and asserts each strategy resolves to the quantity above.
+
+Determinism
+-----------
+Every strategy takes the SAME ``random.Random`` instance the caller already
+threads through ``ParetoFrontier`` (see ``evolution.py``'s ``rng =
+random.Random(config.rng_seed)``), so a seeded run stays reproducible
+end-to-end. ``current_best`` never touches ``rng`` — GEPA parity, ``idxmax``
+is a pure argmax. Its tie-break is defined explicitly (see
+:func:`_first_argmax`) rather than left to dict/set iteration order.
+
+Anti-collapse / distinctness
+-----------------------------
+This module deliberately does NOT implement any minimum-distinct-parents
+or anti-collapse guarantee (e.g. forcing P>1 proposals to sample >=2
+distinct parents). That is a separate, still-open design question tracked
+elsewhere. :func:`select_candidate` is a single seam a future distinctness
+layer could wrap without touching the four strategies themselves.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from typing import Literal
+
+from helix.population import Candidate, EvalResult, ParetoFrontier
+
+CandidateSelectionStrategy = Literal[
+    "pareto", "current_best", "epsilon_greedy", "top_k_pareto"
+]
+
+
+def _aggregate_score_or_floor(result: EvalResult | None) -> float:
+    """HELIX analog of upstream's ``program_full_scores_val_set`` entry."""
+    return result.aggregate_score() if result is not None else float("-inf")
+
+
+def _sum_score_or_floor(result: EvalResult | None) -> float:
+    """HELIX analog of upstream's ``per_program_tracked_scores`` entry."""
+    return result.sum_score() if result is not None else float("-inf")
+
+
+def _first_argmax(
+    frontier: ParetoFrontier,
+    score_of: Callable[[EvalResult | None], float],
+) -> Candidate:
+    """GEPA ``idxmax`` parity: first occurrence of the max score wins ties.
+
+    ``idxmax`` is ``lst.index(max(lst))`` over a list indexed by upstream's
+    append-only ``program_candidates`` (discovery order). HELIX's
+    ``ParetoFrontier._candidates`` dict is populated the same way — every
+    ``add()`` call only ever inserts, never reorders — so Python's
+    insertion-order-preserving dict iteration reproduces "first-discovered
+    candidate among the tied leaders" exactly: scan in discovery order,
+    keep only STRICT improvements, so an earlier candidate is never
+    displaced by a later one with an equal score.
+    """
+    best_id: str | None = None
+    best_score = float("-inf")
+    for cid in frontier.candidates:
+        score = score_of(frontier.get_result(cid))
+        if score > best_score:
+            best_score = score
+            best_id = cid
+    assert best_id is not None  # caller guarantees a non-empty frontier
+    return frontier.candidates[best_id]
+
+
+def select_current_best(frontier: ParetoFrontier) -> Candidate:
+    """Deterministic argmax over aggregate validation score.
+
+    GEPA parity: ``CurrentBestCandidateSelector.select_candidate_idx`` ->
+    ``idxmax(state.program_full_scores_val_set)``. No randomness consumed.
+    """
+    if len(frontier) == 0:
+        raise ValueError(
+            "Frontier is empty — cannot select a current-best candidate."
+        )
+    return _first_argmax(frontier, _aggregate_score_or_floor)
+
+
+def select_epsilon_greedy(
+    frontier: ParetoFrontier, rng: random.Random, epsilon: float
+) -> Candidate:
+    """With probability ``epsilon``, pick uniformly from the whole pool.
+
+    GEPA parity: ``EpsilonGreedyCandidateSelector.select_candidate_idx``.
+    The random draw is over the FULL evaluated pool
+    (``rng.randint(0, len(program_candidates) - 1)``), not the Pareto
+    frontier — deliberately not routed through
+    :func:`select_current_best`'s frontier-only machinery. The greedy
+    branch always delegates to :func:`select_current_best` and consumes no
+    extra randomness, matching upstream's ``else: return idxmax(...)``.
+    """
+    if len(frontier) == 0:
+        raise ValueError(
+            "Frontier is empty — cannot select an epsilon-greedy candidate."
+        )
+    if rng.random() < epsilon:
+        ids = list(frontier.candidates.keys())
+        return frontier.candidates[ids[rng.randint(0, len(ids) - 1)]]
+    return select_current_best(frontier)
+
+
+def select_top_k_pareto(
+    frontier: ParetoFrontier, rng: random.Random, k: int
+) -> Candidate:
+    """Pareto draw restricted to the top-``k`` candidates by ``sum_score()``.
+
+    GEPA parity: ``TopKParetoCandidateSelector.select_candidate_idx``:
+
+    1. Rank all evaluated candidates by score (HELIX: ``sum_score()``,
+       see module docstring) descending; ties keep discovery order (a
+       stable sort over an already discovery-ordered id list, matching
+       upstream's stable ``sorted(range(len(scores)), ...)`` over program
+       indices).
+    2. Intersect the top-k id set into every per-key frontier front
+       (:meth:`ParetoFrontier.active_frontier_snapshot`); drop any key
+       whose intersection is empty.
+    3. If EVERY key's intersection is empty, fall back to a direct argmax
+       over the SAME ``sum_score()`` array used for ranking — upstream's
+       fallback reuses its local ``scores`` variable verbatim, not the
+       ``program_full_scores_val_set``/``aggregate_score()`` quantity
+       ``current_best`` uses. That fallback is load-bearing: replicate it
+       exactly, including which score array it reads.
+    4. Otherwise, run the identical dominance-removal + frequency-weighted
+       draw :meth:`ParetoFrontier.select_parent` uses, over the filtered
+       mapping (reusing :meth:`ParetoFrontier._remove_dominated_programs`,
+       the same canonical implementation, rather than re-deriving it).
+
+    When ``k`` covers the whole pool, the top-k intersection can never
+    remove anything — it is mathematically a no-op — so this degrades
+    directly to :meth:`ParetoFrontier.select_parent` (byte-for-byte
+    ``"pareto"`` behaviour) instead of re-deriving an equivalent result
+    through a differently-ordered mapping.
+    """
+    if len(frontier) == 0:
+        raise ValueError(
+            "Frontier is empty — cannot select a top-k-pareto candidate."
+        )
+    if k >= len(frontier):
+        return frontier.select_parent()
+
+    ordered_ids = list(frontier.candidates.keys())
+    scores = {
+        cid: _sum_score_or_floor(frontier.get_result(cid)) for cid in ordered_ids
+    }
+    ranked = sorted(ordered_ids, key=lambda cid: scores[cid], reverse=True)
+    top_k_ids = set(ranked[:k])
+
+    filtered_mapping: dict[str, set[str]] = {}
+    for key, ids in frontier.active_frontier_snapshot().items():
+        filtered = set(ids) & top_k_ids
+        if filtered:
+            filtered_mapping[key] = filtered
+
+    if not filtered_mapping:
+        return _first_argmax(frontier, _sum_score_or_floor)
+
+    _, cleaned = ParetoFrontier._remove_dominated_programs(filtered_mapping, scores)
+    program_frequency: dict[str, int] = {}
+    for front in cleaned.values():
+        for cid in front:
+            program_frequency[cid] = program_frequency.get(cid, 0) + 1
+    sampling_list = [
+        cid for cid, freq in program_frequency.items() for _ in range(freq)
+    ]
+    if not sampling_list:
+        # Unreachable given a non-empty filtered_mapping (the same
+        # invariant ``ParetoFrontier.select_parent`` relies on for its own
+        # non-"instance" path) — guarded so an algorithm change fails
+        # loudly here instead of surfacing as an opaque IndexError from
+        # ``rng.choice([])``.
+        return _first_argmax(frontier, _sum_score_or_floor)
+    return frontier.candidates[rng.choice(sampling_list)]
+
+
+def select_candidate(
+    strategy: CandidateSelectionStrategy,
+    frontier: ParetoFrontier,
+    rng: random.Random,
+    *,
+    epsilon: float | None = None,
+    top_k: int | None = None,
+) -> Candidate:
+    """Dispatch to the configured candidate-selection strategy.
+
+    ``epsilon``/``top_k`` are only read for their matching strategy; HELIX's
+    config layer (``EvolutionConfig.model_post_init``) already guarantees
+    they're set when required, so the asserts here are pure type narrowing.
+    """
+    if strategy == "pareto":
+        return frontier.select_parent()
+    if strategy == "current_best":
+        return select_current_best(frontier)
+    if strategy == "epsilon_greedy":
+        assert epsilon is not None
+        return select_epsilon_greedy(frontier, rng, epsilon)
+    if strategy == "top_k_pareto":
+        assert top_k is not None
+        return select_top_k_pareto(frontier, rng, top_k)
+    raise ValueError(f"Unknown candidate_selection_strategy: {strategy!r}")
+
+
+def select_parents(
+    strategy: CandidateSelectionStrategy,
+    frontier: ParetoFrontier,
+    rng: random.Random,
+    p: int,
+    *,
+    epsilon: float | None = None,
+    top_k: int | None = None,
+) -> list[Candidate]:
+    """Batch seam: draw ``p`` parents, one independent :func:`select_candidate`
+    call each.
+
+    GEPA parity check: upstream's own ``CandidateSelector`` Protocol is
+    scalar (``select_candidate_idx(self, state) -> int``,
+    ``gepa.proposer.reflective_mutation.base``), and every upstream sampling
+    strategy — including ``PxNSampling(p, n)``, the direct analog of
+    HELIX's ``num_parallel_proposals * mutations_per_parent`` — draws its
+    P parents with a plain ``for _ in range(self.p):
+    candidate_selector.select_candidate_idx(state)`` loop
+    (``gepa.strategies.proposal_sampling``). So this default — looping the
+    existing scalar draw ``p`` times — isn't new behaviour; it's the same
+    loop GEPA already runs today, exposed as a batch-shaped HELIX API.
+
+    This exists purely as a seam: a future JOINT allocation strategy (e.g.
+    systematic/low-variance resampling over the frontier's per-key
+    frequency weights, so P parallel draws stop collapsing onto one
+    candidate) can replace this default without HELIX callers needing to
+    change how they call candidate selection. Deliberately NOT implemented
+    here — every strategy above still draws independently with
+    replacement, exactly as upstream GEPA does; see this module's
+    docstring on distinctness. ``evolution.py``'s proposal loop is not
+    migrated to call this: it already performs the equivalent "p
+    sequential scalar draws" inline, interleaved with per-slot budget and
+    minibatch-sampling logic that a batch call can't express without a
+    larger, out-of-scope restructure.
+    """
+    return [
+        select_candidate(strategy, frontier, rng, epsilon=epsilon, top_k=top_k)
+        for _ in range(p)
+    ]

--- a/src/helix/candidate_selector.py
+++ b/src/helix/candidate_selector.py
@@ -5,12 +5,15 @@ Ports the three strategies GEPA implements as ``CurrentBestCandidateSelector``,
 ``gepa.strategies.candidate_selector`` (gepa-ai/gepa). HELIX's own ``"pareto"``
 strategy is unchanged: :func:`select_candidate` delegates it to
 :meth:`helix.population.ParetoFrontier.select_parent`, which ranks by
-``sum_score()``. Which strategy runs is set by
-``config.evolution.candidate_selection_strategy``.
+``aggregate_score()`` — the mean, same as the three ported strategies below.
+What still sets it apart from ``top_k_pareto`` is scope, not ranking metric:
+it runs dominance removal over the whole active frontier, with no top-k
+membership filter narrowing the field first (see :func:`select_top_k_pareto`).
+Which strategy runs is set by ``config.evolution.candidate_selection_strategy``.
 
 Ranking
 -------
-The three ported strategies rank by ``EvalResult.aggregate_score()`` — the mean
+All four strategies rank by ``EvalResult.aggregate_score()`` — the mean
 of a candidate's instance scores — never ``sum_score()``. Both per-program score
 arrays upstream ranks on are means, so the mean is the faithful analogue
 everywhere here. The two quantities disagree whenever candidates carry unequal
@@ -156,9 +159,11 @@ def select_top_k_pareto(
 
     ``k >= len(frontier)`` makes step 2 a no-op on membership, but the full
     path still runs. :meth:`ParetoFrontier.select_parent` is the tempting
-    shortcut and is not equivalent: it feeds ``sum_score()`` into dominance
-    removal, which selects a different candidate whenever candidates carry
-    unequal numbers of scored instances.
+    shortcut and is not equivalent: it runs dominance removal over the whole
+    active frontier with no top-k membership filter, whereas this function
+    first restricts to the top-``k`` candidates by score and intersects that
+    set with the per-key fronts before removing dominated candidates. The two
+    only coincide when that restriction is a no-op, i.e. ``k >= len(frontier)``.
     """
     if len(frontier) == 0:
         raise ValueError(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -501,17 +501,17 @@ class EvolutionConfig(BaseModel):
         default="pareto",
         description=(
             "How to pick the parent candidate for each mutation proposal. "
-            "Naming credit: GEPA's ``gepa.strategies.candidate_selector`` "
-            "(gepa-ai/gepa) implements the same four strategies.\n\n"
-            '- ``"pareto"`` (default): today\'s HELIX behaviour, unchanged '
-            "— frequency-weighted draw over the dominated-stripped per-key "
-            "Pareto frontier (``ParetoFrontier.select_parent``).\n"
+            "The same four strategies GEPA provides in "
+            "``gepa.strategies.candidate_selector`` (gepa-ai/gepa).\n\n"
+            '- ``"pareto"`` (default): frequency-weighted draw over the '
+            "dominated-stripped per-key Pareto frontier "
+            "(``ParetoFrontier.select_parent``).\n"
             '- ``"current_best"``: deterministic argmax over each '
             "candidate's aggregate validation score; ties resolve to the "
             "earliest-discovered candidate.\n"
             '- ``"epsilon_greedy"``: with probability '
             "``candidate_selection_epsilon``, pick uniformly at random from "
-            "the WHOLE evaluated pool (not just the frontier); otherwise "
+            "the whole evaluated pool, not just the frontier; otherwise "
             'fall back to ``"current_best"``.\n'
             '- ``"top_k_pareto"``: restrict the Pareto frontier draw to the '
             "top ``candidate_selection_top_k`` candidates by score; falls "
@@ -525,10 +525,9 @@ class EvolutionConfig(BaseModel):
             "Random-exploration probability for "
             "``candidate_selection_strategy=\"epsilon_greedy\"``; must be "
             "in [0.0, 1.0]. Required for that strategy and rejected for the "
-            "others, where it would have no effect. HELIX requires this to "
-            "be set explicitly rather than silently defaulting — GEPA's "
-            "own ``EpsilonGreedyCandidateSelector`` default is 0.1, noted "
-            "here for reference only."
+            "others, where it would have no effect. There is no default: "
+            "the exploration rate is a search-budget decision and is stated "
+            "per run. GEPA's ``EpsilonGreedyCandidateSelector`` uses 0.1."
         ),
     )
     candidate_selection_top_k: int | None = Field(
@@ -538,10 +537,10 @@ class EvolutionConfig(BaseModel):
             "``candidate_selection_strategy=\"top_k_pareto\"``: only the "
             "top-K candidates by score are eligible for the Pareto "
             "frontier draw. Required for that strategy (must be >= 1) and "
-            "rejected for the others, where it would have no effect. HELIX "
-            "requires this to be set explicitly rather than silently "
-            "defaulting — GEPA's own ``TopKParetoCandidateSelector`` "
-            "default is 5, noted here for reference only."
+            "rejected for the others, where it would have no effect. There "
+            "is no default: K trades exploration against exploitation and "
+            "is stated per run. GEPA's ``TopKParetoCandidateSelector`` "
+            "uses 5."
         ),
     )
 

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -495,6 +495,55 @@ class EvolutionConfig(BaseModel):
             "falling back to scalar semantics."
         ),
     )
+    candidate_selection_strategy: Literal[
+        "pareto", "current_best", "epsilon_greedy", "top_k_pareto"
+    ] = Field(
+        default="pareto",
+        description=(
+            "How to pick the parent candidate for each mutation proposal. "
+            "Naming credit: GEPA's ``gepa.strategies.candidate_selector`` "
+            "(gepa-ai/gepa) implements the same four strategies.\n\n"
+            '- ``"pareto"`` (default): today\'s HELIX behaviour, unchanged '
+            "— frequency-weighted draw over the dominated-stripped per-key "
+            "Pareto frontier (``ParetoFrontier.select_parent``).\n"
+            '- ``"current_best"``: deterministic argmax over each '
+            "candidate's aggregate validation score; ties resolve to the "
+            "earliest-discovered candidate.\n"
+            '- ``"epsilon_greedy"``: with probability '
+            "``candidate_selection_epsilon``, pick uniformly at random from "
+            "the WHOLE evaluated pool (not just the frontier); otherwise "
+            'fall back to ``"current_best"``.\n'
+            '- ``"top_k_pareto"``: restrict the Pareto frontier draw to the '
+            "top ``candidate_selection_top_k`` candidates by score; falls "
+            "back to a direct argmax when that restriction empties every "
+            "frontier key."
+        ),
+    )
+    candidate_selection_epsilon: float | None = Field(
+        default=None,
+        description=(
+            "Random-exploration probability for "
+            "``candidate_selection_strategy=\"epsilon_greedy\"``; must be "
+            "in [0.0, 1.0]. Required for that strategy and rejected for the "
+            "others, where it would have no effect. HELIX requires this to "
+            "be set explicitly rather than silently defaulting — GEPA's "
+            "own ``EpsilonGreedyCandidateSelector`` default is 0.1, noted "
+            "here for reference only."
+        ),
+    )
+    candidate_selection_top_k: int | None = Field(
+        default=None,
+        description=(
+            "Pool size for "
+            "``candidate_selection_strategy=\"top_k_pareto\"``: only the "
+            "top-K candidates by score are eligible for the Pareto "
+            "frontier draw. Required for that strategy (must be >= 1) and "
+            "rejected for the others, where it would have no effect. HELIX "
+            "requires this to be set explicitly rather than silently "
+            "defaulting — GEPA's own ``TopKParetoCandidateSelector`` "
+            "default is 5, noted here for reference only."
+        ),
+    )
 
     def model_post_init(self, __context: object) -> None:
         if self.max_workers < 1:
@@ -564,6 +613,43 @@ class EvolutionConfig(BaseModel):
             raise ValueError(
                 "evolution.num_sampled_groups and evolution.num_examples_per_group "
                 "must be set together"
+            )
+        if self.candidate_selection_strategy == "epsilon_greedy":
+            if self.candidate_selection_epsilon is None:
+                raise ValueError(
+                    "evolution.candidate_selection_epsilon is required when "
+                    "evolution.candidate_selection_strategy='epsilon_greedy'"
+                )
+            if not 0.0 <= self.candidate_selection_epsilon <= 1.0:
+                raise ValueError(
+                    "evolution.candidate_selection_epsilon must be between "
+                    "0.0 and 1.0 "
+                    f"(got {self.candidate_selection_epsilon})"
+                )
+        elif self.candidate_selection_epsilon is not None:
+            raise ValueError(
+                "evolution.candidate_selection_epsilon is only valid when "
+                "evolution.candidate_selection_strategy='epsilon_greedy' "
+                "(got candidate_selection_strategy="
+                f"{self.candidate_selection_strategy!r})"
+            )
+        if self.candidate_selection_strategy == "top_k_pareto":
+            if self.candidate_selection_top_k is None:
+                raise ValueError(
+                    "evolution.candidate_selection_top_k is required when "
+                    "evolution.candidate_selection_strategy='top_k_pareto'"
+                )
+            if self.candidate_selection_top_k < 1:
+                raise ValueError(
+                    "evolution.candidate_selection_top_k must be >= 1 "
+                    f"(got {self.candidate_selection_top_k})"
+                )
+        elif self.candidate_selection_top_k is not None:
+            raise ValueError(
+                "evolution.candidate_selection_top_k is only valid when "
+                "evolution.candidate_selection_strategy='top_k_pareto' "
+                "(got candidate_selection_strategy="
+                f"{self.candidate_selection_strategy!r})"
             )
         if self.num_sampled_groups is not None and self.batch_sampler != "stratified":
             raise ValueError(

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -25,6 +25,7 @@ from helix.batch_sampler import (
     StratifiedBatchSampler,
 )
 from helix import budget as budget_api
+from helix.candidate_selector import select_candidate
 from helix.config import HelixConfig, load_dataset_examples
 from helix.eval_cache import EvaluationCache as MinibatchEvalCache
 from helix.eval_policy import (
@@ -1301,6 +1302,7 @@ def _plan_proposals(
     config: HelixConfig,
     state: EvolutionState,
     frontier: ParetoFrontier,
+    rng: _random.Random,
     batch_sampler: "BatchSampler[str] | None",
     train_loader: "HelixDataLoader | _RangeDataLoader | None",
     use_minibatch_gate: bool,
@@ -1382,7 +1384,13 @@ def _plan_proposals(
                 )
 
             if parent is None:
-                parent = frontier.select_parent()
+                parent = select_candidate(
+                    config.evolution.candidate_selection_strategy,
+                    frontier,
+                    rng,
+                    epsilon=config.evolution.candidate_selection_epsilon,
+                    top_k=config.evolution.candidate_selection_top_k,
+                )
                 parent_frontier_result = frontier._results.get(parent.id)
 
             # --- Minibatch gate pre-sampling -----------------------------
@@ -2674,6 +2682,7 @@ def _run_evolution_impl(
             presample_contexts, _budget_break = _plan_proposals(
                 config=config,
                 state=state,
+                rng=rng,
                 frontier=frontier,
                 batch_sampler=batch_sampler,
                 train_loader=train_loader,

--- a/tests/unit/test_candidate_selector.py
+++ b/tests/unit/test_candidate_selector.py
@@ -177,21 +177,32 @@ class TestTopKPareto:
         # k larger than the pool must degrade cleanly too.
         assert select_top_k_pareto(frontier, random.Random(0), 99).id == "only"
 
-    def test_k_greater_equal_pool_uses_mean_pareto_not_legacy_sum_pareto(self):
-        """k >= pool size is not equivalent to the legacy ``pareto`` strategy.
+    def test_k_greater_equal_pool_still_ranks_by_mean_not_sum(self):
+        """``k >= len(frontier)`` makes the top-k membership filter a no-op,
+        so this pins that the ranking step itself — separate from that
+        filter — stays mean-based even when it is the only thing left doing
+        any work.
 
-        The top-k membership filter becomes a no-op, but ``select_parent``
-        feeds ``sum_score()`` into dominance removal while this function reads
-        ``aggregate_score()`` throughout. The pool is built so they disagree:
+        This no longer distinguishes this function from
+        ``ParetoFrontier.select_parent``: that method has also ranked by
+        ``aggregate_score()`` since ``fix/default-parent-selection``, and
+        with the membership filter a no-op the two run dominance removal
+        over the identical mapping with the identical scores, producing an
+        identical eligible set with identical frequency weights (verified
+        directly, not just by matching outcomes over repeated draws;
+        ``select_parent`` draws from its own internal RNG rather than the
+        one passed here, so exact draw sequences do not compare). This test
+        now only guards against a regression to sum-based ranking within
+        this function's own ranking step.
 
             a  {i1: 1.0}                agg=1.00  sum=1.00  (wins i1)
             b  {i1: 1.0, i2: 0.9}       agg=0.95  sum=1.90  (wins nothing)
             c  {i2: 1.0}                agg=1.00  sum=1.00  (wins i2)
 
         By mean, "b" is dominated by "a" on i1's front and never survives
-        dominance removal, leaving only "a" and "c". By sum, "b" survives and
-        even displaces "a" from i1's cleaned front. So "b" appearing in the
-        draw means a sum-based path ran.
+        dominance removal, leaving only "a" and "c". By sum, "b" would
+        survive and even displace "a" from i1's cleaned front, so "b"
+        appearing in the draw would mean the ranking regressed to sum.
         """
         frontier = ParetoFrontier()
         add(frontier, "a", {"i1": 1.0})
@@ -212,15 +223,16 @@ class TestTopKPareto:
         assert seen2 == {"a", "c"}
         assert "b" not in seen2
 
-    def test_k_greater_equal_pool_mean_path_holds_under_seed_1(self):
-        """Seed-specific guard against a ``k >= len(frontier)`` shortcut to
-        ``ParetoFrontier.select_parent()``.
+    def test_k_greater_equal_pool_mean_ranking_holds_under_seed_1(self):
+        """Seed-specific companion to
+        ``test_k_greater_equal_pool_still_ranks_by_mean_not_sum``.
 
-        Under ``Random(1)`` that sum-based shortcut selects "b" at ``k=3``,
-        which the mean path cannot (see
-        ``test_k_greater_equal_pool_uses_mean_pareto_not_legacy_sum_pareto``
-        for the dominance trace). Pinned separately because the seed is what
-        makes the difference observable.
+        "b" is dominated out of the sampling list under mean ranking
+        regardless of RNG seed — a sum-based ranking would instead let "b"
+        survive and become drawable — so this pins that guarantee under a
+        second, independently chosen seed. Pinned separately because a
+        single seed's draws could coincidentally avoid "b" even if a
+        sum-based regression made it selectable again.
         """
         frontier = ParetoFrontier()
         add(frontier, "a", {"i1": 1.0})

--- a/tests/unit/test_candidate_selector.py
+++ b/tests/unit/test_candidate_selector.py
@@ -15,7 +15,6 @@ from helix.candidate_selector import (
     select_candidate,
     select_current_best,
     select_epsilon_greedy,
-    select_parents,
     select_top_k_pareto,
 )
 from helix.population import Candidate, EvalResult, ParetoFrontier
@@ -197,10 +196,10 @@ class TestTopKPareto:
         add(frontier_c, "c", {"i1": 0.5, "i2": 0.5})
         assert select_top_k_pareto(frontier_c, frontier_c._rng, 100).id == expected
 
-    def test_ranks_by_sum_score_and_intersects_per_key_fronts(self):
+    def test_ranks_by_mean_score_and_intersects_per_key_fronts(self):
         """Hand-built frontier: A/B/D each own one key; only A/B survive a
-        top-2 filter by sum_score, so D's key must be dropped and the draw
-        must never return D."""
+        top-2 filter by aggregate_score, so D's key must be dropped and the
+        draw must never return D."""
         frontier = ParetoFrontier()
         add(frontier, "a", {"i1": 1.0})  # sum=1.0, wins i1
         add(frontier, "b", {"i2": 1.0})  # sum=1.0, wins i2
@@ -210,26 +209,54 @@ class TestTopKPareto:
         assert seen == {"a", "b"}
         assert "d" not in seen
 
-    def test_empty_filtered_mapping_falls_back_to_sum_score_argmax(self):
-        """A, B, D each win exactly one key. X wins its own unique key with
-        a high aggregate but low sum. Y never wins any key but has the
-        highest SUM overall (two near-misses beat two clean wins + a lone
-        low-sum win). For k=1, top-1-by-sum is Y alone; intersecting Y into
-        every per-key front empties all of them, forcing the fallback.
+    def test_empty_filtered_mapping_falls_back_to_mean_score_argmax(self):
+        """Y has the highest MEAN but wins no per-key front, so a top-1
+        filter empties every front and forces the fallback.
 
-        The fallback must be sum_score()-argmax, not aggregate_score()
-        argmax: aggregate_score() ranks A/B/D (agg=1.0 each, tied) above Y
-        (agg=0.9), so a fallback that mistakenly used aggregate_score would
-        return the tie-break winner "a" instead of "y".
+        A owns key i1 outright (1.0) but carries a 0.0 on i2 that drags its
+        mean to 0.5; B takes i2 with 0.6; Y scores 0.9 on i1 alone — a clean
+        loss on the only key it touches, but the best mean in the pool.
+
+        Both the ranking and the fallback must read aggregate_score(). A
+        sum_score() implementation returns "a" twice over: sums are
+        a=1.0 > y=0.9 > b=0.6, so top-1-by-sum is A, whose front is
+        non-empty, and the draw returns A without ever reaching the
+        fallback. Asserting "y" therefore pins mean semantics end to end.
         """
         frontier = ParetoFrontier()
-        add(frontier, "a", {"i1": 1.0})  # sum=1.0 agg=1.0, wins i1
-        add(frontier, "b", {"i2": 1.0})  # sum=1.0 agg=1.0, wins i2
-        add(frontier, "d", {"i3": 1.0})  # sum=1.0 agg=1.0, wins i3
-        add(frontier, "x", {"i9": 0.99})  # sum=0.99 agg=0.99, wins i9
-        add(frontier, "y", {"i1": 0.9, "i2": 0.9})  # sum=1.8 agg=0.9, wins nothing
+        add(frontier, "a", {"i1": 1.0, "i2": 0.0})  # agg=0.5 sum=1.0, wins i1
+        add(frontier, "b", {"i2": 0.6})  # agg=0.6 sum=0.6, takes i2
+        add(frontier, "y", {"i1": 0.9})  # agg=0.9 sum=0.9, wins nothing
         rng = random.Random(0)
         assert select_top_k_pareto(frontier, rng, 1).id == "y"
+
+    def test_ranking_uses_mean_not_sum_when_cardinality_differs(self):
+        """Regression guard for the sum-vs-mean mapping defect.
+
+        Upstream ranks top-K by ``per_program_tracked_scores``, which is a
+        MEAN (``get_program_average_val_subset`` -> ``sum(...)/num_samples``).
+        Sum and mean only disagree when candidates have unequal numbers of
+        scored instances, so this pool gives Y two instances and everyone
+        else one:
+
+            a/b/d  agg=1.00  sum=1.00   (each owns one key)
+            x      agg=0.99  sum=0.99   (owns its own key)
+            y      agg=0.90  sum=1.80   (wins nothing)
+
+        Top-1 by MEAN is "a" (first among the three tied at 1.0), whose
+        front survives the intersection, so the draw returns "a".
+        Top-1 by SUM would be "y", which owns no key — that empties the
+        filtered mapping and the sum fallback yields "y". The two rankings
+        disagree on the returned candidate, which is exactly the defect.
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "a", {"i1": 1.0})
+        add(frontier, "b", {"i2": 1.0})
+        add(frontier, "d", {"i3": 1.0})
+        add(frontier, "x", {"i9": 0.99})
+        add(frontier, "y", {"i1": 0.9, "i2": 0.9})
+        rng = random.Random(0)
+        assert select_top_k_pareto(frontier, rng, 1).id == "a"
 
 
 # ---------------------------------------------------------------------------
@@ -291,29 +318,3 @@ class TestSeededReproducibility:
         # does) diverge — otherwise the test would trivially pass even if
         # the rng were ignored entirely.
         assert run(999) != seq_a
-
-    def test_select_parents_matches_looped_select_candidate(self):
-        """select_parents(p) must be byte-identical to calling
-        select_candidate() p times with the same shared rng (GEPA parity:
-        PxNSampling's ``for _ in range(p): select_candidate_idx(state)``).
-        """
-        frontier_a = ParetoFrontier()
-        frontier_b = ParetoFrontier()
-        self._build_pool(frontier_a)
-        self._build_pool(frontier_b)
-        rng_a = random.Random(5)
-        rng_b = random.Random(5)
-
-        batched = select_parents(
-            "epsilon_greedy", frontier_a, rng_a, 6, epsilon=0.5
-        )
-        looped = [
-            select_candidate("epsilon_greedy", frontier_b, rng_b, epsilon=0.5)
-            for _ in range(6)
-        ]
-        assert [c.id for c in batched] == [c.id for c in looped]
-
-    def test_select_parents_empty_batch(self):
-        frontier = ParetoFrontier()
-        add(frontier, "only", {"i1": 0.5})
-        assert select_parents("current_best", frontier, random.Random(0), 0) == []

--- a/tests/unit/test_candidate_selector.py
+++ b/tests/unit/test_candidate_selector.py
@@ -297,6 +297,71 @@ class TestTopKPareto:
 
 
 # ---------------------------------------------------------------------------
+# Empty-result floor (-inf, not 0.0) — reviewer-verified blocker
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyResultFloor:
+    """An unscored candidate (``instance_scores == {}``) must rank BELOW
+    every scored candidate, including one with a negative mean — matching
+    upstream ``get_program_average_val_subset``'s ``float("-inf")`` for a
+    program with no recorded subscores. ``EvalResult.aggregate_score()``
+    itself returns ``0.0`` for that case (by design, for other callers), so
+    an unfloored selector wrongly ranks "unscored" above "scored but bad".
+    """
+
+    def test_current_best_prefers_negative_mean_over_empty(self):
+        """Reviewer repro: empty:{} vs negative:{'x': -0.25}. Upstream's
+        equivalent scores are [-inf, -0.25], so upstream picks 'negative'.
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "empty", {})
+        add(frontier, "negative", {"x": -0.25})
+        assert select_current_best(frontier).id == "negative"
+
+    def test_top_k_pareto_ranking_never_lets_empty_bump_a_negative_score(self):
+        """'negative' and 'positive' each own a distinct per-key front;
+        'empty' owns none. A top-2 ranking that floors 'empty' at -inf must
+        keep BOTH real candidates' fronts alive. An unfloored ranking (0.0
+        beats -0.25) instead lets 'empty' displace 'negative' out of the
+        top-2, which drops negative's only front and leaves 'positive' as
+        the sole, deterministic winner.
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "negative", {"i1": -0.25})
+        add(frontier, "positive", {"i2": 0.5})
+        add(frontier, "empty", {})
+        rng = random.Random(11)
+        seen = {select_top_k_pareto(frontier, rng, 2).id for _ in range(100)}
+        assert seen == {"negative", "positive"}
+        assert "empty" not in seen
+
+    def test_top_k_pareto_fallback_prefers_negative_mean_over_empty(self):
+        """Forces the empty-filtered-mapping fallback (neither the
+        top-ranked real candidate nor 'empty' owns a front: 'dominator' has
+        the worse mean but wins the only key either of them touches), then
+        asserts the fallback argmax floors 'empty' below 'negative'.
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "negative", {"i1": -0.1})
+        add(frontier, "dominator", {"i1": 0.0, "i2": -0.9})  # wins i1, mean -0.45
+        add(frontier, "empty", {})
+        assert select_top_k_pareto(frontier, random.Random(0), 1).id == "negative"
+
+    def test_all_empty_pool_returns_first_discovered_not_none_or_raise(self):
+        """Proves ``_first_argmax`` takes its first candidate
+        unconditionally: once every candidate floors to the SAME -inf, a
+        pure strict-improvement scan never satisfies ``score > best_score``
+        for any candidate and would leave ``best_id`` unset.
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "first", {})
+        add(frontier, "second", {})
+        add(frontier, "third", {})
+        assert select_current_best(frontier).id == "first"
+
+
+# ---------------------------------------------------------------------------
 # select_candidate dispatcher
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_candidate_selector.py
+++ b/tests/unit/test_candidate_selector.py
@@ -145,7 +145,7 @@ class TestEpsilonGreedy:
         seen = {select_epsilon_greedy(frontier, rng, 1.0).id for _ in range(200)}
         assert seen == {"dominator", "dominated"}
 
-    def test_epsilon_one_never_consumes_extra_randomness_on_greedy_path(self):
+    def test_epsilon_zero_never_consumes_extra_randomness_on_greedy_path(self):
         """Greedy branch (else) must not draw from rng — only the coin-flip
         draw is consumed when the random branch isn't taken."""
         frontier = ParetoFrontier()
@@ -174,27 +174,64 @@ class TestTopKPareto:
         # k larger than the pool must degrade cleanly too.
         assert select_top_k_pareto(frontier, random.Random(0), 99).id == "only"
 
-    def test_k_greater_equal_pool_matches_pareto(self):
-        """k >= pool size makes the top-k filter a mathematical no-op, so
-        this must reduce exactly to ``pareto`` (frontier.select_parent()),
-        including its exact rng draw for a given seed."""
-        frontier_a = ParetoFrontier(rng=random.Random(42))
-        frontier_b = ParetoFrontier(rng=random.Random(42))
-        for f in (frontier_a, frontier_b):
-            add(f, "a", {"i1": 1.0, "i2": 0.2})
-            add(f, "b", {"i1": 0.2, "i2": 1.0})
-            add(f, "c", {"i1": 0.5, "i2": 0.5})
+    def test_k_greater_equal_pool_uses_mean_pareto_not_legacy_sum_pareto(self):
+        """k >= pool size makes the top-k *membership* filter a no-op, but
+        that must NOT be read as "reduces to legacy `pareto`" — legacy
+        `pareto` (``ParetoFrontier.select_parent``) feeds ``sum_score()``
+        into dominance removal, while every other read in this function
+        uses ``aggregate_score()`` (the mean). The two diverge whenever
+        candidates carry unequal numbers of scored instances, which this
+        pool is built to do:
 
-        expected = frontier_a.select_parent().id
-        got = select_top_k_pareto(frontier_b, frontier_b._rng, 3)
-        assert got.id == expected
+            a  {i1: 1.0}                agg=1.00  sum=1.00  (wins i1)
+            b  {i1: 1.0, i2: 0.9}       agg=0.95  sum=1.90  (wins nothing)
+            c  {i2: 1.0}                agg=1.00  sum=1.00  (wins i2)
 
-        # k strictly larger than the pool degrades the same way.
-        frontier_c = ParetoFrontier(rng=random.Random(42))
-        add(frontier_c, "a", {"i1": 1.0, "i2": 0.2})
-        add(frontier_c, "b", {"i1": 0.2, "i2": 1.0})
-        add(frontier_c, "c", {"i1": 0.5, "i2": 0.5})
-        assert select_top_k_pareto(frontier_c, frontier_c._rng, 100).id == expected
+        By MEAN, "b" (agg=0.95) is dominated by "a" on i1's front and never
+        survives dominance removal — only "a"/"c" (tied at agg=1.00) can be
+        drawn. By SUM, "b" (sum=1.90) survives and even displaces "a" from
+        i1's cleaned front (see ``TestTopKPareto`` module docstring context
+        / the sibling regression test below for the full trace). So at
+        k == len(frontier) == 3, "b" must never be selected — confirming
+        the mean path ran, not a sum-based shortcut.
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "a", {"i1": 1.0})
+        add(frontier, "b", {"i1": 1.0, "i2": 0.9})
+        add(frontier, "c", {"i2": 1.0})
+        rng = random.Random(5)
+        seen = {select_top_k_pareto(frontier, rng, 3).id for _ in range(200)}
+        assert seen == {"a", "c"}
+        assert "b" not in seen
+
+        # k strictly larger than the pool must behave identically.
+        frontier2 = ParetoFrontier()
+        add(frontier2, "a", {"i1": 1.0})
+        add(frontier2, "b", {"i1": 1.0, "i2": 0.9})
+        add(frontier2, "c", {"i2": 1.0})
+        rng2 = random.Random(5)
+        seen2 = {select_top_k_pareto(frontier2, rng2, 100).id for _ in range(200)}
+        assert seen2 == {"a", "c"}
+        assert "b" not in seen2
+
+    def test_k_greater_equal_pool_regression_reviewer_counterexample(self):
+        """Regression guard for the exact counterexample that caught the
+        ``k >= len(frontier): return frontier.select_parent()`` shortcut
+        bug: with ``Random(1)`` seeding the shared frontier rng, the buggy
+        shortcut (sum-based ``ParetoFrontier.select_parent()``) selected
+        "b" at ``k=3``. The mean-based normal path cannot select "b" here
+        (see ``test_k_greater_equal_pool_uses_mean_pareto_not_legacy_sum_pareto``
+        for the full dominance trace) — pin that with the exact seed that
+        exposed the bug.
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "a", {"i1": 1.0})
+        add(frontier, "b", {"i1": 1.0, "i2": 0.9})
+        add(frontier, "c", {"i2": 1.0})
+        rng = random.Random(1)
+        seen = {select_top_k_pareto(frontier, rng, 3).id for _ in range(50)}
+        assert "b" not in seen
+        assert seen == {"a", "c"}
 
     def test_ranks_by_mean_score_and_intersects_per_key_fronts(self):
         """Hand-built frontier: A/B/D each own one key; only A/B survive a

--- a/tests/unit/test_candidate_selector.py
+++ b/tests/unit/test_candidate_selector.py
@@ -1,8 +1,7 @@
 """Unit tests for helix.candidate_selector — GEPA-parity selection strategies.
 
-Companion to tests/unit/test_population.py (which exercises the pre-existing
-``pareto`` strategy via ``ParetoFrontier.select_parent`` directly and is left
-untouched by this PR).
+Companion to tests/unit/test_population.py, which covers the ``pareto``
+strategy through ``ParetoFrontier.select_parent`` directly.
 """
 
 from __future__ import annotations
@@ -72,24 +71,24 @@ class TestCurrentBest:
         assert select_current_best(frontier).id == "strong"
 
     def test_uses_aggregate_not_sum_score(self):
-        """current_best's HELIX analog is aggregate_score() (mean), not
-        sum_score(). X has fewer, better-average instances; Y has more,
-        worse-average instances but a higher sum. current_best must pick X.
+        """current_best ranks by aggregate_score() (mean), not sum_score().
+
+        X has fewer, better-average instances; Y has more, worse-average
+        instances but a higher sum, so the two rankings disagree here.
         """
         frontier = ParetoFrontier()
         add(frontier, "X", {"i1": 0.9})  # sum=0.9, agg=0.9
         add(frontier, "Y", {"i1": 0.5, "i2": 0.5, "i3": 0.5, "i4": 0.5})  # sum=2.0, agg=0.5
         assert select_current_best(frontier).id == "X"
-        # Sanity: sum_score would have picked Y, proving the two quantities
-        # genuinely disagree on this pool.
+        # sum_score would have picked Y — the two quantities disagree here.
         result_x = frontier.get_result("X")
         result_y = frontier.get_result("Y")
         assert result_x is not None and result_y is not None
         assert result_y.sum_score() > result_x.sum_score()
 
     def test_tie_break_is_earliest_discovered(self):
-        """Ties resolve to the earliest-added candidate (GEPA idxmax parity:
-        ``lst.index(max(lst))`` returns the FIRST index achieving the max).
+        """Ties resolve to the earliest-added candidate, matching GEPA's
+        ``idxmax`` (``lst.index(max(lst))`` returns the first index at the max).
         """
         frontier = ParetoFrontier()
         add(frontier, "first", {"i1": 1.0})
@@ -132,11 +131,11 @@ class TestEpsilonGreedy:
             assert select_epsilon_greedy(frontier, rng, 0.0).id == "strong"
 
     def test_epsilon_one_is_always_uniform_over_whole_pool(self):
-        """epsilon=1.0 always takes the random branch (rng.random() < 1.0 is
-        always true) and draws from the WHOLE pool, not the Pareto frontier.
-        Build a pool where a candidate is dominated on every key (so it
-        would never be drawn by "pareto") and confirm it can still be
-        picked here.
+        """epsilon=1.0 always takes the random branch, which draws from the
+        whole pool rather than the Pareto frontier.
+
+        "dominated" loses on every key, so the "pareto" strategy would never
+        draw it; epsilon-greedy exploration still can.
         """
         frontier = ParetoFrontier()
         add(frontier, "dominator", {"i1": 1.0, "i2": 1.0})
@@ -175,25 +174,20 @@ class TestTopKPareto:
         assert select_top_k_pareto(frontier, random.Random(0), 99).id == "only"
 
     def test_k_greater_equal_pool_uses_mean_pareto_not_legacy_sum_pareto(self):
-        """k >= pool size makes the top-k *membership* filter a no-op, but
-        that must NOT be read as "reduces to legacy `pareto`" — legacy
-        `pareto` (``ParetoFrontier.select_parent``) feeds ``sum_score()``
-        into dominance removal, while every other read in this function
-        uses ``aggregate_score()`` (the mean). The two diverge whenever
-        candidates carry unequal numbers of scored instances, which this
-        pool is built to do:
+        """k >= pool size is not equivalent to the legacy ``pareto`` strategy.
+
+        The top-k membership filter becomes a no-op, but ``select_parent``
+        feeds ``sum_score()`` into dominance removal while this function reads
+        ``aggregate_score()`` throughout. The pool is built so they disagree:
 
             a  {i1: 1.0}                agg=1.00  sum=1.00  (wins i1)
             b  {i1: 1.0, i2: 0.9}       agg=0.95  sum=1.90  (wins nothing)
             c  {i2: 1.0}                agg=1.00  sum=1.00  (wins i2)
 
-        By MEAN, "b" (agg=0.95) is dominated by "a" on i1's front and never
-        survives dominance removal — only "a"/"c" (tied at agg=1.00) can be
-        drawn. By SUM, "b" (sum=1.90) survives and even displaces "a" from
-        i1's cleaned front (see ``TestTopKPareto`` module docstring context
-        / the sibling regression test below for the full trace). So at
-        k == len(frontier) == 3, "b" must never be selected — confirming
-        the mean path ran, not a sum-based shortcut.
+        By mean, "b" is dominated by "a" on i1's front and never survives
+        dominance removal, leaving only "a" and "c". By sum, "b" survives and
+        even displaces "a" from i1's cleaned front. So "b" appearing in the
+        draw means a sum-based path ran.
         """
         frontier = ParetoFrontier()
         add(frontier, "a", {"i1": 1.0})
@@ -214,15 +208,15 @@ class TestTopKPareto:
         assert seen2 == {"a", "c"}
         assert "b" not in seen2
 
-    def test_k_greater_equal_pool_regression_reviewer_counterexample(self):
-        """Regression guard for the exact counterexample that caught the
-        ``k >= len(frontier): return frontier.select_parent()`` shortcut
-        bug: with ``Random(1)`` seeding the shared frontier rng, the buggy
-        shortcut (sum-based ``ParetoFrontier.select_parent()``) selected
-        "b" at ``k=3``. The mean-based normal path cannot select "b" here
-        (see ``test_k_greater_equal_pool_uses_mean_pareto_not_legacy_sum_pareto``
-        for the full dominance trace) — pin that with the exact seed that
-        exposed the bug.
+    def test_k_greater_equal_pool_mean_path_holds_under_seed_1(self):
+        """Seed-specific guard against a ``k >= len(frontier)`` shortcut to
+        ``ParetoFrontier.select_parent()``.
+
+        Under ``Random(1)`` that sum-based shortcut selects "b" at ``k=3``,
+        which the mean path cannot (see
+        ``test_k_greater_equal_pool_uses_mean_pareto_not_legacy_sum_pareto``
+        for the dominance trace). Pinned separately because the seed is what
+        makes the difference observable.
         """
         frontier = ParetoFrontier()
         add(frontier, "a", {"i1": 1.0})
@@ -234,9 +228,8 @@ class TestTopKPareto:
         assert seen == {"a", "c"}
 
     def test_ranks_by_mean_score_and_intersects_per_key_fronts(self):
-        """Hand-built frontier: A/B/D each own one key; only A/B survive a
-        top-2 filter by aggregate_score, so D's key must be dropped and the
-        draw must never return D."""
+        """A/B/D each own one key, but only A/B survive a top-2 filter by
+        aggregate_score, so D's key is dropped and D is never drawn."""
         frontier = ParetoFrontier()
         add(frontier, "a", {"i1": 1.0})  # sum=1.0, wins i1
         add(frontier, "b", {"i2": 1.0})  # sum=1.0, wins i2
@@ -254,10 +247,9 @@ class TestTopKPareto:
         mean to 0.5; B takes i2 with 0.6; Y scores 0.9 on i1 alone — a clean
         loss on the only key it touches, but the best mean in the pool.
 
-        Both the ranking and the fallback must read aggregate_score(). A
-        sum_score() implementation returns "a" twice over: sums are
-        a=1.0 > y=0.9 > b=0.6, so top-1-by-sum is A, whose front is
-        non-empty, and the draw returns A without ever reaching the
+        Both the ranking and the fallback read aggregate_score(). Under
+        sum_score() the sums are a=1.0 > y=0.9 > b=0.6, so top-1-by-sum is A,
+        whose front is non-empty, and the draw returns A without reaching the
         fallback. Asserting "y" therefore pins mean semantics end to end.
         """
         frontier = ParetoFrontier()
@@ -268,23 +260,21 @@ class TestTopKPareto:
         assert select_top_k_pareto(frontier, rng, 1).id == "y"
 
     def test_ranking_uses_mean_not_sum_when_cardinality_differs(self):
-        """Regression guard for the sum-vs-mean mapping defect.
+        """Top-k ranking reads the mean, not the sum.
 
-        Upstream ranks top-K by ``per_program_tracked_scores``, which is a
-        MEAN (``get_program_average_val_subset`` -> ``sum(...)/num_samples``).
-        Sum and mean only disagree when candidates have unequal numbers of
-        scored instances, so this pool gives Y two instances and everyone
-        else one:
+        Upstream ranks top-K by ``per_program_tracked_scores``, a mean
+        (``get_program_average_val_subset`` -> ``sum(...)/num_samples``). Sum
+        and mean only disagree when candidates have unequal numbers of scored
+        instances, so this pool gives Y two instances and everyone else one:
 
             a/b/d  agg=1.00  sum=1.00   (each owns one key)
             x      agg=0.99  sum=0.99   (owns its own key)
             y      agg=0.90  sum=1.80   (wins nothing)
 
-        Top-1 by MEAN is "a" (first among the three tied at 1.0), whose
-        front survives the intersection, so the draw returns "a".
-        Top-1 by SUM would be "y", which owns no key — that empties the
-        filtered mapping and the sum fallback yields "y". The two rankings
-        disagree on the returned candidate, which is exactly the defect.
+        Top-1 by mean is "a" (first among the three tied at 1.0), whose front
+        survives the intersection, so the draw returns "a". Top-1 by sum would
+        be "y", which owns no key — that empties the filtered mapping and the
+        fallback yields "y". The two rankings return different candidates.
         """
         frontier = ParetoFrontier()
         add(frontier, "a", {"i1": 1.0})
@@ -297,22 +287,22 @@ class TestTopKPareto:
 
 
 # ---------------------------------------------------------------------------
-# Empty-result floor (-inf, not 0.0) — reviewer-verified blocker
+# Empty-result floor (-inf, not 0.0)
 # ---------------------------------------------------------------------------
 
 
 class TestEmptyResultFloor:
-    """An unscored candidate (``instance_scores == {}``) must rank BELOW
-    every scored candidate, including one with a negative mean — matching
-    upstream ``get_program_average_val_subset``'s ``float("-inf")`` for a
-    program with no recorded subscores. ``EvalResult.aggregate_score()``
-    itself returns ``0.0`` for that case (by design, for other callers), so
-    an unfloored selector wrongly ranks "unscored" above "scored but bad".
+    """An unscored candidate (``instance_scores == {}``) ranks below every
+    scored candidate, including one with a negative mean — matching upstream
+    ``get_program_average_val_subset``'s ``float("-inf")`` for a program with
+    no recorded subscores. ``EvalResult.aggregate_score()`` returns ``0.0``
+    there, by design and for other callers, so an unfloored selector would
+    rank "unscored" above "scored but bad".
     """
 
     def test_current_best_prefers_negative_mean_over_empty(self):
-        """Reviewer repro: empty:{} vs negative:{'x': -0.25}. Upstream's
-        equivalent scores are [-inf, -0.25], so upstream picks 'negative'.
+        """empty:{} vs negative:{'x': -0.25}. The upstream-equivalent scores
+        are [-inf, -0.25], so 'negative' wins.
         """
         frontier = ParetoFrontier()
         add(frontier, "empty", {})
@@ -321,11 +311,11 @@ class TestEmptyResultFloor:
 
     def test_top_k_pareto_ranking_never_lets_empty_bump_a_negative_score(self):
         """'negative' and 'positive' each own a distinct per-key front;
-        'empty' owns none. A top-2 ranking that floors 'empty' at -inf must
-        keep BOTH real candidates' fronts alive. An unfloored ranking (0.0
-        beats -0.25) instead lets 'empty' displace 'negative' out of the
-        top-2, which drops negative's only front and leaves 'positive' as
-        the sole, deterministic winner.
+        'empty' owns none. A top-2 ranking that floors 'empty' at -inf keeps
+        both real candidates' fronts alive. An unfloored ranking (0.0 beats
+        -0.25) instead lets 'empty' displace 'negative' out of the top-2,
+        dropping negative's only front and leaving 'positive' as the sole
+        winner.
         """
         frontier = ParetoFrontier()
         add(frontier, "negative", {"i1": -0.25})
@@ -349,10 +339,10 @@ class TestEmptyResultFloor:
         assert select_top_k_pareto(frontier, random.Random(0), 1).id == "negative"
 
     def test_all_empty_pool_returns_first_discovered_not_none_or_raise(self):
-        """Proves ``_first_argmax`` takes its first candidate
-        unconditionally: once every candidate floors to the SAME -inf, a
-        pure strict-improvement scan never satisfies ``score > best_score``
-        for any candidate and would leave ``best_id`` unset.
+        """``_first_argmax`` takes its first candidate unconditionally: once
+        every candidate floors to the same -inf, a pure strict-improvement
+        scan never satisfies ``score > best_score`` and would leave
+        ``best_id`` unset.
         """
         frontier = ParetoFrontier()
         add(frontier, "first", {})
@@ -416,7 +406,6 @@ class TestSeededReproducibility:
         seq_a = run(2024)
         seq_b = run(2024)
         assert seq_a == seq_b
-        # Sanity: a different seed is allowed to (and, with this pool,
-        # does) diverge — otherwise the test would trivially pass even if
-        # the rng were ignored entirely.
+        # A different seed must diverge on this pool; otherwise the test
+        # would pass even if the rng were ignored entirely.
         assert run(999) != seq_a

--- a/tests/unit/test_candidate_selector.py
+++ b/tests/unit/test_candidate_selector.py
@@ -6,7 +6,11 @@ strategy through ``ParetoFrontier.select_parent`` directly.
 
 from __future__ import annotations
 
+import os
 import random
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
@@ -409,3 +413,48 @@ class TestSeededReproducibility:
         # A different seed must diverge on this pool; otherwise the test
         # would pass even if the rng were ignored entirely.
         assert run(999) != seq_a
+
+    def test_top_k_pareto_same_seed_across_processes(self):
+        """String-hash randomization cannot alter a seeded top-k draw."""
+        selection_script = textwrap.dedent(
+            """
+            import random
+
+            from helix.candidate_selector import select_top_k_pareto
+            from helix.population import Candidate, EvalResult, ParetoFrontier
+
+            frontier = ParetoFrontier()
+            for candidate_id in ("alpha", "bravo", "charlie", "delta"):
+                frontier.add(
+                    Candidate(
+                        id=candidate_id,
+                        worktree_path="",
+                        branch_name="",
+                        generation=0,
+                        parent_id=None,
+                        parent_ids=[],
+                        operation="mutation",
+                    ),
+                    EvalResult(
+                        candidate_id=candidate_id,
+                        scores={},
+                        asi={},
+                        instance_scores={"instance": 1.0},
+                    ),
+                )
+
+            print(select_top_k_pareto(frontier, random.Random(2024), 4).id)
+            """
+        )
+        selections = {
+            subprocess.run(
+                [sys.executable, "-c", selection_script],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONHASHSEED": str(hash_seed)},
+            ).stdout.strip()
+            for hash_seed in range(1, 9)
+        }
+
+        assert len(selections) == 1

--- a/tests/unit/test_candidate_selector.py
+++ b/tests/unit/test_candidate_selector.py
@@ -1,0 +1,319 @@
+"""Unit tests for helix.candidate_selector — GEPA-parity selection strategies.
+
+Companion to tests/unit/test_population.py (which exercises the pre-existing
+``pareto`` strategy via ``ParetoFrontier.select_parent`` directly and is left
+untouched by this PR).
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from helix.candidate_selector import (
+    select_candidate,
+    select_current_best,
+    select_epsilon_greedy,
+    select_parents,
+    select_top_k_pareto,
+)
+from helix.population import Candidate, EvalResult, ParetoFrontier
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors tests/unit/test_population.py's fixtures)
+# ---------------------------------------------------------------------------
+
+
+def make_candidate(cid: str, generation: int = 0) -> Candidate:
+    return Candidate(
+        id=cid,
+        worktree_path=f"/tmp/{cid}",
+        branch_name=f"branch-{cid}",
+        generation=generation,
+        parent_id=None,
+        parent_ids=[],
+        operation="mutation",
+    )
+
+
+def make_result(cid: str, instance_scores: dict[str, float]) -> EvalResult:
+    return EvalResult(
+        candidate_id=cid,
+        scores={},
+        asi={},
+        instance_scores=instance_scores,
+    )
+
+
+def add(frontier: ParetoFrontier, cid: str, instance_scores: dict[str, float]) -> None:
+    frontier.add(make_candidate(cid), make_result(cid, instance_scores))
+
+
+# ---------------------------------------------------------------------------
+# select_current_best
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentBest:
+    def test_empty_frontier_raises(self):
+        with pytest.raises(ValueError):
+            select_current_best(ParetoFrontier())
+
+    def test_single_candidate(self):
+        frontier = ParetoFrontier()
+        add(frontier, "only", {"i1": 0.4})
+        assert select_current_best(frontier).id == "only"
+
+    def test_picks_highest_aggregate_score(self):
+        frontier = ParetoFrontier()
+        add(frontier, "weak", {"i1": 0.2, "i2": 0.2})
+        add(frontier, "strong", {"i1": 0.9, "i2": 0.9})
+        assert select_current_best(frontier).id == "strong"
+
+    def test_uses_aggregate_not_sum_score(self):
+        """current_best's HELIX analog is aggregate_score() (mean), not
+        sum_score(). X has fewer, better-average instances; Y has more,
+        worse-average instances but a higher sum. current_best must pick X.
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "X", {"i1": 0.9})  # sum=0.9, agg=0.9
+        add(frontier, "Y", {"i1": 0.5, "i2": 0.5, "i3": 0.5, "i4": 0.5})  # sum=2.0, agg=0.5
+        assert select_current_best(frontier).id == "X"
+        # Sanity: sum_score would have picked Y, proving the two quantities
+        # genuinely disagree on this pool.
+        result_x = frontier.get_result("X")
+        result_y = frontier.get_result("Y")
+        assert result_x is not None and result_y is not None
+        assert result_y.sum_score() > result_x.sum_score()
+
+    def test_tie_break_is_earliest_discovered(self):
+        """Ties resolve to the earliest-added candidate (GEPA idxmax parity:
+        ``lst.index(max(lst))`` returns the FIRST index achieving the max).
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "first", {"i1": 1.0})
+        add(frontier, "second", {"i1": 1.0})
+        add(frontier, "third", {"i1": 0.1})
+        assert select_current_best(frontier).id == "first"
+
+    def test_tie_break_survives_a_later_strict_improvement(self):
+        frontier = ParetoFrontier()
+        add(frontier, "a", {"i1": 0.5})
+        add(frontier, "b", {"i1": 0.5})
+        add(frontier, "c", {"i1": 0.9})
+        assert select_current_best(frontier).id == "c"
+
+    def test_deterministic_across_repeated_calls(self):
+        frontier = ParetoFrontier()
+        add(frontier, "a", {"i1": 0.5})
+        add(frontier, "b", {"i1": 0.5})
+        add(frontier, "c", {"i1": 0.2})
+        results = {select_current_best(frontier).id for _ in range(20)}
+        assert results == {"a"}
+
+
+# ---------------------------------------------------------------------------
+# select_epsilon_greedy
+# ---------------------------------------------------------------------------
+
+
+class TestEpsilonGreedy:
+    def test_empty_frontier_raises(self):
+        with pytest.raises(ValueError):
+            select_epsilon_greedy(ParetoFrontier(), random.Random(0), 0.5)
+
+    def test_epsilon_zero_is_always_current_best(self):
+        frontier = ParetoFrontier()
+        add(frontier, "weak", {"i1": 0.1})
+        add(frontier, "strong", {"i1": 0.9})
+        rng = random.Random(123)
+        for _ in range(25):
+            assert select_epsilon_greedy(frontier, rng, 0.0).id == "strong"
+
+    def test_epsilon_one_is_always_uniform_over_whole_pool(self):
+        """epsilon=1.0 always takes the random branch (rng.random() < 1.0 is
+        always true) and draws from the WHOLE pool, not the Pareto frontier.
+        Build a pool where a candidate is dominated on every key (so it
+        would never be drawn by "pareto") and confirm it can still be
+        picked here.
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "dominator", {"i1": 1.0, "i2": 1.0})
+        add(frontier, "dominated", {"i1": 0.1, "i2": 0.1})
+        rng = random.Random(7)
+        seen = {select_epsilon_greedy(frontier, rng, 1.0).id for _ in range(200)}
+        assert seen == {"dominator", "dominated"}
+
+    def test_epsilon_one_never_consumes_extra_randomness_on_greedy_path(self):
+        """Greedy branch (else) must not draw from rng — only the coin-flip
+        draw is consumed when the random branch isn't taken."""
+        frontier = ParetoFrontier()
+        add(frontier, "only", {"i1": 0.5})
+        rng_a = random.Random(99)
+        rng_b = random.Random(99)
+        select_epsilon_greedy(frontier, rng_a, 0.0)
+        rng_b.random()  # manually consume exactly one draw (the coin flip)
+        assert rng_a.random() == rng_b.random()
+
+
+# ---------------------------------------------------------------------------
+# select_top_k_pareto
+# ---------------------------------------------------------------------------
+
+
+class TestTopKPareto:
+    def test_empty_frontier_raises(self):
+        with pytest.raises(ValueError):
+            select_top_k_pareto(ParetoFrontier(), random.Random(0), 1)
+
+    def test_single_candidate(self):
+        frontier = ParetoFrontier()
+        add(frontier, "only", {"i1": 0.4})
+        assert select_top_k_pareto(frontier, random.Random(0), 1).id == "only"
+        # k larger than the pool must degrade cleanly too.
+        assert select_top_k_pareto(frontier, random.Random(0), 99).id == "only"
+
+    def test_k_greater_equal_pool_matches_pareto(self):
+        """k >= pool size makes the top-k filter a mathematical no-op, so
+        this must reduce exactly to ``pareto`` (frontier.select_parent()),
+        including its exact rng draw for a given seed."""
+        frontier_a = ParetoFrontier(rng=random.Random(42))
+        frontier_b = ParetoFrontier(rng=random.Random(42))
+        for f in (frontier_a, frontier_b):
+            add(f, "a", {"i1": 1.0, "i2": 0.2})
+            add(f, "b", {"i1": 0.2, "i2": 1.0})
+            add(f, "c", {"i1": 0.5, "i2": 0.5})
+
+        expected = frontier_a.select_parent().id
+        got = select_top_k_pareto(frontier_b, frontier_b._rng, 3)
+        assert got.id == expected
+
+        # k strictly larger than the pool degrades the same way.
+        frontier_c = ParetoFrontier(rng=random.Random(42))
+        add(frontier_c, "a", {"i1": 1.0, "i2": 0.2})
+        add(frontier_c, "b", {"i1": 0.2, "i2": 1.0})
+        add(frontier_c, "c", {"i1": 0.5, "i2": 0.5})
+        assert select_top_k_pareto(frontier_c, frontier_c._rng, 100).id == expected
+
+    def test_ranks_by_sum_score_and_intersects_per_key_fronts(self):
+        """Hand-built frontier: A/B/D each own one key; only A/B survive a
+        top-2 filter by sum_score, so D's key must be dropped and the draw
+        must never return D."""
+        frontier = ParetoFrontier()
+        add(frontier, "a", {"i1": 1.0})  # sum=1.0, wins i1
+        add(frontier, "b", {"i2": 1.0})  # sum=1.0, wins i2
+        add(frontier, "d", {"i3": 0.05})  # sum=0.05, wins i3 (sole entrant)
+        rng = random.Random(3)
+        seen = {select_top_k_pareto(frontier, rng, 2).id for _ in range(50)}
+        assert seen == {"a", "b"}
+        assert "d" not in seen
+
+    def test_empty_filtered_mapping_falls_back_to_sum_score_argmax(self):
+        """A, B, D each win exactly one key. X wins its own unique key with
+        a high aggregate but low sum. Y never wins any key but has the
+        highest SUM overall (two near-misses beat two clean wins + a lone
+        low-sum win). For k=1, top-1-by-sum is Y alone; intersecting Y into
+        every per-key front empties all of them, forcing the fallback.
+
+        The fallback must be sum_score()-argmax, not aggregate_score()
+        argmax: aggregate_score() ranks A/B/D (agg=1.0 each, tied) above Y
+        (agg=0.9), so a fallback that mistakenly used aggregate_score would
+        return the tie-break winner "a" instead of "y".
+        """
+        frontier = ParetoFrontier()
+        add(frontier, "a", {"i1": 1.0})  # sum=1.0 agg=1.0, wins i1
+        add(frontier, "b", {"i2": 1.0})  # sum=1.0 agg=1.0, wins i2
+        add(frontier, "d", {"i3": 1.0})  # sum=1.0 agg=1.0, wins i3
+        add(frontier, "x", {"i9": 0.99})  # sum=0.99 agg=0.99, wins i9
+        add(frontier, "y", {"i1": 0.9, "i2": 0.9})  # sum=1.8 agg=0.9, wins nothing
+        rng = random.Random(0)
+        assert select_top_k_pareto(frontier, rng, 1).id == "y"
+
+
+# ---------------------------------------------------------------------------
+# select_candidate dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestSelectCandidateDispatch:
+    def test_pareto_delegates_to_select_parent(self):
+        frontier = ParetoFrontier(rng=random.Random(1))
+        add(frontier, "only", {"i1": 0.5})
+        assert select_candidate("pareto", frontier, random.Random(1)).id == "only"
+
+    def test_current_best_dispatch(self):
+        frontier = ParetoFrontier()
+        add(frontier, "weak", {"i1": 0.1})
+        add(frontier, "strong", {"i1": 0.9})
+        assert (
+            select_candidate("current_best", frontier, random.Random(0)).id
+            == "strong"
+        )
+
+    def test_unknown_strategy_raises(self):
+        frontier = ParetoFrontier()
+        add(frontier, "only", {"i1": 0.5})
+        with pytest.raises(ValueError):
+            select_candidate("bogus", frontier, random.Random(0))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Seeded reproducibility
+# ---------------------------------------------------------------------------
+
+
+class TestSeededReproducibility:
+    def _build_pool(self, frontier: ParetoFrontier) -> None:
+        add(frontier, "a", {"i1": 1.0, "i2": 0.2, "i3": 0.5})
+        add(frontier, "b", {"i1": 0.2, "i2": 1.0, "i3": 0.4})
+        add(frontier, "c", {"i1": 0.5, "i2": 0.5, "i3": 1.0})
+        add(frontier, "d", {"i1": 0.3, "i2": 0.3, "i3": 0.3})
+
+    @pytest.mark.parametrize("strategy", ["epsilon_greedy", "top_k_pareto"])
+    def test_same_seed_same_sequence(self, strategy):
+        kwargs = {"epsilon": 0.5} if strategy == "epsilon_greedy" else {"top_k": 2}
+
+        def run(seed: int) -> list[str]:
+            frontier = ParetoFrontier()
+            self._build_pool(frontier)
+            rng = random.Random(seed)
+            return [
+                select_candidate(strategy, frontier, rng, **kwargs).id
+                for _ in range(10)
+            ]
+
+        seq_a = run(2024)
+        seq_b = run(2024)
+        assert seq_a == seq_b
+        # Sanity: a different seed is allowed to (and, with this pool,
+        # does) diverge — otherwise the test would trivially pass even if
+        # the rng were ignored entirely.
+        assert run(999) != seq_a
+
+    def test_select_parents_matches_looped_select_candidate(self):
+        """select_parents(p) must be byte-identical to calling
+        select_candidate() p times with the same shared rng (GEPA parity:
+        PxNSampling's ``for _ in range(p): select_candidate_idx(state)``).
+        """
+        frontier_a = ParetoFrontier()
+        frontier_b = ParetoFrontier()
+        self._build_pool(frontier_a)
+        self._build_pool(frontier_b)
+        rng_a = random.Random(5)
+        rng_b = random.Random(5)
+
+        batched = select_parents(
+            "epsilon_greedy", frontier_a, rng_a, 6, epsilon=0.5
+        )
+        looped = [
+            select_candidate("epsilon_greedy", frontier_b, rng_b, epsilon=0.5)
+            for _ in range(6)
+        ]
+        assert [c.id for c in batched] == [c.id for c in looped]
+
+    def test_select_parents_empty_batch(self):
+        frontier = ParetoFrontier()
+        add(frontier, "only", {"i1": 0.5})
+        assert select_parents("current_best", frontier, random.Random(0), 0) == []

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -515,3 +515,87 @@ class TestTomlRoundTrip:
         assert restored.evolution.val_stage_size == 25
         assert restored.evolution.num_sampled_groups == 1
         assert restored.evolution.num_examples_per_group == 2
+
+
+# ---------------------------------------------------------------------------
+# EvolutionConfig.candidate_selection_strategy + its sub-knobs
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateSelectionConfig:
+    def test_default_strategy_is_pareto_with_no_sub_knobs(self):
+        cfg = EvolutionConfig()
+        assert cfg.candidate_selection_strategy == "pareto"
+        assert cfg.candidate_selection_epsilon is None
+        assert cfg.candidate_selection_top_k is None
+
+    def test_current_best_accepts_no_sub_knobs(self):
+        cfg = EvolutionConfig(candidate_selection_strategy="current_best")
+        assert cfg.candidate_selection_epsilon is None
+        assert cfg.candidate_selection_top_k is None
+
+    def test_epsilon_greedy_requires_epsilon(self):
+        with pytest.raises(ValidationError, match="candidate_selection_epsilon is required"):
+            EvolutionConfig(candidate_selection_strategy="epsilon_greedy")
+
+    def test_epsilon_greedy_accepts_boundary_values(self):
+        cfg = EvolutionConfig(
+            candidate_selection_strategy="epsilon_greedy",
+            candidate_selection_epsilon=0.0,
+        )
+        assert cfg.candidate_selection_epsilon == 0.0
+        cfg = EvolutionConfig(
+            candidate_selection_strategy="epsilon_greedy",
+            candidate_selection_epsilon=1.0,
+        )
+        assert cfg.candidate_selection_epsilon == 1.0
+
+    def test_epsilon_greedy_rejects_out_of_range_epsilon(self):
+        with pytest.raises(ValidationError, match="must be between 0.0 and 1.0"):
+            EvolutionConfig(
+                candidate_selection_strategy="epsilon_greedy",
+                candidate_selection_epsilon=1.5,
+            )
+        with pytest.raises(ValidationError, match="must be between 0.0 and 1.0"):
+            EvolutionConfig(
+                candidate_selection_strategy="epsilon_greedy",
+                candidate_selection_epsilon=-0.1,
+            )
+
+    def test_epsilon_rejected_for_other_strategies(self):
+        for strategy in ("pareto", "current_best", "top_k_pareto"):
+            kwargs: dict[str, object] = {"candidate_selection_strategy": strategy}
+            if strategy == "top_k_pareto":
+                kwargs["candidate_selection_top_k"] = 3
+            with pytest.raises(
+                ValidationError, match="candidate_selection_epsilon is only valid"
+            ):
+                EvolutionConfig(candidate_selection_epsilon=0.1, **kwargs)
+
+    def test_top_k_pareto_requires_top_k(self):
+        with pytest.raises(ValidationError, match="candidate_selection_top_k is required"):
+            EvolutionConfig(candidate_selection_strategy="top_k_pareto")
+
+    def test_top_k_pareto_rejects_non_positive_top_k(self):
+        with pytest.raises(ValidationError, match="must be >= 1"):
+            EvolutionConfig(
+                candidate_selection_strategy="top_k_pareto",
+                candidate_selection_top_k=0,
+            )
+
+    def test_top_k_rejected_for_other_strategies(self):
+        for strategy in ("pareto", "current_best", "epsilon_greedy"):
+            kwargs: dict[str, object] = {"candidate_selection_strategy": strategy}
+            if strategy == "epsilon_greedy":
+                kwargs["candidate_selection_epsilon"] = 0.1
+            with pytest.raises(
+                ValidationError, match="candidate_selection_top_k is only valid"
+            ):
+                EvolutionConfig(candidate_selection_top_k=5, **kwargs)
+
+    def test_top_k_pareto_accepts_valid_top_k(self):
+        cfg = EvolutionConfig(
+            candidate_selection_strategy="top_k_pareto",
+            candidate_selection_top_k=5,
+        )
+        assert cfg.candidate_selection_top_k == 5

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -626,8 +626,7 @@ class TestCandidateSelectionConfig:
     )
     def test_strategy_epsilon_top_k_matrix(self, strategy, epsilon, top_k, error_match):
         """Full strategy x epsilon-presence x top_k-presence matrix,
-        including both-knobs-set cases for every strategy (not just the
-        owning ones — see the individual tests above for those)."""
+        including the cases where both knobs are set."""
         kwargs: dict[str, object] = {"candidate_selection_strategy": strategy}
         if epsilon is not None:
             kwargs["candidate_selection_epsilon"] = epsilon

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -599,3 +599,43 @@ class TestCandidateSelectionConfig:
             candidate_selection_top_k=5,
         )
         assert cfg.candidate_selection_top_k == 5
+
+    @pytest.mark.parametrize(
+        "strategy,epsilon,top_k,error_match",
+        [
+            # pareto / current_best own neither knob.
+            ("pareto", None, None, None),
+            ("pareto", None, 3, "candidate_selection_top_k is only valid"),
+            ("pareto", 0.1, None, "candidate_selection_epsilon is only valid"),
+            ("pareto", 0.1, 3, "candidate_selection_epsilon is only valid"),
+            ("current_best", None, None, None),
+            ("current_best", None, 3, "candidate_selection_top_k is only valid"),
+            ("current_best", 0.1, None, "candidate_selection_epsilon is only valid"),
+            ("current_best", 0.1, 3, "candidate_selection_epsilon is only valid"),
+            # epsilon_greedy owns epsilon only.
+            ("epsilon_greedy", None, None, "candidate_selection_epsilon is required"),
+            ("epsilon_greedy", None, 3, "candidate_selection_epsilon is required"),
+            ("epsilon_greedy", 0.1, None, None),
+            ("epsilon_greedy", 0.1, 3, "candidate_selection_top_k is only valid"),
+            # top_k_pareto owns top_k only.
+            ("top_k_pareto", None, None, "candidate_selection_top_k is required"),
+            ("top_k_pareto", None, 3, None),
+            ("top_k_pareto", 0.1, None, "candidate_selection_epsilon is only valid"),
+            ("top_k_pareto", 0.1, 3, "candidate_selection_epsilon is only valid"),
+        ],
+    )
+    def test_strategy_epsilon_top_k_matrix(self, strategy, epsilon, top_k, error_match):
+        """Full strategy x epsilon-presence x top_k-presence matrix,
+        including both-knobs-set cases for every strategy (not just the
+        owning ones — see the individual tests above for those)."""
+        kwargs: dict[str, object] = {"candidate_selection_strategy": strategy}
+        if epsilon is not None:
+            kwargs["candidate_selection_epsilon"] = epsilon
+        if top_k is not None:
+            kwargs["candidate_selection_top_k"] = top_k
+        if error_match is None:
+            cfg = EvolutionConfig(**kwargs)
+            assert cfg.candidate_selection_strategy == strategy
+        else:
+            with pytest.raises(ValidationError, match=error_match):
+                EvolutionConfig(**kwargs)


### PR DESCRIPTION
## What

Adds `evolution.candidate_selection_strategy` with the existing `pareto` default plus `current_best`, `epsilon_greedy`, and `top_k_pareto`. The latter two require their strategy-specific `candidate_selection_epsilon` or `candidate_selection_top_k` setting.

## Why

Different optimization runs need different, explicit parent-selection policies without changing the current default.

## Review focus

Check `candidate_selector._aggregate_score_or_floor`: new strategies rank by aggregate validation score and place unscored candidates below every scored candidate.

## Validation

`uv run pytest tests/unit/test_candidate_selector.py tests/unit/test_config_new_fields.py -q` — 92 passed in 0.20s. Diff: +920/−1 lines.