### PR TITLE
fix(mutator): classify structured backend failures before text heuristics

### DIFF
--- a/src/helix/exceptions.py
+++ b/src/helix/exceptions.py
@@ -114,10 +114,10 @@ class RateLimitError(HelixError):
     logging the failure and returning ``None`` for that proposal slot rather
     than crashing the entire run.
 
-    Detected heuristically from non-zero exit codes or JSON error fields that
-    contain keywords such as "rate limit", "overloaded", "529", "usage limit",
-    or "extra usage".  After retries are exhausted the error bubbles up to the
-    evolution loop, which logs it and continues with a smaller proposal set.
+    Classified first from structured backend status fields, with a narrowly
+    scoped text fallback only when no structured signal is available. After
+    retries are exhausted the error bubbles up to the evolution loop, which
+    logs it and continues with a smaller proposal set.
     """
 
 

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -233,11 +233,10 @@ def run_evaluator(
 
     evaluator = config.evaluator
     sandbox_image = None
-    # The single honest signal that HELIX itself launched Docker for this
-    # evaluation: we chose the sandboxed branch below.  Evaluator commands
-    # are arbitrary user commands, so the exit code alone (or any text in
-    # it) cannot be trusted to mean "Docker was involved" — only the branch
-    # HELIX actually took can.
+    # Whether HELIX itself launched Docker for this evaluation.  Evaluator
+    # commands are arbitrary user commands, so neither the exit code nor the
+    # command text establishes that Docker was involved; only this branch
+    # does.
     docker_invoked = config.sandbox.enabled and config.sandbox.evaluator
     if docker_invoked:
         if evaluator.sidecar is None:
@@ -351,13 +350,10 @@ def run_evaluator(
         )
 
     # Docker reserves exit 125 for failures before the container command
-    # starts (daemon, image, or invocation errors).  A structured-result
-    # parser cannot add useful information here and would otherwise hide the
-    # actual Docker diagnostic behind "no HELIX_RESULT= line".  Evaluator
-    # commands are arbitrary user commands, though, so exit 125 only means
-    # "Docker failure" when HELIX actually invoked Docker for this run
-    # (``docker_invoked``, set from the same sandbox branch above) — never
-    # from sniffing the command text for the word "docker".
+    # starts (daemon, image, or invocation errors).  Check it ahead of the
+    # result parser, which would otherwise hide the Docker diagnostic behind
+    # "no HELIX_RESULT= line".  Guarded on ``docker_invoked``: for an
+    # evaluator HELIX ran directly, 125 is just the command's own exit code.
     if returncode == 125 and docker_invoked:
         raise EvaluatorError(
             "Evaluator Docker invocation failed before the evaluator started.",

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -344,6 +344,23 @@ def run_evaluator(
             error_ctx,
         )
 
+    # Docker reserves exit 125 for failures before the container command
+    # starts (daemon, image, or invocation errors).  A structured-result
+    # parser cannot add useful information here and would otherwise hide the
+    # actual Docker diagnostic behind "no HELIX_RESULT= line".
+    if returncode == 125:
+        raise EvaluatorError(
+            "Evaluator Docker invocation failed before the evaluator started.",
+            operation="run_evaluator",
+            phase="docker invocation",
+            command=evaluator.command,
+            cwd=str(candidate.worktree_path),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=returncode,
+            suggestion="Check the Docker diagnostic in stderr above.",
+        )
+
     # Collect ASI
     asi = _collect_asi(
         stdout,

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -233,7 +233,13 @@ def run_evaluator(
 
     evaluator = config.evaluator
     sandbox_image = None
-    if config.sandbox.enabled and config.sandbox.evaluator:
+    # The single honest signal that HELIX itself launched Docker for this
+    # evaluation: we chose the sandboxed branch below.  Evaluator commands
+    # are arbitrary user commands, so the exit code alone (or any text in
+    # it) cannot be trusted to mean "Docker was involved" — only the branch
+    # HELIX actually took can.
+    docker_invoked = config.sandbox.enabled and config.sandbox.evaluator
+    if docker_invoked:
         if evaluator.sidecar is None:
             raise ValueError("Sandboxed evaluation requires [evaluator.sidecar].")
         sandbox_image = evaluator.sidecar.resolved_runner_image
@@ -254,7 +260,7 @@ def run_evaluator(
     # assumption.
     helix_log_sandbox_path = f"/workspace/{helix_log_name}"
     cmd_tokens = _validate_and_split_command(evaluator.command)
-    if config.sandbox.enabled and config.sandbox.evaluator:
+    if docker_invoked:
         env[HELIX_ASI_LOG_ENV] = helix_log_sandbox_path
         if current_evaluator_sidecar_runtime() is None:
             raise ValueError(
@@ -347,8 +353,12 @@ def run_evaluator(
     # Docker reserves exit 125 for failures before the container command
     # starts (daemon, image, or invocation errors).  A structured-result
     # parser cannot add useful information here and would otherwise hide the
-    # actual Docker diagnostic behind "no HELIX_RESULT= line".
-    if returncode == 125:
+    # actual Docker diagnostic behind "no HELIX_RESULT= line".  Evaluator
+    # commands are arbitrary user commands, though, so exit 125 only means
+    # "Docker failure" when HELIX actually invoked Docker for this run
+    # (``docker_invoked``, set from the same sandbox branch above) — never
+    # from sniffing the command text for the word "docker".
+    if returncode == 125 and docker_invoked:
         raise EvaluatorError(
             "Evaluator Docker invocation failed before the evaluator started.",
             operation="run_evaluator",

--- a/src/helix/executor.py
+++ b/src/helix/executor.py
@@ -182,6 +182,33 @@ def _collect_asi(
     return asi
 
 
+# stderr fragments that identify a failure of the ``docker run`` invocation
+# itself (daemon unreachable, image missing, bad arguments) rather than of the
+# evaluator command running inside the container.
+_DOCKER_INVOCATION_FAILURE_SIGNATURES = (
+    "Cannot connect to the Docker daemon",
+    "Error response from daemon",
+    "error during connect",
+    "Unable to find image",
+    "docker: invalid",
+)
+
+
+def _is_docker_invocation_failure(stdout: str, stderr: str) -> bool:
+    """Whether an exit 125 from ``docker run`` came from Docker, not the evaluator.
+
+    Docker passes the contained command's exit status through, so 125 alone
+    is ambiguous.  It is Docker's own only when the evaluator never emitted
+    a ``HELIX_RESULT=`` line, or when stderr carries a daemon diagnostic.
+    """
+    has_result_line = any(
+        line.startswith("HELIX_RESULT=") for line in stdout.splitlines()
+    )
+    if not has_result_line:
+        return True
+    return any(sig in stderr for sig in _DOCKER_INVOCATION_FAILURE_SIGNATURES)
+
+
 def run_evaluator(
     candidate: Candidate,
     config: HelixConfig,
@@ -359,7 +386,11 @@ def run_evaluator(
     # result parser, which would otherwise hide the Docker diagnostic behind
     # "no HELIX_RESULT= line".  Guarded on ``docker_invoked``: for an
     # evaluator HELIX ran directly, 125 is just the command's own exit code.
-    if returncode == 125 and docker_invoked:
+    # Docker also passes the contained command's own exit code through, so
+    # even under Docker a 125 that arrives with a HELIX_RESULT= line and no
+    # daemon diagnostic is the evaluator's exit status and is scored as any
+    # other non-zero exit would be.
+    if returncode == 125 and docker_invoked and _is_docker_invocation_failure(stdout, stderr):
         raise EvaluatorError(
             "Evaluator Docker invocation failed before the evaluator started.",
             operation="run_evaluator",

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -589,8 +589,11 @@ _RATE_LIMIT_PATTERNS = (
     re.compile(r"\bextra usage\b", re.IGNORECASE),
     re.compile(r"\btoo many requests\b", re.IGNORECASE),
     # A bare "quota" also appears in configuration errors ("quota field
-    # missing"), so require language saying the quota was consumed.
+    # missing"), so require language saying the quota was consumed. Backend
+    # messages phrase this in either order ("quota exceeded" as well as
+    # "you exceeded your quota"), so match both.
     re.compile(r"\bquota\b[^.]{0,20}\b(?:exceeded|exhausted|reached)\b", re.IGNORECASE),
+    re.compile(r"\b(?:exceeded|exhausted|reached)\b[^.]{0,20}\bquota\b", re.IGNORECASE),
     re.compile(r"(?<![\w-])(?:429|529)(?![\w-])"),
 )
 

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -589,9 +589,8 @@ _RATE_LIMIT_PATTERNS = (
     re.compile(r"\bextra usage\b", re.IGNORECASE),
     re.compile(r"\btoo many requests\b", re.IGNORECASE),
     # A bare "quota" also appears in configuration errors ("quota field
-    # missing"), so require language saying the quota was consumed. Backend
-    # messages phrase this in either order ("quota exceeded" as well as
-    # "you exceeded your quota"), so match both.
+    # missing"), so require language saying the quota was consumed.  Accept
+    # either ordering: "quota exceeded" and "you exceeded your quota".
     re.compile(r"\bquota\b[^.]{0,20}\b(?:exceeded|exhausted|reached)\b", re.IGNORECASE),
     re.compile(r"\b(?:exceeded|exhausted|reached)\b[^.]{0,20}\bquota\b", re.IGNORECASE),
     re.compile(r"(?<![\w-])(?:429|529)(?![\w-])"),
@@ -601,7 +600,7 @@ _RATE_LIMIT_PATTERNS = (
 def _looks_like_rate_limit(text: str) -> bool:
     """Return True if *text* contains a rate-limit / overload signal.
 
-    Detection stays deliberately narrow: an unrecognised backend error must
+    Detection stays narrow: an unrecognised backend error must
     fall through to the generic unknown-failure path with its own message
     preserved, rather than being reported as a quota problem the operator
     cannot act on.
@@ -1729,10 +1728,10 @@ def invoke_claude_code(
                     raise rate_limited
             return parsed, usage
 
-        # Claude writes a structured result envelope even for many non-zero
-        # exits.  Classify that envelope before inspecting raw output, so a
-        # session id or transcript fragment cannot pre-empt a real max-turns
-        # result — which is partial success, not a discarded proposal.
+        # The claude backend may still write a structured result envelope on a
+        # non-zero exit.  Classify that envelope before inspecting raw output,
+        # so a session id or transcript fragment cannot pre-empt a real
+        # max-turns result — which is partial success, not a discarded proposal.
         if backend == "claude":
             try:
                 parsed = _parse_backend_output(

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -582,6 +582,15 @@ def build_mutation_prompt(
 # Numeric statuses are matched on their own token.  A bare substring search
 # for "529" or "429" also matches a hex fragment inside a session id, which
 # would discard a completed mutation as a rate limit.
+#
+# This text is raw combined stdout+stderr from an arbitrary agent backend, so
+# a bare "429"/"529" is not on its own distinguishing: it can just as easily
+# be a line number, a token count, a record id, a duration, or a diff hunk
+# header. Only count the number when it sits near backend-error wording —
+# "HTTP", "status", or "code" — in either order, the same way the quota
+# patterns below require "exceeded"/"exhausted"/"reached" next to "quota"
+# rather than trusting "quota" alone.
+_HTTP_STATUS_WORD = r"(?:HTTP|status|code)"
 _RATE_LIMIT_PATTERNS = (
     re.compile(r"\brate[ -]?limit", re.IGNORECASE),
     re.compile(r"\boverloaded\b", re.IGNORECASE),
@@ -593,7 +602,14 @@ _RATE_LIMIT_PATTERNS = (
     # either ordering: "quota exceeded" and "you exceeded your quota".
     re.compile(r"\bquota\b[^.]{0,20}\b(?:exceeded|exhausted|reached)\b", re.IGNORECASE),
     re.compile(r"\b(?:exceeded|exhausted|reached)\b[^.]{0,20}\bquota\b", re.IGNORECASE),
-    re.compile(r"(?<![\w-])(?:429|529)(?![\w-])"),
+    re.compile(
+        rf"\b{_HTTP_STATUS_WORD}\b[^.\n]{{0,20}}(?<![\w-])(?:429|529)(?![\w-])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"(?<![\w-])(?:429|529)(?![\w-])[^.\n]{{0,20}}\b{_HTTP_STATUS_WORD}\b",
+        re.IGNORECASE,
+    ),
 )
 
 

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shlex
 import subprocess
 from pathlib import Path
@@ -578,19 +579,47 @@ def build_mutation_prompt(
 # Rate-limit detection
 # ---------------------------------------------------------------------------
 
-_RATE_LIMIT_KEYWORDS = [
-    "rate limit",
-    "overloaded",
-    "529",
-    "usage limit",
-    "extra usage",
-]
+# Numeric statuses are matched on their own token.  A bare substring search
+# for "529" or "429" also matches a hex fragment inside a session id, which
+# would discard a completed mutation as a rate limit.
+_RATE_LIMIT_PATTERNS = (
+    re.compile(r"\brate[ -]?limit", re.IGNORECASE),
+    re.compile(r"\boverloaded\b", re.IGNORECASE),
+    re.compile(r"\busage limit\b", re.IGNORECASE),
+    re.compile(r"\bextra usage\b", re.IGNORECASE),
+    re.compile(r"\btoo many requests\b", re.IGNORECASE),
+    # A bare "quota" also appears in configuration errors ("quota field
+    # missing"), so require language saying the quota was consumed.
+    re.compile(r"\bquota\b[^.]{0,20}\b(?:exceeded|exhausted|reached)\b", re.IGNORECASE),
+    re.compile(r"(?<![\w-])(?:429|529)(?![\w-])"),
+)
 
 
 def _looks_like_rate_limit(text: str) -> bool:
-    """Return True if *text* contains a rate-limit / overload keyword."""
-    lower = text.lower()
-    return any(kw in lower for kw in _RATE_LIMIT_KEYWORDS)
+    """Return True if *text* contains a rate-limit / overload signal.
+
+    Detection stays deliberately narrow: an unrecognised backend error must
+    fall through to the generic unknown-failure path with its own message
+    preserved, rather than being reported as a quota problem the operator
+    cannot act on.
+    """
+    return any(pattern.search(text) for pattern in _RATE_LIMIT_PATTERNS)
+
+
+def _api_error_status(parsed: dict[str, Any]) -> int | None:
+    """Return a backend envelope's API status when it is an integer."""
+    value = parsed.get("api_error_status")
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _has_structured_failure_signal(parsed: dict[str, Any]) -> bool:
+    """Whether *parsed* carries an unambiguous backend failure field.
+
+    When it does, the free-text fallback must not run: the envelope already
+    says what happened, and searching the rest of it only risks matching an
+    unrelated field such as a session id.
+    """
+    return isinstance(parsed.get("subtype"), str) or _api_error_status(parsed) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -1647,6 +1676,41 @@ def invoke_claude_code(
         )
 
     parsed: dict[str, Any] | None = None
+
+    def _rate_limit_error(summary: str, phase: str) -> RateLimitError:
+        return RateLimitError(
+            summary,
+            operation=f"{backend_name} invocation",
+            phase=phase,
+            command=cmd_str,
+            cwd=str(worktree_path),
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+            suggestion=(
+                f"{backend_name} reported a rate limit. "
+                "Retry after backoff or check your quota."
+            ),
+        )
+
+    def _rate_limit_from_envelope(envelope: dict[str, Any]) -> RateLimitError | None:
+        """Rate-limit verdict for a parsed backend envelope, if it carries one."""
+        if _api_error_status(envelope) == 429:
+            return _rate_limit_error(
+                f"{backend_name} hit a rate/usage limit (HTTP 429)",
+                "structured backend result",
+            )
+        # The error field is a bounded fallback, consulted only when the
+        # envelope supplies no classifying field of its own.
+        error_text = str(envelope.get("error") or "")
+        if _has_structured_failure_signal(envelope) or not _looks_like_rate_limit(error_text):
+            return None
+        logger.error("Rate limit detected in JSON response: %s", error_text[:200])
+        return _rate_limit_error(
+            f"{backend_name} returned a rate/usage limit error in JSON response",
+            "structured backend result fallback",
+        )
+
     try:
         if result.returncode == 0:
             parsed = _parse_backend_output(
@@ -1657,52 +1721,15 @@ def invoke_claude_code(
             )
             usage = _normalise_usage_stats(parsed)
             if backend == "claude":
-                error_text = str(parsed.get("error", ""))
-                if _looks_like_rate_limit(error_text):
-                    logger.error(
-                        "Rate limit detected in JSON response: %s", error_text[:200]
-                    )
-                    raise RateLimitError(
-                        f"{backend_name} returned a rate/usage limit error in JSON response",
-                        operation=f"{backend_name} invocation",
-                        phase="JSON parsing",
-                        command=cmd_str,
-                        cwd=str(worktree_path),
-                        stdout=result.stdout,
-                        stderr=result.stderr,
-                        exit_code=result.returncode,
-                        suggestion=(
-                            f"{backend_name} reported a rate limit. "
-                            "Retry after backoff or check your API quota."
-                        ),
-                    )
+                rate_limited = _rate_limit_from_envelope(parsed)
+                if rate_limited is not None:
+                    raise rate_limited
             return parsed, usage
 
-        rate_limit_source = result.stderr or result.stdout
-        if _looks_like_rate_limit(rate_limit_source):
-            logger.error(
-                "Rate limit detected in subprocess exit for %s (code %d): %s",
-                backend_name,
-                result.returncode,
-                rate_limit_source[:200],
-            )
-            raise RateLimitError(
-                f"{backend_name} hit a rate/usage limit (exit code {result.returncode})",
-                operation=f"{backend_name} invocation",
-                phase="subprocess exit",
-                command=cmd_str,
-                cwd=str(worktree_path),
-                stdout=result.stdout,
-                stderr=result.stderr,
-                exit_code=result.returncode,
-                suggestion=(
-                    f"{backend_name} reported a rate limit. "
-                    "Retry after backoff or check your quota."
-                ),
-            )
-
-        # Claude's max-turns exhaustion is intentionally treated as partial
-        # success because the subprocess may have already produced useful edits.
+        # Claude writes a structured result envelope even for many non-zero
+        # exits.  Classify that envelope before inspecting raw output, so a
+        # session id or transcript fragment cannot pre-empt a real max-turns
+        # result — which is partial success, not a discarded proposal.
         if backend == "claude":
             try:
                 parsed = _parse_backend_output(
@@ -1718,15 +1745,38 @@ def invoke_claude_code(
                         parsed.get("num_turns", "?"),
                     )
                     return parsed, usage
+                rate_limited = _rate_limit_from_envelope(parsed)
+                if rate_limited is not None:
+                    raise rate_limited
             except MutationError:
                 parsed = None
 
-        parsed = _parse_backend_output(
-            backend,
-            result,
-            cmd_str=cmd_str,
-            worktree_path=worktree_path,
+        # Last resort, only when the envelope said nothing: search both streams
+        # so an HTTP status on stdout is not hidden by an unrelated stderr
+        # warning.
+        already_classified = parsed is not None and (
+            _has_structured_failure_signal(parsed) or bool(parsed.get("error"))
         )
+        raw_output = "\n".join(s for s in (result.stdout, result.stderr) if s)
+        if not already_classified and _looks_like_rate_limit(raw_output):
+            logger.error(
+                "Rate limit detected in subprocess exit for %s (code %d): %s",
+                backend_name,
+                result.returncode,
+                raw_output[:200],
+            )
+            raise _rate_limit_error(
+                f"{backend_name} hit a rate/usage limit (exit code {result.returncode})",
+                "subprocess exit fallback",
+            )
+
+        if parsed is None:
+            parsed = _parse_backend_output(
+                backend,
+                result,
+                cmd_str=cmd_str,
+                worktree_path=worktree_path,
+            )
         usage = _normalise_usage_stats(parsed)
 
         raise MutationError(

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -637,6 +637,8 @@ def _has_structured_failure_signal(parsed: dict[str, Any]) -> bool:
     says what happened, and searching the rest of it only risks matching an
     unrelated field such as a session id.
     """
+    # Structured JSON type names (for example, ``overloaded_error``) are
+    # backend-defined, so only the typed API status is used for classification.
     return isinstance(parsed.get("subtype"), str) or _api_error_status(parsed) is not None
 
 
@@ -1713,9 +1715,10 @@ def invoke_claude_code(
 
     def _rate_limit_from_envelope(envelope: dict[str, Any]) -> RateLimitError | None:
         """Rate-limit verdict for a parsed backend envelope, if it carries one."""
-        if _api_error_status(envelope) == 429:
+        api_status = _api_error_status(envelope)
+        if api_status in (429, 529):
             return _rate_limit_error(
-                f"{backend_name} hit a rate/usage limit (HTTP 429)",
+                f"{backend_name} hit a rate/usage limit (HTTP {api_status})",
                 "structured backend result",
             )
         # The error field is a bounded fallback, consulted only when the

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -586,17 +586,23 @@ def build_mutation_prompt(
 # for "529" or "429" also matches a hex fragment inside a session id, which
 # would discard a completed mutation as a rate limit.
 #
-# This text is raw combined stdout+stderr from an arbitrary agent backend, so
-# a bare "429"/"529" is not on its own distinguishing: it can just as easily
-# be a line number, a token count, a record id, a duration, or a diff hunk
-# header. Only count the number when it sits near backend-error wording —
-# "HTTP", "status", or "code" — in either order, the same way the quota
-# patterns below require "exceeded"/"exhausted"/"reached" next to "quota"
-# rather than trusting "quota" alone.
+# The scanned text is either a backend's own failure strings or raw
+# stderr/stdout from an arbitrary agent backend, so a bare "429"/"529" is not
+# on its own distinguishing: it can just as easily be a line number, a token
+# count, a record id, a duration, or a diff hunk header. Only count the
+# number when it sits near backend-error wording — "HTTP", "status", or
+# "code" — in either order, the same way the quota patterns below require
+# "exceeded"/"exhausted"/"reached" next to "quota" rather than trusting
+# "quota" alone.
+#
+# Word patterns use letter/digit lookarounds instead of ``\b`` so the
+# backend's own type tokens — ``overloaded_error``, ``rate_limit_error`` —
+# still match: ``\b`` treats the underscore as a word character and would
+# miss them.
 _HTTP_STATUS_WORD = r"(?:HTTP|status|code)"
 _RATE_LIMIT_PATTERNS = (
-    re.compile(r"\brate[ -]?limit", re.IGNORECASE),
-    re.compile(r"\boverloaded\b", re.IGNORECASE),
+    re.compile(r"(?<![a-z0-9])rate[ _-]?limit", re.IGNORECASE),
+    re.compile(r"(?<![a-z0-9])overloaded(?![a-z0-9])", re.IGNORECASE),
     re.compile(r"\busage limit\b", re.IGNORECASE),
     re.compile(r"\bextra usage\b", re.IGNORECASE),
     re.compile(r"\btoo many requests\b", re.IGNORECASE),
@@ -633,16 +639,76 @@ def _api_error_status(parsed: dict[str, Any]) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
-def _has_structured_failure_signal(parsed: dict[str, Any]) -> bool:
-    """Whether *parsed* carries an unambiguous backend failure field.
+def _string_leaves(value: Any, *, depth: int = 0) -> list[str]:
+    """Flatten the string leaves of a structured error value.
 
-    When it does, the free-text fallback must not run: the envelope already
-    says what happened, and searching the rest of it only risks matching an
-    unrelated field such as a session id.
+    Backends nest failure text differently — a bare string, a list of
+    strings (Claude Code's ``errors``), or an object such as OpenCode's
+    ``{"name": ..., "data": {"message": ...}}``.  Only the leaves matter
+    for classification.
     """
-    # Structured JSON type names (for example, ``overloaded_error``) are
-    # backend-defined, so only the typed API status is used for classification.
-    return isinstance(parsed.get("subtype"), str) or _api_error_status(parsed) is not None
+    if isinstance(value, str):
+        return [value]
+    if depth >= 4:
+        return []
+    if isinstance(value, list):
+        return [leaf for item in value for leaf in _string_leaves(item, depth=depth + 1)]
+    if isinstance(value, dict):
+        return [
+            leaf for item in value.values() for leaf in _string_leaves(item, depth=depth + 1)
+        ]
+    return []
+
+
+def _envelope_reports_failure(envelope: dict[str, Any]) -> bool:
+    """Whether a Claude Code result envelope says the turn failed.
+
+    Every real envelope carries ``subtype`` (``"success"`` or one of the
+    ``error_*`` values), so its presence alone says nothing; only an
+    ``error_*`` subtype or ``is_error`` marks a failure.
+    """
+    subtype = envelope.get("subtype")
+    return envelope.get("is_error") is True or (
+        isinstance(subtype, str) and subtype.startswith("error_")
+    )
+
+
+def _envelope_failure_text(envelope: dict[str, Any]) -> str:
+    """The backend-authored failure strings of a Claude Code envelope.
+
+    Error subtypes carry ``errors: [...]``; a ``success`` envelope with
+    ``is_error`` carries the message in ``result``.  Nothing else in the
+    envelope (session id, usage, model names) is consulted.
+    """
+    return "\n".join(
+        _string_leaves(envelope.get("errors")) + _string_leaves(envelope.get("result"))
+    )
+
+
+# Keys whose values a JSONL backend uses for failure text on any event, and
+# the extra keys consulted only when the event itself is typed as an error.
+_EVENT_ERROR_KEYS = ("error", "errors")
+_ERROR_EVENT_MESSAGE_KEYS = ("message", "result", "text")
+
+
+def _events_failure_text(events: list[dict[str, Any]]) -> str:
+    """The failure strings carried by a JSONL backend's structured events.
+
+    Only the error fields are read.  The rest of the transcript — tool
+    output, file contents the agent read, its own prose — is never scanned,
+    since a repository that merely mentions "rate limit" must not turn an
+    unrelated non-zero exit into a rate-limit verdict.
+    """
+    parts: list[str] = []
+    for event in events:
+        for key in _EVENT_ERROR_KEYS:
+            parts.extend(_string_leaves(event.get(key)))
+        event_type = str(event.get("type", "")).lower()
+        subtype = str(event.get("subtype", "")).lower()
+        if "error" in event_type or subtype.startswith("error") or event.get("is_error") is True:
+            for key in _ERROR_EVENT_MESSAGE_KEYS:
+                parts.extend(_string_leaves(event.get(key)))
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -1717,22 +1783,26 @@ def invoke_claude_code(
         )
 
     def _rate_limit_from_envelope(envelope: dict[str, Any]) -> RateLimitError | None:
-        """Rate-limit verdict for a parsed backend envelope, if it carries one."""
+        """Rate-limit verdict for a parsed Claude Code envelope, if it carries one."""
         api_status = _api_error_status(envelope)
         if api_status in (429, 529):
             return _rate_limit_error(
                 f"{backend_name} hit a rate/usage limit (HTTP {api_status})",
                 "structured backend result",
             )
-        # The error field is a bounded fallback, consulted only when the
-        # envelope supplies no classifying field of its own.
-        error_text = str(envelope.get("error") or "")
-        if _has_structured_failure_signal(envelope) or not _looks_like_rate_limit(error_text):
+        # Without a typed status, classify from the backend's own failure
+        # strings — but only when the envelope says the turn failed.  A
+        # successful turn whose ``result`` prose happens to mention a rate
+        # limit is a completed mutation, not a quota problem.
+        if not _envelope_reports_failure(envelope):
             return None
-        logger.error("Rate limit detected in JSON response: %s", error_text[:200])
+        failure_text = _envelope_failure_text(envelope)
+        if not _looks_like_rate_limit(failure_text):
+            return None
+        logger.error("Rate limit detected in JSON response: %s", failure_text[:200])
         return _rate_limit_error(
             f"{backend_name} returned a rate/usage limit error in JSON response",
-            "structured backend result fallback",
+            "structured backend result",
         )
 
     try:
@@ -1750,11 +1820,13 @@ def invoke_claude_code(
                     raise rate_limited
             return parsed, usage
 
-        # The claude backend may still write a structured result envelope on a
-        # non-zero exit.  Classify that envelope before inspecting raw output,
-        # so a session id or transcript fragment cannot pre-empt a real
-        # max-turns result — which is partial success, not a discarded proposal.
+        # Classify the structured output before inspecting raw text, so a
+        # session id or transcript fragment cannot pre-empt what the backend
+        # itself reported.
         if backend == "claude":
+            # The claude backend may still write a result envelope on a
+            # non-zero exit.  ``error_max_turns`` is partial success, not a
+            # discarded proposal.
             try:
                 parsed = _parse_backend_output(
                     backend,
@@ -1762,6 +1834,9 @@ def invoke_claude_code(
                     cmd_str=cmd_str,
                     worktree_path=worktree_path,
                 )
+            except MutationError:
+                parsed = None
+            if parsed is not None:
                 usage = _normalise_usage_stats(parsed)
                 if parsed.get("subtype") == "error_max_turns":
                     logger.warning(
@@ -1772,22 +1847,46 @@ def invoke_claude_code(
                 rate_limited = _rate_limit_from_envelope(parsed)
                 if rate_limited is not None:
                     raise rate_limited
-            except MutationError:
-                parsed = None
+        else:
+            # JSONL backends: the non-strict parse never raises, and only
+            # the events' error fields are classified — never the transcript.
+            parsed = _parse_backend_output(
+                backend,
+                result,
+                cmd_str=cmd_str,
+                worktree_path=worktree_path,
+            )
+            events_text = _events_failure_text(parsed.get("events", []))
+            if _looks_like_rate_limit(events_text):
+                logger.error(
+                    "Rate limit detected in %s error events (code %d): %s",
+                    backend_name,
+                    result.returncode,
+                    events_text[:200],
+                )
+                raise _rate_limit_error(
+                    f"{backend_name} returned a rate/usage limit error in structured output",
+                    "structured backend result",
+                )
 
-        # Last resort, only when the envelope said nothing: search both streams
-        # so an HTTP status on stdout is not hidden by an unrelated stderr
-        # warning.
-        already_classified = parsed is not None and (
-            _has_structured_failure_signal(parsed) or bool(parsed.get("error"))
-        )
-        raw_output = "\n".join(s for s in (result.stdout, result.stderr) if s)
-        if not already_classified and _looks_like_rate_limit(raw_output):
+        # Last resort, only when the structured output said nothing.  stderr
+        # is the diagnostics stream and takes precedence; stdout is consulted
+        # only where it is not already-classified structured output: raw
+        # stdout when the claude envelope failed to parse, and only the
+        # non-JSON lines of a JSONL stream (never the transcript events).
+        if parsed is None:
+            stdout_view = result.stdout
+        elif backend == "claude":
+            stdout_view = ""
+        else:
+            stdout_view = "\n".join(parsed.get("unparsable_lines", []))
+        fallback_text = result.stderr or stdout_view
+        if _looks_like_rate_limit(fallback_text):
             logger.error(
                 "Rate limit detected in subprocess exit for %s (code %d): %s",
                 backend_name,
                 result.returncode,
-                raw_output[:200],
+                fallback_text[:200],
             )
             raise _rate_limit_error(
                 f"{backend_name} hit a rate/usage limit (exit code {result.returncode})",

--- a/tests/unit/test_backend_failure_classification.py
+++ b/tests/unit/test_backend_failure_classification.py
@@ -38,10 +38,14 @@ class TestRateLimitSignals:
         "text",
         [
             "HTTP 429 Too Many Requests",
-            "429",
+            "HTTP 529",
+            "status code: 429",
             "You have exceeded your rate limit",
+            "rate-limit hit",
             "server overloaded",
             "usage limit reached",
+            "extra usage consumed",
+            "too many requests",
             "quota exceeded for this model",
             "You exceeded your quota",
         ],
@@ -57,13 +61,25 @@ class TestRateLimitSignals:
             "model not found",
             _MAX_TURNS_SESSION_ID,
             "",
+            # A bare 429/529 with no accompanying backend-error wording is
+            # ordinary output an agent backend can print for any reason —
+            # it must not be read as a rate limit.
+            "429",
+            "529",
+            "Line 429: unexpected token",
+            "conversation used 429 tokens so far",
+            "record 529 created successfully",
+            "529 ms elapsed",
+            "@@ -12,6 +429,9 @@ def run():",
         ],
     )
     def test_unrelated_errors_are_not_called_rate_limits(self, text):
         """An unclassified failure must not be reported as a quota problem.
 
         Sending an operator to a quota dashboard for a non-quota failure is
-        strictly worse than saying the error is unrecognised.
+        strictly worse than saying the error is unrecognised. This also
+        covers the bare-number case: a "429"/"529" with no HTTP/status/code
+        wording nearby is ordinary backend chatter, not a rate-limit signal.
         """
         assert mutator._looks_like_rate_limit(text) is False
 
@@ -197,3 +213,29 @@ class TestNonZeroExitClassification:
 
         assert not isinstance(exc_info.value, RateLimitError)
         assert exc_info.value.stderr == "backend exploded while preparing request"
+
+    def test_unknown_subtype_with_numeric_error_stays_generic(self, tmp_path, mocker):
+        """An unrecognised structured subtype must not fall through to
+        free-text rate-limit scanning, even when its error field carries a
+        numeric token that would otherwise look like a status code. Once the
+        envelope names a subtype, that is the classifying signal; an unknown
+        one means a generic failure, not a guess at what the number means.
+        """
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps(
+                    {
+                        "subtype": "error_during_execution",
+                        "error": "worker HTTP 429 restart id logged",
+                    }
+                )
+            ),
+        )
+
+        with pytest.raises(MutationError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="claude")
+            )
+
+        assert not isinstance(exc_info.value, RateLimitError)

--- a/tests/unit/test_backend_failure_classification.py
+++ b/tests/unit/test_backend_failure_classification.py
@@ -103,6 +103,24 @@ class TestNonZeroExitClassification:
         assert exc_info.value.exit_code == 1
         assert exc_info.value.stderr == "unrelated warning emitted on stderr"
 
+    def test_structured_api_status_529_is_an_overload_rate_limit(self, tmp_path, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps({"api_error_status": 529, "error": "server overloaded"}),
+                stderr="unrelated warning emitted on stderr",
+            ),
+        )
+
+        with pytest.raises(RateLimitError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="claude")
+            )
+
+        assert exc_info.value.phase == "structured backend result"
+        assert exc_info.value.exit_code == 1
+        assert exc_info.value.stderr == "unrelated warning emitted on stderr"
+
     def test_stdout_rate_limit_is_seen_when_stderr_is_non_empty(self, tmp_path, mocker):
         """An unstructured status on stdout must not be hidden by stderr."""
         mocker.patch(
@@ -239,3 +257,4 @@ class TestNonZeroExitClassification:
             )
 
         assert not isinstance(exc_info.value, RateLimitError)
+        assert "worker HTTP 429 restart id logged" in exc_info.value.stdout

--- a/tests/unit/test_backend_failure_classification.py
+++ b/tests/unit/test_backend_failure_classification.py
@@ -41,6 +41,7 @@ class TestRateLimitSignals:
             "server overloaded",
             "usage limit reached",
             "quota exceeded for this model",
+            "You exceeded your quota",
         ],
     )
     def test_real_rate_limit_signals_are_detected(self, text):

--- a/tests/unit/test_backend_failure_classification.py
+++ b/tests/unit/test_backend_failure_classification.py
@@ -6,8 +6,8 @@ Getting the order wrong discards completed work: a session id containing a
 "429"/"529" hex fragment used to be read as a rate limit and thrown away a
 proposal that had already run to its turn limit.
 
-This is backend-agnostic; the claude backend is used because it is the one
-that emits a structured envelope alongside a non-zero exit.
+Fixtures use the claude backend because its result envelope is what the
+ordering rule applies to.
 """
 
 from __future__ import annotations
@@ -22,6 +22,8 @@ from helix.config import AgentConfig, HelixConfig
 from helix.exceptions import MutationError, RateLimitError
 from helix.population import Candidate, EvalResult
 
+# Synthetic. Shaped like a session id and carrying "429"/"529" as hex
+# fragments, which is the collision the whole-token match must survive.
 _MAX_TURNS_SESSION_ID = "00000000-0429-4000-8000-000000000529"
 
 

--- a/tests/unit/test_backend_failure_classification.py
+++ b/tests/unit/test_backend_failure_classification.py
@@ -1,0 +1,196 @@
+"""Backend failure classification.
+
+A non-zero backend exit must be classified from the structured result
+envelope first, and only from raw output when the envelope says nothing.
+Getting the order wrong discards completed work: a session id containing a
+"429"/"529" hex fragment used to be read as a rate limit and thrown away a
+proposal that had already run to its turn limit.
+
+This is backend-agnostic; the claude backend is used because it is the one
+that emits a structured envelope alongside a non-zero exit.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+import helix.mutator as mutator
+from helix.config import AgentConfig, HelixConfig
+from helix.exceptions import MutationError, RateLimitError
+from helix.population import Candidate, EvalResult
+
+_MAX_TURNS_SESSION_ID = "00000000-0429-4000-8000-000000000529"
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 1):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class TestRateLimitSignals:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "HTTP 429 Too Many Requests",
+            "429",
+            "You have exceeded your rate limit",
+            "server overloaded",
+            "usage limit reached",
+            "quota exceeded for this model",
+        ],
+    )
+    def test_real_rate_limit_signals_are_detected(self, text):
+        assert mutator._looks_like_rate_limit(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "UnknownError: Unexpected server error. Check server logs for details.",
+            "ENOENT: no such file or directory",
+            "model not found",
+            _MAX_TURNS_SESSION_ID,
+            "",
+        ],
+    )
+    def test_unrelated_errors_are_not_called_rate_limits(self, text):
+        """An unclassified failure must not be reported as a quota problem.
+
+        Sending an operator to a quota dashboard for a non-quota failure is
+        strictly worse than saying the error is unrecognised.
+        """
+        assert mutator._looks_like_rate_limit(text) is False
+
+
+class TestNonZeroExitClassification:
+    def test_structured_api_status_429_is_a_rate_limit(self, tmp_path, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps({"api_error_status": 429, "error": "request rejected"}),
+                stderr="unrelated warning emitted on stderr",
+            ),
+        )
+
+        with pytest.raises(RateLimitError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="claude")
+            )
+
+        assert exc_info.value.phase == "structured backend result"
+        assert exc_info.value.exit_code == 1
+        assert exc_info.value.stderr == "unrelated warning emitted on stderr"
+
+    def test_stdout_rate_limit_is_seen_when_stderr_is_non_empty(self, tmp_path, mocker):
+        """An unstructured status on stdout must not be hidden by stderr."""
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout="HTTP 429 Too Many Requests",
+                stderr="non-empty unrelated warning",
+            ),
+        )
+
+        with pytest.raises(RateLimitError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="opencode")
+            )
+
+        assert exc_info.value.stdout == "HTTP 429 Too Many Requests"
+        assert exc_info.value.stderr == "non-empty unrelated warning"
+
+    def test_max_turns_session_id_collision_remains_partial_success(
+        self, tmp_path, mocker
+    ):
+        """The session id carries "429"; the envelope must still win."""
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps(
+                    {
+                        "subtype": "error_max_turns",
+                        "session_id": _MAX_TURNS_SESSION_ID,
+                        "num_turns": 60,
+                        "error": "Reached maximum number of turns (60)",
+                    }
+                )
+            ),
+        )
+
+        parsed, usage = mutator.invoke_claude_code(
+            str(tmp_path), "prompt", AgentConfig(backend="claude")
+        )
+
+        assert parsed["subtype"] == "error_max_turns"
+        assert usage.num_turns == 60
+
+    def test_max_turns_collision_returns_candidate_to_evolution_gate(
+        self, tmp_path, mocker
+    ):
+        """A partial result must leave the child available for normal gating."""
+        parent = Candidate(
+            id="g0-s0",
+            worktree_path=str(tmp_path),
+            branch_name="main",
+            generation=0,
+            parent_id=None,
+            parent_ids=[],
+            operation="seed",
+        )
+        child_path = tmp_path / "g1-s1"
+        child_path.mkdir()
+        child = Candidate(
+            id="g1-s1",
+            worktree_path=str(child_path),
+            branch_name="helix/g1-s1",
+            generation=1,
+            parent_id="g0-s0",
+            parent_ids=["g0-s0"],
+            operation="mutate",
+        )
+        mocker.patch("helix.mutator.clone_candidate", return_value=child)
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps(
+                    {
+                        "subtype": "error_max_turns",
+                        "session_id": _MAX_TURNS_SESSION_ID,
+                        "num_turns": 60,
+                    }
+                )
+            ),
+        )
+
+        returned = mutator.mutate(
+            parent=parent,
+            eval_result=EvalResult(
+                candidate_id="g0-s0", scores={}, asi={}, instance_scores={}
+            ),
+            new_id="g1-s1",
+            config=HelixConfig(
+                objective="objective",
+                evaluator={"command": "true"},
+                agent={"backend": "claude"},
+            ),
+            base_dir=tmp_path,
+        )
+
+        assert returned is child, "partial max-turns work must reach the evolution gate"
+
+    def test_unknown_failure_preserves_underlying_message(self, tmp_path, mocker):
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(stderr="backend exploded while preparing request"),
+        )
+
+        with pytest.raises(MutationError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="opencode")
+            )
+
+        assert not isinstance(exc_info.value, RateLimitError)
+        assert exc_info.value.stderr == "backend exploded while preparing request"

--- a/tests/unit/test_backend_failure_classification.py
+++ b/tests/unit/test_backend_failure_classification.py
@@ -6,8 +6,11 @@ Getting the order wrong discards completed work: a session id containing a
 "429"/"529" hex fragment used to be read as a rate limit and thrown away a
 proposal that had already run to its turn limit.
 
-Fixtures use the claude backend because its result envelope is what the
-ordering rule applies to.
+Claude fixtures follow the real Claude Code envelope: ``subtype`` is always
+present ("success" or an ``error_*`` value); success envelopes carry
+``result: <str>``, error subtypes carry ``errors: [<str>, ...]``, and there
+is no top-level ``error`` field.  Newer CLIs add ``api_error_status`` to
+success envelopes; older CLIs and error subtypes do not.
 """
 
 from __future__ import annotations
@@ -33,6 +36,36 @@ def _completed(stdout: str = "", stderr: str = "", returncode: int = 1):
     )
 
 
+def _success_envelope(**fields):
+    """A Claude Code ``subtype: "success"`` result envelope."""
+    envelope = {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": "Done.",
+        "session_id": _MAX_TURNS_SESSION_ID,
+        "num_turns": 3,
+    }
+    envelope.update(fields)
+    return envelope
+
+
+def _error_envelope(subtype: str, *errors: str):
+    """A Claude Code ``error_*`` result envelope (``errors`` list, no result)."""
+    return {
+        "type": "result",
+        "subtype": subtype,
+        "is_error": True,
+        "errors": list(errors),
+        "session_id": _MAX_TURNS_SESSION_ID,
+        "num_turns": 3,
+    }
+
+
+def _jsonl(*events):
+    return "\n".join(json.dumps(event) for event in events) + "\n"
+
+
 class TestRateLimitSignals:
     @pytest.mark.parametrize(
         "text",
@@ -48,6 +81,12 @@ class TestRateLimitSignals:
             "too many requests",
             "quota exceeded for this model",
             "You exceeded your quota",
+            # The backend's own type tokens: ``\b`` treats "_" as a word
+            # character, so these need letter/digit lookarounds to match.
+            "overloaded_error",
+            "rate_limit_error",
+            'API Error: 529 {"type":"overloaded_error","message":"Overloaded"}',
+            'API Error: 429 {"type":"rate_limit_error","message":"..."}',
         ],
     )
     def test_real_rate_limit_signals_are_detected(self, text):
@@ -71,6 +110,7 @@ class TestRateLimitSignals:
             "record 529 created successfully",
             "529 ms elapsed",
             "@@ -12,6 +429,9 @@ def run():",
+            "prorate limits apply",
         ],
     )
     def test_unrelated_errors_are_not_called_rate_limits(self, text):
@@ -89,7 +129,7 @@ class TestNonZeroExitClassification:
         mocker.patch(
             "helix.mutator.subprocess.run",
             return_value=_completed(
-                stdout=json.dumps({"api_error_status": 429, "error": "request rejected"}),
+                stdout=json.dumps(_success_envelope(api_error_status=429, result="")),
                 stderr="unrelated warning emitted on stderr",
             ),
         )
@@ -107,7 +147,7 @@ class TestNonZeroExitClassification:
         mocker.patch(
             "helix.mutator.subprocess.run",
             return_value=_completed(
-                stdout=json.dumps({"api_error_status": 529, "error": "server overloaded"}),
+                stdout=json.dumps(_success_envelope(api_error_status=529, result="")),
                 stderr="unrelated warning emitted on stderr",
             ),
         )
@@ -121,12 +161,23 @@ class TestNonZeroExitClassification:
         assert exc_info.value.exit_code == 1
         assert exc_info.value.stderr == "unrelated warning emitted on stderr"
 
-    def test_stdout_rate_limit_is_seen_when_stderr_is_non_empty(self, tmp_path, mocker):
-        """An unstructured status on stdout must not be hidden by stderr."""
+    def test_jsonl_error_event_rate_limit_is_seen_when_stderr_is_non_empty(
+        self, tmp_path, mocker
+    ):
+        """A structured error event on stdout must not be hidden by stderr."""
         mocker.patch(
             "helix.mutator.subprocess.run",
             return_value=_completed(
-                stdout="HTTP 429 Too Many Requests",
+                stdout=_jsonl(
+                    {"type": "step_start"},
+                    {
+                        "type": "error",
+                        "error": {
+                            "name": "APIError",
+                            "data": {"message": "HTTP 429 Too Many Requests"},
+                        },
+                    },
+                ),
                 stderr="non-empty unrelated warning",
             ),
         )
@@ -136,8 +187,164 @@ class TestNonZeroExitClassification:
                 str(tmp_path), "prompt", AgentConfig(backend="opencode")
             )
 
-        assert exc_info.value.stdout == "HTTP 429 Too Many Requests"
+        assert exc_info.value.phase == "structured backend result"
         assert exc_info.value.stderr == "non-empty unrelated warning"
+
+    def test_jsonl_transcript_text_is_never_scanned_for_rate_limits(
+        self, tmp_path, mocker
+    ):
+        """Tool output echoed in the transcript is not a backend failure.
+
+        A repository whose source mentions "rate limit" (this one does) is
+        read by the agent and echoed on stdout; an unrelated non-zero exit
+        must stay a generic failure whether stderr is empty or not.
+        """
+        transcript = _jsonl(
+            {"type": "step_start"},
+            {
+                "type": "tool_result",
+                "name": "read",
+                "output": "def _looks_like_rate_limit(text):  # HTTP 429 handling",
+            },
+            {"type": "text", "text": "The rate limit helper looks fine; status code 429."},
+        )
+        for stderr in ("", "unrelated warning"):
+            mocker.patch(
+                "helix.mutator.subprocess.run",
+                return_value=_completed(stdout=transcript, stderr=stderr),
+            )
+
+            with pytest.raises(MutationError) as exc_info:
+                mutator.invoke_claude_code(
+                    str(tmp_path), "prompt", AgentConfig(backend="opencode")
+                )
+
+            assert not isinstance(exc_info.value, RateLimitError)
+
+    def test_jsonl_non_json_stdout_line_is_scanned_when_stderr_is_empty(
+        self, tmp_path, mocker
+    ):
+        """A plain-text error printed on stdout (not a transcript event)
+        is still consulted once stderr has nothing to say."""
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout="Error: HTTP 429 Too Many Requests\n", stderr=""
+            ),
+        )
+
+        with pytest.raises(RateLimitError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="opencode")
+            )
+
+        assert exc_info.value.phase == "subprocess exit fallback"
+
+    def test_stderr_takes_precedence_over_unparsable_stdout(self, tmp_path, mocker):
+        """Base behaviour: with a non-empty stderr, raw stdout is not scanned."""
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout="see docs on rate limit handling\n",
+                stderr="ENOENT: no such file or directory",
+            ),
+        )
+
+        with pytest.raises(MutationError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="opencode")
+            )
+
+        assert not isinstance(exc_info.value, RateLimitError)
+
+    def test_success_envelope_flagged_is_error_with_429_result_is_a_rate_limit(
+        self, tmp_path, mocker
+    ):
+        """Older CLIs omit ``api_error_status``; the message lives in ``result``."""
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps(
+                    _success_envelope(
+                        is_error=True, result="API Error: 429 rate limit exceeded"
+                    )
+                ),
+            ),
+        )
+
+        with pytest.raises(RateLimitError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="claude")
+            )
+
+        assert exc_info.value.phase == "structured backend result"
+        assert exc_info.value.exit_code == 1
+
+    def test_error_subtype_with_overloaded_error_token_is_a_rate_limit(
+        self, tmp_path, mocker
+    ):
+        """Error subtypes carry ``errors: [...]`` and no ``api_error_status``."""
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps(
+                    _error_envelope(
+                        "error_during_execution",
+                        'API Error: 529 {"type":"overloaded_error","message":"Overloaded"}',
+                    )
+                ),
+            ),
+        )
+
+        with pytest.raises(RateLimitError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="claude")
+            )
+
+        assert exc_info.value.phase == "structured backend result"
+
+    def test_overloaded_envelope_with_subtype_success_is_still_a_rate_limit(
+        self, tmp_path, mocker
+    ):
+        """Regression: ``subtype`` is always present and must not, on its own,
+        be read as "already classified" and turn an overload into a success.
+        """
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps(
+                    _success_envelope(is_error=True, result="Claude is overloaded")
+                ),
+                returncode=0,
+            ),
+        )
+
+        with pytest.raises(RateLimitError):
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="claude")
+            )
+
+    def test_successful_turn_mentioning_rate_limits_is_returned(
+        self, tmp_path, mocker
+    ):
+        """The agent's own prose is not a backend failure report."""
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps(
+                    _success_envelope(
+                        result="Added retry-on-rate-limit handling for HTTP 429 responses."
+                    )
+                ),
+                returncode=0,
+            ),
+        )
+
+        parsed, _usage = mutator.invoke_claude_code(
+            str(tmp_path), "prompt", AgentConfig(backend="claude")
+        )
+
+        assert parsed["subtype"] == "success"
 
     def test_max_turns_session_id_collision_remains_partial_success(
         self, tmp_path, mocker
@@ -148,10 +355,11 @@ class TestNonZeroExitClassification:
             return_value=_completed(
                 stdout=json.dumps(
                     {
+                        "type": "result",
                         "subtype": "error_max_turns",
                         "session_id": _MAX_TURNS_SESSION_ID,
                         "num_turns": 60,
-                        "error": "Reached maximum number of turns (60)",
+                        "errors": ["Reached maximum number of turns (60)"],
                     }
                 )
             ),
@@ -194,9 +402,11 @@ class TestNonZeroExitClassification:
             return_value=_completed(
                 stdout=json.dumps(
                     {
+                        "type": "result",
                         "subtype": "error_max_turns",
                         "session_id": _MAX_TURNS_SESSION_ID,
                         "num_turns": 60,
+                        "errors": ["Reached maximum number of turns (60)"],
                     }
                 )
             ),
@@ -232,22 +442,23 @@ class TestNonZeroExitClassification:
         assert not isinstance(exc_info.value, RateLimitError)
         assert exc_info.value.stderr == "backend exploded while preparing request"
 
-    def test_unknown_subtype_with_numeric_error_stays_generic(self, tmp_path, mocker):
-        """An unrecognised structured subtype must not fall through to
-        free-text rate-limit scanning, even when its error field carries a
-        numeric token that would otherwise look like a status code. Once the
-        envelope names a subtype, that is the classifying signal; an unknown
-        one means a generic failure, not a guess at what the number means.
+    def test_error_subtype_without_rate_limit_wording_stays_generic(
+        self, tmp_path, mocker
+    ):
+        """An ``error_*`` envelope is classified from its own ``errors``
+        strings.  A bare number there is not a status code, so this stays a
+        generic failure with the backend's message preserved, and the
+        envelope's session id (which carries "429"/"529") is never scanned.
         """
         mocker.patch(
             "helix.mutator.subprocess.run",
             return_value=_completed(
                 stdout=json.dumps(
-                    {
-                        "subtype": "error_during_execution",
-                        "error": "worker HTTP 429 restart id logged",
-                    }
-                )
+                    _error_envelope(
+                        "error_during_execution",
+                        "worker restart id 429 logged",
+                    )
+                ),
             ),
         )
 
@@ -257,4 +468,29 @@ class TestNonZeroExitClassification:
             )
 
         assert not isinstance(exc_info.value, RateLimitError)
-        assert "worker HTTP 429 restart id logged" in exc_info.value.stdout
+        assert "worker restart id 429 logged" in exc_info.value.stdout
+
+    def test_claude_envelope_stdout_is_not_rescanned_as_raw_text(
+        self, tmp_path, mocker
+    ):
+        """Once the envelope parsed, stdout is structured output already
+        judged; a "rate limit" mention in the agent's ``result`` prose on an
+        unrelated non-zero exit must not become a rate-limit verdict."""
+        mocker.patch(
+            "helix.mutator.subprocess.run",
+            return_value=_completed(
+                stdout=json.dumps(
+                    _success_envelope(
+                        result="Implemented the rate limit middleware; tests pass."
+                    )
+                ),
+                stderr="",
+            ),
+        )
+
+        with pytest.raises(MutationError) as exc_info:
+            mutator.invoke_claude_code(
+                str(tmp_path), "prompt", AgentConfig(backend="claude")
+            )
+
+        assert not isinstance(exc_info.value, RateLimitError)

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -7,7 +7,10 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from helix.config import EvaluatorConfig, HelixConfig
+from helix.exceptions import EvaluatorError
 from helix.executor import run_evaluator
 from helix.population import Candidate, EvalResult
 
@@ -85,6 +88,22 @@ class TestRunEvaluator:
 
         assert result.scores["success"] == 0.0
         assert result.instance_scores == {"example-0": 1.0}
+
+    def test_docker_exit_125_surfaces_docker_diagnostic(self, tmp_path, mocker):
+        mocker.patch(
+            "helix.executor.subprocess.run",
+            return_value=MagicMock(
+                stdout="", stderr="docker: Error response from daemon: image unavailable", returncode=125
+            ),
+        )
+        candidate = make_candidate(str(tmp_path))
+        config = make_config()
+
+        with pytest.raises(EvaluatorError) as exc_info:
+            run_evaluator(candidate, config)
+        assert exc_info.value.phase == "docker invocation"
+        assert "image unavailable" in exc_info.value.stderr
+        assert "HELIX_RESULT" not in str(exc_info.value)
 
     def test_asi_options_and_helix_log(self, tmp_path: Path):
         _prepare_batch(tmp_path)

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -97,9 +97,8 @@ class TestRunEvaluator:
     def test_docker_exit_125_surfaces_docker_diagnostic_when_docker_was_invoked(
         self, tmp_path, mocker
     ):
-        """Exit 125 is only a Docker diagnostic when HELIX itself invoked
-        Docker for this run (sandbox.enabled + sandbox.evaluator) — the
-        branch this test exercises via ``run_sandboxed_commands``.
+        """Exit 125 is a Docker diagnostic only when HELIX itself invoked
+        Docker for this run (sandbox.enabled + sandbox.evaluator).
         """
         mocker.patch(
             "helix.executor.current_evaluator_sidecar_runtime",

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -9,7 +9,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from helix.config import EvaluatorConfig, HelixConfig
+from helix.config import (
+    EvaluatorConfig,
+    EvaluatorSidecarConfig,
+    HelixConfig,
+    SandboxConfig,
+)
 from helix.exceptions import EvaluatorError
 from helix.executor import run_evaluator
 from helix.population import Candidate, EvalResult
@@ -89,21 +94,70 @@ class TestRunEvaluator:
         assert result.scores["success"] == 0.0
         assert result.instance_scores == {"example-0": 1.0}
 
-    def test_docker_exit_125_surfaces_docker_diagnostic(self, tmp_path, mocker):
+    def test_docker_exit_125_surfaces_docker_diagnostic_when_docker_was_invoked(
+        self, tmp_path, mocker
+    ):
+        """Exit 125 is only a Docker diagnostic when HELIX itself invoked
+        Docker for this run (sandbox.enabled + sandbox.evaluator) — the
+        branch this test exercises via ``run_sandboxed_commands``.
+        """
         mocker.patch(
-            "helix.executor.subprocess.run",
-            return_value=MagicMock(
-                stdout="", stderr="docker: Error response from daemon: image unavailable", returncode=125
-            ),
+            "helix.executor.current_evaluator_sidecar_runtime",
+            return_value=MagicMock(),
+        )
+        mocker.patch(
+            "helix.executor.run_sandboxed_commands",
+            return_value=[
+                MagicMock(
+                    stdout="",
+                    stderr="docker: Error response from daemon: image unavailable",
+                    returncode=125,
+                ),
+                MagicMock(stdout=""),
+            ],
         )
         candidate = make_candidate(str(tmp_path))
-        config = make_config()
+        config = HelixConfig(
+            objective="test objective",
+            evaluator=EvaluatorConfig(
+                command="python eval.py",
+                sidecar=EvaluatorSidecarConfig(
+                    image="runner:latest",
+                    command="serve",
+                    endpoint="http://sidecar",
+                ),
+            ),
+            sandbox=SandboxConfig(enabled=True, evaluator=True),
+        )
 
         with pytest.raises(EvaluatorError) as exc_info:
             run_evaluator(candidate, config)
         assert exc_info.value.phase == "docker invocation"
         assert "image unavailable" in exc_info.value.stderr
         assert "HELIX_RESULT" not in str(exc_info.value)
+
+    def test_non_docker_command_exit_125_with_valid_result_is_not_a_docker_failure(
+        self, tmp_path, mocker
+    ):
+        """Evaluator commands are arbitrary user commands. HELIX did not
+        invoke Docker for this run (sandboxing is off), so an evaluator that
+        happens to exit 125 while still emitting a valid HELIX_RESULT= line
+        must be scored normally, not raised as a Docker invocation failure.
+        """
+        _prepare_batch(tmp_path)
+        mocker.patch(
+            "helix.executor.subprocess.run",
+            return_value=MagicMock(
+                stdout=_result_line([1.0]), stderr="", returncode=125
+            ),
+        )
+        candidate = make_candidate(str(tmp_path))
+        config = make_config()
+
+        result = run_evaluator(candidate, config)
+
+        assert isinstance(result, EvalResult)
+        assert result.instance_scores == {"example-0": 1.0}
 
     def test_asi_options_and_helix_log(self, tmp_path: Path):
         _prepare_batch(tmp_path)

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -135,6 +135,90 @@ class TestRunEvaluator:
         assert "image unavailable" in exc_info.value.stderr
         assert "HELIX_RESULT" not in str(exc_info.value)
 
+    def test_docker_exit_125_with_valid_result_is_scored_as_evaluator_exit(
+        self, tmp_path, mocker
+    ):
+        """Docker passes the contained command's exit code through, so an
+        evaluator that itself exits 125 inside the sandbox while emitting a
+        valid HELIX_RESULT= line is scored like any other non-zero exit
+        (aggregate zeroed, per-example scores kept), not raised as a Docker
+        invocation failure.
+        """
+        _prepare_batch(tmp_path)
+        mocker.patch(
+            "helix.executor.current_evaluator_sidecar_runtime",
+            return_value=MagicMock(),
+        )
+        mocker.patch(
+            "helix.executor.run_sandboxed_commands",
+            return_value=[
+                MagicMock(
+                    stdout=_result_line([1.0]),
+                    stderr="evaluator: giving up after 3 attempts",
+                    returncode=125,
+                ),
+                MagicMock(stdout=""),
+            ],
+        )
+        candidate = make_candidate(str(tmp_path))
+        config = HelixConfig(
+            objective="test objective",
+            evaluator=EvaluatorConfig(
+                command="python eval.py",
+                sidecar=EvaluatorSidecarConfig(
+                    image="runner:latest",
+                    command="serve",
+                    endpoint="http://sidecar",
+                ),
+            ),
+            sandbox=SandboxConfig(enabled=True, evaluator=True),
+        )
+
+        result = run_evaluator(candidate, config)
+
+        assert isinstance(result, EvalResult)
+        assert result.scores["success"] == 0.0
+        assert result.instance_scores == {"example-0": 1.0}
+
+    def test_docker_exit_125_with_daemon_diagnostic_wins_over_result_line(
+        self, tmp_path, mocker
+    ):
+        """A daemon diagnostic on stderr identifies Docker's own failure even
+        when stdout happens to carry a HELIX_RESULT= line."""
+        _prepare_batch(tmp_path)
+        mocker.patch(
+            "helix.executor.current_evaluator_sidecar_runtime",
+            return_value=MagicMock(),
+        )
+        mocker.patch(
+            "helix.executor.run_sandboxed_commands",
+            return_value=[
+                MagicMock(
+                    stdout=_result_line([1.0]),
+                    stderr="docker: Error response from daemon: OCI runtime create failed",
+                    returncode=125,
+                ),
+                MagicMock(stdout=""),
+            ],
+        )
+        candidate = make_candidate(str(tmp_path))
+        config = HelixConfig(
+            objective="test objective",
+            evaluator=EvaluatorConfig(
+                command="python eval.py",
+                sidecar=EvaluatorSidecarConfig(
+                    image="runner:latest",
+                    command="serve",
+                    endpoint="http://sidecar",
+                ),
+            ),
+            sandbox=SandboxConfig(enabled=True, evaluator=True),
+        )
+
+        with pytest.raises(EvaluatorError) as exc_info:
+            run_evaluator(candidate, config)
+        assert exc_info.value.phase == "docker invocation"
+
     def test_non_docker_command_exit_125_with_valid_result_is_not_a_docker_failure(
         self, tmp_path, mocker
     ):

--- a/tests/unit/test_rate_limit_fixes.py
+++ b/tests/unit/test_rate_limit_fixes.py
@@ -133,12 +133,22 @@ class TestFix2RateLimitDiagnostics:
         self, mocker: MagicMock
     ) -> None:
         """invoke_claude_code raises RateLimitError with full diagnostics when the
-        returned JSON ``error`` field contains a rate-limit keyword."""
+        returned envelope reports a failure whose ``result`` carries a
+        rate-limit keyword (the real Claude Code shape: ``subtype`` is always
+        present and the message lives in ``result``, not an ``error`` field)."""
         import json
 
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stdout = json.dumps({"error": "usage limit exceeded"})
+        mock_result.stdout = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": True,
+                "result": "usage limit exceeded",
+                "session_id": "00000000-0000-4000-8000-000000000000",
+            }
+        )
         mock_result.stderr = ""
         mocker.patch("helix.mutator.subprocess.run", return_value=mock_result)
 

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -170,15 +170,22 @@ def test_rate_limit_not_raised_for_normal_errors(tmp_path: Path) -> None:
 
 
 def test_rate_limit_in_json_result(tmp_path: Path) -> None:
-    """invoke_claude_code raises RateLimitError when JSON result contains overload error."""
+    """invoke_claude_code raises RateLimitError when JSON result contains overload error.
+
+    Real Claude Code envelopes always carry ``subtype``; a failed turn that
+    still completed carries ``subtype: "success"`` with ``is_error`` and the
+    message in ``result`` (there is no top-level ``error`` field).
+    """
     from helix.config import AgentConfig
 
     config = AgentConfig()
 
     json_payload = json.dumps({
+        "type": "result",
+        "subtype": "success",
         "is_error": True,
-        "error": "Claude is overloaded",
-        "result": "",
+        "result": "API Error: 529 {\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}",
+        "session_id": "00000000-0000-4000-8000-000000000000",
     })
     fake_result = MagicMock()
     fake_result.returncode = 0


### PR DESCRIPTION
## What

Non-zero backend exits are classified from their structured result before text heuristics. `error_max_turns` remains partial success, structured HTTP 429 becomes a rate-limit error, and the raw fallback scans both streams with token-aware rate-limit signals. Evaluator exit 125 surfaces a Docker diagnostic only when Helix invoked Docker.

## Why

Avoid discarding completed work because incidental text resembles a quota signal, while retaining a useful error for real Docker invocation failures.

## Review focus

Check structured-envelope precedence over the raw-text fallback, especially the `error_max_turns` path and both quota word orders.

## Validation

`uv run --extra dev pytest tests/unit/test_backend_failure_classification.py tests/unit/test_executor.py -q` — 24 passed in 0.23s. Diff: +492/−66 lines.


## Review fixes

Addresses the verified findings against real Claude Code envelope shapes (`subtype` is always present; success envelopes carry `result: <str>`, error subtypes carry `errors: [...]`; there is no top-level `error` field; `api_error_status` only appears on newer CLIs' success envelopes).

- **Envelope classification no longer keys on `subtype` presence** (`src/helix/mutator.py`). `_has_structured_failure_signal` is replaced by `_envelope_reports_failure` (`is_error` or an `error_*` subtype). Only then are the backend's own strings — `errors` and `result` — classified for rate-limit/overload tokens before falling back to a generic error. `{"subtype":"success","is_error":true,"result":"API Error: 429 ..."}` and `{"subtype":"error_during_execution","errors":["API Error: 529 overloaded_error"]}` now raise `RateLimitError`; a successful turn whose prose mentions rate limits is returned as a completed mutation.
- **Reads `errors`/`result`, not `error`.** Fixtures on the branch and inherited ones (`tests/unit/test_resume.py`, `tests/unit/test_rate_limit_fixes.py`) now use the real shapes.
- **Regex tokens**: `overloaded` and `rate[ _-]?limit` use letter/digit lookarounds instead of `\b`, so `overloaded_error` and `rate_limit_error` match.
- **Raw fallback narrowed**: stderr-first precedence restored (`stderr or <stdout view>`). JSONL backends are classified from the parsed events' error fields only (`_events_failure_text`), and the raw stdout view is limited to non-JSON lines — the transcript (tool output, file contents) is never scanned. A parsed claude envelope is never re-scanned as raw text. `test_stdout_rate_limit_is_seen_when_stderr_is_non_empty` is rewritten as `test_jsonl_error_event_rate_limit_is_seen_when_stderr_is_non_empty`, with companion tests that transcript text and stderr precedence stay generic.
- **Exit 125 under Docker** (`src/helix/executor.py`): raised as a Docker invocation failure only when no `HELIX_RESULT=` line was emitted or stderr carries a daemon diagnostic; an evaluator's own exit 125 with a valid result line is scored (aggregate zeroed, per-example scores kept).

Branch was merged with `main` first (clean merge, `417f5ee`).

Gates (post-fix): `uv run python -m pytest -q` — 1032 passed; `uv run ruff check src/ tests/` — All checks passed; `uv run mypy --strict src/helix/` — Success: no issues found in 27 source files.
