### PR TITLE
circle_packing: emit actionable feedback, not just a bare score

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,13 +741,23 @@ from `helix_batch.json` and emit one `[score, side_info]` pair per id:
 
 ```python
 print("HELIX_RESULT=" + json.dumps([
-    [2.63, {"scores": {"sum_radii": 2.63}}],
+    [2.63, {"scores": {"sum_radii": 2.63}, "feedback": "..."}],
 ]))
 ```
 
 For a batch, the payload must have the same length and order as
 `helix_batch.json`. `side_info` is retained for reflection; its optional
 `scores` dictionary supplies named objective axes.
+
+`side_info` — not the score — is what the *next* mutation actually reasons
+from: HELIX renders it into the mutation prompt's Diagnostics section, which
+the agent reads before the number. `{"scores": {"accuracy": 0.0}}` alone
+tells the next mutation only that it failed, not why; `{"scores": {"accuracy":
+0.0}, "feedback": "expected '3.13.2', got '3.12.0' -- used a cached version
+list"}` gives it something to act on. See
+[`examples/web_researcher/evaluate.py`](examples/web_researcher/evaluate.py)
+and [`examples/circle_packing/evaluate.py`](examples/circle_packing/evaluate.py)
+for evaluators that emit this shape.
 
 For GEPA-style reflective feedback, prefer structured per-example
 `side_info` with the built-in result parser. For additional

--- a/examples/circle_packing/README.md
+++ b/examples/circle_packing/README.md
@@ -50,6 +50,9 @@ No Sonnet, no Opus, no extended thinking — just Haiku with low effort and a ha
 - `solve.py` — the evolving solver (this is what HELIX mutates).
 - `evaluate.py` — scorer that checks validity and emits one
   `HELIX_RESULT=[[score, side_info], ...]` pair per id in `helix_batch.json`.
+  `side_info` carries actionable feedback (which circles overlap or escape
+  the square and by how much, radius spread, gap to the best known packing)
+  so the next mutation has something to act on beyond a bare number.
 - `helix.toml` — project configuration.
 - `solve_optimized.py` — a hand-tuned reference implementation that scores **2.635982**. It is not used during evolution; it is provided as a sanity check / target for comparison.
 
@@ -68,7 +71,7 @@ tmp_dir=$(mktemp -d) && cp "$(git rev-parse --show-toplevel)/examples/circle_pac
   && printf '["reference"]\n' > "$tmp_dir/helix_batch.json" \
   && cd "$tmp_dir" \
   && uv run --no-project --python 3.12 --with numpy --with scipy python3 evaluate.py
-# HELIX_RESULT=[[2.635982, {"scores": {"sum_radii": 2.635982}, "violations": 0, "arrangement": "26 circles in 6x5 grid, avg_r=0.1014, violations=0"}]]
+# HELIX_RESULT=[[2.635982, {"scores": {"sum_radii": 2.635982}, "feedback": "All 26 circles are valid: inside the square, no overlaps. Radii range 0.0692-0.1370 (mean 0.1014) across 26 circles. Sum of radii has reached the best known packing for 26 circles (2.635982).", "bounds_violations": {"count": 0, "worst": []}, "overlap_violations": {"count": 0, "total_overlap_depth": 0.0, "worst": []}, "radius_stats": {"n_circles": 26, "min": 0.069181, "max": 0.13701, "mean": 0.101384}}]]
 ```
 
 A score of `0.0` with `"ERROR: Could not import solve.py"` means the evaluator

--- a/examples/circle_packing/README.md
+++ b/examples/circle_packing/README.md
@@ -51,8 +51,12 @@ No Sonnet, no Opus, no extended thinking — just Haiku with low effort and a ha
 - `evaluate.py` — scorer that checks validity and emits one
   `HELIX_RESULT=[[score, side_info], ...]` pair per id in `helix_batch.json`.
   `side_info` carries actionable feedback (which circles overlap or escape
-  the square and by how much, radius spread, gap to the best known packing)
-  so the next mutation has something to act on beyond a bare number.
+  the square and by how much, radius spread, which circle has the most room
+  to grow and what stops it, where the largest remaining empty gap is) so
+  the next mutation has something to act on beyond a bare number. The
+  evaluator never sees or reports a target to match — every measure is
+  computed from the candidate's own geometry, so it keeps producing signal
+  no matter how good the packing gets.
 - `helix.toml` — project configuration.
 - `solve_optimized.py` — a hand-tuned reference implementation that scores **2.635982**. It is not used during evolution; it is provided as a sanity check / target for comparison.
 
@@ -71,7 +75,7 @@ tmp_dir=$(mktemp -d) && cp "$(git rev-parse --show-toplevel)/examples/circle_pac
   && printf '["reference"]\n' > "$tmp_dir/helix_batch.json" \
   && cd "$tmp_dir" \
   && uv run --no-project --python 3.12 --with numpy --with scipy python3 evaluate.py
-# HELIX_RESULT=[[2.635982, {"scores": {"sum_radii": 2.635982}, "feedback": "All 26 circles are valid: inside the square, no overlaps. Radii range 0.0692-0.1370 (mean 0.1014) across 26 circles. Sum of radii has reached the best known packing for 26 circles (2.635982).", "bounds_violations": {"count": 0, "worst": []}, "overlap_violations": {"count": 0, "total_overlap_depth": 0.0, "worst": []}, "radius_stats": {"n_circles": 26, "min": 0.069181, "max": 0.13701, "mean": 0.101384}}]]
+# HELIX_RESULT=[[2.635982, {"scores": {"sum_radii": 2.635982}, "feedback": "All 26 circles are valid: inside the square, no overlaps. Radii range 0.0692-0.1370 (mean 0.1014, spread ratio 1.98) across 26 circles. Circle 5 could grow 0.0000 before the left wall (total headroom 0.0000). Largest empty gap: r0.0238 near (0.97, 0.62).", "bounds_violations": {"count": 0, "worst": []}, "overlap_violations": {"count": 0, "total_overlap_depth": 0.0, "worst": []}, "radius_stats": {"n_circles": 26, "min": 0.069181, "max": 0.13701, "mean": 0.101384}}]]
 ```
 
 A score of `0.0` with `"ERROR: Could not import solve.py"` means the evaluator

--- a/examples/circle_packing/evaluate.py
+++ b/examples/circle_packing/evaluate.py
@@ -10,24 +10,21 @@ GEPA blog: https://gepa-ai.github.io/gepa/blog/2026/02/18/introducing-optimize-a
 
 ``side_info`` carries the feedback the *next* mutation actually reasons from
 (see the "Evaluator Contract" note in skills/helix/SKILL.md): which circles
-overlap and by how much, which escape the unit square and by how much, the
-radius spread, and the gap to the best known packing — the kind of thing a
-human reviewing a bad arrangement would ask for, derived only from data this
-evaluator already computes. It stays bounded regardless of instance size by
-listing only the worst few offenders (see MAX_OFFENDERS_LISTED) rather than
-enumerating every circle or every pair.
+overlap and by how much, which escape the unit square and by how much, radius
+spread, which circle has the most room left to grow and what stops it, and
+where the largest remaining empty gap is — the kind of thing a human
+reviewing an arrangement would point at, derived only from data this
+evaluator already computes about THIS candidate. None of it is a target to
+match: every measure keeps producing a concrete next move no matter how good
+the packing gets, because it describes the candidate's own geometry rather
+than a distance to an external number. It stays bounded regardless of
+instance size by listing only the worst few offenders (see
+MAX_OFFENDERS_LISTED) rather than enumerating every circle or every pair.
 """
 import json
 import math
 from pathlib import Path
 
-# Best published sum-of-radii for 26 circles in a unit square: matches
-# solve_optimized.py's reference score and the figures already quoted in
-# README.md / helix.toml (GEPA optimize_anything blog: 2.63598+; AlphaEvolve:
-# 2.6358). Used only to report a distance-to-target in side_info -- it does
-# not affect the score and is only meaningful for the N_CIRCLES instance
-# actually evaluated here.
-BEST_KNOWN_SUM_RADII = 2.635982
 N_CIRCLES = 26
 
 # Cap how many individual offenders (overlapping pairs, out-of-bounds
@@ -37,6 +34,11 @@ N_CIRCLES = 26
 # under the 32 KiB retained-evaluator-output cap (MAX_EVALUATOR_OUTPUT_BYTES
 # in src/helix/change_summary.py).
 MAX_OFFENDERS_LISTED = 5
+
+# Resolution of the grid search used to locate the largest still-empty gap
+# (see _largest_gap). Fixed and independent of n, so cost stays O(GRID^2)
+# instead of growing with instance size.
+GRID_STEPS = 40
 
 
 def _read_batch_ids() -> list[str]:
@@ -50,6 +52,81 @@ def _read_batch_ids() -> list[str]:
 def _bounds_escape(x: float, y: float, r: float) -> float:
     """How far a circle pokes outside [0, 1] x [0, 1]; 0.0 if fully inside."""
     return max(0.0, r - x, r - y, x + r - 1.0, y + r - 1.0)
+
+
+def _wall_gap(x: float, y: float, r: float) -> tuple[float, str]:
+    """Distance from a circle's edge to its nearest wall, and which wall."""
+    gaps = {"left": x - r, "right": 1.0 - x - r, "bottom": y - r, "top": 1.0 - y - r}
+    side = min(gaps, key=lambda k: gaps[k])
+    return gaps[side], side
+
+
+def _headroom_stats(circles: list[tuple[float, float, float]]) -> list[dict]:
+    """How much each circle could grow before it touches something.
+
+    For every circle, take the smaller of (a) its clearance to the nearest
+    wall and (b) its clearance to its nearest neighbour. That is exactly how
+    much its radius could increase in isolation before something has to
+    give. Clamped at 0 for a circle that already overlaps or escapes the
+    square -- that circle needs to move before it can grow, which the
+    bounds/overlap violations already say. This is unbounded in the useful
+    direction: it is strictly positive for any candidate that is not
+    already a local optimum, so it never runs dry the way a fixed target
+    would.
+    """
+    n = len(circles)
+    stats = []
+    for i, (x, y, r) in enumerate(circles):
+        wall_val, wall_side = _wall_gap(x, y, r)
+        nb_val = math.inf
+        nb_idx = None
+        for j, (xj, yj, rj) in enumerate(circles):
+            if j == i:
+                continue
+            gap = math.hypot(x - xj, y - yj) - r - rj
+            if gap < nb_val:
+                nb_val, nb_idx = gap, j
+        if n == 1 or wall_val <= nb_val:
+            binder = f"the {wall_side} wall"
+        else:
+            binder = f"circle {nb_idx}"
+        stats.append(
+            {
+                "circle": i,
+                "headroom": max(0.0, min(wall_val, nb_val)),
+                "binder": binder,
+            }
+        )
+    return stats
+
+
+def _largest_gap(
+    circles: list[tuple[float, float, float]],
+) -> tuple[float, float, float]:
+    """Approximate radius and location of the largest still-empty region.
+
+    Grid search over the unit square: at each point, the largest circle
+    that could be centered there without touching a wall or an existing
+    circle. Fixed grid resolution (GRID_STEPS), so cost does not grow with
+    n. Like headroom, this stays positive for any candidate short of a
+    perfect covering, so it keeps giving the agent somewhere to push
+    circles toward instead of going silent once some milestone is passed.
+    """
+    best_r, best_x, best_y = -math.inf, 0.5, 0.5
+    for gi in range(GRID_STEPS + 1):
+        gx = gi / GRID_STEPS
+        for gj in range(GRID_STEPS + 1):
+            gy = gj / GRID_STEPS
+            clearance = min(gx, gy, 1.0 - gx, 1.0 - gy)
+            for x, y, r in circles:
+                if clearance <= 0.0:
+                    break
+                d = math.hypot(gx - x, gy - y) - r
+                if d < clearance:
+                    clearance = d
+            if clearance > best_r:
+                best_r, best_x, best_y = clearance, gx, gy
+    return max(0.0, best_r), best_x, best_y
 
 
 def _analyze(circles: list[tuple[float, float, float]]) -> dict:
@@ -108,23 +185,25 @@ def _analyze(circles: list[tuple[float, float, float]]) -> dict:
                 f"{worst['overlap_by']:.4f}) -- push those centers apart or shrink "
                 "one of each pair."
             )
+    min_r, max_r = min(radii), max(radii)
+    spread = f"{max_r / min_r:.2f}" if min_r > 1e-9 else "inf"
     feedback.append(
-        f"Radii range {min(radii):.4f}-{max(radii):.4f} (mean "
-        f"{sum_radii / n:.4f}) across {n} circles."
+        f"Radii range {min_r:.4f}-{max_r:.4f} (mean {sum_radii / n:.4f}, "
+        f"spread ratio {spread}) across {n} circles."
     )
-    if n == N_CIRCLES:
-        # Round before comparing: the score itself is reported rounded to 6
-        # decimals, so a candidate that lands on the published best must not
-        # read as "0.0000 below" (true float sum) instead of "reached".
-        gap = round(BEST_KNOWN_SUM_RADII - round(sum_radii, 6), 6)
-        feedback.append(
-            f"Sum of radii is {gap:.4f} below the best known packing for "
-            f"{n} circles ({BEST_KNOWN_SUM_RADII}), "
-            f"{100.0 * gap / BEST_KNOWN_SUM_RADII:.2f}% short."
-            if gap > 1e-9
-            else "Sum of radii has reached the best known packing for "
-            f"{n} circles ({BEST_KNOWN_SUM_RADII})."
-        )
+
+    headroom = _headroom_stats(circles)
+    total_headroom = sum(h["headroom"] for h in headroom)
+    loosest = max(headroom, key=lambda h: h["headroom"])
+    feedback.append(
+        f"Circle {loosest['circle']} could grow {loosest['headroom']:.4f} "
+        f"before {loosest['binder']} (total headroom {total_headroom:.4f})."
+    )
+
+    gap_r, gap_x, gap_y = _largest_gap(circles)
+    feedback.append(
+        f"Largest empty gap: r{gap_r:.4f} near ({gap_x:.2f}, {gap_y:.2f})."
+    )
 
     # Render the itemized "worst" lists as plain strings rather than nested
     # dicts: HELIX's diagnostics renderer (mutator._render_side_info_value,

--- a/examples/circle_packing/evaluate.py
+++ b/examples/circle_packing/evaluate.py
@@ -1,16 +1,42 @@
 """
 Evaluator for circle packing solution.
 
-Imports solve.pack_circles(26), checks validity constraints,
-computes total radius sum as score, and prints one ``HELIX_RESULT=`` line.
-Exits with code 0 on success.
+Imports solve.pack_circles(26), checks validity constraints, computes total
+radius sum as score, and prints one ``HELIX_RESULT=`` line. Exits with code 0
+on success.
 
 Score = sum of all radii (no penalty for violations — matching the
 GEPA blog: https://gepa-ai.github.io/gepa/blog/2026/02/18/introducing-optimize-anything/)
+
+``side_info`` carries the feedback the *next* mutation actually reasons from
+(see the "Evaluator Contract" note in skills/helix/SKILL.md): which circles
+overlap and by how much, which escape the unit square and by how much, the
+radius spread, and the gap to the best known packing — the kind of thing a
+human reviewing a bad arrangement would ask for, derived only from data this
+evaluator already computes. It stays bounded regardless of instance size by
+listing only the worst few offenders (see MAX_OFFENDERS_LISTED) rather than
+enumerating every circle or every pair.
 """
 import json
 import math
 from pathlib import Path
+
+# Best published sum-of-radii for 26 circles in a unit square: matches
+# solve_optimized.py's reference score and the figures already quoted in
+# README.md / helix.toml (GEPA optimize_anything blog: 2.63598+; AlphaEvolve:
+# 2.6358). Used only to report a distance-to-target in side_info -- it does
+# not affect the score and is only meaningful for the N_CIRCLES instance
+# actually evaluated here.
+BEST_KNOWN_SUM_RADII = 2.635982
+N_CIRCLES = 26
+
+# Cap how many individual offenders (overlapping pairs, out-of-bounds
+# circles) side_info enumerates. Counts and aggregate totals are always
+# exact; only the itemized "worst" lists are truncated, so side_info stays
+# O(1) in n instead of O(n^2) pairs for a much larger instance -- well
+# under the 32 KiB retained-evaluator-output cap (MAX_EVALUATOR_OUTPUT_BYTES
+# in src/helix/change_summary.py).
+MAX_OFFENDERS_LISTED = 5
 
 
 def _read_batch_ids() -> list[str]:
@@ -21,12 +47,122 @@ def _read_batch_ids() -> list[str]:
     return ids
 
 
-def _emit(score: float, *, violations: int, arrangement: str) -> None:
-    side_info = {
-        "scores": {"sum_radii": score},
-        "violations": violations,
-        "arrangement": arrangement,
+def _bounds_escape(x: float, y: float, r: float) -> float:
+    """How far a circle pokes outside [0, 1] x [0, 1]; 0.0 if fully inside."""
+    return max(0.0, r - x, r - y, x + r - 1.0, y + r - 1.0)
+
+
+def _analyze(circles: list[tuple[float, float, float]]) -> dict:
+    """Derive actionable, bounded feedback from a packing.
+
+    Everything here comes from data the evaluator already has after computing
+    the score -- no extra work, no invented facts. An agent should be able to
+    act on the returned dict (and its "feedback" summary) without ever seeing
+    the numeric score.
+    """
+    n = len(circles)
+    if n == 0:
+        return {"feedback": "pack_circles returned no circles."}
+
+    bounds_offenders = []
+    for i, (x, y, r) in enumerate(circles):
+        escape = _bounds_escape(x, y, r)
+        if escape > 1e-9:
+            bounds_offenders.append({"circle": i, "escapes_by": round(escape, 6)})
+    bounds_offenders.sort(key=lambda o: -o["escapes_by"])
+
+    overlap_offenders = []
+    total_overlap = 0.0
+    for i in range(n):
+        x_i, y_i, r_i = circles[i]
+        for j in range(i + 1, n):
+            x_j, y_j, r_j = circles[j]
+            dist = math.hypot(x_i - x_j, y_i - y_j)
+            overlap = r_i + r_j - dist
+            if overlap > 1e-9:  # same tolerance as the validity check below
+                total_overlap += overlap
+                overlap_offenders.append(
+                    {"circles": [i, j], "overlap_by": round(overlap, 6)}
+                )
+    overlap_offenders.sort(key=lambda o: -o["overlap_by"])
+
+    radii = [r for _, _, r in circles]
+    sum_radii = sum(radii)
+
+    feedback = []
+    if not bounds_offenders and not overlap_offenders:
+        feedback.append(f"All {n} circles are valid: inside the square, no overlaps.")
+    else:
+        if bounds_offenders:
+            worst = bounds_offenders[0]
+            feedback.append(
+                f"{len(bounds_offenders)} circle(s) extend outside the unit square "
+                f"(worst: circle {worst['circle']} by {worst['escapes_by']:.4f}) -- "
+                "shrink or reposition those before anything else."
+            )
+        if overlap_offenders:
+            worst = overlap_offenders[0]
+            feedback.append(
+                f"{len(overlap_offenders)} pair(s) overlap, total overlap depth "
+                f"{total_overlap:.4f} (worst: circles {worst['circles']} by "
+                f"{worst['overlap_by']:.4f}) -- push those centers apart or shrink "
+                "one of each pair."
+            )
+    feedback.append(
+        f"Radii range {min(radii):.4f}-{max(radii):.4f} (mean "
+        f"{sum_radii / n:.4f}) across {n} circles."
+    )
+    if n == N_CIRCLES:
+        # Round before comparing: the score itself is reported rounded to 6
+        # decimals, so a candidate that lands on the published best must not
+        # read as "0.0000 below" (true float sum) instead of "reached".
+        gap = round(BEST_KNOWN_SUM_RADII - round(sum_radii, 6), 6)
+        feedback.append(
+            f"Sum of radii is {gap:.4f} below the best known packing for "
+            f"{n} circles ({BEST_KNOWN_SUM_RADII}), "
+            f"{100.0 * gap / BEST_KNOWN_SUM_RADII:.2f}% short."
+            if gap > 1e-9
+            else "Sum of radii has reached the best known packing for "
+            f"{n} circles ({BEST_KNOWN_SUM_RADII})."
+        )
+
+    # Render the itemized "worst" lists as plain strings rather than nested
+    # dicts: HELIX's diagnostics renderer (mutator._render_side_info_value,
+    # GEPA format_samples parity) turns a list of dicts into two more levels
+    # of markdown headers per item, which buries the numbers the mutator
+    # actually needs. A list of short strings renders as one flat "Item N"
+    # per offender instead.
+    bounds_worst = [
+        f"circle {o['circle']} escapes the square by {o['escapes_by']:.4f}"
+        for o in bounds_offenders[:MAX_OFFENDERS_LISTED]
+    ]
+    overlap_worst = [
+        f"circles {o['circles'][0]} & {o['circles'][1]} overlap by {o['overlap_by']:.4f}"
+        for o in overlap_offenders[:MAX_OFFENDERS_LISTED]
+    ]
+
+    return {
+        "feedback": " ".join(feedback),
+        "bounds_violations": {
+            "count": len(bounds_offenders),
+            "worst": bounds_worst,
+        },
+        "overlap_violations": {
+            "count": len(overlap_offenders),
+            "total_overlap_depth": round(total_overlap, 6),
+            "worst": overlap_worst,
+        },
+        "radius_stats": {
+            "n_circles": n,
+            "min": round(min(radii), 6),
+            "max": round(max(radii), 6),
+            "mean": round(sum_radii / n, 6),
+        },
     }
+
+
+def _emit(score: float, *, side_info_extra: dict) -> None:
+    side_info = {"scores": {"sum_radii": score}, **side_info_extra}
     payload = [[score, side_info] for _ in _read_batch_ids()]
     print("HELIX_RESULT=" + json.dumps(payload))
 
@@ -37,46 +173,29 @@ def evaluate():
     except Exception as e:
         _emit(
             0.0,
-            violations=1,
-            arrangement=f"ERROR: Could not import solve.py: {type(e).__name__}: {e}",
+            side_info_extra={
+                "feedback": f"ERROR: Could not import solve.py: {type(e).__name__}: {e}",
+            },
         )
         return
 
     try:
-        circles = solve.pack_circles(26)
+        circles = solve.pack_circles(N_CIRCLES)
     except Exception as e:
-        _emit(0.0, violations=1, arrangement=f"ERROR: pack_circles(26) raised: {e}")
+        _emit(
+            0.0,
+            side_info_extra={
+                "feedback": (
+                    f"ERROR: pack_circles({N_CIRCLES}) raised "
+                    f"{type(e).__name__}: {e}"
+                ),
+            },
+        )
         return
 
-    violations = 0
-
-    # Check bounds: each circle must be fully within the unit square
-    for i, (x, y, r) in enumerate(circles):
-        if not (r <= x <= 1 - r and r <= y <= 1 - r):
-            violations += 1
-
-    # Check non-overlap: distance between any two centers >= r_i + r_j
-    for i in range(len(circles)):
-        x_i, y_i, r_i = circles[i]
-        for j in range(i + 1, len(circles)):
-            x_j, y_j, r_j = circles[j]
-            dist = math.sqrt((x_i - x_j) ** 2 + (y_i - y_j) ** 2)
-            if dist < r_i + r_j - 1e-9:  # small tolerance for floating point
-                violations += 1
-
     # Score = sum of all radii (no violation penalty, matching GEPA blog)
-    score = sum(r for _, _, r in circles)
-
-    n = len(circles)
-    cols = math.ceil(math.sqrt(n))
-    rows = math.ceil(n / cols)
-    avg_r = score / n if n > 0 else 0.0
-    arrangement = (
-        f"{n} circles in {cols}x{rows} grid, avg_r={avg_r:.4f}, "
-        f"violations={violations}"
-    )
-
-    _emit(round(score, 6), violations=violations, arrangement=arrangement)
+    score = round(sum(r for _, _, r in circles), 6)
+    _emit(score, side_info_extra=_analyze(circles))
 
 
 if __name__ == "__main__":

--- a/skills/helix/SKILL.md
+++ b/skills/helix/SKILL.md
@@ -206,6 +206,25 @@ HELIX_RESULT=[[0.8, 1.0, 0.5], {"details": "..."}]
 
 Those shapes are intentionally rejected. Emit one entry per example instead.
 
+`side_info` is the channel the *next* mutation actually reasons from: HELIX
+renders it into the mutation prompt's `## Diagnostics` section, which the
+agent reads before the score. An evaluator that emits only a score gives
+that agent nothing to act on beyond "better" or "worse" — put in `side_info`
+what a human reviewing a bad output would want to know: why the score was
+low and which specific things were wrong.
+
+```python
+# Good -- actionable: says what was wrong and why.
+side_info = {
+    "scores": {"accuracy": 0.0},
+    "feedback": "Expected '3.13.2', got '3.12.0' -- agent read a cached "
+                "version list instead of fetching the live one.",
+}
+
+# Bad -- score only, no signal about *why*; the next mutation is guessing.
+side_info = {"scores": {"accuracy": 0.0}}
+```
+
 ## Running And Monitoring
 
 Common commands:


### PR DESCRIPTION
## Why

HELIX mutates code with an LLM agent, evaluates the candidate, and feeds the
result back into the next mutation prompt. The upstream system HELIX derives
from steers its reflection prompt on per-example feedback text -- the input,
the response, and *why* it was judged that way -- and shows the model no
score at all. HELIX shows scores prominently and leaves feedback to whatever
the operator's evaluator emits in `side_info`.

The shipped examples are the template every operator copies:

- `examples/web_researcher` already emits the good shape: question,
  expected, expected_source, got, correct, match_mode, category,
  `scores.accuracy`.
- `examples/circle_packing` -- the flagship example -- emitted almost pure
  number: `scores.sum_radii`, a `violations` count, and an `arrangement`
  string computed from `n` alone (not the actual layout). When a candidate
  did badly, the next mutation was told a number and essentially nothing
  about *why*.

## What changed

`examples/circle_packing/evaluate.py` now derives, from data it already
computes after scoring:

- which circles overlap and by how much (worst few, plus an exact count and
  total overlap depth)
- which circles escape the unit square and by how much (worst few, plus an
  exact count)
- the radius spread, including a min/max ratio as an unevenness indicator
- which circle has the most headroom to grow before it touches a wall or
  another circle, and the total recoverable headroom across all circles
- the size and rough location of the largest still-empty gap in the packing

...folded into a plain-English `feedback` string plus a small structured
breakdown, so an agent can act on it without ever seeing the score.

`scores` is untouched -- still exactly `{"sum_radii": score}`.

**No target in the loop.** An earlier version of this evaluator also
reported the gap to a hard-coded `BEST_KNOWN_SUM_RADII = 2.635982` and, once
a candidate matched it, literally said so. For an optimizer that anchors the
search on a specific number instead of "better" and goes silent past it --
and it meant this repo's own README claim of matching the best published
result was being partly fed to the thing being measured. `evaluate.py` no
longer knows, mentions, or implies any external target; the headroom and
largest-gap measures above are computed purely from the candidate's own
geometry and stay positive -- so they keep giving the agent something
concrete to push on -- for any candidate short of a true local optimum,
unlike a fixed target that runs out of signal the moment it's matched.
(`solve_optimized.py` still documents 2.635982 as a reference score; it is
not used during evolution and evaluate.py never reads it.)

**Size discipline:** the itemized "worst" lists are capped at 5 entries each
(`MAX_OFFENDERS_LISTED`); counts and totals are always exact, and the
headroom/largest-gap measures are two short sentences regardless of `n`.
This keeps the payload O(1) in `n` instead of O(n²) pairs for a larger
instance. Measured worst-case for the shipped 26-circle config
(heavily-violating synthetic candidate, all offender lists maxed): **1105
bytes**, close to the pre-fix baseline and about 3.4% of the 32 KiB
retained-evaluator-output cap.

`examples/web_researcher/evaluate.py` was reviewed and is already the good
shape -- left unchanged.

## Docs

Added a short paragraph + good/bad contrast wherever the evaluator contract
is documented:

- `skills/helix/SKILL.md`'s "Evaluator Contract" section
- `README.md`'s "Score Parser" section

Both say the same thing: `side_info`, not the score, is what the next
mutation actually reasons from -- HELIX renders it into the mutation
prompt's Diagnostics section, which the agent reads before the number.

`examples/circle_packing/README.md`'s "Files" section and reproduction
snippet were updated to match the current, target-free `evaluate.py`
output; the prose documenting the historical 2.635982 / AlphaEvolve result
elsewhere in that README is unchanged -- stating a result in docs is fine,
the defect was only the evaluator telling the agent at run time.

## Proof

Before (seed `solve.py`, original evaluator):
```
HELIX_RESULT=[[0.979764, {"scores": {"sum_radii": 0.979764}, "violations": 0, "arrangement": "26 circles in 6x5 grid, avg_r=0.0377, violations=0"}]]
```

After (same seed `solve.py`, current evaluator -- no external target
anywhere in the payload):
```
HELIX_RESULT=[[0.979764, {"scores": {"sum_radii": 0.979764}, "feedback": "All 26 circles are valid: inside the square, no overlaps. Radii range 0.0100-0.1303 (mean 0.0377, spread ratio 13.03) across 26 circles. Circle 0 could grow 0.1113 before circle 8 (total headroom 0.3665). Largest empty gap: r0.1211 near (0.88, 0.88).", "bounds_violations": {"count": 0, "worst": []}, "overlap_violations": {"count": 0, "total_overlap_depth": 0.0, "worst": []}, "radius_stats": {"n_circles": 26, "min": 0.01, "max": 0.130332, "mean": 0.037683}}]]
```

And critically, feeding `solve_optimized.py` (the 2.635982 reference
packing) through the same evaluator still produces live, non-zero signal
instead of a stop message:
```
HELIX_RESULT=[[2.635982, {"scores": {"sum_radii": 2.635982}, "feedback": "All 26 circles are valid: inside the square, no overlaps. Radii range 0.0692-0.1370 (mean 0.1014, spread ratio 1.98) across 26 circles. Circle 5 could grow 0.0000 before the left wall (total headroom 0.0000). Largest empty gap: r0.0238 near (0.97, 0.62).", "bounds_violations": {"count": 0, "worst": []}, "overlap_violations": {"count": 0, "total_overlap_depth": 0.0, "worst": []}, "radius_stats": {"n_circles": 26, "min": 0.069181, "max": 0.13701, "mean": 0.101384}}]]
```

Rendered mutation-prompt Diagnostics section for a deliberately bad
candidate (25 circles clustered at center, one escaping the square, heavy
overlap), via HELIX's own `mutator._render_per_example_diagnostics`:

```
## Diagnostics

### Example 0
#### bounds_violations
##### count
1

##### worst
###### Item 1
circle 25 escapes the square by 0.1200
#### feedback
1 circle(s) extend outside the unit square (worst: circle 25 by 0.1200) -- shrink or reposition those before anything else. 300 pair(s) overlap, total overlap depth 48.0000 (worst: circles [0, 1] by 0.1600) -- push those centers apart or shrink one of each pair. Radii range 0.0800-0.1300 (mean 0.0819, spread ratio 1.62) across 26 circles. Circle 0 could grow 0.0000 before circle 1 (total headroom 0.0000). Largest empty gap: r0.2500 near (0.25, 0.25).
#### overlap_violations
##### count
300

##### total_overlap_depth
48.0

##### worst
###### Item 1
circles 0 & 1 overlap by 0.1600
[... 4 more, capped at 5]
#### radius_stats
##### n_circles
26
##### min
0.08
##### max
0.13
##### mean
0.081923
#### Scores (Higher is Better)
##### sum_radii
2.13
```

The agent sees exactly what's wrong, where, and what to try next -- never a
number it's supposed to reach.

## Out of scope

Does not touch the `HELIX_RESULT` contract, `src/helix/change_summary.py`
(note: this file lives only on the unmerged `feat/change-summary` branch,
not on `main` -- nothing to touch here), the mutation prompt, or
`web_researcher`.

## Gates

- `uv run python -m pytest`: 922 passed
- `uv run ruff check src/ tests/ examples/`: all checks passed
- `git diff --shortstat origin/main...HEAD`: 4 files changed, 276
  insertions(+), 42 deletions(-)
