### PR TITLE
fix(population): rank default parent selection by mean, not sum, and make it replayable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MissingObjectiveScoresError` when selection needs that axis; explicitly
   requesting `"hybrid"` warns and no-ops its objective axis, continuing on
   the instance axis.
+- **BEHAVIOUR**: `ParetoFrontier.get_non_dominated()` and
+  `ParetoFrontier.select_parent()` now rank candidates by
+  `EvalResult.aggregate_score()` (the mean instance score) instead of
+  `EvalResult.sum_score()`. This is the default parent-selection path, so
+  every run is affected. The aggregate score does not define dominance —
+  `ParetoFrontier._is_dominated` decides that from per-key frontier
+  membership, unchanged — it *orders* the dominance-elimination scan, which
+  stops at the first dominated candidate it finds. The change therefore
+  affects which candidate survives when several are mutually eliminable,
+  not what "dominated" means. Sum and mean rank a pool identically whenever
+  all candidates carry the same instance count, so runs where every
+  candidate was evaluated on the full valset see no difference. The
+  previous behaviour was justified in-code as GEPA parity; that
+  justification was incorrect. Upstream feeds
+  `gepa.strategies.candidate_selector.ParetoCandidateSelector` from
+  `gepa.core.state.GEPAState.per_program_tracked_scores`, which returns
+  `GEPAState.get_program_average_val_subset(program_idx)[0]` — an average.
+  `EvalResult.sum_score()`, `CandidateSummary.sum_score`, and the
+  `sum_scores` mapping in the result schema are unchanged and still
+  reported; sums also still drive the acceptance gate, which does match
+  upstream's `StrictImprovementAcceptance`.
+
+### Fixed
+- `ParetoFrontier.select_parent()` and `ParetoFrontier.get_non_dominated()`
+  are now reproducible across processes for a given seed. Candidate ids are
+  `str` and the per-key fronts are `set` objects, so set iteration order —
+  which varies with the per-process string-hash salt — reached both the
+  dominance-elimination scan order and the order of the selection sampling
+  list. Two orderings are now imposed: the elimination scan sorts by
+  `(score, candidate_id)`, and the sampling list is built in sorted
+  candidate-id order. Previously, a run pinned to `random.Random(7)` over
+  four identically-scored candidates returned a different parent under
+  different `PYTHONHASHSEED` values. Upstream GEPA indexes programs by
+  integer, so it was never exposed to this; HELIX's port changed the
+  identifier type.
 
 ## [0.2.2] - 2026-05-13
 

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -2507,9 +2507,11 @@ def _run_evolution_impl(
                                 # itself backed by
                                 # ``_evaluate_programs_on_valset``.
                                 # Without this, the merged entry carries only
-                                # subsample coverage and Pareto dominance /
-                                # ``sum_score`` comparisons skew against the
-                                # merged candidate once it is picked as a parent.
+                                # subsample coverage, so its per-key frontier
+                                # membership and its ``aggregate_score()`` are
+                                # both computed over a handful of ids — skewing
+                                # Pareto dominance against the merged candidate
+                                # once it is picked as a parent.
                                 # Budget accounting charges the uncached
                                 # full-val example count; single-task/no-example
                                 # evals still charge 0/1 metric calls via _cached_eval.

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -690,8 +690,12 @@ class ParetoFrontier:
 
         Iterative fixed-point elimination:
         1. Collect all programs appearing in any frontier key.
-        2. Sort by score ascending (worst first — lower-scoring programs are
-           checked first and more likely to be eliminated).
+        2. Sort by ``(score, candidate_id)`` ascending (worst first — lower-scoring
+           programs are checked first and more likely to be eliminated).  The id
+           is part of the sort key, not decoration: the programs are collected by
+           walking ``set`` fronts, so equal-scoring candidates would otherwise be
+           ordered by the per-process string-hash salt, and step 3 stops at the
+           *first* dominated candidate it finds.
         3. Repeatedly scan: for each non-eliminated candidate y, check if y is
            dominated by ``set(programs) - {y} - dominated``.  If dominated,
            mark and restart scan.  Repeat until a full pass finds nothing.
@@ -709,7 +713,7 @@ class ParetoFrontier:
         if scores is None:
             scores = dict.fromkeys(programs, 1.0)
 
-        programs = sorted(programs, key=lambda x: scores.get(x, 0.0), reverse=False)
+        programs = sorted(programs, key=lambda x: (scores.get(x, 0.0), x), reverse=False)
 
         found_to_remove = True
         while found_to_remove:
@@ -739,15 +743,21 @@ class ParetoFrontier:
         """Return the non-dominated set via GEPA's iterative fixed-point elimination.
 
         Dominance is computed against :meth:`_active_frontier`, which
-        dispatches on ``frontier_type``.  Uses each candidate's
-        ``sum_score()`` as the tiebreaker (lower-scoring candidates are
-        eliminated first, matching GEPA's
-        ``train_val_weighted_agg_scores_for_all_programs``).
+        dispatches on ``frontier_type``.  Membership in the per-key fronts
+        is what decides dominance (see :meth:`_is_dominated`); the
+        aggregate score passed here only *orders* the elimination scan,
+        so it selects which of several mutually-eliminable candidates is
+        dropped first, not what "dominated" means.
 
-        GEPA parity (W1): use sum_score() to match GEPA semantics, which
-        diverges from aggregate_score() when candidates have different instance counts.
+        GEPA parity: rank by ``aggregate_score()`` (the mean), not by
+        ``sum_score()``.  Upstream feeds
+        ``gepa.strategies.candidate_selector.ParetoCandidateSelector``
+        from ``gepa.core.state.GEPAState.per_program_tracked_scores``,
+        which returns ``get_program_average_val_subset(program_idx)[0]``
+        — an average, not a sum.  Sum and mean rank pools identically
+        only when every candidate carries the same instance count.
         """
-        scores = {cid: r.sum_score() for cid, r in self._results.items()}
+        scores = {cid: r.aggregate_score() for cid, r in self._results.items()}
         dominators, _ = self._remove_dominated_programs(
             self._active_frontier(), scores,
         )
@@ -789,17 +799,25 @@ class ParetoFrontier:
         """GEPA ``select_program_candidate_from_pareto_front()``.
 
         1. Run ``remove_dominated_programs()`` over :meth:`_active_frontier`
-           with sum scores (GEPA parity W1).
+           with mean aggregate scores, matching the ``scores`` argument
+           upstream's ``ParetoCandidateSelector`` passes to
+           ``gepa.gepa_utils.select_program_candidate_from_pareto_front``.
         2. Count per-key frequency of surviving programs in the *cleaned*
            frontier (dominated programs stripped from every front).
         3. Build a flat sampling list where each program appears *freq* times.
         4. Pick uniformly at random (``rng.choice(sampling_list)`` in GEPA).
+
+        The sampling list is built in sorted candidate-id order so a
+        seeded ``rng`` reproduces the same parent across processes; the
+        cleaned fronts are ``set`` objects and HELIX keys them by ``str``
+        ids, whose hashes are salted per interpreter.  (Upstream keys
+        programs by ``int`` index, so upstream never had this exposure.)
         """
         if not self._candidates:
             raise ValueError("Frontier is empty — cannot select parent.")
 
-        # GEPA parity (W1): use sum_score() to match GEPA semantics.
-        scores = {cid: r.sum_score() for cid, r in self._results.items()}
+        # GEPA parity: rank by mean, as GEPAState.per_program_tracked_scores does.
+        scores = {cid: r.aggregate_score() for cid, r in self._results.items()}
         _, cleaned_per_key_best = self._remove_dominated_programs(
             self._active_frontier(), scores,
         )
@@ -812,9 +830,15 @@ class ParetoFrontier:
                     program_frequency[cid] = 0
                 program_frequency[cid] += 1
 
-        # Build flat sampling list (GEPA: sampling_list)
+        # Build flat sampling list (GEPA: sampling_list).  Iterate in
+        # sorted id order: ``program_frequency`` is populated by walking
+        # ``set`` fronts, so its insertion order varies with the
+        # per-process string-hash salt and would otherwise reach
+        # ``rng.choice`` below.
         sampling_list = [
-            cid for cid, freq in program_frequency.items() for _ in range(freq)
+            cid
+            for cid in sorted(program_frequency)
+            for _ in range(program_frequency[cid])
         ]
 
         # Instance mode keeps HELIX's score-only fallback. Hybrid mode can

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -1689,10 +1689,11 @@ class TestMergeBehavior:
 
         Before this fix, the frontier entry for the merged candidate
         only carried scores for the 5 subsample ids, so
-        ``ParetoFrontier._update_per_key`` registered it on 5 keys and
-        ``sum_score()`` collapsed to a fraction of the full-val sum,
-        systematically under-representing merged candidates as dominators
-        and over-representing them as tiebreak-eliminated candidates.
+        ``ParetoFrontier._update_per_key`` registered it on 5 keys
+        instead of the full valset and its aggregate score was computed
+        over those 5 ids alone — systematically under-representing merged
+        candidates as dominators and giving the elimination scan an
+        unrepresentative position for them.
 
         Regression invariant: ``val_stage_size`` gates the mutation path
         only (consumed via ``_stage_val_example_ids()`` in the proposal's

--- a/tests/unit/test_population.py
+++ b/tests/unit/test_population.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import random
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
@@ -341,3 +345,172 @@ class TestGetNonDominated:
         non_dom = frontier.get_non_dominated()
         assert "a" in non_dom
         assert "b" not in non_dom
+
+
+# ---------------------------------------------------------------------------
+# Elimination-scan ranking metric
+# ---------------------------------------------------------------------------
+
+class TestEliminationScanRanksByMean:
+    """Pin mean-based ranking for the dominance-elimination scan.
+
+    The aggregate score does not *define* dominance — ``_is_dominated``
+    decides that from per-key frontier membership.  It orders the
+    elimination scan, which stops at the first dominated candidate it
+    finds, so on a pool of mutually-eliminable candidates the ranking
+    metric decides which one survives.
+
+    This pool is built so mean and sum disagree.  ``a`` and ``b`` tie for
+    best on ``i1`` and appear in no other front (``c`` owns ``i2``), so
+    each is dominated by the other and exactly one survives:
+
+    ==========  ==========================  ======  ======
+    candidate   instance scores             sum     mean
+    ==========  ==========================  ======  ======
+    ``a``       ``{i1: 1.0}``               1.0     1.0
+    ``b``       ``{i1: 1.0, i2: 0.2}``      1.2     0.6
+    ``c``       ``{i2: 0.9}``               0.9     0.9
+    ==========  ==========================  ======  ======
+
+    Ranking by mean scans ``b`` first and drops it, leaving ``a``.
+    Ranking by sum scans ``a`` first and drops it, leaving ``b``.
+    """
+
+    @staticmethod
+    def _build_split_pool(frontier: ParetoFrontier) -> None:
+        frontier.add(make_candidate("a"), make_result("a", {"i1": 1.0}))
+        frontier.add(make_candidate("b"), make_result("b", {"i1": 1.0, "i2": 0.2}))
+        frontier.add(make_candidate("c"), make_result("c", {"i2": 0.9}))
+
+    def test_pool_actually_separates_mean_from_sum(self):
+        """Guard the fixture: if these rankings ever agree, the tests below go vacuous."""
+        frontier = ParetoFrontier()
+        self._build_split_pool(frontier)
+        results = frontier.results
+        by_mean = sorted(results, key=lambda cid: results[cid].aggregate_score())
+        by_sum = sorted(results, key=lambda cid: results[cid].sum_score())
+        assert by_mean == ["b", "c", "a"]
+        assert by_sum == ["c", "a", "b"]
+        # ``a`` and ``b`` must occupy the same fronts, or neither eliminates the other.
+        assert frontier._per_key_best["i1"] == {"a", "b"}
+        assert frontier._per_key_best["i2"] == {"c"}
+
+    def test_non_dominated_set_follows_mean_ranking(self):
+        frontier = ParetoFrontier()
+        self._build_split_pool(frontier)
+        # Mean ranking keeps ``a``; the superseded sum ranking kept ``b``.
+        assert frontier.get_non_dominated() == {"a", "c"}
+
+    def test_select_parent_never_draws_the_sum_ranked_survivor(self):
+        frontier = ParetoFrontier(rng=random.Random(11))
+        self._build_split_pool(frontier)
+        drawn = {frontier.select_parent().id for _ in range(50)}
+        assert drawn == {"a", "c"}
+
+    def test_equal_instance_counts_rank_identically_under_both_metrics(self):
+        """Mean and sum only diverge when instance counts differ."""
+        frontier = ParetoFrontier()
+        frontier.add(make_candidate("a"), make_result("a", {"i1": 0.9, "i2": 0.1}))
+        frontier.add(make_candidate("b"), make_result("b", {"i1": 0.1, "i2": 0.9}))
+        results = frontier.results
+        assert sorted(results, key=lambda cid: results[cid].aggregate_score()) == sorted(
+            results, key=lambda cid: results[cid].sum_score()
+        )
+
+    def test_sum_score_reporting_surfaces_survive(self):
+        """Selection stopped ranking by sum; the metric itself is still reported."""
+        result = make_result("a", {"i1": 1.0, "i2": 0.2})
+        assert result.sum_score() == pytest.approx(1.2)
+        assert result.aggregate_score() == pytest.approx(0.6)
+
+
+# ---------------------------------------------------------------------------
+# Cross-process reproducibility
+# ---------------------------------------------------------------------------
+
+class TestCrossProcessReproducibility:
+    """A seeded ``ParetoFrontier`` must pick the same parent in any process.
+
+    Candidate ids are ``str`` and the per-key fronts are ``set`` objects,
+    so anything that lets set iteration order reach a selection decision
+    becomes a function of ``PYTHONHASHSEED``.  Upstream GEPA keys
+    programs by ``int`` index and is not exposed to this; HELIX's port
+    changed the identifier type, so the ordering has to be imposed.
+    """
+
+    def _run_under_hash_seeds(self, script: str) -> set[str]:
+        source = textwrap.dedent(script)
+        return {
+            subprocess.run(
+                [sys.executable, "-c", source],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONHASHSEED": str(hash_seed)},
+            ).stdout.strip()
+            for hash_seed in range(1, 9)
+        }
+
+    def test_select_parent_is_stable_across_hash_seeds(self):
+        """All-tied pool: every candidate shares one front, so ordering alone decides."""
+        selections = self._run_under_hash_seeds(
+            """
+            import random
+
+            from helix.population import Candidate, EvalResult, ParetoFrontier
+
+            frontier = ParetoFrontier(rng=random.Random(7))
+            for candidate_id in ("alpha", "bravo", "charlie", "delta"):
+                frontier.add(
+                    Candidate(
+                        id=candidate_id,
+                        worktree_path="",
+                        branch_name="",
+                        generation=0,
+                        parent_id=None,
+                        parent_ids=[],
+                        operation="mutation",
+                    ),
+                    EvalResult(
+                        candidate_id=candidate_id,
+                        scores={},
+                        asi={},
+                        instance_scores={"instance": 1.0},
+                    ),
+                )
+
+            print(frontier.select_parent().id)
+            """
+        )
+        assert len(selections) == 1
+
+    def test_non_dominated_set_is_stable_across_hash_seeds(self):
+        """Equal-scoring, mutually-eliminable candidates must survive identically."""
+        survivors = self._run_under_hash_seeds(
+            """
+            from helix.population import Candidate, EvalResult, ParetoFrontier
+
+            frontier = ParetoFrontier()
+            for candidate_id in ("alpha", "bravo", "charlie", "delta"):
+                frontier.add(
+                    Candidate(
+                        id=candidate_id,
+                        worktree_path="",
+                        branch_name="",
+                        generation=0,
+                        parent_id=None,
+                        parent_ids=[],
+                        operation="mutation",
+                    ),
+                    EvalResult(
+                        candidate_id=candidate_id,
+                        scores={},
+                        asi={},
+                        instance_scores={"i1": 1.0, "i2": 1.0},
+                    ),
+                )
+
+            print(",".join(sorted(frontier.get_non_dominated())))
+            """
+        )
+        assert len(survivors) == 1


### PR DESCRIPTION
## Summary

The default parent-selection path ranked candidates by `EvalResult.sum_score()`, justified in-code as GEPA parity. That justification was false. This PR switches both ranking sites to `EvalResult.aggregate_score()` (the mean), removes the false comments, and fixes a separate cross-process reproducibility bug in the same code path.

This is behaviour-changing on the path every run uses today.

## What this changes — and what it does not

**It does not change what "dominated" means.** `ParetoFrontier._is_dominated` decides dominance from per-key frontier membership — whether every front a candidate appears in is already covered by the surviving set — and is untouched. The aggregate score is only the `scores` argument that *orders* the elimination scan in `ParetoFrontier._remove_dominated_programs`. That scan stops at the first dominated candidate it finds, so the ordering decides which of several mutually-eliminable candidates is dropped first.

So the observable effect is: **which candidate survives elimination in ties and edge cases.** Sum and mean rank a pool identically whenever every candidate carries the same instance count, so runs where every candidate was evaluated on the full valset see no difference at all. The two diverge only on mixed-coverage pools.

**Reporting surfaces are untouched.** `EvalResult.sum_score()`, `CandidateSummary.sum_score`, and the `sum_scores` mapping in the result schema are all unchanged and still populated — removing them would change the public result shape. Sums also still drive the regression/acceptance gate in `evolution._is_regression`, which genuinely does match upstream (`StrictImprovementAcceptance` in `gepa.strategies.acceptance` compares sums of subsample scores). This PR changes what selection *ranks by*, not what the codebase measures.

## Defect 1 — the parity claim was false

The removed comment read:

> GEPA parity (W1): use sum_score() to match GEPA semantics, which diverges from aggregate_score() when candidates have different instance counts.

Verified against a fresh clone of `gepa-ai/gepa` at `b265bf9`, cited by file + symbol:

- `gepa.core.state.GEPAState.get_program_average_val_subset` returns `sum(scores.values()) / num_samples` — an average.
- `gepa.core.state.GEPAState.per_program_tracked_scores` maps that over every program.
- `gepa.strategies.candidate_selector.ParetoCandidateSelector.select_candidate_idx` passes exactly that list to `gepa.gepa_utils.select_program_candidate_from_pareto_front`.

All four upstream selectors rank by that mean: `ParetoCandidateSelector` and `TopKParetoCandidateSelector` via `per_program_tracked_scores`, `CurrentBestCandidateSelector` and `EpsilonGreedyCandidateSelector` via `program_full_scores_val_set` (same averaging expression). No upstream selector uses a sum.

The replacement docstring on `get_non_dominated` states the mean-based parity, cites `ParetoCandidateSelector` / `per_program_tracked_scores` / `get_program_average_val_subset` by symbol, and spells out that the score orders the scan rather than defining dominance.

## Defect 2 — the path was not replayable across processes

Candidate ids are `str` and the per-key fronts are `set` objects, so set iteration order — salted per interpreter — reached two decision points. Reproduced on main with `ParetoFrontier(rng=random.Random(7))` over four identically-scored candidates, calling `select_parent()`:

| PYTHONHASHSEED | before | after |
|---|---|---|
| 1 | bravo | delta |
| 2 | charlie | delta |
| 3 | bravo | delta |
| 4 | delta | delta |
| 5 | charlie | delta |
| 6 | bravo | delta |
| 7 | alpha | delta |
| 8 | charlie | delta |

Two minimal orderings are imposed; the algorithm is otherwise unchanged.

1. `_remove_dominated_programs` sorts the scan by `(score, candidate_id)` instead of `score` alone. The programs list is collected by walking `set` fronts, and Python's sort is stable, so equal-scoring candidates previously kept their salt-dependent arrival order.
2. `select_parent` builds `sampling_list` in sorted candidate-id order. `program_frequency` is populated by walking the cleaned `set` fronts, so its insertion order — and therefore the list handed to `rng.choice` — varied per process.

Upstream indexes programs by integer, so upstream never had this exposure; HELIX's port changed the identifier type. This is the same class of bug recently fixed in `candidate_selector.py`, still live here.

## Sites changed

| File | Symbol | Change |
|---|---|---|
| `src/helix/population.py` | `ParetoFrontier.get_non_dominated` | rank by `aggregate_score()`; docstring rewritten with verified upstream citation |
| `src/helix/population.py` | `ParetoFrontier.select_parent` | rank by `aggregate_score()`; sampling list built in sorted id order; comments corrected |
| `src/helix/population.py` | `ParetoFrontier._remove_dominated_programs` | scan sorted by `(score, candidate_id)`; docstring step 2 explains why |
| `src/helix/evolution.py` | merge full-valset comment | corrected a stale reference to `sum_score` as the dominance ranking metric |
| `CHANGELOG.md` | Unreleased | behaviour entry under Changed, reproducibility entry under Fixed |

I confirmed the set is complete: `_remove_dominated_programs` has exactly two call sites, both listed above, and both now pass mean scores. No other module ranks candidates for selection or dominance. The remaining `sum_score` references in `src/` are the reporting surfaces and the acceptance gate, all intentionally retained.

## Tests

Seven tests added to `tests/unit/test_population.py`, in the subprocess style the selector module's tests already use.

`TestCrossProcessReproducibility` runs selection in **separate processes** across eight `PYTHONHASHSEED` values via `subprocess` and asserts a single distinct winner — one test for `select_parent`, one for `get_non_dominated`.

`TestEliminationScanRanksByMean` pins the ranking metric on a pool built so mean and sum disagree. `a` and `b` tie for best on `i1` and appear in no other front (`c` owns `i2`), so each is dominated by the other and exactly one survives:

| candidate | instance scores | sum | mean |
|---|---|---|---|
| `a` | `{i1: 1.0}` | 1.0 | 1.0 |
| `b` | `{i1: 1.0, i2: 0.2}` | 1.2 | 0.6 |
| `c` | `{i2: 0.9}` | 0.9 | 0.9 |

Mean ranking scans `b` first and drops it, leaving `{a, c}`. Sum ranking scans `a` first and drops it, leaving `{b, c}`. Confirmed empirically in both directions.

**Non-vacuity, proven in both directions.** Reverting only `src/helix/population.py` and re-running the new tests fails exactly the four that assert behaviour:

```
FAILED TestEliminationScanRanksByMean::test_non_dominated_set_follows_mean_ranking
FAILED TestEliminationScanRanksByMean::test_select_parent_never_draws_the_sum_ranked_survivor
FAILED TestCrossProcessReproducibility::test_select_parent_is_stable_across_hash_seeds
FAILED TestCrossProcessReproducibility::test_non_dominated_set_is_stable_across_hash_seeds
4 failed, 3 passed
```

All seven pass on the fixed module. The three that pass on unfixed code are deliberately metric-independent guards: one asserts the fixture actually separates mean from sum (so the pinning tests can't go vacuous if the pool is ever edited), one asserts mean and sum agree at equal instance counts, and one asserts `sum_score()` still reports.

**Tests changed: none.** No existing test encoded the sum behaviour on this path, so the full suite goes 922 → 929 passing with no assertion edits. One docstring in `tests/unit/test_evolution.py` was corrected in place — it narrated the merge-coverage fix in terms of `sum_score()` collapsing to a fraction of the full-val sum, which is no longer the mechanism. It now describes the aggregate being computed over the subsample ids alone. No assertion in that test moved.

## Known interaction with the unmerged candidate-selection-strategies work

The unmerged branch that adds pluggable selection strategies deliberately delegates its `pareto` strategy to this legacy path, and has tests asserting that path is the sum-based one. When that branch rebases onto this change, those assertions will need updating to expect mean-based ranking. Afterwards all four strategies agree on mean, which is the desired end state. That branch is untouched here.

## Gates

Run after `uv sync --extra dev`, using `uv run python -m pytest` (not bare `uv run pytest`, which reuses the original venv in a copied tree and gives a false pass).

```
uv run python -m pytest          929 passed  (922 on main, +7 added, 0 changed)
uv run ruff check src/ tests/    All checks passed!
uv run mypy --strict src/helix/  Success: no issues found in 26 source files
git diff --shortstat origin/main...HEAD
                                 5 files changed, 258 insertions(+), 23 deletions(-)
```
