### PR TITLE
Cite upstream GEPA by symbol instead of line number

### DIFF
--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -306,10 +306,11 @@ class EvolutionConfig(BaseModel):
     # Total cap on merge invocations across the entire run (not per-gen).
     max_merge_invocations: int = 5
     # Minimum val-set overlap floor for merge candidates. Must be > 0
-    # (GEPA parity: merge.py:243-244 rejects val_overlap_floor <= 0).
+    # (GEPA parity: merge.py::MergeProposer.__init__ rejects val_overlap_floor <= 0).
     merge_val_overlap_floor: int = 5
     # Number of val ids sampled for merge acceptance. Default 5 matches
-    # GEPA (merge.py:262 num_subsample_ids=5). Must be >= 1.
+    # GEPA (merge.py::MergeProposer.select_eval_subsample_for_merged_program
+    # num_subsample_ids=5). Must be >= 1.
     merge_subsample_size: int = 5
     # HELIX's own P: the number of parents sampled per iteration for
     # parallel mutation proposals. Upstream expresses the same idea via
@@ -522,7 +523,7 @@ class EvolutionConfig(BaseModel):
             raise ValueError(
                 f"evolution.val_stage_size must be >= 0 (got {self.val_stage_size})"
             )
-        # GEPA parity (merge.py:243-244): reject non-positive overlap floors.
+        # GEPA parity (merge.py::MergeProposer.__init__): reject non-positive overlap floors.
         if self.merge_val_overlap_floor <= 0:
             raise ValueError(
                 "evolution.merge_val_overlap_floor must be > 0 "

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -2177,7 +2177,9 @@ def _run_evolution_impl(
             # the effective mutation count by the merge-gate failure rate.
             # GEPA-parity note: the *merge operator itself* (helix.merger.merge,
             # invoked below) deliberately diverges from GEPA's deterministic
-            # text-component splicing (gepa/proposer/merge.py:155-203).  GEPA
+            # text-component splicing
+            # (gepa/proposer/merge.py::
+            # sample_and_attempt_merge_programs_by_common_predictors).  GEPA
             # candidates are dict[str, str], so a syntactic per-component swap
             # is well-defined; helix candidates are full git worktrees, where
             # LLM-mediated file editing is the only viable approach.  Every
@@ -2209,7 +2211,7 @@ def _run_evolution_impl(
                         score_map[cid] = sum(inst_scores.values()) / len(inst_scores)
 
                 # GEPA parity (M2): merge candidates must be non-dominated.
-                # GEPA merge.py:299-304 uses find_dominator_programs() to filter.
+                # GEPA merge.py::MergeProposer.propose uses find_dominator_programs() to filter.
                 non_dominated = frontier.get_non_dominated()
                 merge_candidate_ids = [
                     cid for cid in frontier._candidates if cid in non_dominated
@@ -2224,7 +2226,9 @@ def _run_evolution_impl(
                 # ``MergeProposer.propose`` returns ``None``.
                 #
                 # GEPA parity (merge-pairing audit D1):
-                # mirror GEPA ``merge.py:130-131`` — you need two siblings plus
+                # mirror GEPA
+                # ``merge.py::sample_and_attempt_merge_programs_by_common_predictors``
+                # — you need two siblings plus
                 # one ancestor, so fewer than 3 total candidates can never
                 # yield a valid triplet.  Kept as an explicit guard for
                 # clarity; functionally equivalent to ``find_merge_triplet``
@@ -2241,7 +2245,8 @@ def _run_evolution_impl(
                     # blocked sample triggers resampling rather than bailing
                     # the iteration.  Mirrors GEPA
                     # ``sample_and_attempt_merge_programs_by_common_predictors``
-                    # (merge.py:118-207) where the same filters are inside the
+                    # (merge.py::sample_and_attempt_merge_programs_by_common_predictors)
+                    # where the same filters are inside the
                     # ``for _ in range(max_attempts)`` loop.
                     _attempted_pairs: set[tuple[str, str]] = {
                         (p[0], p[1]) for p in state.merge_attempted_pairs if len(p) >= 2
@@ -2267,7 +2272,7 @@ def _run_evolution_impl(
                     )
 
                 if triplet is not None:
-                    # GEPA parity (merge.py:94-95): ``find_merge_triplet``
+                    # GEPA parity (merge.py::find_common_ancestor_pair): ``find_merge_triplet``
                     # now returns the canonical ``(i, j)`` (lex-sorted),
                     # so ``cid_i <= cid_j`` always — the merge subprocess,
                     # attempted-pair ledger and the description-triplet
@@ -2295,7 +2300,9 @@ def _run_evolution_impl(
                     # prompt (GEPA parity at the file-hunk level: feed the
                     # agent the same three-way structure GEPA's algorithm
                     # uses to attribute changes —
-                    # ``gepa/proposer/merge.py:163-191``).  The ancestor
+                    # ``gepa/proposer/merge.py::
+                    # sample_and_attempt_merge_programs_by_common_predictors``).
+                    # The ancestor
                     # came from ``find_merge_triplet``; resolve it through
                     # the frontier's append-only candidate map.  ``None``
                     # is tolerated downstream — ``merge()`` falls back to
@@ -2381,7 +2388,8 @@ def _run_evolution_impl(
                             _save_state(state)
                             # GEPA parity (merge-pairing audit C1): the
                             # HEAD SHA of the snapshotted worktree is HELIX's
-                            # port of GEPA's ``new_prog_desc`` (merge.py:195-203);
+                            # port of GEPA's ``new_prog_desc``
+                            # (merge.py::sample_and_attempt_merge_programs_by_common_predictors);
                             # content-addressed so two different triplets that
                             # land on the same merged output hash once and skip
                             # the eval on the duplicate, while the same pair
@@ -2406,10 +2414,11 @@ def _run_evolution_impl(
                             # GEPA parity (M5): merge acceptance evaluates merged on a
                             # size-bounded stratified subsample of ids both parents have
                             # val-scored. Subsample selection ported from GEPA
-                            # merge.py:258-288 (select_eval_subsample_for_merged_program);
+                            # merge.py::MergeProposer.select_eval_subsample_for_merged_program;
                             # default size 5 matches GEPA's hardcoded constant, overridable
                             # via evolution.merge_subsample_size. Required score is
-                            # max(parent subsample sums); mirrors GEPA merge.py:344-345, 394-395.
+                            # max(parent subsample sums); mirrors GEPA
+                            # merge.py::MergeProposer.propose.
                             merge_subsample_ids = sorted(
                                 select_eval_subsample_for_merged_program(
                                     era.instance_scores,
@@ -2453,13 +2462,13 @@ def _run_evolution_impl(
                                 break
 
                             # Merged subsample sum must be >= max of parent
-                            # subsample sums (GEPA merge.py:344-345, 394-395).
+                            # subsample sums (GEPA merge.py::MergeProposer.propose).
                             # merge_subsample_ids is sorted(select_eval_subsample_for_merged_program(
                             #   era.instance_scores, erb.instance_scores, ...))
                             # — every sampled id is drawn from the intersection
                             # of era.instance_scores and erb.instance_scores
                             # (common_val_ids above).  The asserts keep the
-                            # invariant loud (GEPA merge.py:342-343).
+                            # invariant loud (GEPA merge.py::MergeProposer.propose).
                             assert set(merge_subsample_ids).issubset(
                                 era.instance_scores
                             ), (
@@ -2757,8 +2766,9 @@ def _run_evolution_impl(
                         "reason": "perfect_subsample",
                         "parent_eval": wr.parent_eval_result.to_dict(),
                     })
-                    # GEPA parity: reflective_mutation.py:308-327 skips a
-                    # proposal when every parent subsample score is perfect.
+                    # GEPA parity:
+                    # reflective_mutation.py::ReflectiveMutationProposer.propose
+                    # skips a proposal when every parent subsample score is perfect.
                     print_info(
                         f"Iteration {gen}: all subsample scores perfect for parent "
                         f"{_parent.id}; skipping proposal."

--- a/src/helix/lineage.py
+++ b/src/helix/lineage.py
@@ -117,24 +117,25 @@ def find_merge_triplet(
     common ancestor, and neither may be an ancestor of the other.
 
     GEPA parity (M3): uses random sampling with *max_attempts* retries
-    instead of exhaustive O(n²) search.  Mirrors GEPA merge.py:87-90.
+    instead of exhaustive O(n²) search.  Mirrors GEPA merge.py::find_common_ancestor_pair.
 
     GEPA parity (M4): ancestor selection is weighted random by ancestor
-    score, not deterministic best.  Mirrors GEPA merge.py:108-112.
+    score, not deterministic best.  Mirrors GEPA merge.py::find_common_ancestor_pair.
 
     GEPA parity (L1): improvement filter is non-strict (``>``) matching
-    GEPA merge.py:59 — ancestor score must not exceed either candidate.
+    GEPA merge.py::filter_ancestors — ancestor score must not exceed either candidate.
 
     GEPA parity (merge-pairing audit B1/B2/C3):
     - Canonicalize ``(i, j)`` inside the sampling loop so downstream
       consumers (the merge subprocess, the attempted-pair ledger) always
-      see a lex-sorted tuple.  Mirrors GEPA ``merge.py:94-95``
+      see a lex-sorted tuple.  Mirrors GEPA ``merge.py::find_common_ancestor_pair``
       (``if j < i: i, j = j, i``).
     - Filter already-attempted pairs (``attempted_pairs``) and pairs
       that fail the val-support overlap floor (``has_val_support_overlap``)
       *inside* the retry loop, so a blocked sample triggers resampling
       rather than bailing out of the iteration.  Mirrors GEPA
-      ``merge.py:147-148, 199-201`` (inside ``sample_and_attempt_...``).
+      ``merge.py::sample_and_attempt_merge_programs_by_common_predictors``
+      (inside ``sample_and_attempt_...``).
 
     Parameters
     ----------
@@ -149,7 +150,9 @@ def find_merge_triplet(
         Seeded RNG instance.  Falls back to ``random.Random(0)`` if None.
     max_attempts:
         Maximum random sampling attempts before giving up.  Defaults to 10
-        to match GEPA ``merge.py:76,126`` (``max_attempts=10``).
+        to match GEPA ``merge.py::find_common_ancestor_pair`` and
+        ``merge.py::sample_and_attempt_merge_programs_by_common_predictors``
+        (``max_attempts=10``).
     attempted_pairs:
         Optional set of canonical ``(i, j)`` tuples (lex-sorted) that have
         already been attempted in earlier iterations.  Sampled pairs matching
@@ -159,7 +162,7 @@ def find_merge_triplet(
         ``has_val_support_overlap(i, j)`` returns ``False``.  Mirrors the
         ``has_val_support_overlap`` parameter in
         ``sample_and_attempt_merge_programs_by_common_predictors`` at
-        GEPA ``merge.py:125,199-201``.
+        GEPA ``merge.py::sample_and_attempt_merge_programs_by_common_predictors``.
 
     Returns
     -------
@@ -179,12 +182,12 @@ def find_merge_triplet(
     }
 
     for _ in range(max_attempts):
-        # GEPA parity (M3): random pair sampling (merge.py:87-90)
+        # GEPA parity (M3): random pair sampling (merge.py::find_common_ancestor_pair)
         i, j = rng.sample(frontier_ids, 2)
         if i == j:
             continue
 
-        # GEPA parity (merge-pairing audit C3, merge.py:94-95): canonicalize
+        # GEPA parity (merge-pairing audit C3, merge.py::find_common_ancestor_pair): canonicalize
         # pair so (i, j) and (j, i) land on the same (i, j) tuple for all
         # downstream consumers (merge subprocess arg order, attempted-pair
         # ledger, description-triplet dedup).  HELIX ids are strings, so
@@ -192,13 +195,15 @@ def find_merge_triplet(
         if j < i:
             i, j = j, i
 
-        # GEPA parity (merge-pairing audit B2, merge.py:147-148): skip
+        # GEPA parity (merge-pairing audit B2,
+        # merge.py::sample_and_attempt_merge_programs_by_common_predictors): skip
         # already-attempted pairs inside the retry loop instead of burning
         # the whole propose() call.
         if attempted_pairs is not None and (i, j) in attempted_pairs:
             continue
 
-        # GEPA parity (merge-pairing audit B1, merge.py:199-201): skip
+        # GEPA parity (merge-pairing audit B1,
+        # merge.py::sample_and_attempt_merge_programs_by_common_predictors): skip
         # pairs with insufficient val-support overlap inside the retry
         # loop.  This lets the next sample win instead of consuming the
         # whole generation on the first unlucky draw.
@@ -228,7 +233,7 @@ def find_merge_triplet(
             if i_score is None or j_score is None:
                 continue
             # GEPA parity (L1): non-strict improvement filter.
-            # GEPA merge.py:59 uses ``agg_scores[ancestor] > agg_scores[i]``
+            # GEPA merge.py::filter_ancestors uses ``agg_scores[ancestor] > agg_scores[i]``
             # to SKIP — meaning both must be >= ancestor (non-strict).
             if ca_score > i_score or ca_score > j_score:
                 continue
@@ -238,7 +243,7 @@ def find_merge_triplet(
             continue
 
         # GEPA parity (M4): weighted random ancestor selection.
-        # Mirrors GEPA merge.py:108-112 — rng.choices() with score weights.
+        # Mirrors GEPA merge.py::find_common_ancestor_pair — rng.choices() with score weights.
         ancestor_weights = [
             max(frontier_scores.get(ca, 0.0), 1e-9)
             for ca in valid_ancestors

--- a/src/helix/merger.py
+++ b/src/helix/merger.py
@@ -25,7 +25,8 @@ def select_eval_subsample_for_merged_program(
     num_subsample_ids: int = 5,
 ) -> list[str]:
     """Port of GEPA's MergeProposer.select_eval_subsample_for_merged_program
-    (gepa/src/gepa/proposer/merge.py:258-288). Stratifies the subsample
+    (gepa/src/gepa/proposer/merge.py::MergeProposer.select_eval_subsample_for_merged_program).
+    Stratifies the subsample
     across ids where one parent wins, the other parent wins, or they tie,
     then tops up from unused common ids (with-replacement fallback when
     common ids are exhausted).
@@ -134,7 +135,9 @@ def build_merge_prompt(
 
     **Diff section format** — two-diff (ancestor-relative) vs single (A↔B):
 
-    GEPA's merge operator (``gepa/proposer/merge.py:155-203``) reasons over
+    GEPA's merge operator
+    (``gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors``)
+    reasons over
     *three* program states — common ancestor, candidate A, candidate B —
     to attribute each component change to whichever parent diverged from
     the ancestor.  When ``ancestor_id`` + both ``diff_a_from_ancestor``
@@ -246,7 +249,8 @@ def merge(
       labelled sections in the prompt.  The agent can then attribute
       each hunk to whichever parent diverged from the common ancestor —
       file-hunk-level analogue of GEPA's component-wise attribution
-      (``gepa/proposer/merge.py:163-191``: ``if pred_anc == pred_id1 …``
+      (``gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors``:
+      ``if pred_anc == pred_id1 …``
       → take id2's version; ``elif pred_anc != pred_id1 and pred_anc !=
       pred_id2`` → tiebreak by score).
     * **Single (A↔B)** — fallback when no ancestor is provided.
@@ -255,7 +259,9 @@ def merge(
       infer three-way info from a two-way comparison.
 
     GEPA-parity note: this is the correct domain adaptation of GEPA's
-    text-component merge (``gepa/proposer/merge.py:155-203``) for HELIX's
+    text-component merge
+    (``gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors``)
+    for HELIX's
     full-codebase setting.  GEPA can splice ``dict[str, str]`` programs
     deterministically by swapping components from each parent; HELIX
     candidates are full git worktrees, where syntactic per-component swap

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -341,7 +341,7 @@ def _render_side_info_value(value: Any, level: int) -> str:
 
     Line-for-line port of GEPA's ``render_value`` closure inside
     ``format_samples`` at
-    ``src/gepa/strategies/instruction_proposal.py:63-85``:
+    ``src/gepa/strategies/instruction_proposal.py::format_samples.render_value``:
 
       * ``dict`` → ``{'#' * level} {key}`` for each item, recursing
         at ``level + 1`` (capped at ``#_MAX_MARKDOWN_HEADER_LEVEL``
@@ -394,7 +394,7 @@ def _render_per_example_diagnostics(
     Mirrors GEPA's ``OptimizeAnythingAdapter.make_reflective_dataset`` +
     ``format_samples`` in
     ``adapters/optimize_anything_adapter/optimize_anything_adapter.py``
-    and ``src/gepa/strategies/instruction_proposal.py:54-95``:
+    and ``src/gepa/strategies/instruction_proposal.py::format_samples``:
 
       * each example gets an ``{'#' * example_header_level} Example <id>``
         header (id recovered from ``helix_batch.json`` via
@@ -493,7 +493,7 @@ def _render_diagnostics(eval_result: EvalResult) -> str:
          populated; mirrors GEPA's
          ``OptimizeAnythingAdapter.make_reflective_dataset`` combined
          with ``format_samples`` at
-         ``gepa/strategies/instruction_proposal.py:54-95``.
+         ``gepa/strategies/instruction_proposal.py::format_samples``.
       2. ``eval_result.side_info`` (legacy batch-level dict) when
          per-example data is absent.
       3. Empty string when neither is present.

--- a/src/helix/parsers/helix_result.py
+++ b/src/helix/parsers/helix_result.py
@@ -43,7 +43,7 @@ observability).  The executor stores the full list on
 :func:`helix.mutator._render_per_example_diagnostics` renders it into
 the mutation prompt's ``## Diagnostics`` section (GEPA
 ``format_samples`` parity at
-``src/gepa/strategies/instruction_proposal.py:54-95``).
+``src/gepa/strategies/instruction_proposal.py::format_samples``).
 
 Reserved key: ``side_info_i["scores"]``
 ---------------------------------------

--- a/src/helix/population.py
+++ b/src/helix/population.py
@@ -73,12 +73,13 @@ class EvalResult:
       evaluators never type a HELIX-internal id.
     - ``per_example_side_info`` is positional to ``instance_scores``
       by id order (same order as ``helix_batch.json``).  GEPA analogue:
-      ``EvaluationBatch.trajectories`` (``src/gepa/core/adapter.py:25``).
+      ``EvaluationBatch.trajectories``
+      (``src/gepa/core/adapter.py::EvaluationBatch.trajectories``).
       Carries freeform per-example diagnostics; rendered into the
       mutation prompt's Diagnostics section by
       :func:`helix.mutator._render_per_example_diagnostics` (GEPA
       ``format_samples`` parity at
-      ``src/gepa/strategies/instruction_proposal.py:54-95``).
+      ``src/gepa/strategies/instruction_proposal.py::format_samples``).
     """
     candidate_id: str
     scores: dict[str, float]          # aggregate/summary scores

--- a/src/helix/state.py
+++ b/src/helix/state.py
@@ -89,7 +89,8 @@ class EvolutionState:
     # circuit already-seen pairs (merge-pairing audit B2).
     merge_attempted_pairs: list[list[str]] = field(default_factory=list)
     # GEPA parity (merge-pairing audit C1):
-    # mirrors GEPA ``merges_performed[1]`` at gepa/proposer/merge.py:195-203.
+    # mirrors GEPA ``merges_performed[1]`` at
+    # gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors.
     # Each entry is [cid_i, cid_j, desc_hash] with cid_i <= cid_j
     # lexicographically and desc_hash = post-snapshot git SHA of the
     # merged worktree.  Blocks only the *same* (pair, output) triplet,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -235,7 +235,8 @@ class TestDirectModelConstruction:
         assert cfg.max_generations == 10
 
     def test_merge_subsample_size_default_is_5(self) -> None:
-        """Pin default to 5 per GEPA merge.py:262.
+        """Pin default to 5 per GEPA
+        merge.py::MergeProposer.select_eval_subsample_for_merged_program.
 
         Changing this default without intent should be a conscious act — the
         constant is algorithmically load-bearing (stratification math uses
@@ -245,7 +246,8 @@ class TestDirectModelConstruction:
         cfg = EvolutionConfig()
         assert cfg.merge_subsample_size == 5, (
             "Default must match GEPA's num_subsample_ids=5 constant "
-            "(gepa/src/gepa/proposer/merge.py:262).  If you are intentionally "
+            "(gepa/src/gepa/proposer/merge.py::MergeProposer."
+            "select_eval_subsample_for_merged_program).  If you are intentionally "
             "changing this default, update this test AND the comment in "
             "config.py that cites the GEPA line."
         )

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -194,7 +194,9 @@ def all_mocks(mocker):
         "HelixLiveDisplay": mocker.patch("helix.evolution.HelixLiveDisplay"),
         # GEPA parity (merge-pairing audit D1): the merge branch now
         # enforces GEPA's ``len(parent_program_for_candidate) < 3``
-        # early-exit (merge.py:130-131), i.e. you need two siblings plus one
+        # early-exit
+        # (merge.py::sample_and_attempt_merge_programs_by_common_predictors),
+        # i.e. you need two siblings plus one
         # ancestor.  Provide a 3-entry dummy lineage by default so merge tests
         # that mock ``find_merge_triplet`` directly continue to exercise the
         # downstream merge flow.  Merge tests that want to assert the gate
@@ -1375,7 +1377,7 @@ class TestMergeBehavior:
     ):
         """Merge acceptance compares subsample sums, not full-val sums.
 
-        GEPA parity (M5, merge.py:332-400): the merged candidate is evaluated
+        GEPA parity (M5, merge.py::MergeProposer.propose): the merged candidate is evaluated
         only on ``subsample_ids`` (intersection of parent val coverage) and
         compared against ``max(parent_a_subsample, parent_b_subsample)`` —
         not ``max(parent_a_full, parent_b_full)``.
@@ -1484,7 +1486,9 @@ class TestMergeBehavior:
     def test_merge_subsample_size_configurable(self, mocker, tmp_path, all_mocks):
         """evolution.merge_subsample_size caps the merge-eval batch size.
 
-        GEPA parity (merge.py:262 num_subsample_ids=5, overridable): when
+        GEPA parity
+        (merge.py::MergeProposer.select_eval_subsample_for_merged_program
+        num_subsample_ids=5, overridable): when
         both parents cover 10 common val ids but config sets
         merge_subsample_size=3, the merge eval must run on exactly 3 ids
         drawn from the 10-id intersection.
@@ -1559,8 +1563,9 @@ class TestMergeBehavior:
         When only 2 common val ids exist but ``merge_subsample_size=5``, the
         GEPA port falls through to ``rng.choices(common_ids, k=remaining)``
         (merger.select_eval_subsample_for_merged_program → GEPA
-        merge.py:286), producing a subsample with duplicate ids.  GEPA
-        (merge.py:344-345, 394-395) sums scores by iterating those
+        merge.py::MergeProposer.select_eval_subsample_for_merged_program),
+        producing a subsample with duplicate ids.  GEPA
+        (merge.py::MergeProposer.propose) sums scores by iterating those
         duplicate-bearing lists on both parents and the merged program, so
         duplicates contribute equally to all three aggregates.
 
@@ -1815,7 +1820,7 @@ class TestMergeBehavior:
     def test_merge_attempted_pairs_stored_canonically(
         self, mocker, tmp_path, all_mocks
     ):
-        """GEPA parity (merge-pairing audit C3, merge.py:94-95).
+        """GEPA parity (merge-pairing audit C3, merge.py::find_common_ancestor_pair).
 
         ``find_merge_triplet`` canonicalizes the sampled pair via lex sort
         before returning, so the attempted-pair ledger stores
@@ -1911,14 +1916,15 @@ class TestMergeBehavior:
     def test_merge_description_triplet_recorded_on_accept(
         self, mocker, tmp_path, all_mocks
     ):
-        """GEPA parity (merge-pairing audit C1, merge.py:195-203).
+        """GEPA parity (merge-pairing audit C1,
+        merge.py::sample_and_attempt_merge_programs_by_common_predictors).
 
         Forward-direction test: an accepted merge records a
         ``(id1, id2, desc_hash)`` triplet in
         ``state.merge_description_triplets``, keyed canonically on the
         lex-sorted pair and the snapshotted worktree's git SHA.  Mirrors
         GEPA ``merges_performed[1].append((id1, id2, new_prog_desc))`` at
-        merge.py:203.
+        merge.py::sample_and_attempt_merge_programs_by_common_predictors.
 
         The reverse direction (dedup SKIPS when the triplet is already
         recorded) is covered structurally by the identical ``in``-list
@@ -2004,7 +2010,8 @@ class TestMergeBehavior:
         )
 
     def test_merge_gate_requires_three_candidates(self, mocker, tmp_path, all_mocks):
-        """GEPA parity (merge-pairing audit D1, merge.py:130-131).
+        """GEPA parity (merge-pairing audit D1,
+        merge.py::sample_and_attempt_merge_programs_by_common_predictors).
 
         The ``len(parent_program_for_candidate) < 3`` early-exit means a
         run with only two recorded candidates (seed + one child) skips

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -1,13 +1,14 @@
 """Unit tests for helix.lineage.find_merge_triplet.
 
 Ported from GEPA's merge pair-selection behavior
-(gepa/proposer/merge.py:87-115, 118-207).  Covers the post-align-merge
-changes spelled out below:
+(gepa/proposer/merge.py::find_common_ancestor_pair,
+gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors).
+Covers the post-align-merge changes spelled out below:
 
 - B1: overlap-floor filter moved INTO the retry loop.
 - B2: attempted-pair filter moved INTO the retry loop.
 - C3: canonical (lex-sorted) pair returned, mirroring GEPA
-  ``merge.py:94-95`` ``if j < i: i, j = j, i``.
+  ``merge.py::find_common_ancestor_pair`` ``if j < i: i, j = j, i``.
 """
 
 from __future__ import annotations
@@ -34,7 +35,7 @@ def _build_lineage(parents_by_id: dict[str, list[str]]) -> dict[str, LineageEntr
 
 
 class TestFindMergeTripletCanonicalization:
-    """GEPA parity (merge-pairing audit C3, merge.py:94-95).
+    """GEPA parity (merge-pairing audit C3, merge.py::find_common_ancestor_pair).
 
     The sampled pair is lex-sorted inside ``find_merge_triplet`` so that
     ``(A, B)`` and ``(B, A)`` both surface as ``(A, B)`` regardless of the
@@ -67,7 +68,8 @@ class TestFindMergeTripletCanonicalization:
 
 
 class TestFindMergeTripletWithinRetryFilters:
-    """GEPA parity (merge-pairing audit B1+B2, merge.py:147-148, 199-201).
+    """GEPA parity (merge-pairing audit B1+B2,
+    merge.py::sample_and_attempt_merge_programs_by_common_predictors).
 
     The attempted-pair and val-overlap filters live INSIDE the retry loop
     (``for _ in range(max_attempts)``).  A blocked sample resamples within
@@ -170,7 +172,7 @@ class TestFindMergeTripletWithinRetryFilters:
 
 
 class TestFindMergeTripletBackwardCompat:
-    """GEPA parity (merge.py:87-115): without the new optional filters, the
+    """GEPA parity (merge.py::find_common_ancestor_pair): without the new optional filters, the
     behavior is unchanged — attempted_pairs=None, has_val_support_overlap=None
     means "no filtering" and the canonical ``(i, j, ancestor)`` triplet is
     returned for any valid frontier.  The ``val_stage_size``-None invariant

--- a/tests/unit/test_merger.py
+++ b/tests/unit/test_merger.py
@@ -118,7 +118,8 @@ class TestBuildMergePromptTwoDiff:
     """GEPA-parity two-diff form: when ``ancestor_id`` and both
     ancestor-relative diffs are supplied, the prompt emits two labelled
     sections instead of the single A↔B diff.  Mirrors GEPA's
-    three-way attribution reasoning (``gepa/proposer/merge.py:163-191``)
+    three-way attribution reasoning
+    (``gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors``)
     at the file-hunk level — agent reads off A's contribution and B's
     contribution directly instead of inferring three-way info from a
     two-way comparison.
@@ -465,7 +466,8 @@ class TestMerge:
 class TestSelectEvalSubsample:
     """Pure-function tests for the GEPA-parity subsample helper.
 
-    Mirrors gepa/src/gepa/proposer/merge.py:258-288 — stratifies across
+    Mirrors gepa/src/gepa/proposer/merge.py::MergeProposer.select_eval_subsample_for_merged_program
+    — stratifies across
     p1_wins / p2_wins / ties buckets, tops up from unused common ids, and
     falls back to rng.choices (with replacement) when common ids are
     exhausted.
@@ -512,7 +514,9 @@ class TestSelectEvalSubsample:
 
     def test_subsample_fewer_than_size(self):
         # 2 common ids, all in p1 bucket, size 5 → returns 5 entries via the
-        # rng.choices top-up (GEPA merge.py:285-286) drawn from the 2 ids.
+        # rng.choices top-up
+        # (GEPA merge.py::MergeProposer.select_eval_subsample_for_merged_program)
+        # drawn from the 2 ids.
         scores1 = {"a": 1.0, "b": 1.0}
         scores2 = {"a": 0.0, "b": 0.0}
         rng = random.Random(0)

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -253,7 +253,7 @@ class TestPerExampleDiagnostics:
     as the Diagnostics section under the new GEPA O.A. contract
     (``OptimizeAnythingAdapter.make_reflective_dataset`` in
     ``optimize_anything_adapter.py`` + ``format_samples``
-    at ``gepa/strategies/instruction_proposal.py:54-95``).  The legacy
+    at ``gepa/strategies/instruction_proposal.py::format_samples``).  The legacy
     batch-level ``side_info`` rendering is used only when
     ``per_example_side_info`` is absent.
     """


### PR DESCRIPTION
## Why

This repo cites the upstream GEPA optimizer it derives from by file **and line number**
(e.g. `gepa/proposer/merge.py:163-191`). Line numbers into another repository rot
silently: upstream has moved 80+ commits since most of these were written, so a large
share now point at the wrong code, and nothing in CI can detect it — the suite stays
green while a citation is meaningless. Two upstream-code claims in this repo's history
turned out to name symbols that never existed at all.

This PR replaces every such citation with the enclosing **function / method / class**
name, which survives refactors the way a line number cannot. Citation form only — no
behavior changes.

## Scope: how citations were found

The task brief supplied a starting query and 18 as an observed floor, explicit that it
was a floor and not a target. Sweeping the repo turned up a second, more common
citation style the starting query does not match — a bare `merge.py:NNN` form without
a leading path — bringing the real total to **59** line-number citations across
13 files (production code, tests, comments, and docstrings; `.py`/`.md`/`.toml`).

Queries used, both re-run against this branch to confirm zero remaining matches:

```
grep -rnE '(gepa|src/gepa|adapters)/[A-Za-z0-9_/]+\.py:[0-9]+' --include='*.py' --include='*.md' --include='*.toml' .
grep -rnE '[A-Za-z0-9_]+\.py:[0-9]+(-[0-9]+)?(,\s*[0-9]+(-[0-9]+)?)*' --include='*.py' --include='*.md' --include='*.toml' .
```
(the second query's two hits outside the citation set, `auth.py:42` / `routes.py:18`
in `README.md`, are an unrelated multi-file-editing example, not upstream citations —
excluded.)

## Verification method

Every replacement symbol was checked against a **fresh, full clone** of
`github.com/gepa-ai/gepa` at HEAD (`b265bf9c`), not the developer's local pinned/stale
copy. All 59 resolved to a real, present symbol — none were invented. Two citations
(`merge.py:344-345, 394-395` and `reflective_mutation.py:308-327`) had drifted far
enough from their original line numbers (by ~50 and ~140 lines respectively) that the
cited *code* had moved to a different part of the same enclosing function/method —
exactly the failure mode this change eliminates. Both are flagged `MOVED` below.

## Per-citation table (all 59)

| File:Line | Original citation | New citation | Status |
|---|---|---|---|
| config.py:309 | `merge.py:243-244` | `merge.py::MergeProposer.__init__` | VERIFIED PRESENT |
| config.py:312 | `merge.py:262` | `merge.py::MergeProposer.select_eval_subsample_for_merged_program` | VERIFIED PRESENT |
| config.py:525 | `merge.py:243-244` | `merge.py::MergeProposer.__init__` | VERIFIED PRESENT |
| evolution.py:2180 | `gepa/proposer/merge.py:155-203` | `gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| evolution.py:2212 | `merge.py:299-304` | `merge.py::MergeProposer.propose` | VERIFIED PRESENT |
| evolution.py:2227 | `merge.py:130-131` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| evolution.py:2244 | `merge.py:118-207` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| evolution.py:2270 | `merge.py:94-95` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| evolution.py:2298 | `gepa/proposer/merge.py:163-191` | `gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| evolution.py:2384 | `merge.py:195-203` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| evolution.py:2409 | `merge.py:258-288` | `merge.py::MergeProposer.select_eval_subsample_for_merged_program` | VERIFIED PRESENT |
| evolution.py:2412 | `merge.py:344-345, 394-395` | `merge.py::MergeProposer.propose` | VERIFIED PRESENT — **MOVED** (code now ~lines 343-400) |
| evolution.py:2456 | `merge.py:344-345, 394-395` | `merge.py::MergeProposer.propose` | VERIFIED PRESENT — **MOVED** |
| evolution.py:2462 | `merge.py:342-343` | `merge.py::MergeProposer.propose` | VERIFIED PRESENT |
| evolution.py:2760 | `reflective_mutation.py:308-327` | `reflective_mutation.py::ReflectiveMutationProposer.propose` | VERIFIED PRESENT — **MOVED** (code now ~lines 449-463) |
| lineage.py:120 | `merge.py:87-90` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| lineage.py:123 | `merge.py:108-112` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| lineage.py:126 | `merge.py:59` | `merge.py::filter_ancestors` | VERIFIED PRESENT |
| lineage.py:131 | `merge.py:94-95` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| lineage.py:137 | `merge.py:147-148, 199-201` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| lineage.py:152 | `merge.py:76,126` | `merge.py::find_common_ancestor_pair`, `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT (both) |
| lineage.py:162 | `merge.py:125,199-201` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| lineage.py:182 | `merge.py:87-90` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| lineage.py:187 | `merge.py:94-95` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| lineage.py:195 | `merge.py:147-148` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| lineage.py:201 | `merge.py:199-201` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| lineage.py:231 | `merge.py:59` | `merge.py::filter_ancestors` | VERIFIED PRESENT |
| lineage.py:241 | `merge.py:108-112` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| merger.py:28 | `gepa/src/gepa/proposer/merge.py:258-288` | `gepa/src/gepa/proposer/merge.py::MergeProposer.select_eval_subsample_for_merged_program` | VERIFIED PRESENT |
| merger.py:137 | `gepa/proposer/merge.py:155-203` | `gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| merger.py:249 | `gepa/proposer/merge.py:163-191` | `gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| merger.py:258 | `gepa/proposer/merge.py:155-203` | `gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| mutator.py:344 | `src/gepa/strategies/instruction_proposal.py:63-85` | `src/gepa/strategies/instruction_proposal.py::format_samples.render_value` | VERIFIED PRESENT |
| mutator.py:397 | `src/gepa/strategies/instruction_proposal.py:54-95` | `src/gepa/strategies/instruction_proposal.py::format_samples` | VERIFIED PRESENT |
| mutator.py:496 | `gepa/strategies/instruction_proposal.py:54-95` | `gepa/strategies/instruction_proposal.py::format_samples` | VERIFIED PRESENT |
| parsers/helix_result.py:46 | `src/gepa/strategies/instruction_proposal.py:54-95` | `src/gepa/strategies/instruction_proposal.py::format_samples` | VERIFIED PRESENT |
| population.py:76 | `src/gepa/core/adapter.py:25` | `src/gepa/core/adapter.py::EvaluationBatch.trajectories` | VERIFIED PRESENT |
| population.py:81 | `src/gepa/strategies/instruction_proposal.py:54-95` | `src/gepa/strategies/instruction_proposal.py::format_samples` | VERIFIED PRESENT |
| state.py:92 | `gepa/proposer/merge.py:195-203` | `gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| test_config.py:238 | `merge.py:262` | `merge.py::MergeProposer.select_eval_subsample_for_merged_program` | VERIFIED PRESENT |
| test_config.py:248 | `gepa/src/gepa/proposer/merge.py:262` | `gepa/src/gepa/proposer/merge.py::MergeProposer.select_eval_subsample_for_merged_program` | VERIFIED PRESENT |
| test_evolution.py:197 | `merge.py:130-131` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| test_evolution.py:1378 | `merge.py:332-400` | `merge.py::MergeProposer.propose` | VERIFIED PRESENT |
| test_evolution.py:1487 | `merge.py:262` | `merge.py::MergeProposer.select_eval_subsample_for_merged_program` | VERIFIED PRESENT |
| test_evolution.py:1562 | `merge.py:286` | `merge.py::MergeProposer.select_eval_subsample_for_merged_program` | VERIFIED PRESENT |
| test_evolution.py:1563 | `merge.py:344-345, 394-395` | `merge.py::MergeProposer.propose` | VERIFIED PRESENT — **MOVED** |
| test_evolution.py:1818 | `merge.py:94-95` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| test_evolution.py:1914 | `merge.py:195-203` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| test_evolution.py:1921 | `merge.py:203` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| test_evolution.py:2007 | `merge.py:130-131` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| test_lineage.py:4 | `gepa/proposer/merge.py:87-115, 118-207` | `gepa/proposer/merge.py::find_common_ancestor_pair`, `gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT (both) |
| test_lineage.py:10 | `merge.py:94-95` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| test_lineage.py:37 | `merge.py:94-95` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| test_lineage.py:70 | `merge.py:147-148, 199-201` | `merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| test_lineage.py:173 | `merge.py:87-115` | `merge.py::find_common_ancestor_pair` | VERIFIED PRESENT |
| test_merger.py:121 | `gepa/proposer/merge.py:163-191` | `gepa/proposer/merge.py::sample_and_attempt_merge_programs_by_common_predictors` | VERIFIED PRESENT |
| test_merger.py:468 | `gepa/src/gepa/proposer/merge.py:258-288` | `gepa/src/gepa/proposer/merge.py::MergeProposer.select_eval_subsample_for_merged_program` | VERIFIED PRESENT |
| test_merger.py:515 | `merge.py:285-286` | `merge.py::MergeProposer.select_eval_subsample_for_merged_program` | VERIFIED PRESENT |
| test_mutator.py:256 | `gepa/strategies/instruction_proposal.py:54-95` | `gepa/strategies/instruction_proposal.py::format_samples` | VERIFIED PRESENT |

No citation resolved to `NEVER EXISTED` in this sweep — all 59 target symbols that
still exist upstream at HEAD (the two previously-fabricated symbols mentioned in the
task brief were not among these 59 and are not reintroduced here).

## Noticed but out of scope

`src/helix/population.py` (lines ~748, 802) contains comments claiming "GEPA parity
(W1): use sum_score() to match GEPA semantics" — this claim is false (upstream ranks
by mean, not sum). This is a pre-existing correctness-of-claim issue, not a citation-
form issue, and is already being fixed on a separate branch. Left untouched here to
avoid conflicting with that work.

## Gates

- `uv sync --extra dev`
- `uv run python -m pytest` → **922 passed**
- `uv run ruff check src/ tests/` → **All checks passed!**
- `uv run mypy --strict src/helix/` → **Success: no issues found in 26 source files**
- `git diff --shortstat origin/main...HEAD` → **13 files changed, 100 insertions(+), 61 deletions(-)**
- Postcondition sweep (both queries above, re-run against this branch) → **0 remaining line citations**

## Scope discipline

Citation form only. No behavior changes, no refactors, no reformatting beyond what each
citation edit required.
