### PR TITLE
feat(backends)!: replace gemini with agy; publish runner images weekly

### DIFF
--- a/.github/workflows/publish-runners.yml
+++ b/.github/workflows/publish-runners.yml
@@ -116,14 +116,14 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - name: agy
+            dockerfile: docker/agy.Dockerfile
           - name: claude
             dockerfile: docker/claude.Dockerfile
           - name: codex
             dockerfile: docker/codex.Dockerfile
           - name: cursor
             dockerfile: docker/cursor.Dockerfile
-          - name: gemini
-            dockerfile: docker/gemini.Dockerfile
           - name: opencode
             dockerfile: docker/opencode.Dockerfile
         platform:
@@ -195,10 +195,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - name: agy
           - name: claude
           - name: codex
           - name: cursor
-          - name: gemini
           - name: opencode
     steps:
       - name: Download digests
@@ -248,14 +248,14 @@ jobs:
         image:
           - name: base
             command: "python --version && uv --version && git --version"
+          - name: agy
+            command: "agy --version"
           - name: claude
             command: "claude --version"
           - name: codex
             command: "codex --version"
           - name: cursor
             command: "cursor agent --version"
-          - name: gemini
-            command: "gemini --version"
           - name: opencode
             command: "opencode --version"
 

--- a/.github/workflows/publish-runners.yml
+++ b/.github/workflows/publish-runners.yml
@@ -6,8 +6,10 @@ on:
       - "v*"
   # Weekly rebuild of `latest` so the images track the agent CLIs' own
   # release cadence instead of waiting for the next HELIX version tag.
+  # 12:00 UTC Monday matches the "before 6am on monday" America/Los_Angeles
+  # window in the repo's Renovate config (PR #54), so both land together.
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "0 12 * * 1"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/publish-runners.yml
+++ b/.github/workflows/publish-runners.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v*"
+  # Weekly rebuild of `latest` so the images track the agent CLIs' own
+  # release cadence instead of waiting for the next HELIX version tag.
+  schedule:
+    - cron: "0 6 * * 1"
   workflow_dispatch:
 
 env:
@@ -11,6 +15,32 @@ env:
   IMAGE_PREFIX: ghcr.io/ke7/helix-evo-runner
 
 jobs:
+  # ── 0. Pick the image tag every later job builds against and publishes ───
+  # A `v*` tag publishes its version; `main` (a scheduled or manual run)
+  # publishes `latest`; any other branch publishes its own name, so a manual
+  # dispatch from a feature branch has a tag to push instead of failing at
+  # the manifest step with "can't push with no tags specified".
+  resolve-tag:
+    name: Resolve image tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.value }}
+      is-branch: ${{ steps.tag.outputs.is-branch }}
+    steps:
+      - id: tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            echo "is-branch=false" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+            echo "value=latest" >> "$GITHUB_OUTPUT"
+            echo "is-branch=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+            echo "is-branch=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # ── 1. Build base image, one job per arch, push by digest ─────────────────
   build-base:
     name: Build base image (${{ matrix.platform }})
@@ -66,7 +96,7 @@ jobs:
   merge-base:
     name: Merge base image manifests
     runs-on: ubuntu-latest
-    needs: build-base
+    needs: [build-base, resolve-tag]
     permissions:
       contents: read
       packages: write
@@ -97,6 +127,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=tag
             type=semver,pattern={{version}}
+            type=raw,value=${{ needs.resolve-tag.outputs.tag }},enable=${{ needs.resolve-tag.outputs.is-branch }}
 
       - name: Create and push merged manifest list
         working-directory: /tmp/digests
@@ -108,7 +139,7 @@ jobs:
   # ── 3. Build each backend (5 images × 2 arches = 10 jobs), push by digest ─
   build-backends:
     name: Build ${{ matrix.image.name }} (${{ matrix.platform }})
-    needs: merge-base
+    needs: [merge-base, resolve-tag]
     permissions:
       contents: read
       packages: write
@@ -148,16 +179,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Choose base tag
-        id: base-tag
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
-            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=latest" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Build and push backend by digest
         id: build
         uses: docker/build-push-action@v6
@@ -166,7 +187,7 @@ jobs:
           file: ${{ matrix.image.dockerfile }}
           platforms: ${{ matrix.platform }}
           build-args: |
-            BASE_IMAGE=${{ env.IMAGE_PREFIX }}-base:${{ steps.base-tag.outputs.value }}
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}-base:${{ needs.resolve-tag.outputs.tag }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -186,7 +207,7 @@ jobs:
   # ── 4. Merge each backend's 2 arch digests into a multi-arch manifest ─────
   merge-backends:
     name: Merge ${{ matrix.image.name }} image manifests
-    needs: build-backends
+    needs: [build-backends, resolve-tag]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -227,6 +248,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=tag
             type=semver,pattern={{version}}
+            type=raw,value=${{ needs.resolve-tag.outputs.tag }},enable=${{ needs.resolve-tag.outputs.is-branch }}
 
       - name: Create and push merged manifest list
         working-directory: /tmp/digests
@@ -239,7 +261,7 @@ jobs:
   verify:
     name: Verify published runner images
     runs-on: ubuntu-latest
-    needs: merge-backends
+    needs: [merge-backends, resolve-tag]
     permissions:
       packages: read
     strategy:
@@ -260,16 +282,6 @@ jobs:
             command: "opencode --version"
 
     steps:
-      - name: Choose tag
-        id: tag
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
-            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=latest" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -277,9 +289,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Probe as `node`, the unprivileged user HELIX runs every agent
+      # container as (`_docker_args` in src/helix/sandbox.py). An installer
+      # that leaves its binary under /root passes this check as root and
+      # fails for every real run.
       - name: Pull and verify
         shell: bash
         run: |
-          image="${IMAGE_PREFIX}-${{ matrix.image.name }}:${{ steps.tag.outputs.value }}"
+          image="${IMAGE_PREFIX}-${{ matrix.image.name }}:${{ needs.resolve-tag.outputs.tag }}"
           docker pull "$image"
-          docker run --rm "$image" sh -lc '${{ matrix.image.command }}'
+          docker run --rm --user node "$image" sh -lc '${{ matrix.image.command }}'

--- a/.github/workflows/runner-images.yml
+++ b/.github/workflows/runner-images.yml
@@ -1,0 +1,42 @@
+name: Runner Images
+
+# Build every runner image from this checkout's own Dockerfiles and probe
+# each CLI as `node`, the unprivileged user HELIX runs agent containers as.
+# publish-runners.yml pushes `latest` before it verifies, so this is the only
+# gate that keeps a broken Dockerfile off `latest` -- and the only one that
+# can cover a backend whose image does not exist on GHCR yet.
+on:
+  pull_request:
+    paths:
+      - "docker/**"
+      - "src/helix/backends.py"
+      - ".github/workflows/runner-images.yml"
+  workflow_dispatch:
+
+jobs:
+  build-and-probe:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: agy,      command: "agy --version" }
+          - { name: claude,   command: "claude --version" }
+          - { name: codex,    command: "codex --version" }
+          - { name: cursor,   command: "cursor agent --version" }
+          - { name: opencode, command: "opencode --version" }
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build base image
+        run: docker build -f docker/base.Dockerfile -t helix-runner-base:ci .
+      - name: Build ${{ matrix.name }} image
+        run: >-
+          docker build -f docker/${{ matrix.name }}.Dockerfile
+          --build-arg BASE_IMAGE=helix-runner-base:ci
+          -t helix-runner-${{ matrix.name }}:ci .
+      - name: Probe CLI as the unprivileged agent user
+        run: >-
+          docker run --rm --user node --network none
+          helix-runner-${{ matrix.name }}:ci
+          sh -lc '${{ matrix.command }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **BREAKING**: Removed the `gemini` mutation backend and replaced it with
+  `agy` (Google's Antigravity CLI). Configs with `agent.backend = "gemini"`
+  are rejected; migrate to `"agy"`. `helix-auth-gemini` sandbox volumes are
+  no longer read; run `helix sandbox login agy` to create `helix-auth-agy`.
+  Unlike `gemini`, `agy` propagates `agent.effort` to its CLI (`--effort`,
+  same `low`/`medium`/`high` values as `claude`) instead of silently
+  ignoring it.
 - **BREAKING**: Removed the `evaluator.score_parser` configuration field. The built-in
   `helix_result` parser is now implicit; configurations that still provide the
   removed field are rejected by Pydantic's `extra="forbid"` validation.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Evolutionary optimization for full codebases using agentic coding tools as the mutation engine and git worktrees as the population pool.**
 
-HELIX brings reflective Pareto evolution out of the single-artifact setting and into real software projects: entire repositories, multi-turn agentic mutation, tool use, web research, and verification loops, all inside a single evolutionary stage. Supported mutation backends include Claude Code, Codex CLI, Cursor Agent, Gemini CLI, and OpenCode.
+HELIX brings reflective Pareto evolution out of the single-artifact setting and into real software projects: entire repositories, multi-turn agentic mutation, tool use, web research, and verification loops, all inside a single evolutionary stage. Supported mutation backends include Antigravity CLI, Claude Code, Codex CLI, Cursor Agent, and OpenCode.
 
 <br>
 
@@ -109,7 +109,7 @@ flowchart TD
     subgraph DOCKER["🐳  Docker Sandbox  —  isolated execution environment"]
         direction LR
         subgraph ANET["  Agent Network  (normal egress)  "]
-            AGENT["Mutation / Merge Container\n──────────────────────────\nclaude · codex · cursor\ngemini · opencode\nAuth: helix-auth-BACKEND"]:::agent
+            AGENT["Mutation / Merge Container\n──────────────────────────\nagy · claude · codex\ncursor · opencode\nAuth: helix-auth-BACKEND"]:::agent
         end
         subgraph ENET["  Private Evaluator Network  (helix-eval-*)  "]
             ERUN["Eval Runners\n(short-lived,\ncopied workspace)"]:::eval
@@ -201,7 +201,7 @@ Install and start Docker, then log in to your selected backend inside its
 persistent sandbox auth volume:
 
 ```bash
-helix sandbox login claude      # or codex, cursor, gemini, opencode
+helix sandbox login claude      # or agy, codex, cursor, opencode
 helix sandbox status claude
 ```
 
@@ -407,7 +407,7 @@ frontier_type = "instance"       # Pareto dimensionality (GEPA FrontierType pari
                                  # raise MissingObjectiveScoresError at selection.
 
 [agent]
-backend = "claude"               # "claude" | "codex" | "cursor" | "gemini" | "opencode"
+backend = "claude"               # "agy" | "claude" | "codex" | "cursor" | "opencode"
 # model = "sonnet"               # optional backend-specific model name
 effort = "medium"                # optional: "low" | "medium" | "high" | "xhigh" | "max"
 max_turns = 20
@@ -629,14 +629,13 @@ For Claude, HELIX uses `claude setup-token` for sandbox login because that is
 the flow that works cleanly in browserless Docker/SSH-style environments; it
 prints a URL and then accepts the code from the browser in the terminal.
 Codex similarly uses `codex login --device-auth` so the callback does not depend
-on a localhost server inside the container. Gemini starts its normal
-interactive CLI with `--skip-trust` so its authentication picker is not blocked
-by the temporary sandbox workspace trust prompt. OpenCode starts the normal TUI
-so you can choose the provider/model and complete provider login in one setup
-session.
+on a localhost server inside the container. Antigravity CLI (`agy`) has no
+dedicated login subcommand, so HELIX starts its normal interactive CLI, same
+as OpenCode, which starts the normal TUI so you can choose the provider/model
+and complete provider login in one setup session.
 
-The volume names are `helix-auth-claude`, `helix-auth-codex`,
-`helix-auth-cursor`, `helix-auth-gemini`, and `helix-auth-opencode`.
+The volume names are `helix-auth-agy`, `helix-auth-claude`, `helix-auth-codex`,
+`helix-auth-cursor`, and `helix-auth-opencode`.
 This avoids copying host credential stores into Docker. On macOS, Claude/Cursor
 browser-login tokens may live in Keychain; on Linux they may live in
 Secret Service/libsecret, GNOME Keyring, KWallet, or another desktop keyring.
@@ -647,10 +646,10 @@ usual. Docker Desktop supports `host.docker.internal`; Linux users can set
 `add_host_gateway = true`.
 
 By default HELIX chooses a published backend-specific mutator image from
-`agent.backend`: `ghcr.io/ke7/helix-evo-runner-claude`,
+`agent.backend`: `ghcr.io/ke7/helix-evo-runner-agy`,
+`ghcr.io/ke7/helix-evo-runner-claude`,
 `ghcr.io/ke7/helix-evo-runner-codex`,
-`ghcr.io/ke7/helix-evo-runner-cursor`,
-`ghcr.io/ke7/helix-evo-runner-gemini`, or
+`ghcr.io/ke7/helix-evo-runner-cursor`, or
 `ghcr.io/ke7/helix-evo-runner-opencode`. To build locally instead, build the
 shared base first with
 `docker build -t helix-runner-base:latest -f docker/base.Dockerfile .`, then
@@ -800,7 +799,7 @@ stderr as fallback debug context.
 --evaluator TEXT     Override the evaluator command
 --generations INT   Override max_generations
 --no-merge          Disable merge operations
---backend BACKEND   Override the mutation backend [claude|codex|cursor|gemini|opencode]
+--backend BACKEND   Override the mutation backend [agy|claude|codex|cursor|opencode]
 --model TEXT        Override the backend model (backend-specific naming)
 --effort LEVEL      Reasoning effort: low | medium | high | xhigh | max
 ```
@@ -887,10 +886,10 @@ BSD 3-Clause License. See [LICENSE](LICENSE) for details.
 HELIX's core evolutionary algorithm is based on **GEPA optimize_anything** by Agrawal, Lee, Ma, Elmaaroufi, Tan, Seshia, Sen, Klein, Stoica, Gonzalez, Khattab, Dimakis, and Zaharia. Their work on applying reflective Pareto evolution to any text made HELIX possible — we extended their algorithm to full codebases and agentic mutation but the foundation is theirs.
 
 - **[GEPA optimize_anything](https://gepa-ai.github.io/gepa/blog/2026/02/18/introducing-optimize-anything/)** — The algorithmic foundation: minibatch-gated Pareto evolution with reflective LLM mutation
+- **[Antigravity CLI](https://antigravity.google/cli)** — Supported HELIX mutation backend
 - **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — Supported HELIX mutation backend
 - **[Codex CLI](https://developers.openai.com/codex/cli)** — Supported HELIX mutation backend
 - **[Cursor CLI](https://cursor.com/cli/)** — Supported HELIX mutation backend
-- **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — Supported HELIX mutation backend
 - **[OpenCode](https://opencode.ai/docs/cli/)** — Supported HELIX mutation backend
 - **[OMAR](http://omar.tech/)** — The multi-agent orchestration system used to build HELIX
 

--- a/docker/agy.Dockerfile
+++ b/docker/agy.Dockerfile
@@ -1,0 +1,16 @@
+ARG BASE_IMAGE=helix-runner-base:latest
+FROM ${BASE_IMAGE}
+
+# The installer places the binary under /root/.local/bin, a directory only
+# root can traverse. HELIX always runs the agent container as the unprivileged
+# `node` user (see `_docker_args` in src/helix/sandbox.py), so a symlink
+# straight into /root would resolve to nothing for that user -- confirmed by
+# actually running this image as `node`, not just as root. Copy the binary out
+# to /opt (world-traversable, the same fix cursor.Dockerfile already applies to
+# its own root-owned install) before exposing it on PATH.
+RUN curl -fsSL https://antigravity.google/cli/install.sh | bash \
+    && cp /root/.local/bin/agy /opt/agy \
+    && chmod 755 /opt/agy \
+    && ln -s /opt/agy /usr/local/bin/agy
+
+WORKDIR /workspace

--- a/docker/gemini.Dockerfile
+++ b/docker/gemini.Dockerfile
@@ -1,6 +1,0 @@
-ARG BASE_IMAGE=helix-runner-base:latest
-FROM ${BASE_IMAGE}
-
-RUN npm install -g @google/gemini-cli
-
-WORKDIR /workspace

--- a/skills/helix/references/run-debug.md
+++ b/skills/helix/references/run-debug.md
@@ -186,10 +186,10 @@ helix sandbox logout claude
 
 Backend login behavior:
 
+- Agy: full interactive `agy` launch (no dedicated login subcommand)
 - Claude: `claude setup-token`
 - Codex: `codex login --device-auth`
 - Cursor: `cursor-agent login`
-- Gemini: `gemini --skip-trust`
 - OpenCode: full `opencode` TUI for provider/model/login setup
 
 Network:

--- a/skills/helix/references/toml.md
+++ b/skills/helix/references/toml.md
@@ -155,7 +155,7 @@ Important choices:
 
 ```toml
 [agent]
-backend = "claude"  # claude | codex | cursor | gemini | opencode
+backend = "claude"  # agy | claude | codex | cursor | opencode
 model = "sonnet"
 effort = "medium"
 max_turns = 20
@@ -169,9 +169,10 @@ network boundary, not from telling the agent not to edit evaluator files.
 
 Backend notes:
 
+- Agy: usually `agy`, optional model/effort.
 - Claude: usually `claude`, `max_turns`, optional model/effort.
 - Codex: usually `codex`, model optional.
-- Cursor/Gemini/OpenCode: check CLI support and model naming before pinning.
+- Cursor/OpenCode: check CLI support and model naming before pinning.
 
 ## Sandbox
 

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Literal, TypeAlias
 
 
-BackendName: TypeAlias = Literal["claude", "codex", "cursor", "gemini", "opencode"]
+BackendName: TypeAlias = Literal["agy", "claude", "codex", "cursor", "opencode"]
 
-BACKENDS: tuple[BackendName, ...] = ("claude", "codex", "cursor", "gemini", "opencode")
+BACKENDS: tuple[BackendName, ...] = ("agy", "claude", "codex", "cursor", "opencode")
 
 
 # ---------------------------------------------------------------------------
@@ -18,6 +18,7 @@ BACKENDS: tuple[BackendName, ...] = ("claude", "codex", "cursor", "gemini", "ope
 # budget" on backends that expose one.  The string value is forwarded to a
 # backend-native CLI flag in ``helix.mutator``:
 #
+#   - ``agy``:       ``--effort <value>``   (Antigravity CLI reasoning effort)
 #   - ``claude``:    ``--effort <value>``   (Claude Code thinking budget)
 #   - ``codex``:     ``-c model_reasoning_effort=<value>`` (Codex CLI config)
 #   - ``opencode``:  ``--variant <value>``  (model variant selector)
@@ -27,7 +28,7 @@ BACKENDS: tuple[BackendName, ...] = ("claude", "codex", "cursor", "gemini", "ope
 # without hard-coding backend knowledge into ``HelixConfig``.
 
 EFFORT_AWARE_BACKENDS: frozenset[BackendName] = frozenset(
-    {"claude", "codex", "opencode"}
+    {"agy", "claude", "codex", "opencode"}
 )
 """Backends that propagate ``agent.effort`` to their underlying CLI."""
 
@@ -40,35 +41,62 @@ EFFORT_AWARE_BACKENDS: frozenset[BackendName] = frozenset(
 # surfaces), users will see a non-fatal "not a recognized value" warning
 # until this map is updated; the value still passes through to the CLI.
 EFFORT_VALID_VALUES: dict[BackendName, frozenset[str] | None] = {
+    "agy": frozenset({"low", "medium", "high"}),
     "claude": frozenset({"low", "medium", "high"}),
     "codex": frozenset({"minimal", "low", "medium", "high", "xhigh"}),
     "opencode": None,  # variant strings are model-specific; opencode validates them.
 }
 
 BACKEND_DISPLAY_NAMES: dict[str, str] = {
+    "agy": "Antigravity CLI",
     "claude": "Claude Code",
     "codex": "Codex CLI",
     "cursor": "Cursor Agent",
-    "gemini": "Gemini CLI",
     "opencode": "OpenCode",
 }
 
 DEFAULT_BACKEND_IMAGES: dict[str, str] = {
+    "agy": "ghcr.io/ke7/helix-evo-runner-agy:latest",
     "claude": "ghcr.io/ke7/helix-evo-runner-claude:latest",
     "codex": "ghcr.io/ke7/helix-evo-runner-codex:latest",
     "cursor": "ghcr.io/ke7/helix-evo-runner-cursor:latest",
-    "gemini": "ghcr.io/ke7/helix-evo-runner-gemini:latest",
     "opencode": "ghcr.io/ke7/helix-evo-runner-opencode:latest",
 }
 
+# Ambient credential variable names forwarded to a backend when the operator
+# has them set. A backend with no entry here (``agy``, ``codex``) authenticates
+# only through its sandbox login volume; naming a variable for it would be
+# claiming a credential path this project has not established.
 BACKEND_AUTH_ENV: dict[str, tuple[str, ...]] = {
     "claude": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
     "cursor": ("CURSOR_API_KEY",),
-    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
     "opencode": ("OPENCODE_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"),
 }
 
 BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {
+    "agy": {
+        # No dedicated non-interactive login subcommand; the bare interactive
+        # launch is the login flow, same pattern as ``opencode`` below.
+        "login": ["agy"],
+        # ``agy models`` returns exit 0 even when logged out, so it cannot be
+        # used as the status signal. Probe the credential file directly
+        # instead, mirroring claude's file-probe pattern below. The path was
+        # derived by tracing the CLI's own file opens and has not yet been
+        # confirmed against a completed sign-in.
+        "status": [
+            "sh",
+            "-lc",
+            'set -eu; test -s "${HOME:-/home/node}/.gemini/antigravity-cli/antigravity-oauth-token"',
+        ],
+        # Surgical: only remove agy's own state directory. ``~/.gemini`` also
+        # holds unrelated Google CLI state, so a blanket ``rm -rf ~/.gemini``
+        # would destroy state this backend does not own.
+        "logout": [
+            "sh",
+            "-lc",
+            'set -eu; rm -rf "${HOME:-/home/node}/.gemini/antigravity-cli"',
+        ],
+    },
     "claude": {
         "login": ["claude", "auth", "login", "--claudeai"],
         # ``claude auth status --text`` returns 0 even when there are no
@@ -94,18 +122,6 @@ BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {
         "login": ["cursor-agent", "login"],
         "status": ["cursor-agent", "status"],
         "logout": ["cursor-agent", "logout"],
-    },
-    "gemini": {
-        "login": ["gemini", "--skip-trust"],
-        "status": ["gemini", "--version"],
-        # The auth volume is mounted at /home/node and is shared across
-        # backends, so logout must scrub only Gemini's state directory rather
-        # than the whole home tree.
-        "logout": [
-            "sh",
-            "-lc",
-            'set -eu; rm -rf "/home/node/.gemini" "/home/node/.config/google-gemini"',
-        ],
     },
     "opencode": {
         "login": ["opencode"],

--- a/src/helix/cli.py
+++ b/src/helix/cli.py
@@ -427,10 +427,11 @@ def sandbox_login(
 
     volume = sandbox_auth_volume_name(backend)
     print_info(f"Using Docker auth volume [cyan]{volume}[/cyan].")
-    if backend == "gemini":
+    if backend == "agy":
         print_warning(
-            "Gemini CLI does not expose a dedicated login subcommand; HELIX "
-            "starts the interactive Gemini CLI so you can complete its auth flow."
+            "Antigravity CLI does not expose a dedicated login subcommand; "
+            "HELIX starts the interactive Antigravity CLI so you can "
+            "complete its auth flow."
         )
     extra_hosts = _parse_extra_hosts(extra_hosts_list)
     result = run_sandbox_auth_command(
@@ -588,7 +589,7 @@ def sandbox_logout(
 @click.option(
     "--backend",
     default=None,
-    type=click.Choice(["claude", "codex", "cursor", "gemini", "opencode"]),
+    type=click.Choice(["agy", "claude", "codex", "cursor", "opencode"]),
     help="Override the mutation backend.",
 )
 @click.option("--model", default=None, help="Override the backend model.")
@@ -597,10 +598,10 @@ def sandbox_logout(
     default=None,
     help=(
         "Override backend reasoning-effort level. Forwarded as --effort to "
-        "the 'claude' backend (low|medium|high), as model_reasoning_effort "
-        "to the 'codex' backend, and as --variant to the 'opencode' backend; "
-        "ignored by cursor/gemini (a warning is emitted when set on a backend "
-        "that does not support it)."
+        "the 'agy' and 'claude' backends (low|medium|high), as "
+        "model_reasoning_effort to the 'codex' backend, and as --variant to "
+        "the 'opencode' backend; ignored by cursor (a warning is emitted "
+        "when set on a backend that does not support it)."
     ),
 )
 def evolve(

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -779,7 +779,7 @@ def _validate_agent_effort(agent: AgentConfig) -> None:
 
     Two cases are surfaced:
 
-    1. **Backend ignores the field** (``cursor`` / ``gemini``):
+    1. **Backend ignores the field** (``cursor``):
        ``effort`` is silently dropped by ``helix.mutator`` because those CLIs
        don't expose an equivalent flag.  Without a warning, users assume the
        knob is taking effect.

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1,4 +1,4 @@
-"""HELIX mutator: applies code mutations via agentic coding backends (claude, codex, cursor, gemini, opencode)."""
+"""HELIX mutator: applies code mutations via agentic coding backends (agy, claude, codex, cursor, opencode)."""
 
 from __future__ import annotations
 
@@ -97,7 +97,7 @@ def _turn_budget_section(max_turns: int | None) -> str:
       limit, and the resulting ``subtype="error_max_turns"`` response is
       detected at :func:`invoke_claude_code` and treated as partial
       success.
-    * ``codex`` / ``cursor`` / ``gemini`` / ``opencode`` — soft hint only.
+    * ``agy`` / ``codex`` / ``cursor`` / ``opencode`` — soft hint only.
       None of these CLIs expose an equivalent flag (verified against
       ``--help`` for the installed binaries), so the in-prompt request is
       the only signal the agent receives.  Whether the agent self-honors
@@ -736,6 +736,27 @@ def _build_backend_args(
     prompt_artifact_name: str,
 ) -> list[str]:
     backend = config.backend
+    if backend == "agy":
+        args = [
+            "agy",
+            "--dangerously-skip-permissions",
+            "--print",
+            "--output-format",
+            "json",
+        ]
+        if config.model:
+            args.extend(["--model", config.model])
+        if config.effort:
+            args.extend(["--effort", config.effort])
+        # Every other HELIX backend takes its prompt as a trailing positional
+        # argument (see the ``claude`` / ``codex`` / ``cursor`` / ``opencode``
+        # branches below); ``agy --help`` documents ``-p``/``--print`` and a
+        # ``--prompt`` alias but not the exact invocation grammar. This follows
+        # the established convention; the first real run against the CLI must
+        # confirm it before it is relied on.
+        args.append(_prompt_file_instruction(prompt_artifact_name))
+        return args
+
     if backend == "claude":
         args = [
             "claude",
@@ -791,18 +812,6 @@ def _build_backend_args(
             "--trust",
             "--workspace",
             worktree_path,
-        ]
-        if config.model:
-            args.extend(["--model", config.model])
-        args.append(_prompt_file_instruction(prompt_artifact_name))
-        return args
-
-    if backend == "gemini":
-        args = [
-            "gemini",
-            "--yolo",
-            "--output-format",
-            "stream-json",
         ]
         if config.model:
             args.extend(["--model", config.model])
@@ -897,12 +906,6 @@ def _parse_jsonl_output(
             parsed = json.loads(line)
         except json.JSONDecodeError:
             if strict:
-                # Gemini CLI may prepend advisory text such as MCP-health
-                # warnings before the JSON stream even when
-                # `--output-format stream-json` is requested.
-                if backend == "gemini":
-                    unparsable.append(line)
-                    continue
                 raise MutationError(
                     f"Failed to parse {backend_display_name(backend)} JSONL output line",
                     operation=f"{backend_display_name(backend)} invocation",
@@ -934,7 +937,7 @@ def _parse_backend_output(
     cmd_str: str,
     worktree_path: str,
 ) -> dict[str, Any]:
-    if backend == "claude":
+    if backend in {"agy", "claude"}:
         return _parse_json_object_output(
             result.stdout,
             backend=backend,
@@ -943,7 +946,7 @@ def _parse_backend_output(
             stderr=result.stderr,
             exit_code=result.returncode,
         )
-    if backend in {"codex", "cursor", "gemini", "opencode"}:
+    if backend in {"codex", "cursor", "opencode"}:
         return _parse_jsonl_output(
             result.stdout,
             backend=backend,
@@ -1290,36 +1293,6 @@ def _count_cursor_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
     return count, names
 
 
-def _count_gemini_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
-    """Count tool invocations from a Gemini stream-json stdout artifact.
-
-    Gemini emits ``tool_use`` events (correctly counted by
-    ``_normalise_usage_stats``) but stores the tool name in ``tool_name``
-    rather than ``name``, so ``tool_names`` remains empty after the initial
-    parse.  This function provides both the count and the names.
-    """
-    count = 0
-    names: list[str] = []
-    try:
-        for raw in path.read_text(encoding="utf-8").splitlines():
-            raw = raw.strip()
-            if not raw:
-                continue
-            try:
-                event = json.loads(raw)
-            except (json.JSONDecodeError, ValueError):
-                continue
-            if not isinstance(event, dict) or event.get("type") != "tool_use":
-                continue
-            count += 1
-            name = event.get("tool_name")
-            if isinstance(name, str) and name:
-                names.append(name)
-    except OSError:
-        return 0, []
-    return count, names
-
-
 def _count_opencode_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
     """Count tool invocations from an OpenCode ``--format json`` stdout artifact.
 
@@ -1352,11 +1325,15 @@ def _count_opencode_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
 
 
 # Dispatcher: maps backend name → per-backend counter function.
+#
+# ``agy`` has no entry yet: writing one correctly needs a real
+# ``--output-format json`` transcript sample, which this project does not have.
+# Until then it falls back to ``_normalise_usage_stats``'s generic walk below,
+# same as any backend without a dedicated counter.
 _TRANSCRIPT_TOOL_COUNTERS: dict[str, Callable[[Path], tuple[int, list[str]]]] = {
     "claude": _count_claude_transcript_tool_events,
     "codex": _count_codex_stdout_tool_events,
     "cursor": _count_cursor_stdout_tool_events,
-    "gemini": _count_gemini_stdout_tool_events,
     "opencode": _count_opencode_stdout_tool_events,
 }
 
@@ -1602,8 +1579,6 @@ def invoke_claude_code(
         passthrough_env=passthrough_env, fixed_env=fixed_env
     )
     _add_backend_auth_env(backend_env, backend)
-    if backend == "gemini":
-        backend_env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"
     if backend == "opencode" and (sandbox is None or not sandbox.enabled):
         # Per-candidate SQLite isolation for concurrent opencode subprocesses.
         #

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1092,6 +1092,8 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> UsageStats:
                     "cacheReadInputTokens",
                     "cacheReadTokens",
                     "cacheRead",
+                    # agy: ``usage.cache_read_tokens``
+                    "cache_read_tokens",
                 ),
             ),
             (
@@ -1102,6 +1104,8 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> UsageStats:
                     "reasoning_output_tokens",
                     "thoughts",
                     "reasoning",
+                    # agy: ``usage.thinking_tokens``
+                    "thinking_tokens",
                 ),
             ),
             (
@@ -1125,6 +1129,8 @@ def _normalise_usage_stats(parsed: dict[str, Any]) -> UsageStats:
                 "chatId",
                 "thread_id",
                 "threadId",
+                # agy: top-level ``conversation_id``
+                "conversation_id",
             ):
                 value = node.get(alias)
                 if isinstance(value, str) and value:
@@ -1343,10 +1349,14 @@ def _count_opencode_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
 
 # Dispatcher: maps backend name → per-backend counter function.
 #
-# ``agy`` has no entry yet: writing one correctly needs a real
-# ``--output-format json`` transcript sample, which this project does not have.
-# Until then it falls back to ``_normalise_usage_stats``'s generic walk below,
-# same as any backend without a dedicated counter.
+# ``agy`` has no entry because there is nothing to count: its
+# ``--output-format json`` output (observed against agy 1.1.27) is a single
+# envelope -- ``conversation_id``, ``status``, ``response``, ``error`` (on
+# failure), ``duration_seconds``, ``num_turns`` and a ``usage`` block of
+# ``input_tokens`` / ``output_tokens`` / ``thinking_tokens`` /
+# ``cache_read_tokens`` / ``total_tokens`` -- with no per-tool event list.
+# ``_normalise_usage_stats`` reads the envelope's token fields directly; tool
+# events for agy stay at 0 like any backend without a dedicated counter.
 _TRANSCRIPT_TOOL_COUNTERS: dict[str, Callable[[Path], tuple[int, list[str]]]] = {
     "claude": _count_claude_transcript_tool_events,
     "codex": _count_codex_stdout_tool_events,

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -740,7 +740,6 @@ def _build_backend_args(
         args = [
             "agy",
             "--dangerously-skip-permissions",
-            "--print",
             "--output-format",
             "json",
         ]
@@ -748,13 +747,15 @@ def _build_backend_args(
             args.extend(["--model", config.model])
         if config.effort:
             args.extend(["--effort", config.effort])
-        # Every other HELIX backend takes its prompt as a trailing positional
-        # argument (see the ``claude`` / ``codex`` / ``cursor`` / ``opencode``
-        # branches below); ``agy --help`` documents ``-p``/``--print`` and a
-        # ``--prompt`` alias but not the exact invocation grammar. This follows
-        # the established convention; the first real run against the CLI must
-        # confirm it before it is relied on.
-        args.append(_prompt_file_instruction(prompt_artifact_name))
+        # Unlike ``claude``, agy's ``-p``/``--print`` (alias ``--prompt``) is
+        # not a boolean flag: it takes the prompt as its VALUE, and a trailing
+        # positional is ignored.  ``agy --print --output-format json <prompt>``
+        # exits 2 with ``--print took "--output-format" as its prompt``
+        # (verified against agy 1.1.27).  So every other flag goes first and
+        # ``--print <prompt>`` is the final argv pair; Go's flag parser accepts
+        # the space-separated form, and the instruction text never starts
+        # with ``-``.  ``test_agy_cli_args_include_required_flags`` pins this.
+        args.extend(["--print", _prompt_file_instruction(prompt_artifact_name)])
         return args
 
     if backend == "claude":

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -730,6 +730,20 @@ def _add_backend_auth_env(env: dict[str, str], backend: str) -> None:
             env[key] = os.environ[key]
 
 
+# agy's ``--print-timeout`` is a Go ``time.Duration`` flag (default ``5m0s``)
+# that aborts a headless run when it expires; per agy's changelog a mid-turn
+# expiry returns *partial* output with only a stderr warning, so a cut-off
+# mutation could pass for a finished one.  There is no disable value: ``0``
+# and negative durations fail immediately with ``timeout waiting for
+# response``, and no env var or settings key overrides the flag.  So we pass
+# the largest duration Go can represent (``math.MaxInt64`` ns, ~292 years) --
+# ``2562048h`` is rejected as out of range, so this is the ceiling of the
+# flag's type.  Verified against agy 1.1.27.  This keeps agy on the same
+# no-timeout policy every other backend already gets (their subprocesses run
+# with no ``timeout`` at all; see ``test_no_timeout_in_subprocess``).
+_AGY_PRINT_TIMEOUT = "2562047h47m16.854775807s"
+
+
 def _build_backend_args(
     worktree_path: str,
     config: AgentConfig,
@@ -742,6 +756,8 @@ def _build_backend_args(
             "--dangerously-skip-permissions",
             "--output-format",
             "json",
+            "--print-timeout",
+            _AGY_PRINT_TIMEOUT,
         ]
         if config.model:
             args.extend(["--model", config.model])

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -29,10 +29,10 @@ from helix.trace import TRACE, EventType
 # ``invoke_claude_code`` actually dispatched to the requested backend CLI
 # (rather than short-circuiting via the differential-testing override).
 _BACKEND_EXECUTABLE = {
+    "agy": "agy",
     "claude": "claude",
     "codex": "codex",
     "cursor": "cursor",
-    "gemini": "gemini",
     "opencode": "opencode",
 }
 
@@ -196,21 +196,6 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
             id="cursor",
         ),
         pytest.param(
-            "gemini",
-            "\n".join(
-                [
-                    "MCP advisory preamble tolerated by the Gemini parser.",
-                    '{"type":"init","session_id":"gemini-session"}',
-                    (
-                        '{"type":"result","usageMetadata":{"prompt_tokens":14,'
-                        '"completion_tokens":10},"cost":0.34}'
-                    ),
-                ]
-            ),
-            (14, 10, 0.34),
-            id="gemini",
-        ),
-        pytest.param(
             "opencode",
             "\n".join(
                 [
@@ -223,6 +208,24 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
             ),
             (15, 11, 0.35),
             id="opencode",
+        ),
+        pytest.param(
+            # agy's confirmed dispatch is the same single-JSON-object branch
+            # claude uses (see _parse_backend_output); its real field names
+            # are not yet confirmed (needs a real --print run, out of scope
+            # for this migration), so this envelope is illustrative -- it
+            # exercises the generic _normalise_usage_stats walk, not a
+            # verified agy transcript shape.
+            "agy",
+            json.dumps(
+                {
+                    "session_id": "agy-session",
+                    "usage": {"input_tokens": 16, "output_tokens": 12},
+                    "total_cost_usd": 0.36,
+                }
+            ),
+            (16, 12, 0.36),
+            id="agy",
         ),
     ],
 )
@@ -345,26 +348,6 @@ def test_backend_usage_parsing_charges_llm_budget(
             id="cursor",
         ),
         pytest.param(
-            "gemini",
-            "\n".join(
-                [
-                    '{"type":"init","session_id":"gemini-session"}',
-                    (
-                        '{"type":"result","usageMetadata":{"prompt_tokens":14,'
-                        '"completion_tokens":10,"cachedTokens":23},'
-                        '"thoughts":8,"cost":0.34}'
-                    ),
-                ]
-            ),
-            {
-                "input_tokens": 14,
-                "output_tokens": 10,
-                "cached_input_tokens": 23,
-                "reasoning_tokens": 8,
-            },
-            id="gemini",
-        ),
-        pytest.param(
             "opencode",
             "\n".join(
                 [
@@ -382,6 +365,30 @@ def test_backend_usage_parsing_charges_llm_budget(
                 "reasoning_tokens": 9,
             },
             id="opencode",
+        ),
+        pytest.param(
+            # Illustrative envelope on agy's confirmed dispatch path (the
+            # same single-JSON-object branch claude uses); real field names
+            # are not yet confirmed, see the "agy" case above.
+            "agy",
+            json.dumps(
+                {
+                    "session_id": "agy-session",
+                    "usage": {
+                        "input_tokens": 16,
+                        "output_tokens": 12,
+                        "cached_input_tokens": 25,
+                        "reasoning_tokens": 10,
+                    },
+                }
+            ),
+            {
+                "input_tokens": 16,
+                "output_tokens": 12,
+                "cached_input_tokens": 25,
+                "reasoning_tokens": 10,
+            },
+            id="agy",
         ),
     ],
 )

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -210,21 +210,28 @@ def test_charge_evaluation_updates_counter_and_emits_event() -> None:
             id="opencode",
         ),
         pytest.param(
-            # agy's confirmed dispatch is the same single-JSON-object branch
-            # claude uses (see _parse_backend_output); its real field names
-            # are not yet confirmed (needs a real --print run, out of scope
-            # for this migration), so this envelope is illustrative -- it
-            # exercises the generic _normalise_usage_stats walk, not a
-            # verified agy transcript shape.
+            # Real ``agy --output-format json`` envelope (agy 1.1.27), parsed
+            # on the same single-JSON-object branch claude uses (see
+            # _parse_backend_output).  agy reports no cost field, so
+            # ``cost_usd`` stays 0 for this backend.
             "agy",
             json.dumps(
                 {
-                    "session_id": "agy-session",
-                    "usage": {"input_tokens": 16, "output_tokens": 12},
-                    "total_cost_usd": 0.36,
+                    "conversation_id": "agy-conversation",
+                    "status": "SUCCESS",
+                    "response": "ok ",
+                    "duration_seconds": 1.13,
+                    "num_turns": 1,
+                    "usage": {
+                        "input_tokens": 6246,
+                        "output_tokens": 25,
+                        "thinking_tokens": 24,
+                        "cache_read_tokens": 8126,
+                        "total_tokens": 6271,
+                    },
                 }
             ),
-            (16, 12, 0.36),
+            (6246, 25, 0.0),
             id="agy",
         ),
     ],
@@ -367,26 +374,34 @@ def test_backend_usage_parsing_charges_llm_budget(
             id="opencode",
         ),
         pytest.param(
-            # Illustrative envelope on agy's confirmed dispatch path (the
-            # same single-JSON-object branch claude uses); real field names
-            # are not yet confirmed, see the "agy" case above.
+            # Real ``agy --output-format json`` envelope (agy 1.1.27), see the
+            # "agy" case above.  ``thinking_tokens`` maps to the reasoning
+            # counter and ``cache_read_tokens`` to the cache-read counter;
+            # agy reports no separate cached-input or cache-creation figure.
             "agy",
             json.dumps(
                 {
-                    "session_id": "agy-session",
+                    "conversation_id": "agy-conversation",
+                    "status": "SUCCESS",
+                    "response": "ok ",
+                    "duration_seconds": 1.13,
+                    "num_turns": 1,
                     "usage": {
-                        "input_tokens": 16,
-                        "output_tokens": 12,
-                        "cached_input_tokens": 25,
-                        "reasoning_tokens": 10,
+                        "input_tokens": 6246,
+                        "output_tokens": 25,
+                        "thinking_tokens": 24,
+                        "cache_read_tokens": 8126,
+                        "total_tokens": 6271,
                     },
                 }
             ),
             {
-                "input_tokens": 16,
-                "output_tokens": 12,
-                "cached_input_tokens": 25,
-                "reasoning_tokens": 10,
+                "input_tokens": 6246,
+                "output_tokens": 25,
+                "cache_read_input_tokens": 8126,
+                "reasoning_tokens": 24,
+                "cached_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
             },
             id="agy",
         ),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -295,13 +295,21 @@ class TestAgentEffortValidation:
             )
         assert [w for w in recwarn.list if issubclass(w.category, UserWarning)] == []
 
-    def test_effort_warns_on_ignoring_backend_gemini(self, recwarn):
+    def test_effort_accepts_valid_value_on_agy(self, recwarn):
+        for value in ("low", "medium", "high"):
+            HelixConfig(
+                **self._base_kwargs(),
+                agent=AgentConfig(backend="agy", effort=value),
+            )
+        assert [w for w in recwarn.list if issubclass(w.category, UserWarning)] == []
+
+    def test_effort_warns_on_unknown_value_for_agy(self, recwarn):
         HelixConfig(
             **self._base_kwargs(),
-            agent=AgentConfig(backend="gemini", effort="high"),
+            agent=AgentConfig(backend="agy", effort="extreme"),
         )
         warnings = [str(w.message) for w in recwarn.list if w.category is UserWarning]
-        assert any("does not propagate" in w for w in warnings), warnings
+        assert any("not a recognized value" in w and "extreme" in w for w in warnings), warnings
 
     def test_effort_warns_on_ignoring_backend_cursor(self, recwarn):
         HelixConfig(
@@ -350,7 +358,7 @@ class TestAgentEffortValidation:
         with pytest.warns(UserWarning, match="does not propagate"):
             HelixConfig(
                 **self._base_kwargs(),
-                agent=AgentConfig(backend="gemini", effort="high"),
+                agent=AgentConfig(backend="cursor", effort="high"),
             )
 
     def test_every_backend_has_effort_metadata(self):

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -408,12 +408,12 @@ class TestSandboxConfig:
             # Inline comment after unquoted value (POSIX/foreman convention).
             "OPENAI_API_KEY=plain-key   # this is a trailing comment\n"
             # Hash inside a quoted value must be preserved verbatim.
-            'GEMINI_API_KEY="gem#key#with#hashes"\n'
+            'SERVICE_API_KEY="quoted#key#with#hashes"\n'
         )
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("CURSOR_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("SERVICE_API_KEY", raising=False)
         monkeypatch.setenv("EXISTING", "from-shell")
 
         load_config(toml)
@@ -424,7 +424,7 @@ class TestSandboxConfig:
         # Trailing inline comment must be stripped from unquoted values.
         assert os.environ["OPENAI_API_KEY"] == "plain-key"
         # Embedded ``#`` inside a quoted value must be preserved.
-        assert os.environ["GEMINI_API_KEY"] == "gem#key#with#hashes"
+        assert os.environ["SERVICE_API_KEY"] == "quoted#key#with#hashes"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -726,6 +726,42 @@ class TestInvokeClaudeCode:
         assert ".agent_task_prompt.md" in args_list[-1]
         assert "input" not in call_args[1]
 
+    def test_agy_cli_args_include_required_flags(self, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"session_id":"sess_123"}', stderr="", returncode=0
+        )
+        config = AgentConfig(backend="agy", model="test-model", effort="high")
+
+        result, _ = invoke_claude_code("/tmp/wt", "the prompt", config)
+
+        args_list = mock_run.call_args[0][0]
+        assert args_list[0] == "agy"
+        assert "--dangerously-skip-permissions" in args_list
+        assert "--print" in args_list
+        assert "--output-format" in args_list
+        assert "json" in args_list
+        assert "--model" in args_list
+        assert "test-model" in args_list
+        assert "--effort" in args_list
+        assert "high" in args_list
+        assert "--sandbox" not in args_list
+        assert "the prompt" not in args_list
+        assert ".agent_task_prompt.md" in args_list[-1]
+        assert "input" not in mock_run.call_args[1]
+        assert result["session_id"] == "sess_123"
+
+    def test_agy_cli_args_omit_optional_flags_when_unset(self, mocker):
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
+        config = AgentConfig(backend="agy")
+
+        invoke_claude_code("/tmp/wt", "the prompt", config)
+
+        args_list = mock_run.call_args[0][0]
+        assert "--model" not in args_list
+        assert "--effort" not in args_list
+
     def test_uses_correct_cwd(self, mocker):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
@@ -914,29 +950,6 @@ class TestInvokeClaudeCode:
                 id="cursor",
             ),
             pytest.param(
-                "gemini",
-                "\n".join(
-                    [
-                        "MCP advisory preamble tolerated by the Gemini parser.",
-                        '{"type":"init","session_id":"gemini-session"}',
-                        (
-                            '{"type":"result","stats":{"input_tokens":14,'
-                            '"output_tokens":10,"cached":23,"input":14,'
-                            '"models":{"gemini":{"total_tokens":47,'
-                            '"input_tokens":14,"output_tokens":10,'
-                            '"cached":23,"input":14}}}}'
-                        ),
-                    ]
-                ),
-                {
-                    "input_tokens": 14,
-                    "output_tokens": 10,
-                    "cached_input_tokens": 23,
-                    "session_id": "gemini-session",
-                },
-                id="gemini",
-            ),
-            pytest.param(
                 "opencode",
                 "\n".join(
                     [
@@ -1069,30 +1082,9 @@ class TestInvokeClaudeCode:
         assert payload["transcript_artifacts"][0]["available"] is False
         assert payload["transcript_artifacts"][0]["reason"] == "transcript_not_found"
 
-    def test_gemini_tolerates_text_preamble_before_json_stream(self, mocker):
-        mock_run = mocker.patch("helix.mutator.subprocess.run")
-        mock_run.return_value = MagicMock(
-            stdout=(
-                "MCP issues detected. Run /mcp list for status.\n"
-                '{"type":"init","session_id":"sess_123"}\n'
-                '{"type":"result","status":"success","stats":{"input_tokens":10,"output_tokens":2}}\n'
-            ),
-            stderr="",
-            returncode=0,
-        )
-        config = AgentConfig(backend="gemini")
-
-        result, _ = invoke_claude_code("/tmp/wt", "prompt", config)
-
-        assert result["events"][0]["type"] == "init"
-        assert result["unparsable_lines"] == [
-            "MCP issues detected. Run /mcp list for status."
-        ]
-
     @pytest.mark.parametrize(
         ("backend", "expected_prefix", "expected_flags"),
         [
-            ("gemini", ["gemini"], ["--yolo", "--output-format", "stream-json"]),
             (
                 "opencode",
                 ["opencode", "run"],
@@ -1100,7 +1092,7 @@ class TestInvokeClaudeCode:
             ),
         ],
     )
-    def test_gemini_and_opencode_cli_args(
+    def test_opencode_cli_args(
         self, mocker, backend, expected_prefix, expected_flags
     ):
         mock_run = mocker.patch("helix.mutator.subprocess.run")
@@ -1662,54 +1654,6 @@ class TestCountCursorStdoutToolEvents:
         assert names == []
 
 
-class TestCountGeminiStdoutToolEvents:
-    """Tests for ``_count_gemini_stdout_tool_events``."""
-
-    def test_counts_tool_use_and_extracts_tool_name(self, tmp_path: Path) -> None:
-        from helix.mutator import _count_gemini_stdout_tool_events
-
-        stdout = tmp_path / "stdout.jsonl"
-        stdout.write_text(
-            json.dumps(
-                {
-                    "type": "tool_use",
-                    "tool_name": "read_file",
-                    "tool_id": "t1",
-                }
-            )
-            + "\n"
-            + json.dumps(
-                {
-                    "type": "tool_result",
-                    "tool_id": "t1",
-                    "content": "...",
-                }
-            )
-            + "\n"  # tool_result → skip (not tool_use)
-            + json.dumps(
-                {
-                    "type": "tool_use",
-                    "tool_name": "write_file",
-                    "tool_id": "t2",
-                }
-            )
-            + "\n"
-        )
-
-        count, names = _count_gemini_stdout_tool_events(stdout)
-
-        assert count == 2
-        assert names == ["read_file", "write_file"]
-
-    def test_missing_file_returns_zero(self, tmp_path: Path) -> None:
-        from helix.mutator import _count_gemini_stdout_tool_events
-
-        count, names = _count_gemini_stdout_tool_events(tmp_path / "nope.jsonl")
-
-        assert count == 0
-        assert names == []
-
-
 class TestCountOpencodeStdoutToolEvents:
     """Tests for ``_count_opencode_stdout_tool_events``."""
 
@@ -1800,18 +1744,22 @@ class TestCountTranscriptToolEventsDispatcher:
         assert count == 1
         assert names == ["Read"]
 
-    def test_dispatches_to_gemini_counter(self, tmp_path: Path) -> None:
+    def test_agy_has_no_dedicated_counter_yet(self, tmp_path: Path) -> None:
+        """agy has no dedicated per-field counter (needs a real transcript sample
+        to write correctly, see ``_TRANSCRIPT_TOOL_COUNTERS``), so it falls back
+        to the dispatcher's unknown-backend behavior even for an existing file.
+        ``_normalise_usage_stats``'s generic walk still produces best-effort
+        stats independently of this counter.
+        """
         from helix.mutator import _count_transcript_tool_events
 
-        stdout = tmp_path / "stdout.jsonl"
-        stdout.write_text(
-            json.dumps({"type": "tool_use", "tool_name": "grep"}) + "\n"
-        )
+        stdout = tmp_path / "stdout.json"
+        stdout.write_text(json.dumps({"type": "tool_use", "tool_name": "grep"}))
 
-        count, names = _count_transcript_tool_events(stdout, "gemini")
+        count, names = _count_transcript_tool_events(stdout, "agy")
 
-        assert count == 1
-        assert names == ["grep"]
+        assert count == 0
+        assert names == []
 
 
 class TestTranscriptToolPatchesUsageInArtifact:
@@ -1962,11 +1910,11 @@ class TestOpenCodeSubprocessIsolation:
     def test_opencode_isolation_not_applied_to_other_backends(
         self, tmp_path: Path, mocker
     ):
-        """XDG_DATA_HOME must NOT be injected for claude/codex/cursor/gemini."""
+        """XDG_DATA_HOME must NOT be injected for agy/claude/codex/cursor."""
         mock_run = mocker.patch("helix.mutator.subprocess.run")
         mock_run.return_value = MagicMock(stdout="{}", stderr="", returncode=0)
 
-        for backend in ("claude", "codex", "cursor", "gemini"):
+        for backend in ("agy", "claude", "codex", "cursor"):
             invoke_claude_code(
                 str(tmp_path), "prompt", AgentConfig(backend=backend)
             )

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -738,7 +738,6 @@ class TestInvokeClaudeCode:
         args_list = mock_run.call_args[0][0]
         assert args_list[0] == "agy"
         assert "--dangerously-skip-permissions" in args_list
-        assert "--print" in args_list
         assert "--output-format" in args_list
         assert "json" in args_list
         assert "--model" in args_list
@@ -747,7 +746,15 @@ class TestInvokeClaudeCode:
         assert "high" in args_list
         assert "--sandbox" not in args_list
         assert "the prompt" not in args_list
+        # agy's ``--print`` takes the prompt as its VALUE (it is not a boolean
+        # flag like claude's), so the prompt must be the element immediately
+        # after ``--print`` and the pair must be the final two argv elements
+        # -- otherwise agy consumes the next flag as the prompt and exits 2.
+        assert args_list.count("--print") == 1
+        assert args_list[-2] == "--print"
         assert ".agent_task_prompt.md" in args_list[-1]
+        assert not args_list[-1].startswith("-")
+        assert "--output-format" not in args_list[args_list.index("--print") :]
         assert "input" not in mock_run.call_args[1]
         assert result["session_id"] == "sess_123"
 
@@ -761,6 +768,10 @@ class TestInvokeClaudeCode:
         args_list = mock_run.call_args[0][0]
         assert "--model" not in args_list
         assert "--effort" not in args_list
+        # The ``--print <prompt>`` pair must still close the argv when no
+        # optional flags are present.
+        assert args_list[-2] == "--print"
+        assert ".agent_task_prompt.md" in args_list[-1]
 
     def test_uses_correct_cwd(self, mocker):
         mock_run = mocker.patch("helix.mutator.subprocess.run")

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -12,6 +12,7 @@ import pytest
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, EvaluatorConfig, SandboxConfig
 from helix.mutator import (
+    _AGY_PRINT_TIMEOUT,
     MutationError,
     BACKEND_RESULT_ARTIFACT_NAME,
     BACKEND_STDERR_ARTIFACT_NAME,
@@ -755,6 +756,13 @@ class TestInvokeClaudeCode:
         assert ".agent_task_prompt.md" in args_list[-1]
         assert not args_list[-1].startswith("-")
         assert "--output-format" not in args_list[args_list.index("--print") :]
+        # agy's ``--print-timeout`` defaults to 5m and has no disable value, so
+        # the argv must carry Go's maximum duration explicitly, as a
+        # ``--print-timeout <value>`` pair ahead of the closing ``--print``.
+        assert args_list.count("--print-timeout") == 1
+        timeout_idx = args_list.index("--print-timeout")
+        assert args_list[timeout_idx + 1] == _AGY_PRINT_TIMEOUT
+        assert timeout_idx < args_list.index("--print")
         assert "input" not in mock_run.call_args[1]
         assert result["session_id"] == "sess_123"
 
@@ -768,6 +776,9 @@ class TestInvokeClaudeCode:
         args_list = mock_run.call_args[0][0]
         assert "--model" not in args_list
         assert "--effort" not in args_list
+        # ``--print-timeout`` is unconditional, not tied to any optional knob.
+        assert args_list.count("--print-timeout") == 1
+        assert args_list[args_list.index("--print-timeout") + 1] == _AGY_PRINT_TIMEOUT
         # The ``--print <prompt>`` pair must still close the argv when no
         # optional flags are present.
         assert args_list[-2] == "--print"

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -1766,12 +1766,12 @@ class TestCountTranscriptToolEventsDispatcher:
         assert count == 1
         assert names == ["Read"]
 
-    def test_agy_has_no_dedicated_counter_yet(self, tmp_path: Path) -> None:
-        """agy has no dedicated per-field counter (needs a real transcript sample
-        to write correctly, see ``_TRANSCRIPT_TOOL_COUNTERS``), so it falls back
-        to the dispatcher's unknown-backend behavior even for an existing file.
-        ``_normalise_usage_stats``'s generic walk still produces best-effort
-        stats independently of this counter.
+    def test_agy_has_no_dedicated_counter(self, tmp_path: Path) -> None:
+        """agy has no dedicated per-field counter: its ``--output-format json``
+        envelope carries token totals but no per-tool event list (see
+        ``_TRANSCRIPT_TOOL_COUNTERS``), so the dispatcher treats it like an
+        unknown backend even for an existing file.  ``_normalise_usage_stats``
+        reads the envelope's token fields independently of this counter.
         """
         from helix.mutator import _count_transcript_tool_events
 

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -65,12 +65,12 @@ def test_resolve_sandbox_image_defaults_from_backend():
         == "ghcr.io/ke7/helix-evo-runner-cursor:latest"
     )
     assert (
-        resolve_sandbox_image(cfg, "gemini")
-        == "ghcr.io/ke7/helix-evo-runner-gemini:latest"
-    )
-    assert (
         resolve_sandbox_image(cfg, "opencode")
         == "ghcr.io/ke7/helix-evo-runner-opencode:latest"
+    )
+    assert (
+        resolve_sandbox_image(cfg, "agy")
+        == "ghcr.io/ke7/helix-evo-runner-agy:latest"
     )
 
 
@@ -941,16 +941,51 @@ def test_sandbox_auth_codex_login_uses_device_auth_flow():
     assert args[-3:] == ["codex", "login", "--device-auth"]
 
 
-def test_sandbox_auth_gemini_login_skips_workspace_trust_prompt():
+def test_sandbox_auth_agy_login_uses_bare_interactive_launch():
+    # agy has no dedicated login subcommand; the login flow is the same bare
+    # interactive launch as opencode's below.
     args = sandbox_auth_docker_args(
-        "gemini",
-        image="helix-gemini:latest",
+        "agy",
+        image="helix-agy:latest",
         action="login",
         interactive=True,
     )
 
-    assert "helix-auth-gemini:/home/node:rw" in args
-    assert args[-2:] == ["gemini", "--skip-trust"]
+    assert "helix-auth-agy:/home/node:rw" in args
+    assert args[-1:] == ["agy"]
+
+
+def test_sandbox_auth_agy_status_uses_credential_file_probe():
+    # ``agy models`` exits 0 even when logged out, so status is a file probe
+    # against the traced credential path, matching claude's pattern above.
+    args = sandbox_auth_docker_args(
+        "agy",
+        image="helix-agy:latest",
+        action="status",
+    )
+
+    assert "helix-auth-agy:/home/node:rw" in args
+    assert args[-3:-1] == ["sh", "-lc"]
+    script = args[-1]
+    assert (
+        'test -s "${HOME:-/home/node}/.gemini/antigravity-cli/antigravity-oauth-token"'
+        in script
+    )
+
+
+def test_sandbox_auth_agy_logout_only_removes_its_own_state_directory():
+    # ~/.gemini also holds unrelated Google CLI state; logout must not
+    # blanket-remove it.
+    args = sandbox_auth_docker_args(
+        "agy",
+        image="helix-agy:latest",
+        action="logout",
+    )
+
+    assert args[-3:-1] == ["sh", "-lc"]
+    script = args[-1]
+    assert '"${HOME:-/home/node}/.gemini/antigravity-cli"' in script
+    assert script.count(".gemini") == 1
 
 
 def test_sandbox_auth_opencode_login_uses_full_setup_tui():


### PR DESCRIPTION
Replaces the `gemini` mutation backend with `agy` (Google's Antigravity CLI),
fixes the runner-image publish workflow so the images actually get
refreshed, and adds a pull-request check that builds and probes every image.

Both changes are independent of the credential-projection work explored on
`impl/auth-two-modes`. That branch's central idea — giving each candidate a
private copy of the operator's credential — is not adopted here: nothing in
this branch changes how the sandbox authenticates. `agy` gets the same
whole-`$HOME` `helix-auth-agy` mount every other backend already gets.

## `agy` replaces `gemini`

**BREAKING**: `agent.backend = "gemini"` is no longer accepted. Migrate to
`"agy"` and run `helix sandbox login agy`; existing `helix-auth-gemini`
volumes are no longer read.

The migration touches the backend registry, argv construction and output
parsing, the config `Literal` and CLI `--backend` choice, a new
`docker/agy.Dockerfile`, the publish-runners matrices, and every doc, skill,
and test reference. Unlike `gemini`, `agy` propagates `agent.effort`
(`--effort low|medium|high`) instead of warning that the knob is ignored.

Two things are deliberately claimed no more strongly than they have been
established:

- The credential path the `status` probe tests
  (`$HOME/.gemini/antigravity-cli/antigravity-oauth-token`) was derived by
  tracing the CLI's own file opens, not confirmed against a completed
  sign-in. `logout` therefore removes only `~/.gemini/antigravity-cli`,
  never the shared `~/.gemini` root.
- `agy` gets no `BACKEND_AUTH_ENV` row: naming ambient credential variables
  would assert a shape nobody here has observed. Its `--output-format json`
  envelope, on the other hand, *has* been captured (agy 1.1.27): a single
  object with `conversation_id`, `status`, `response`, `error` (on failure),
  `duration_seconds`, `num_turns`, and a `usage` block of `input_tokens` /
  `output_tokens` / `thinking_tokens` / `cache_read_tokens` / `total_tokens`.
  `_normalise_usage_stats` now maps `thinking_tokens` to the reasoning
  counter, `cache_read_tokens` to the cache-read counter, and
  `conversation_id` to `session_id`; before this those two token counts were
  always charged as 0. The envelope has no cost field, so `cost_usd` stays 0
  for agy, and no per-tool event list, so `_TRANSCRIPT_TOOL_COUNTERS` still
  has no agy entry. The budget tests' agy fixtures are the captured envelope
  rather than an illustrative one.

**Argv grammar.** agy's `-p`/`--print` (alias `--prompt`) takes the prompt
as its *value*; it is not a boolean flag like claude's. The argv therefore
puts every other flag first and ends with `--print <prompt>` as the final
pair. Verified against `agy 1.1.27`: the old order (`--print --output-format
json ... <prompt>`) exits 2 with `--print took "--output-format" as its
prompt`, while `--output-format json --print "<prompt>" --bogus` fails only
on `--bogus`, proving the prompt is consumed as the flag's value. The unit
test now pins `--print` as the second-to-last element and the prompt as the
last, instead of only asserting `"--print" in args`. (An earlier revision of
this description claimed `--print` was boolean after a probe against
`agy 1.1.17`, which silently ran "--output-format" as the prompt instead of
erroring; that claim was wrong.)

**Print timeout.** agy's `--print-timeout` is a Go `time.Duration` flag
defaulting to `5m0s`; when it expires the headless run stops, and per agy's
changelog a mid-turn expiry returns partial output with only a stderr
warning, so a cut-off mutation can look like a finished one. There is no
disable value: `0` and `-1s` both fail immediately with `timeout waiting for
response`, `-1` without a unit is an invalid duration, and no environment
variable or settings key overrides the flag. The argv therefore passes the
largest duration Go can represent, `2562047h47m16.854775807s`
(`math.MaxInt64` nanoseconds, ~292 years), which agy 1.1.27 accepts and
completes a turn under; `2562048h` is rejected, so this is the ceiling of
the flag's type. The maximum was chosen over a `24h` cap because every other
backend runs its subprocess with no timeout at all
(`test_no_timeout_in_subprocess`), and this keeps agy on the same policy.
The flag sits among the leading flags, ahead of the closing `--print
<prompt>` pair; the argv tests pin it to exactly one occurrence, immediately
followed by the value, before `--print`.

## Runner images get published on a schedule

The images were only ever published on a `v*` tag. The last successful
publish was `v0.2.1` on 2026-05-10, so `latest` had been drifting behind the
agent CLIs' own releases for months. The one attempt to refresh it, a manual
dispatch from `feat/agy-backend` on 2026-08-24, failed at the manifest step
with `can't push with no tags specified`, because a non-default branch
produced no tag to push.

Three changes to `publish-runners.yml`, no new files:

- **Weekly `schedule` trigger** (Mondays 12:00 UTC, inside the
  "before 6am on monday" America/Los_Angeles window Renovate uses in #54). A scheduled run is on
  `main`, so it publishes `latest` through the existing tagging rules.
- **Verify as `node`.** The post-publish smoke test now runs each CLI's
  version probe as the unprivileged user every agent container runs as, not
  as root. Root cannot see an installer that leaves its binary under `/root`,
  which is exactly the bug `agy.Dockerfile` has to work around; this makes
  that class of bug fail the publish instead of the first real run.
- **Branch dispatch gets a tag.** A single `resolve-tag` job now decides the
  tag every later job builds against and publishes: the version for a `v*`
  tag, `latest` on `main`, and the branch name (slashes replaced) anywhere
  else. It replaces the two copied shell snippets that previously made the
  same choice and never handled the branch case.

## Runner images get a pull-request check

`publish-runners.yml` pushes `latest` before it verifies, so a broken
Dockerfile reaches `latest` before anything notices, and a backend added in
a PR (like `agy` here) has no published image to probe at all. A new
`runner-images.yml` workflow closes both gaps: on any PR touching
`docker/**`, `src/helix/backends.py`, or the workflow itself, each matrix
leg builds the base image and one backend image from this checkout, then
runs the CLI's version probe as `node`. No layer cache, so each run installs
the CLI versions a release build would. It is 42 lines of plain YAML with no
bake file or test module.

## Gates

- `uv run python -m pytest` — **985 passed**
- `uv run ruff check src/ tests/` — clean
- `uv run mypy --strict src/helix/` — clean
- `actionlint .github/workflows/runner-images.yml` — clean
- `actionlint .github/workflows/publish-runners.yml` — no new findings (the
  four pre-existing SC2046 warnings on the `imagetools create` lines are
  unchanged from `main`)
- `git diff --shortstat origin/main...HEAD` — 17 files changed, 426 insertions(+), 295 deletions(-)

**Dockerfile build proof.** `docker/agy.Dockerfile` was built from this
branch (`--no-cache`, `linux/arm64`) and exercised as the unprivileged user:

```
$ docker run --rm --user node --network none --security-opt no-new-privileges <image> sh -lc 'agy --version'
1.1.21
$ ... sh -lc 'id'
uid=1000(node) gid=1000(node) groups=1000(node)
```

The `/opt` copy is load-bearing, not cosmetic: `/root` is mode 0700, and
invoking the installer's own `/root/.local/bin/agy` as `node` gives
`Permission denied`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HBBoDVQK7baNMQBhgRkh4


