### PR TITLE
fix!: preserve every backend's transcript, always, and reset sandbox agent state every generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upstream's `StrictImprovementAcceptance`.
 
 ### Fixed
+- `sandbox.preserve_backend_transcripts` now covers every backend. It was
+  only ever implemented for `claude`; `codex`, `opencode`, `agy`, and
+  `cursor` runs silently kept no native transcript. Each backend's own
+  session record is now located by a single per-backend table
+  (`helix.backends.BACKEND_TRANSCRIPT_SOURCES`), copied out of the
+  `helix-auth-<backend>` volume (or the operator's `$HOME` when unsandboxed)
+  into `.helix_artifacts/backend_transcripts/<backend>/<session_id>.jsonl`,
+  and reported in `.helix_backend_result.json` with an explicit reason when
+  it cannot be found. OpenCode keeps sessions only in a shared sqlite
+  database, so just that session's `session`/`message`/`part` rows are
+  exported as JSONL rather than copying the whole file.
 - Backend token usage is no longer discarded when the backend's output fails
   to parse. `budget.charge_llm_usage` was reachable only from the success
   paths of `mutate` / `merge`, so a `MutationError` raised while parsing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Sandboxed runs now reset the backend CLI's session state in its
+  `helix-auth-<backend>` volume at the start of every generation
+  (`helix.sandbox.reset_sandbox_agent_state`, driven by
+  `helix.backends.BACKEND_STATE_PATHS`): transcripts, memories, shell
+  snapshots and session indexes are removed so no candidate sees another's
+  history. Credentials and operator configuration are never touched; for
+  OpenCode only the `session`/`message`/`part` rows are deleted from
+  `opencode.db` because the same file holds the account's tokens. A failed
+  wipe is a warning, never fatal. Unsandboxed runs are not affected.
+- Tool-call counts for `agy` are now read from its native
+  `transcript.jsonl` (`tool_calls[*].name` on planner steps); its JSON
+  stdout envelope carries no per-tool events.
+
 ### Changed
+- **BREAKING**: Removed the `sandbox.preserve_backend_transcripts`
+  configuration field. Every backend's native transcript is now always
+  copied out of the auth volume (or `$HOME` when unsandboxed) at the end of
+  each invocation, always kept under
+  `.helix_artifacts/backend_transcripts/<backend>/<session_id>.jsonl`, and
+  always used for tool-call accounting; there is no way to opt out because
+  the sandbox resets the backend's state every generation and the copy is
+  the only record. Configurations that still set the field are rejected by
+  Pydantic's `extra="forbid"` validation. Previously turning the option off
+  also lost Claude's tool-call counts, which only the transcript carries.
 - **BREAKING**: Removed the `gemini` mutation backend and replaced it with
   `agy` (Google's Antigravity CLI). Configs with `agent.backend = "gemini"`
   are rejected; migrate to `"agy"`. `helix-auth-gemini` sandbox volumes are
@@ -65,9 +89,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upstream's `StrictImprovementAcceptance`.
 
 ### Fixed
-- `sandbox.preserve_backend_transcripts` now covers every backend. It was
-  only ever implemented for `claude`; `codex`, `opencode`, `agy`, and
-  `cursor` runs silently kept no native transcript. Each backend's own
+- Backend transcript preservation now covers every backend. It was only ever
+  implemented for `claude`; `codex`, `opencode`, `agy`, and `cursor` runs
+  silently kept no native transcript. Each backend's own
   session record is now located by a single per-backend table
   (`helix.backends.BACKEND_TRANSCRIPT_SOURCES`), copied out of the
   `helix-auth-<backend>` volume (or the operator's `$HOME` when unsandboxed)

--- a/README.md
+++ b/README.md
@@ -636,6 +636,15 @@ and complete provider login in one setup session.
 
 The volume names are `helix-auth-agy`, `helix-auth-claude`, `helix-auth-codex`,
 `helix-auth-cursor`, and `helix-auth-opencode`.
+
+Backend state in the sandbox never survives a generation; the run's artifacts
+are the record. At the start of every generation HELIX wipes the backend
+CLI's session state in its auth volume (transcripts, memories, shell
+snapshots, session indexes; never credentials or operator configuration) so
+no candidate sees another candidate's history. Each invocation's native
+transcript (every backend) is copied out of the volume first and kept at
+`.helix_artifacts/backend_transcripts/<backend>/<session_id>.jsonl` in the
+candidate worktree, where tool-call accounting also reads it.
 This avoids copying host credential stores into Docker. On macOS, Claude/Cursor
 browser-login tokens may live in Keychain; on Linux they may live in
 Secret Service/libsecret, GNOME Keyring, KWallet, or another desktop keyring.

--- a/skills/helix/references/run-debug.md
+++ b/skills/helix/references/run-debug.md
@@ -104,10 +104,9 @@ For backend diagnostics in a candidate worktree, inspect:
 The backend result JSON includes normalized usage metadata and
 `transcript_artifacts` entries describing the backend CLI's own transcript
 for the invocation (`available: false` plus a `reason` when it could not be
-found).  With `preserve_backend_transcripts = true` (the default) HELIX copies
-that native transcript for every backend, in Docker sandbox mode out of the
-`helix-auth-<backend>` volume before syncing changes back, otherwise from the
-operator's `$HOME`:
+found).  HELIX always copies that native transcript for every backend, in
+Docker sandbox mode out of the `helix-auth-<backend>` volume before syncing
+changes back, otherwise from the operator's `$HOME`:
 
 | backend | native source (relative to `$HOME`) | artifact |
 | --- | --- | --- |
@@ -121,6 +120,13 @@ The structured stdout of the JSONL backends is still kept verbatim in
 `.helix_backend_stdout.txt`; the native transcript is preserved in addition
 because it carries the full per-turn record (tool payloads, reasoning items)
 that the streamed events elide.
+
+In Docker sandbox mode the backend's session state in `helix-auth-<backend>`
+is wiped at the start of every generation (see `helix.backends.
+BACKEND_STATE_PATHS`; one `reset <backend> agent state in ...` INFO line per
+generation, a WARNING if the wipe fails), so a transcript that could not be
+copied is logged at WARNING with the candidate id and the path looked for,
+and cannot be recovered from the volume afterwards.
 
 ## Resuming
 

--- a/skills/helix/references/run-debug.md
+++ b/skills/helix/references/run-debug.md
@@ -98,17 +98,29 @@ For backend diagnostics in a candidate worktree, inspect:
 .helix_backend_result.json
 .helix_backend_stdout.txt
 .helix_backend_stderr.txt
-.helix_artifacts/backend_transcripts/claude/<session_id>.jsonl
+.helix_artifacts/backend_transcripts/<backend>/<session_id>.jsonl
 ```
 
-The backend result JSON includes normalized usage metadata and, for Claude Code,
-`transcript_artifacts` entries when HELIX can copy the JSONL transcript. In
-Docker sandbox mode HELIX copies Claude transcripts from the backend auth volume
-at `/home/node/.claude/projects/-workspace/<session_id>.jsonl` into the
-candidate worktree before syncing changes back. Codex structured stdout is
-preserved in `.helix_backend_stdout.txt`; durable Codex transcript copying is an
-extension point because HELIX does not currently know a stable Codex transcript
-path in the sandbox auth volume.
+The backend result JSON includes normalized usage metadata and
+`transcript_artifacts` entries describing the backend CLI's own transcript
+for the invocation (`available: false` plus a `reason` when it could not be
+found).  With `preserve_backend_transcripts = true` (the default) HELIX copies
+that native transcript for every backend, in Docker sandbox mode out of the
+`helix-auth-<backend>` volume before syncing changes back, otherwise from the
+operator's `$HOME`:
+
+| backend | native source (relative to `$HOME`) | artifact |
+| --- | --- | --- |
+| claude | `.claude/projects/-workspace/<session_id>.jsonl` (`claude_transcript_root`) | `claude/<session_id>.jsonl` |
+| codex | `.codex/sessions/YYYY/MM/DD/rollout-<ts>-<thread_id>.jsonl` | `codex/<thread_id>.jsonl` |
+| cursor | `.cursor/projects/<cwd-slug>/agent-transcripts/<session_id>/<session_id>.jsonl` | `cursor/<session_id>.jsonl` |
+| agy | `.gemini/antigravity-cli/brain/<conversation_id>/.system_generated/logs/transcript{,_full}.jsonl` | `agy/<id>.jsonl`, `agy/<id>.full.jsonl` |
+| opencode | this session's `session`/`message`/`part` rows of `.local/share/opencode/opencode.db` | `opencode/<sessionID>.jsonl` (one `{"table", "row"}` object per line) |
+
+The structured stdout of the JSONL backends is still kept verbatim in
+`.helix_backend_stdout.txt`; the native transcript is preserved in addition
+because it carries the full per-turn record (tool payloads, reasoning items)
+that the streamed events elide.
 
 ## Resuming
 

--- a/skills/helix/references/toml.md
+++ b/skills/helix/references/toml.md
@@ -212,14 +212,16 @@ Sandbox behavior:
 - Evaluator containers do not get agent auth volumes.
 - `helix.toml`, `.env`, `.env.*`, `.git`, and HELIX artifacts are excluded
   from sandbox workspace copies/sync-back.
-- Claude Code transcript preservation is enabled by default for agent
-  sandboxes. HELIX looks for
-  `/home/node/.claude/projects/-workspace/<session_id>.jsonl` in the auth
-  volume and copies it to
-  `.helix_artifacts/backend_transcripts/claude/<session_id>.jsonl`.
+- Backend transcript preservation is enabled by default for every backend.
+  After each agent invocation HELIX copies the CLI's own transcript for that
+  session (claude `projects/-workspace/<id>.jsonl`, codex `sessions/.../
+  rollout-*-<thread_id>.jsonl`, cursor `projects/*/agent-transcripts/<id>/`,
+  agy `brain/<id>/.system_generated/logs/transcript*.jsonl`, opencode this
+  session's rows exported from `opencode.db`) out of the auth volume into
+  `.helix_artifacts/backend_transcripts/<backend>/<session_id>.jsonl`.
   Set `preserve_backend_transcripts = false` under `[sandbox]` to disable it,
   or override `transcript_artifact_dir` / `claude_transcript_root` for custom
-  layouts.
+  layouts. See `run-debug.md` for the full per-backend table.
 - Special files are skipped by default; set `skip_special_files = false` to
   raise on unsupported file types instead.
 

--- a/skills/helix/references/toml.md
+++ b/skills/helix/references/toml.md
@@ -212,16 +212,19 @@ Sandbox behavior:
 - Evaluator containers do not get agent auth volumes.
 - `helix.toml`, `.env`, `.env.*`, `.git`, and HELIX artifacts are excluded
   from sandbox workspace copies/sync-back.
-- Backend transcript preservation is enabled by default for every backend.
-  After each agent invocation HELIX copies the CLI's own transcript for that
+- After each agent invocation HELIX copies the CLI's own transcript for that
   session (claude `projects/-workspace/<id>.jsonl`, codex `sessions/.../
   rollout-*-<thread_id>.jsonl`, cursor `projects/*/agent-transcripts/<id>/`,
   agy `brain/<id>/.system_generated/logs/transcript*.jsonl`, opencode this
   session's rows exported from `opencode.db`) out of the auth volume into
-  `.helix_artifacts/backend_transcripts/<backend>/<session_id>.jsonl`.
-  Set `preserve_backend_transcripts = false` under `[sandbox]` to disable it,
-  or override `transcript_artifact_dir` / `claude_transcript_root` for custom
-  layouts. See `run-debug.md` for the full per-backend table.
+  `.helix_artifacts/backend_transcripts/<backend>/<session_id>.jsonl`. This
+  always happens for every backend; override `transcript_artifact_dir` /
+  `claude_transcript_root` under `[sandbox]` for custom layouts. See
+  `run-debug.md` for the full per-backend table.
+- Sandboxed runs reset the backend CLI's session state in its auth volume at
+  the start of every generation. Credentials and operator configuration are
+  never touched; the copied transcripts are the only durable record of what
+  the agent did.
 - Special files are skipped by default; set `skip_special_files = false` to
   raise on unsupported file types instead.
 

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -138,7 +138,7 @@ def backend_display_name(backend: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Native transcript stores (``sandbox.preserve_backend_transcripts``)
+# Native transcript stores
 # ---------------------------------------------------------------------------
 #
 # Every backend CLI keeps its own durable record of a session somewhere under
@@ -250,3 +250,94 @@ def transcript_session_id_keys(backend: str) -> tuple[str, ...]:
     if source is None:
         return ("session_id", "sessionId", "sessionID")
     return source.id_keys
+
+
+# ---------------------------------------------------------------------------
+# Per-generation sandbox state reset
+# ---------------------------------------------------------------------------
+#
+# Every sandboxed agent run leaves session state behind in the
+# ``helix-auth-<backend>`` volume: transcripts, memories, shell snapshots,
+# indexes.  Left alone it accumulates across a whole evolution run and leaks
+# earlier candidates' work into later ones through the CLI's own history and
+# memory features.  ``helix.sandbox.reset_sandbox_agent_state`` deletes the
+# ``$HOME``-relative paths below at the start of every generation, after the
+# previous generation's transcripts were copied into the run.  Credentials and
+# operator configuration are deliberately absent from this table; the unit
+# test ``test_sandbox_state_paths_never_match_credentials`` guards that.  The
+# entries were verified against local installs of codex 0.154, opencode 1.18,
+# agy 1.1, cursor-agent 2026.08 and claude code; unknown directories were left
+# alone rather than guessed at.
+BACKEND_STATE_PATHS: dict[str, tuple[str, ...]] = {
+    "claude": (
+        ".claude/projects",  # per-project transcripts, memory/, todo state
+        ".claude/sessions",  # session index
+        ".claude/telemetry",
+        ".claude/backups",  # settings/conversation backups
+        ".claude/history.jsonl",  # prompt history
+        ".claude/shell-snapshots",
+        ".claude/file-history",  # pre-edit file copies
+        ".claude/session-env",
+        ".claude/debug",  # per-session debug logs
+        ".claude/paste-cache",
+        # kept: .credentials.json, settings.json, plugins, skills, cache, ~/.claude.json
+    ),
+    "codex": (
+        ".codex/sessions",  # rollout JSONL transcripts
+        ".codex/archived_sessions",
+        ".codex/session_index.jsonl",
+        ".codex/history.jsonl",  # prompt history
+        ".codex/memories",  # auto-memory text
+        ".codex/memories_*.sqlite*",
+        ".codex/shell_snapshots",
+        ".codex/state_*.sqlite*",  # thread state (state_5.sqlite + wal/shm)
+        ".codex/thread_history*.sqlite*",
+        ".codex/logs_*.sqlite*",
+        ".codex/models_cache.json",
+        ".codex/log",
+        # kept: auth.json, config.toml, AGENTS.md, installation_id, version.json,
+        #       .codex-global-state.json, skills, rules, plugins
+    ),
+    "agy": (
+        ".gemini/antigravity-cli/conversations",  # per-conversation .db/.pb
+        ".gemini/antigravity-cli/brain",  # transcripts, steps, task logs
+        ".gemini/antigravity-cli/cache",
+        ".gemini/antigravity-cli/log",
+        ".gemini/antigravity-cli/cli.log",
+        ".gemini/antigravity-cli/crashes",
+        ".gemini/antigravity-cli/presence",
+        ".gemini/antigravity-cli/knowledge",  # auto-memory
+        ".gemini/antigravity-cli/history.jsonl",
+        ".gemini/antigravity-cli/conversation_summaries.db",
+        # kept: antigravity-oauth-token, settings.json, installation_id,
+        #       keybindings.json, mcp, plugins, bin, builtin, updater
+    ),
+    "cursor": (
+        ".cursor/projects",  # agent-transcripts/, per-project state
+        ".cursor/chats",  # per-session store.db + meta.json
+        ".cursor/ai-tracking",
+        ".cursor/browser-logs",
+        ".cursor/prompt_history.json",
+        ".cursor/snapshots",
+        ".cursor/worktrees",
+        # kept: cli-config.json, mcp.json, agent-cli-state.json, extensions,
+        #       plugins, skills-cursor, ~/.config/cursor/auth.json
+    ),
+    "opencode": (
+        ".local/share/opencode/storage",  # legacy per-session JSON tree
+        ".local/share/opencode/snapshot",  # per-session git snapshots
+        ".local/share/opencode/tool-output",
+        ".local/share/opencode/log",
+        ".local/state/opencode/prompt-history.jsonl",
+        # opencode.db is NOT a path here: its ``account`` table holds the
+        # opencode account's access/refresh tokens, so the file is kept and
+        # only session rows are deleted (``OPENCODE_STATE_TABLES``).
+        # kept: auth.json, account.json, bin, ~/.local/state/opencode/locks
+    ),
+}
+
+# Tables in ``~/.local/share/opencode/opencode.db`` whose rows are per-session
+# state.  ``session`` is the parent; the others reference it by ``session_id``
+# (``part`` also by ``message_id``).  Listed children-first so the deletes do
+# not depend on foreign-key enforcement being on.
+OPENCODE_STATE_TABLES: tuple[str, ...] = ("part", "message", "session")

--- a/src/helix/backends.py
+++ b/src/helix/backends.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import re
 from typing import Literal, TypeAlias
 
 
@@ -133,3 +135,118 @@ BACKEND_AUTH_COMMANDS: dict[str, dict[str, list[str]]] = {
 
 def backend_display_name(backend: str) -> str:
     return BACKEND_DISPLAY_NAMES.get(backend, backend)
+
+
+# ---------------------------------------------------------------------------
+# Native transcript stores (``sandbox.preserve_backend_transcripts``)
+# ---------------------------------------------------------------------------
+#
+# Every backend CLI keeps its own durable record of a session somewhere under
+# ``$HOME`` (``/home/node`` inside the sandbox auth volume).  The table below
+# is the single place that knows where, keyed by backend, so that
+# ``helix.sandbox`` (copy out of the ``helix-auth-<backend>`` volume) and
+# ``helix.mutator`` (copy from the operator's ``$HOME`` when unsandboxed,
+# then record the artifact) can share one locator.  Paths were established
+# against codex 0.154, opencode 1.18, agy 1.1 and cursor-agent 2026.08; they
+# are best-effort and a miss is recorded, never raised.
+#
+# ``claude`` is listed for completeness of ``id_keys`` only: its source path is
+# ``SandboxConfig.claude_transcript_root`` (or ``HELIX_CLAUDE_TRANSCRIPT_ROOT``)
+# and is handled by the pre-existing claude-specific code path.
+
+# Session ids are interpolated into shell globs and file names, so only accept
+# the shapes the CLIs actually emit (UUIDs, ``ses_…``, ``thr_…``).
+TRANSCRIPT_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+@dataclass(frozen=True)
+class BackendTranscriptSource:
+    """Where a backend CLI persists one session's transcript.
+
+    ``id_keys`` are the field names, in priority order, that carry the session
+    id in the backend's structured stdout.  ``files`` maps a ``$HOME``-relative
+    glob (``{session_id}`` is substituted; ``*`` is left for the shell/glob) to
+    the file name written under ``<transcript_artifact_dir>/<backend>/``.
+    ``sqlite_export`` names the staged raw sqlite copy in ``files`` and the
+    ``(table, session_id_column)`` pairs whose rows for this session are
+    exported to ``{session_id}.jsonl`` once the raw copy is on the host.
+    """
+
+    id_keys: tuple[str, ...]
+    files: tuple[tuple[str, str], ...]
+    sqlite_export: tuple[str, tuple[tuple[str, str], ...]] | None = None
+
+
+BACKEND_TRANSCRIPT_SOURCES: dict[str, BackendTranscriptSource] = {
+    "claude": BackendTranscriptSource(
+        id_keys=("session_id", "sessionId", "sessionID"),
+        files=(),
+    ),
+    # ``codex exec --json`` opens with ``thread.started {thread_id}``; the
+    # rollout file is date-partitioned by local start time and its name ends
+    # in that thread id.  ``session_meta.payload.id`` inside equals it.
+    "codex": BackendTranscriptSource(
+        id_keys=("thread_id", "session_id", "sessionId"),
+        files=(
+            (
+                ".codex/sessions/*/*/*/rollout-*-{session_id}.jsonl",
+                "{session_id}.jsonl",
+            ),
+        ),
+    ),
+    # ``cursor-agent --output-format stream-json`` reports the session id on
+    # its ``system`` event.  Cursor keeps a binary blob store under
+    # ``~/.cursor/chats/<cwd-hash>/<session>/store.db`` and a plain JSONL
+    # transcript under ``~/.cursor/projects/<cwd-slug>/agent-transcripts``;
+    # the JSONL is the one preserved.
+    "cursor": BackendTranscriptSource(
+        id_keys=("session_id", "sessionId", "sessionID"),
+        files=(
+            (
+                ".cursor/projects/*/agent-transcripts/{session_id}/{session_id}.jsonl",
+                "{session_id}.jsonl",
+            ),
+        ),
+    ),
+    # Antigravity keeps the readable transcript (and a ``_full`` variant with
+    # tool payloads) per conversation under ``brain/``.  The sibling
+    # ``conversations/<id>.db`` / ``.pb`` are the same conversation in binary
+    # form and are not copied.
+    "agy": BackendTranscriptSource(
+        id_keys=("conversation_id",),
+        files=(
+            (
+                ".gemini/antigravity-cli/brain/{session_id}/.system_generated/logs/transcript.jsonl",
+                "{session_id}.jsonl",
+            ),
+            (
+                ".gemini/antigravity-cli/brain/{session_id}/.system_generated/logs/transcript_full.jsonl",
+                "{session_id}.full.jsonl",
+            ),
+        ),
+    ),
+    # OpenCode >= 1.x persists sessions only in one sqlite database shared by
+    # every session (the older ``storage/`` JSON tree is no longer written).
+    # The db and its WAL are staged next to the artifacts under a dot-prefixed
+    # name, this session's ``session``/``message``/``part`` rows are exported
+    # to ``{session_id}.jsonl``, and the staged copy is removed.
+    "opencode": BackendTranscriptSource(
+        id_keys=("sessionID", "session_id", "sessionId"),
+        files=(
+            (".local/share/opencode/opencode.db", ".{session_id}.opencode.db"),
+            (".local/share/opencode/opencode.db-wal", ".{session_id}.opencode.db-wal"),
+        ),
+        sqlite_export=(
+            ".{session_id}.opencode.db",
+            (("session", "id"), ("message", "session_id"), ("part", "session_id")),
+        ),
+    ),
+}
+
+
+def transcript_session_id_keys(backend: str) -> tuple[str, ...]:
+    """Structured-stdout field names that carry ``backend``'s session id."""
+    source = BACKEND_TRANSCRIPT_SOURCES.get(backend)
+    if source is None:
+        return ("session_id", "sessionId", "sessionID")
+    return source.id_keys

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -704,16 +704,17 @@ class SandboxConfig(BaseModel):
     extra_hosts: dict[str, str] = Field(default_factory=dict)
     skip_special_files: bool = True
     omit_from_agent: list[str] = Field(default_factory=list)
-    # Copy each agent invocation's native CLI transcript into the candidate
-    # worktree under ``transcript_artifact_dir/<backend>/<session_id>.jsonl``.
-    # Applies to every backend: claude (``claude_transcript_root``), codex
-    # (``~/.codex/sessions`` rollout), cursor (``~/.cursor/projects/*/
-    # agent-transcripts``), agy (``brain/<id>/.../transcript.jsonl`` plus a
-    # ``<id>.full.jsonl`` companion) and opencode (this session's rows
-    # exported from ``opencode.db``).  Sandboxed runs read the backend's
-    # ``helix-auth-<backend>`` volume; unsandboxed runs read ``$HOME``.  See
-    # ``helix.backends.BACKEND_TRANSCRIPT_SOURCES`` for the per-backend table.
-    preserve_backend_transcripts: bool = True
+    # Every agent invocation's native CLI transcript is copied into the
+    # candidate worktree under ``transcript_artifact_dir/<backend>/
+    # <session_id>.jsonl`` and used for tool-call accounting: claude
+    # (``claude_transcript_root``), codex (``~/.codex/sessions`` rollout),
+    # cursor (``~/.cursor/projects/*/agent-transcripts``), agy
+    # (``brain/<id>/.../transcript.jsonl`` plus ``<id>.full.jsonl``) and
+    # opencode (this session's rows exported from ``opencode.db``); see
+    # ``helix.backends.BACKEND_TRANSCRIPT_SOURCES``.  Sandboxed runs read the
+    # ``helix-auth-<backend>`` volume, whose session state is reset at the
+    # start of every generation (``helix.backends.BACKEND_STATE_PATHS``), so
+    # these copies are the only durable record of what the agent did.
     transcript_artifact_dir: str = ".helix_artifacts/backend_transcripts"
     claude_transcript_root: str = "/home/node/.claude/projects/-workspace"
 

--- a/src/helix/config.py
+++ b/src/helix/config.py
@@ -704,6 +704,15 @@ class SandboxConfig(BaseModel):
     extra_hosts: dict[str, str] = Field(default_factory=dict)
     skip_special_files: bool = True
     omit_from_agent: list[str] = Field(default_factory=list)
+    # Copy each agent invocation's native CLI transcript into the candidate
+    # worktree under ``transcript_artifact_dir/<backend>/<session_id>.jsonl``.
+    # Applies to every backend: claude (``claude_transcript_root``), codex
+    # (``~/.codex/sessions`` rollout), cursor (``~/.cursor/projects/*/
+    # agent-transcripts``), agy (``brain/<id>/.../transcript.jsonl`` plus a
+    # ``<id>.full.jsonl`` companion) and opencode (this session's rows
+    # exported from ``opencode.db``).  Sandboxed runs read the backend's
+    # ``helix-auth-<backend>`` volume; unsandboxed runs read ``$HOME``.  See
+    # ``helix.backends.BACKEND_TRANSCRIPT_SOURCES`` for the per-backend table.
     preserve_backend_transcripts: bool = True
     transcript_artifact_dir: str = ".helix_artifacts/backend_transcripts"
     claude_transcript_root: str = "/home/node/.claude/projects/-workspace"

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -78,7 +78,7 @@ from helix.population import (
     HelixResult,
     ParetoFrontier,
 )
-from helix.sandbox import start_evaluator_sidecar
+from helix.sandbox import reset_sandbox_agent_state, start_evaluator_sidecar
 from helix.state import (
     BudgetState,
     clear_eval_cache,
@@ -1704,6 +1704,13 @@ def _dispatch_proposals(
     return worker_results
 
 
+def _reset_sandbox_agent_state_for_generation(config: HelixConfig, gen: int) -> None:
+    """Generation-start hook: reset the sandbox backend state (sandboxed runs only)."""
+    if not config.sandbox.enabled:
+        return
+    reset_sandbox_agent_state(config.agent.backend, generation=gen)
+
+
 def run_evolution(
     config: HelixConfig,
     project_root: Path,
@@ -2227,6 +2234,13 @@ def _run_evolution_impl(
             if budget_api.budget_exhausted(state, config):
                 print_warning("Budget exhausted -- stopping early.")
                 break
+
+            # Sandboxed runs: wipe the backend CLI's session state in its auth
+            # volume before any candidate of this generation is dispatched
+            # (merge or mutate), so no candidate sees another's history.
+            # Transcripts from the previous generation were already copied
+            # into the run at the end of each invocation.
+            _reset_sandbox_agent_state_for_generation(config, gen)
 
             # =============================================================
             # GEPA parity (Fix 6/7): Merge OR mutate per iteration.

--- a/src/helix/evolution.py
+++ b/src/helix/evolution.py
@@ -78,7 +78,11 @@ from helix.population import (
     HelixResult,
     ParetoFrontier,
 )
-from helix.sandbox import reset_sandbox_agent_state, start_evaluator_sidecar
+from helix.sandbox import (
+    reset_sandbox_agent_state,
+    resolve_sandbox_image,
+    start_evaluator_sidecar,
+)
 from helix.state import (
     BudgetState,
     clear_eval_cache,
@@ -1708,7 +1712,15 @@ def _reset_sandbox_agent_state_for_generation(config: HelixConfig, gen: int) -> 
     """Generation-start hook: reset the sandbox backend state (sandboxed runs only)."""
     if not config.sandbox.enabled:
         return
-    reset_sandbox_agent_state(config.agent.backend, generation=gen)
+    # Resolve the image from the run's own sandbox config: an operator who
+    # points ``sandbox.image`` at a private registry may not be able to pull
+    # the public default at all, and a reset that fails to start is only a
+    # warning -- the run would keep going with the isolation silently gone.
+    reset_sandbox_agent_state(
+        config.agent.backend,
+        image=resolve_sandbox_image(config.sandbox, config.agent.backend),
+        generation=gen,
+    )
 
 
 def run_evolution(

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1411,18 +1411,54 @@ def _count_opencode_stdout_tool_events(path: Path) -> tuple[int, list[str]]:
     return count, names
 
 
-# Dispatcher: maps backend name → per-backend counter function.
+def _count_agy_transcript_tool_events(path: Path) -> tuple[int, list[str]]:
+    """Count tool invocations from an Antigravity ``transcript.jsonl`` file.
+
+    The native transcript (``brain/<conversation_id>/.system_generated/logs/
+    transcript.jsonl``, observed against agy 1.1.28) is one JSON object per
+    step; ``PLANNER_RESPONSE`` steps carry ``tool_calls: [{"name", "args"}]``.
+    Every ``tool_calls`` entry with a string ``name`` counts as one event.
+    """
+    count = 0
+    names: list[str] = []
+    try:
+        for raw_line in split_lf_lines(
+            path.read_text(encoding="utf-8", errors="replace")
+        ):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                step = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(step, dict):
+                continue
+            calls = step.get("tool_calls")
+            if not isinstance(calls, list):
+                continue
+            for call in calls:
+                if isinstance(call, dict) and isinstance(call.get("name"), str):
+                    count += 1
+                    names.append(call["name"])
+    except OSError:
+        return 0, []
+    return count, names
+
+
+# Dispatcher: maps backend name → per-backend counter function.  These read
+# the file HELIX writes for the backend: the stdout artifact for the JSONL
+# backends (codex/cursor/opencode) and the copied native transcript for
+# claude and agy (``_collect_backend_transcript_artifacts``).
 #
-# ``agy`` has no entry because there is nothing to count: its
-# ``--output-format json`` output (observed against agy 1.1.27) is a single
-# envelope -- ``conversation_id``, ``status``, ``response``, ``error`` (on
-# failure), ``duration_seconds``, ``num_turns`` and a ``usage`` block of
-# ``input_tokens`` / ``output_tokens`` / ``thinking_tokens`` /
-# ``cache_read_tokens`` / ``total_tokens`` -- with no per-tool event list.
-# ``_normalise_usage_stats`` reads the envelope's token fields directly; tool
-# events for agy stay at 0 like any backend without a dedicated counter.
+# ``agy``'s ``--output-format json`` stdout (observed against agy 1.1.27) is a
+# single envelope -- ``conversation_id``, ``status``, ``response``, ``error``
+# (on failure), ``duration_seconds``, ``num_turns`` and a ``usage`` block --
+# with no per-tool event list, so its counter is fed the native transcript
+# and is not applied to stdout.
 _TRANSCRIPT_TOOL_COUNTERS: dict[str, Callable[[Path], tuple[int, list[str]]]] = {
     "claude": _count_claude_transcript_tool_events,
+    "agy": _count_agy_transcript_tool_events,
     "codex": _count_codex_stdout_tool_events,
     "cursor": _count_cursor_stdout_tool_events,
     "opencode": _count_opencode_stdout_tool_events,
@@ -1561,6 +1597,7 @@ def _copy_local_backend_transcripts(
     session_id: str,
     artifact_dir: str = BACKEND_TRANSCRIPT_ARTIFACT_DIR,
     home: Path | None,
+    miss_level: int = logging.DEBUG,
 ) -> list[dict[str, Any]]:
     """Collect ``backend``'s native transcript for ``session_id`` into the worktree.
 
@@ -1655,14 +1692,21 @@ def _copy_local_backend_transcripts(
         artifacts.append(entry)
     for entry in artifacts:
         if not entry["available"]:
-            logger.debug(
-                "%s transcript %s not preserved: %s (looked at %s)",
+            logger.log(
+                miss_level,
+                "%s transcript for candidate %s not preserved: %s (expected %s from %s)",
                 backend,
-                entry["path"],
+                Path(worktree_path).name,
                 entry.get("reason"),
+                entry["path"],
                 entry["source"],
             )
     return artifacts
+
+
+# Backends whose tool events are counted from the copied native transcript
+# rather than from the stdout artifact.
+_NATIVE_TRANSCRIPT_COUNTED_BACKENDS = frozenset({"claude", "agy"})
 
 
 def _collect_backend_transcript_artifacts(
@@ -1679,9 +1723,12 @@ def _collect_backend_transcript_artifacts(
     ``BACKEND_TRANSCRIPT_SOURCES``.  In sandbox mode the files were copied out
     of the auth volume by ``helix.sandbox`` before sync-back; unsandboxed they
     are read from the operator's ``$HOME``.
+
+    The copy is always made and kept: it is the run's only durable record
+    once the sandbox resets the backend's state at the next generation, and
+    it feeds tool-event counting for the backends whose stdout carries none
+    (claude, agy).
     """
-    if sandbox is not None and not sandbox.preserve_backend_transcripts:
-        return []
     session_id = usage.session_id
     if not isinstance(session_id, str) or not session_id:
         logger.debug(
@@ -1693,46 +1740,59 @@ def _collect_backend_transcript_artifacts(
         if sandbox is not None
         else BACKEND_TRANSCRIPT_ARTIFACT_DIR
     )
+    sandboxed = sandbox is not None and sandbox.enabled
+    # The sandbox wipes the backend's state at the next generation start, so
+    # a miss there is the last chance to notice; unsandboxed, the operator's
+    # $HOME keeps the source and debug is enough.
+    miss_level = logging.WARNING if sandboxed else logging.DEBUG
     if backend != "claude":
-        return _copy_local_backend_transcripts(
+        artifacts = _copy_local_backend_transcripts(
             worktree_path,
             backend=backend,
             session_id=session_id,
             artifact_dir=artifact_dir,
-            home=None if sandbox is not None and sandbox.enabled else Path.home(),
+            home=None if sandboxed else Path.home(),
+            miss_level=miss_level,
         )
-    transcript_root = (
-        "sandbox_auth_volume"
-        if sandbox is not None and sandbox.enabled
-        else sandbox.claude_transcript_root
-        if sandbox is not None
-        else None
-    )
-    artifact = _copy_local_claude_transcript(
-        worktree_path,
-        session_id=session_id,
-        artifact_dir=artifact_dir,
-        transcript_root=transcript_root,
-    )
-    if artifact is not None and artifact.get("available"):
-        # Claude's ``--output-format json`` summary omits per-turn tool
-        # invocations.  Now that the transcript is on disk, read it and
-        # patch the ``usage`` object with the accurate counts.  Only
-        # applied when the summary gave 0 tool events to avoid overriding
-        # a non-zero value that a future Claude version might expose.
-        dst = Path(worktree_path) / Path(artifact["path"])
-        tc, tn = _count_transcript_tool_events(dst, "claude")
-        if tc > 0 and usage.tool_event_count == 0:
-            usage.tool_event_count = tc
-            usage.tool_names = list(tn)
-    elif artifact is not None:
-        logger.debug(
-            "claude transcript %s not preserved: %s (looked at %s)",
-            artifact["path"],
-            artifact.get("reason"),
-            artifact["source"],
+    else:
+        transcript_root = (
+            "sandbox_auth_volume"
+            if sandboxed
+            else sandbox.claude_transcript_root
+            if sandbox is not None
+            else None
         )
-    return [artifact] if artifact is not None else []
+        artifact = _copy_local_claude_transcript(
+            worktree_path,
+            session_id=session_id,
+            artifact_dir=artifact_dir,
+            transcript_root=transcript_root,
+        )
+        artifacts = [artifact] if artifact is not None else []
+        if artifact is not None and not artifact.get("available"):
+            logger.log(
+                miss_level,
+                "claude transcript for candidate %s not preserved: %s (expected %s from %s)",
+                Path(worktree_path).name,
+                artifact.get("reason"),
+                artifact["path"],
+                artifact["source"],
+            )
+    if backend in _NATIVE_TRANSCRIPT_COUNTED_BACKENDS:
+        # The structured stdout of these backends omits per-turn tool
+        # invocations.  Now that the native transcript is on disk, read it
+        # and patch the ``usage`` object with the accurate counts.  Only
+        # applied when the summary gave 0 tool events to avoid overriding a
+        # non-zero value that a future CLI version might expose.  The first
+        # artifact is the primary transcript (``<session_id>.jsonl``).
+        primary = next((a for a in artifacts if a.get("available")), None)
+        if primary is not None:
+            dst = Path(worktree_path) / Path(primary["path"])
+            tc, tn = _count_transcript_tool_events(dst, backend)
+            if tc > 0 and usage.tool_event_count == 0:
+                usage.tool_event_count = tc
+                usage.tool_names = list(tn)
+    return artifacts
 
 
 def _write_backend_artifacts(
@@ -1759,12 +1819,12 @@ def _write_backend_artifacts(
             usage = fallback_usage
         else:
             usage = _normalise_usage_stats({})
-        # For non-Claude backends the stdout JSONL IS the transcript; patch
+        # For the JSONL backends the stdout stream IS the transcript; patch
         # ``usage`` with backend-specific tool-event counts now that the
-        # stdout artifact is on disk.  Claude is handled separately inside
-        # ``_collect_backend_transcript_artifacts`` where the external
+        # stdout artifact is on disk.  Claude and agy are handled inside
+        # ``_collect_backend_transcript_artifacts`` where the native
         # transcript file is copied first.
-        if backend != "claude":
+        if backend not in _NATIVE_TRANSCRIPT_COUNTED_BACKENDS:
             stdout_path = wt / BACKEND_STDOUT_ARTIFACT_NAME
             tc, tn = _count_transcript_tool_events(stdout_path, backend)
             if tc > 0:

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -1416,8 +1416,10 @@ def _count_agy_transcript_tool_events(path: Path) -> tuple[int, list[str]]:
 
     The native transcript (``brain/<conversation_id>/.system_generated/logs/
     transcript.jsonl``, observed against agy 1.1.28) is one JSON object per
-    step; ``PLANNER_RESPONSE`` steps carry ``tool_calls: [{"name", "args"}]``.
-    Every ``tool_calls`` entry with a string ``name`` counts as one event.
+    step; ``tool_calls: [{"name", "args"}]`` was observed on
+    ``PLANNER_RESPONSE`` steps.  Every ``tool_calls`` entry with a string
+    ``name`` counts as one event, whatever the step type, so a future step
+    type carrying the same field is counted rather than silently dropped.
     """
     count = 0
     names: list[str] = []
@@ -1627,69 +1629,77 @@ def _copy_local_backend_transcripts(
     out_dir = Path(worktree_path) / rel_dir
     artifacts: list[dict[str, Any]] = []
     staged: list[Path] = []
-    for pattern, dest_name in source_spec.files:
-        rel_path = rel_dir / dest_name.format(session_id=session_id)
-        dst = Path(worktree_path) / rel_path
-        entry: dict[str, Any] = {
-            "backend": backend,
-            "session_id": session_id,
-            "path": str(rel_path),
-            "source": "sandbox_auth_volume",
-            "available": dst.is_file(),
-        }
-        if home is not None and not dst.is_file():
-            glob_pattern = pattern.format(session_id=session_id)
-            matches = sorted(p for p in home.glob(glob_pattern) if p.is_file())
-            entry["source"] = str(matches[0]) if matches else str(home / glob_pattern)
-            if matches:
-                try:
-                    dst.parent.mkdir(parents=True, exist_ok=True)
-                    import shutil
+    try:
+        for pattern, dest_name in source_spec.files:
+            rel_path = rel_dir / dest_name.format(session_id=session_id)
+            dst = Path(worktree_path) / rel_path
+            entry: dict[str, Any] = {
+                "backend": backend,
+                "session_id": session_id,
+                "path": str(rel_path),
+                "source": "sandbox_auth_volume",
+                "available": dst.is_file(),
+            }
+            if home is not None and not dst.is_file():
+                glob_pattern = pattern.format(session_id=session_id)
+                matches = sorted(p for p in home.glob(glob_pattern) if p.is_file())
+                entry["source"] = str(matches[0]) if matches else str(home / glob_pattern)
+                if matches:
+                    try:
+                        dst.parent.mkdir(parents=True, exist_ok=True)
+                        import shutil
 
-                    shutil.copy2(matches[0], dst)
-                    entry["available"] = True
-                except OSError as exc:
-                    entry["reason"] = f"copy_failed: {exc}"
-        if not entry["available"]:
-            entry.setdefault("reason", "transcript_not_found")
-        if dest_name.startswith("."):
-            staged.append(dst)
-        else:
+                        shutil.copy2(matches[0], dst)
+                        entry["available"] = True
+                    except OSError as exc:
+                        entry["reason"] = f"copy_failed: {exc}"
+            if not entry["available"]:
+                entry.setdefault("reason", "transcript_not_found")
+            if dest_name.startswith("."):
+                staged.append(dst)
+            else:
+                artifacts.append(entry)
+        if source_spec.sqlite_export is not None:
+            raw_name, tables = source_spec.sqlite_export
+            raw_db = out_dir / raw_name.format(session_id=session_id)
+            rel_path = rel_dir / f"{session_id}.jsonl"
+            entry = {
+                "backend": backend,
+                "session_id": session_id,
+                "path": str(rel_path),
+                "source": str(raw_db)
+                if home is None
+                else str(home / source_spec.files[0][0]),
+                "available": False,
+            }
+            if raw_db.is_file():
+                try:
+                    rows = _export_sqlite_session_rows(
+                        raw_db,
+                        session_id=session_id,
+                        tables=tables,
+                        dst=Path(worktree_path) / rel_path,
+                    )
+                    entry["available"] = rows > 0
+                    if rows == 0:
+                        entry["reason"] = "session_rows_not_found"
+                except Exception as exc:  # noqa: BLE001 - sqlite errors are not fatal
+                    entry["reason"] = f"export_failed: {exc}"
+            else:
+                entry["reason"] = "transcript_not_found"
             artifacts.append(entry)
-    if source_spec.sqlite_export is not None:
-        raw_name, tables = source_spec.sqlite_export
-        raw_db = out_dir / raw_name.format(session_id=session_id)
-        rel_path = rel_dir / f"{session_id}.jsonl"
-        entry = {
-            "backend": backend,
-            "session_id": session_id,
-            "path": str(rel_path),
-            "source": str(raw_db)
-            if home is None
-            else str(home / source_spec.files[0][0]),
-            "available": False,
-        }
-        if raw_db.is_file():
-            try:
-                rows = _export_sqlite_session_rows(
-                    raw_db,
-                    session_id=session_id,
-                    tables=tables,
-                    dst=Path(worktree_path) / rel_path,
-                )
-                entry["available"] = rows > 0
-                if rows == 0:
-                    entry["reason"] = "session_rows_not_found"
-            except Exception as exc:  # noqa: BLE001 - sqlite errors are not fatal
-                entry["reason"] = f"export_failed: {exc}"
-        else:
-            entry["reason"] = "transcript_not_found"
+    finally:
+        # ``staged`` holds raw CLI state copied out verbatim -- for opencode
+        # the whole ``opencode.db``, whose ``account`` table carries the OAuth
+        # tokens and whose rows cover every candidate, not just this one.  It
+        # is removed here rather than after the export so that an interrupt
+        # (Ctrl-C, SIGTERM) between the copy and the export cannot leave a
+        # credential-bearing file behind in the candidate worktree.
         for path in staged:
             try:
                 path.unlink(missing_ok=True)
             except OSError:
                 pass
-        artifacts.append(entry)
     for entry in artifacts:
         if not entry["available"]:
             logger.log(

--- a/src/helix/mutator.py
+++ b/src/helix/mutator.py
@@ -10,7 +10,12 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
-from helix.backends import BACKEND_AUTH_ENV, backend_display_name
+from helix.backends import (
+    BACKEND_AUTH_ENV,
+    BACKEND_TRANSCRIPT_SOURCES,
+    TRANSCRIPT_SESSION_ID_RE,
+    backend_display_name,
+)
 from helix.display import UsageStats
 from helix.population import Candidate, EvalResult
 from helix.config import AgentConfig, HelixConfig, SandboxConfig
@@ -1511,6 +1516,155 @@ def _copy_local_claude_transcript(
     }
 
 
+def _export_sqlite_session_rows(
+    db_path: Path,
+    *,
+    session_id: str,
+    tables: tuple[tuple[str, str], ...],
+    dst: Path,
+) -> int:
+    """Write this session's rows from ``tables`` in ``db_path`` to ``dst`` as JSONL.
+
+    One line per row, ``{"table": <name>, "row": {<column>: <value>, ...}}``,
+    ordered as the tables are listed.  ``db_path`` must be a private copy:
+    sqlite may replay the sibling ``-wal`` into it.  Returns the row count.
+    """
+    import sqlite3
+
+    written = 0
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        with dst.open("w", encoding="utf-8") as out:
+            for table, column in tables:
+                rows = conn.execute(
+                    f'SELECT * FROM "{table}" WHERE "{column}" = ? ORDER BY rowid',
+                    (session_id,),
+                )
+                for row in rows:
+                    record = {
+                        key: (
+                            value.decode("utf-8", "replace")
+                            if isinstance(value, bytes)
+                            else value
+                        )
+                        for key, value in dict(row).items()
+                    }
+                    out.write(json.dumps({"table": table, "row": record}) + "\n")
+                    written += 1
+    return written
+
+
+def _copy_local_backend_transcripts(
+    worktree_path: str,
+    *,
+    backend: str,
+    session_id: str,
+    artifact_dir: str = BACKEND_TRANSCRIPT_ARTIFACT_DIR,
+    home: Path | None,
+) -> list[dict[str, Any]]:
+    """Collect ``backend``'s native transcript for ``session_id`` into the worktree.
+
+    Driven by ``BACKEND_TRANSCRIPT_SOURCES``.  With ``home`` set (unsandboxed)
+    the files are globbed under that directory and copied; with ``home`` of
+    ``None`` (sandboxed) the sandbox helper has already staged them under the
+    artifact dir and only their presence is recorded.  An sqlite-backed store
+    is then reduced to this session's rows and the staged copy removed.  A
+    missing source yields an ``available: False`` entry with a reason, mirroring
+    the claude path, plus a debug log saying why nothing was preserved.
+    """
+    source_spec = BACKEND_TRANSCRIPT_SOURCES.get(backend)
+    if source_spec is None or not source_spec.files:
+        logger.debug(
+            "%s transcript not preserved: no known native transcript location",
+            backend,
+        )
+        return []
+    if not TRANSCRIPT_SESSION_ID_RE.match(session_id):
+        logger.debug(
+            "%s transcript not preserved: unexpected session id %r",
+            backend,
+            session_id,
+        )
+        return []
+    rel_dir = Path(artifact_dir) / backend
+    out_dir = Path(worktree_path) / rel_dir
+    artifacts: list[dict[str, Any]] = []
+    staged: list[Path] = []
+    for pattern, dest_name in source_spec.files:
+        rel_path = rel_dir / dest_name.format(session_id=session_id)
+        dst = Path(worktree_path) / rel_path
+        entry: dict[str, Any] = {
+            "backend": backend,
+            "session_id": session_id,
+            "path": str(rel_path),
+            "source": "sandbox_auth_volume",
+            "available": dst.is_file(),
+        }
+        if home is not None and not dst.is_file():
+            glob_pattern = pattern.format(session_id=session_id)
+            matches = sorted(p for p in home.glob(glob_pattern) if p.is_file())
+            entry["source"] = str(matches[0]) if matches else str(home / glob_pattern)
+            if matches:
+                try:
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    import shutil
+
+                    shutil.copy2(matches[0], dst)
+                    entry["available"] = True
+                except OSError as exc:
+                    entry["reason"] = f"copy_failed: {exc}"
+        if not entry["available"]:
+            entry.setdefault("reason", "transcript_not_found")
+        if dest_name.startswith("."):
+            staged.append(dst)
+        else:
+            artifacts.append(entry)
+    if source_spec.sqlite_export is not None:
+        raw_name, tables = source_spec.sqlite_export
+        raw_db = out_dir / raw_name.format(session_id=session_id)
+        rel_path = rel_dir / f"{session_id}.jsonl"
+        entry = {
+            "backend": backend,
+            "session_id": session_id,
+            "path": str(rel_path),
+            "source": str(raw_db)
+            if home is None
+            else str(home / source_spec.files[0][0]),
+            "available": False,
+        }
+        if raw_db.is_file():
+            try:
+                rows = _export_sqlite_session_rows(
+                    raw_db,
+                    session_id=session_id,
+                    tables=tables,
+                    dst=Path(worktree_path) / rel_path,
+                )
+                entry["available"] = rows > 0
+                if rows == 0:
+                    entry["reason"] = "session_rows_not_found"
+            except Exception as exc:  # noqa: BLE001 - sqlite errors are not fatal
+                entry["reason"] = f"export_failed: {exc}"
+        else:
+            entry["reason"] = "transcript_not_found"
+        for path in staged:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        artifacts.append(entry)
+    for entry in artifacts:
+        if not entry["available"]:
+            logger.debug(
+                "%s transcript %s not preserved: %s (looked at %s)",
+                backend,
+                entry["path"],
+                entry.get("reason"),
+                entry["source"],
+            )
+    return artifacts
+
+
 def _collect_backend_transcript_artifacts(
     worktree_path: str,
     *,
@@ -1518,18 +1672,35 @@ def _collect_backend_transcript_artifacts(
     usage: UsageStats,
     sandbox: SandboxConfig | None,
 ) -> list[dict[str, Any]]:
-    if backend != "claude":
-        return []
+    """Copy the backend's native transcript for this invocation into the worktree.
+
+    Claude keeps its pre-existing path (``claude_transcript_root`` /
+    ``HELIX_CLAUDE_TRANSCRIPT_ROOT``); every other backend is located through
+    ``BACKEND_TRANSCRIPT_SOURCES``.  In sandbox mode the files were copied out
+    of the auth volume by ``helix.sandbox`` before sync-back; unsandboxed they
+    are read from the operator's ``$HOME``.
+    """
     if sandbox is not None and not sandbox.preserve_backend_transcripts:
         return []
     session_id = usage.session_id
     if not isinstance(session_id, str) or not session_id:
+        logger.debug(
+            "%s transcript not preserved: no session id in backend output", backend
+        )
         return []
     artifact_dir = (
         sandbox.transcript_artifact_dir
         if sandbox is not None
         else BACKEND_TRANSCRIPT_ARTIFACT_DIR
     )
+    if backend != "claude":
+        return _copy_local_backend_transcripts(
+            worktree_path,
+            backend=backend,
+            session_id=session_id,
+            artifact_dir=artifact_dir,
+            home=None if sandbox is not None and sandbox.enabled else Path.home(),
+        )
     transcript_root = (
         "sandbox_auth_volume"
         if sandbox is not None and sandbox.enabled
@@ -1554,6 +1725,13 @@ def _collect_backend_transcript_artifacts(
         if tc > 0 and usage.tool_event_count == 0:
             usage.tool_event_count = tc
             usage.tool_names = list(tn)
+    elif artifact is not None:
+        logger.debug(
+            "claude transcript %s not preserved: %s (looked at %s)",
+            artifact["path"],
+            artifact.get("reason"),
+            artifact["source"],
+        )
     return [artifact] if artifact is not None else []
 
 

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -19,7 +19,13 @@ import uuid
 from pathlib import Path
 from typing import Literal
 
-from helix.backends import BACKEND_AUTH_COMMANDS, DEFAULT_BACKEND_IMAGES
+from helix.backends import (
+    BACKEND_AUTH_COMMANDS,
+    BACKEND_TRANSCRIPT_SOURCES,
+    DEFAULT_BACKEND_IMAGES,
+    TRANSCRIPT_SESSION_ID_RE,
+    transcript_session_id_keys,
+)
 from helix.config import EvaluatorSidecarConfig, SandboxConfig
 from helix.lines import split_lf_lines
 
@@ -140,8 +146,19 @@ def _ignore_for_sync(path: Path) -> bool:
     )
 
 
-def _extract_session_id_from_json_output(stdout: str) -> str | None:
-    """Best-effort session id extraction from backend structured stdout."""
+_DEFAULT_SESSION_ID_KEYS = ("session_id", "sessionId", "sessionID")
+
+
+def _extract_session_id_from_json_output(
+    stdout: str,
+    keys: tuple[str, ...] = _DEFAULT_SESSION_ID_KEYS,
+) -> str | None:
+    """Best-effort session id extraction from backend structured stdout.
+
+    ``keys`` are the candidate field names in priority order; backends name
+    the id differently (``thread_id`` for codex, ``conversation_id`` for agy,
+    ``sessionID`` for opencode), see ``transcript_session_id_keys``.
+    """
     if not stdout.strip():
         return None
     payloads: list[object] = []
@@ -160,7 +177,7 @@ def _extract_session_id_from_json_output(stdout: str) -> str | None:
     # Check top-level payloads first
     for payload in payloads:
         if isinstance(payload, dict):
-            for key in ("session_id", "sessionId", "sessionID"):
+            for key in keys:
                 value = payload.get(key)
                 if isinstance(value, str) and value:
                     return value
@@ -178,14 +195,64 @@ def _extract_session_id_from_json_output(stdout: str) -> str | None:
         for node in walk(payload):
             if not isinstance(node, dict) or node is payload:
                 continue
-            for key in ("session_id", "sessionId", "sessionID"):
+            for key in keys:
                 value = node.get(key)
                 if isinstance(value, str) and value:
                     return value
     return None
 
 
-def _copy_claude_transcript_from_auth_volume(
+def _shell_glob_word(pattern: str) -> str:
+    """Quote ``pattern`` for ``sh`` while leaving ``*`` free to glob."""
+    return "*".join(shlex.quote(part) if part else "" for part in pattern.split("*"))
+
+
+def _backend_transcript_copy_script(
+    *,
+    agent_backend: str,
+    sandbox: SandboxConfig,
+    session_id: str,
+) -> str | None:
+    """Build the ``sh`` script that copies one session's transcript files.
+
+    Returns ``None`` when nothing is known to copy for ``agent_backend``.
+    Every source is optional: a missing file is skipped, never an error, so
+    the helper container exits 0 and the mutator records the miss.
+    """
+    rel_dir = Path(sandbox.transcript_artifact_dir) / agent_backend
+    if agent_backend == "claude":
+        rel_file = rel_dir / f"{session_id}.jsonl"
+        source = Path(sandbox.claude_transcript_root) / f"{session_id}.jsonl"
+        rel_file_str = str(rel_file).lstrip("/")
+        return (
+            "set -eu; "
+            f"src={shlex.quote(str(source))}; "
+            f"dst={shlex.quote('/workspace/' + rel_file_str)}; "
+            '[ -f "$src" ] || exit 0; '
+            'mkdir -p "$(dirname "$dst")"; '
+            'cp "$src" "$dst"'
+        )
+    source_spec = BACKEND_TRANSCRIPT_SOURCES.get(agent_backend)
+    if source_spec is None or not source_spec.files:
+        return None
+    steps = []
+    for pattern, dest_name in source_spec.files:
+        glob_word = '"$HOME"/' + _shell_glob_word(pattern.format(session_id=session_id))
+        rel_file = rel_dir / dest_name.format(session_id=session_id)
+        dst = shlex.quote("/workspace/" + str(rel_file).lstrip("/"))
+        steps.append(
+            f"for src in {glob_word}; do "
+            '[ -f "$src" ] || continue; '
+            f"dst={dst}; "
+            'mkdir -p "$(dirname "$dst")"; '
+            'cp "$src" "$dst"; '
+            "break; "
+            "done"
+        )
+    return "set -u; " + "; ".join(steps)
+
+
+def _copy_backend_transcript_from_auth_volume(
     *,
     workspace: Path,
     image: str,
@@ -193,23 +260,43 @@ def _copy_claude_transcript_from_auth_volume(
     sandbox: SandboxConfig,
     stdout: str,
 ) -> None:
-    if agent_backend != "claude" or not sandbox.preserve_backend_transcripts:
+    """Copy the backend's native transcript for this run out of its auth volume.
+
+    The backend CLI writes its session store under ``/home/node`` in the
+    ``helix-auth-<backend>`` volume, which the agent container mounts.  A
+    short-lived helper container mounts that volume read-only alongside the
+    workspace and copies the per-session files named by
+    ``BACKEND_TRANSCRIPT_SOURCES`` (or ``claude_transcript_root`` for claude)
+    into ``<transcript_artifact_dir>/<backend>/`` so the regular sync-back
+    carries them to the candidate worktree.
+    """
+    if agent_backend is None or not sandbox.preserve_backend_transcripts:
         return
-    session_id = _extract_session_id_from_json_output(stdout)
-    if not session_id:
-        return
-    rel_dir = Path(sandbox.transcript_artifact_dir) / "claude"
-    rel_file = rel_dir / f"{session_id}.jsonl"
-    source = Path(sandbox.claude_transcript_root) / f"{session_id}.jsonl"
-    rel_file_str = str(rel_file).lstrip("/")
-    command = (
-        "set -eu; "
-        f"src={shlex.quote(str(source))}; "
-        f"dst={shlex.quote('/workspace/' + rel_file_str)}; "
-        '[ -f "$src" ] || exit 0; '
-        'mkdir -p "$(dirname "$dst")"; '
-        'cp "$src" "$dst"'
+    session_id = _extract_session_id_from_json_output(
+        stdout, transcript_session_id_keys(agent_backend)
     )
+    if not session_id:
+        logger.debug(
+            "%s transcript not preserved: no session id in backend output",
+            agent_backend,
+        )
+        return
+    if agent_backend != "claude" and not TRANSCRIPT_SESSION_ID_RE.match(session_id):
+        logger.debug(
+            "%s transcript not preserved: unexpected session id %r",
+            agent_backend,
+            session_id,
+        )
+        return
+    command = _backend_transcript_copy_script(
+        agent_backend=agent_backend, sandbox=sandbox, session_id=session_id
+    )
+    if command is None:
+        logger.debug(
+            "%s transcript not preserved: no known native transcript location",
+            agent_backend,
+        )
+        return
     args = [
         "docker",
         "run",
@@ -1047,7 +1134,7 @@ def run_sandboxed_commands(
                 finally:
                     _run_docker(["docker", "rm", "-f", container_name], check=False)
                 if scope == "agent":
-                    _copy_claude_transcript_from_auth_volume(
+                    _copy_backend_transcript_from_auth_volume(
                         workspace=workspace,
                         image=docker_image,
                         agent_backend=agent_backend,

--- a/src/helix/sandbox.py
+++ b/src/helix/sandbox.py
@@ -21,8 +21,10 @@ from typing import Literal
 
 from helix.backends import (
     BACKEND_AUTH_COMMANDS,
+    BACKEND_STATE_PATHS,
     BACKEND_TRANSCRIPT_SOURCES,
     DEFAULT_BACKEND_IMAGES,
+    OPENCODE_STATE_TABLES,
     TRANSCRIPT_SESSION_ID_RE,
     transcript_session_id_keys,
 )
@@ -269,8 +271,11 @@ def _copy_backend_transcript_from_auth_volume(
     ``BACKEND_TRANSCRIPT_SOURCES`` (or ``claude_transcript_root`` for claude)
     into ``<transcript_artifact_dir>/<backend>/`` so the regular sync-back
     carries them to the candidate worktree.
+
+    This always runs: the mutator needs the copy to count tool events, and
+    the volume is reset at the next generation, so the copy is the record.
     """
-    if agent_backend is None or not sandbox.preserve_backend_transcripts:
+    if agent_backend is None:
         return
     session_id = _extract_session_id_from_json_output(
         stdout, transcript_session_id_keys(agent_backend)
@@ -321,6 +326,114 @@ def _copy_backend_transcript_from_auth_volume(
         command,
     ]
     _run_docker(args, check=False)
+
+
+_OPENCODE_STATE_ROWS_SCRIPT = (
+    "import os, sqlite3\n"
+    "db = os.path.expanduser('~/.local/share/opencode/opencode.db')\n"
+    "if os.path.isfile(db):\n"
+    "    con = sqlite3.connect(db)\n"
+    "    names = {r[0] for r in con.execute(\"select name from sqlite_master where type='table'\")}\n"
+    "    for t in %s:\n"
+    "        if t in names: con.execute('delete from \"%%s\"' %% t)\n"
+    "    con.commit(); con.close()\n"
+) % (OPENCODE_STATE_TABLES,)
+
+
+def _backend_state_reset_script(agent_backend: str) -> str | None:
+    """Build the ``sh`` script that deletes ``agent_backend``'s session state.
+
+    Returns ``None`` when the table has nothing for the backend.  Paths are
+    ``$HOME``-relative globs from ``BACKEND_STATE_PATHS``; for opencode the
+    session rows are additionally deleted from ``opencode.db`` in place so the
+    credential rows in the same file survive.
+    """
+    paths = BACKEND_STATE_PATHS.get(agent_backend)
+    if not paths:
+        return None
+    words = " ".join('"$HOME"/' + _shell_glob_word(path) for path in paths)
+    script = f"set -u; rm -rf {words}"
+    if agent_backend == "opencode":
+        script += "; python3 -c " + shlex.quote(_OPENCODE_STATE_ROWS_SCRIPT)
+    return script
+
+
+def reset_sandbox_agent_state(
+    agent_backend: str,
+    *,
+    image: str | None = None,
+    generation: int | None = None,
+) -> int:
+    """Delete the backend CLI's session state from its sandbox auth volume.
+
+    Runs once per generation from ``run_evolution`` (sandboxed runs only) in a
+    single-writer container that mounts ``helix-auth-<backend>`` read-write
+    with no network, so each generation's candidates start from a CLI with no
+    memory of earlier candidates.  Transcripts were already copied into the
+    run at the end of each invocation, so nothing HELIX keeps is lost.  Credentials and operator configuration are
+    never touched (see ``BACKEND_STATE_PATHS``).  Returns the number of state
+    paths in the table; a failure is logged as a warning and never raised.
+    """
+    script = _backend_state_reset_script(agent_backend)
+    if script is None:
+        logger.debug("no sandbox state paths known for backend %s", agent_backend)
+        return 0
+    volume = sandbox_auth_volume_name(agent_backend)
+    docker_image = image or resolve_sandbox_image(
+        SandboxConfig(enabled=True), agent_backend
+    )
+    args = [
+        "docker",
+        "run",
+        "--rm",
+        "--workdir",
+        "/home/node",
+        "--user",
+        "node",
+        "--network",
+        "none",
+        "--security-opt",
+        "no-new-privileges",
+        "-v",
+        f"{volume}:/home/node:rw",
+        "-e",
+        "HOME=/home/node",
+        docker_image,
+        "sh",
+        "-c",
+        script,
+    ]
+    count = len(BACKEND_STATE_PATHS[agent_backend])
+    label = f" before generation {generation}" if generation is not None else ""
+    try:
+        result = _run_docker(args, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning(
+            "failed to reset %s agent state in %s%s: %s",
+            agent_backend,
+            volume,
+            label,
+            exc,
+        )
+        return 0
+    if result.returncode != 0:
+        logger.warning(
+            "failed to reset %s agent state in %s%s (exit %s): %s",
+            agent_backend,
+            volume,
+            label,
+            result.returncode,
+            (result.stderr or "").strip()[-500:],
+        )
+        return 0
+    logger.info(
+        "reset %s agent state in %s%s (%d paths)",
+        agent_backend,
+        volume,
+        label,
+        count,
+    )
+    return count
 
 
 def _matches_omitted_path(path: Path, omitted: set[Path]) -> bool:

--- a/tests/unit/test_config_new_fields.py
+++ b/tests/unit/test_config_new_fields.py
@@ -296,7 +296,6 @@ class TestSandboxConfig:
         assert cfg.network == "bridge"
         assert cfg.extra_hosts == {}
         assert cfg.skip_special_files is True
-        assert cfg.preserve_backend_transcripts is True
         assert cfg.transcript_artifact_dir == ".helix_artifacts/backend_transcripts"
         assert cfg.claude_transcript_root == "/home/node/.claude/projects/-workspace"
 
@@ -357,7 +356,6 @@ class TestSandboxConfig:
             timeout_seconds = 300
             add_host_gateway = true
             skip_special_files = false
-            preserve_backend_transcripts = false
             transcript_artifact_dir = ".helix/custom-transcripts"
             claude_transcript_root = "/custom/claude/projects"
 
@@ -381,7 +379,6 @@ class TestSandboxConfig:
         assert cfg.sandbox.timeout_seconds == 300
         assert cfg.sandbox.add_host_gateway is True
         assert cfg.sandbox.skip_special_files is False
-        assert cfg.sandbox.preserve_backend_transcripts is False
         assert cfg.sandbox.transcript_artifact_dir == ".helix/custom-transcripts"
         assert cfg.sandbox.claude_transcript_root == "/custom/claude/projects"
         assert cfg.sandbox.extra_hosts == {

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from helix import budget as budget_api
+from helix.backends import DEFAULT_BACKEND_IMAGES
 from helix.config import (
     DatasetConfig,
     EvolutionConfig,
@@ -2719,7 +2720,11 @@ class TestSandboxAgentStateResetPerGeneration:
 
         assert reset.call_count == 2
         assert reset.call_args_list[0].args == (make_config().agent.backend,)
-        assert reset.call_args_list[0].kwargs == {"generation": 1}
+        assert reset.call_args_list[0].kwargs["generation"] == 1
+        assert (
+            reset.call_args_list[0].kwargs["image"]
+            == DEFAULT_BACKEND_IMAGES[make_config().agent.backend]
+        )
         # Generation 1's copy completes before generation 2's reset.
         assert events == [
             ("reset", 1),
@@ -2727,6 +2732,27 @@ class TestSandboxAgentStateResetPerGeneration:
             ("reset", 2),
             ("candidate-transcript-copy", 2),
         ]
+
+    def test_reset_uses_the_runs_configured_sandbox_image(
+        self, tmp_path, all_mocks, mocker
+    ):
+        """A private ``sandbox.image`` must reach the reset container.
+
+        Resolving from a default ``SandboxConfig`` instead would run the reset
+        on the public image, which an operator pinned to their own registry may
+        not be able to pull at all -- and a reset that cannot start is only a
+        warning, so the run would continue with the isolation silently gone.
+        """
+        _, reset = self._run(
+            tmp_path,
+            all_mocks,
+            mocker,
+            SandboxConfig(enabled=True, image="registry.internal/runner:v9"),
+        )
+
+        assert reset.call_count == 2
+        for call in reset.call_args_list:
+            assert call.kwargs["image"] == "registry.internal/runner:v9"
 
     def test_no_reset_when_unsandboxed(self, tmp_path, all_mocks, mocker):
         events, reset = self._run(tmp_path, all_mocks, mocker, SandboxConfig(enabled=False))

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -2675,3 +2675,61 @@ class TestActiveFrontierSyncOnObjectiveMode:
             "init sync must rebuild active_frontier from the loaded "
             f"EvalResult; got {first_snapshot!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# run_evolution — per-generation sandbox agent state reset
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxAgentStateResetPerGeneration:
+    def _run(self, tmp_path, all_mocks, mocker, sandbox: SandboxConfig):
+        events: list[tuple[str, int]] = []
+        seed = make_candidate("g0-s0")
+        all_mocks["create_seed_worktree"].return_value = seed
+        all_mocks["run_evaluator"].side_effect = (
+            lambda candidate, config, split=None, instances=None, **kw: make_eval_result(
+                candidate.id, {"i1": 0.5}
+            )
+        )
+        gen_counter = {"n": 0}
+
+        def fake_mutate(*args, **kwargs):
+            gen_counter["n"] += 1
+            # Stands in for the invocation, whose tail copies the transcript.
+            events.append(("candidate-transcript-copy", gen_counter["n"]))
+            return None
+
+        def fake_reset(backend, *, generation=None, **kwargs):
+            events.append(("reset", generation))
+            return 5
+
+        all_mocks["mutate"].side_effect = fake_mutate
+        reset = mocker.patch(
+            "helix.evolution.reset_sandbox_agent_state", side_effect=fake_reset
+        )
+        config = make_config(max_generations=2, max_evaluations=10000).model_copy(
+            update={"sandbox": sandbox}
+        )
+        run_evolution(config, tmp_path, tmp_path / ".helix")
+        return events, reset
+
+    def test_reset_runs_before_each_generation(self, tmp_path, all_mocks, mocker):
+        events, reset = self._run(tmp_path, all_mocks, mocker, SandboxConfig(enabled=True))
+
+        assert reset.call_count == 2
+        assert reset.call_args_list[0].args == (make_config().agent.backend,)
+        assert reset.call_args_list[0].kwargs == {"generation": 1}
+        # Generation 1's copy completes before generation 2's reset.
+        assert events == [
+            ("reset", 1),
+            ("candidate-transcript-copy", 1),
+            ("reset", 2),
+            ("candidate-transcript-copy", 2),
+        ]
+
+    def test_no_reset_when_unsandboxed(self, tmp_path, all_mocks, mocker):
+        events, reset = self._run(tmp_path, all_mocks, mocker, SandboxConfig(enabled=False))
+
+        reset.assert_not_called()
+        assert [e for e, _ in events] == ["candidate-transcript-copy"] * 2

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -2119,3 +2119,258 @@ class TestSalvageBackendUsage:
                 ),
             )
             assert usage == UsageStats(), stdout
+
+
+# ---------------------------------------------------------------------------
+# preserve_backend_transcripts for non-Claude backends
+# ---------------------------------------------------------------------------
+
+
+def _collect(
+    worktree: Path,
+    backend: str,
+    session_id: str | None,
+    sandbox: SandboxConfig | None = None,
+) -> list[dict[str, Any]]:
+    from helix.mutator import _collect_backend_transcript_artifacts
+
+    return _collect_backend_transcript_artifacts(
+        str(worktree),
+        backend=backend,
+        usage=UsageStats(session_id=session_id),
+        sandbox=sandbox,
+    )
+
+
+def _make_opencode_db(path: Path, session_ids: list[str]) -> None:
+    import sqlite3
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            "CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, data BLOB);"
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, data TEXT);"
+            "CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT,"
+            " session_id TEXT, data TEXT);"
+        )
+        for sid in session_ids:
+            conn.execute(
+                "INSERT INTO session VALUES (?, ?, ?)", (sid, f"title {sid}", b"raw")
+            )
+            conn.execute(
+                "INSERT INTO message VALUES (?, ?, ?)",
+                (f"msg_{sid}", sid, json.dumps({"role": "user"})),
+            )
+            conn.execute(
+                "INSERT INTO part VALUES (?, ?, ?, ?)",
+                (f"prt_{sid}", f"msg_{sid}", sid, json.dumps({"type": "text"})),
+            )
+
+
+class TestBackendTranscriptCollection:
+    """``_collect_backend_transcript_artifacts`` for codex/cursor/agy/opencode."""
+
+    @pytest.fixture
+    def home(self, tmp_path: Path, monkeypatch) -> Path:
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        return home
+
+    @pytest.fixture
+    def worktree(self, tmp_path: Path) -> Path:
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        return wt
+
+    def test_codex_copies_dated_rollout_file(self, home: Path, worktree: Path):
+        sid = "01a00000-0000-7000-8000-00000000c0de"
+        src = (
+            home
+            / ".codex/sessions/2026/09/10"
+            / f"rollout-2026-09-10T19-17-26-{sid}.jsonl"
+        )
+        src.parent.mkdir(parents=True)
+        src.write_text('{"type":"session_meta"}\n')
+
+        artifacts = _collect(worktree, "codex", sid)
+
+        rel = f".helix_artifacts/backend_transcripts/codex/{sid}.jsonl"
+        assert artifacts == [
+            {
+                "backend": "codex",
+                "session_id": sid,
+                "path": rel,
+                "source": str(src),
+                "available": True,
+            }
+        ]
+        assert (worktree / rel).read_text() == '{"type":"session_meta"}\n'
+
+    def test_cursor_copies_project_agent_transcript(self, home: Path, worktree: Path):
+        sid = "00000000-0000-4000-8000-0000curs0r01"
+        src = home / ".cursor/projects/workspace/agent-transcripts" / sid / f"{sid}.jsonl"
+        src.parent.mkdir(parents=True)
+        src.write_text('{"role":"user"}\n')
+
+        artifacts = _collect(worktree, "cursor", sid)
+
+        assert [a["available"] for a in artifacts] == [True]
+        assert artifacts[0]["source"] == str(src)
+        assert (
+            worktree / ".helix_artifacts/backend_transcripts/cursor" / f"{sid}.jsonl"
+        ).read_text() == '{"role":"user"}\n'
+
+    def test_agy_copies_both_brain_transcripts(self, home: Path, worktree: Path):
+        sid = "00000000-0000-4000-8000-00000000a6b1"
+        logs = home / ".gemini/antigravity-cli/brain" / sid / ".system_generated/logs"
+        logs.mkdir(parents=True)
+        (logs / "transcript.jsonl").write_text("short\n")
+        (logs / "transcript_full.jsonl").write_text("full\n")
+
+        artifacts = _collect(worktree, "agy", sid)
+
+        out = worktree / ".helix_artifacts/backend_transcripts/agy"
+        assert [a["path"].rsplit("/", 1)[1] for a in artifacts] == [
+            f"{sid}.jsonl",
+            f"{sid}.full.jsonl",
+        ]
+        assert all(a["available"] for a in artifacts)
+        assert (out / f"{sid}.jsonl").read_text() == "short\n"
+        assert (out / f"{sid}.full.jsonl").read_text() == "full\n"
+
+    def test_opencode_exports_only_this_sessions_rows(self, home: Path, worktree: Path):
+        sid = "ses_000000000000TestSession01"
+        db = home / ".local/share/opencode/opencode.db"
+        _make_opencode_db(db, [sid, "ses_other"])
+
+        artifacts = _collect(worktree, "opencode", sid)
+
+        out = worktree / ".helix_artifacts/backend_transcripts/opencode"
+        assert len(artifacts) == 1
+        assert artifacts[0]["available"] is True
+        assert artifacts[0]["path"].endswith(f"opencode/{sid}.jsonl")
+        assert artifacts[0]["source"] == str(db)
+        lines = [json.loads(line) for line in (out / f"{sid}.jsonl").read_text().splitlines()]
+        assert [line["table"] for line in lines] == ["session", "message", "part"]
+        assert lines[0]["row"]["id"] == sid
+        assert lines[0]["row"]["data"] == "raw"
+        assert lines[1]["row"]["session_id"] == sid
+        assert "ses_other" not in (out / f"{sid}.jsonl").read_text()
+        # The staged raw database copy does not survive in the worktree.
+        assert sorted(p.name for p in out.iterdir()) == [f"{sid}.jsonl"]
+
+    def test_opencode_session_missing_from_db(self, home: Path, worktree: Path):
+        _make_opencode_db(home / ".local/share/opencode/opencode.db", ["ses_other"])
+
+        artifacts = _collect(worktree, "opencode", "ses_missing")
+
+        assert artifacts[0]["available"] is False
+        assert artifacts[0]["reason"] == "session_rows_not_found"
+        out = worktree / ".helix_artifacts/backend_transcripts/opencode"
+        assert not any(p.name.startswith(".") for p in out.iterdir())
+
+    @pytest.mark.parametrize("backend", ["codex", "cursor", "agy", "opencode"])
+    def test_missing_transcript_is_recorded_and_logged(
+        self, home: Path, worktree: Path, backend: str, caplog
+    ):
+        caplog.set_level("DEBUG", logger="helix.mutator")
+
+        artifacts = _collect(worktree, backend, "sess-404")
+
+        assert artifacts, backend
+        assert all(a["available"] is False for a in artifacts)
+        assert all(a["reason"] == "transcript_not_found" for a in artifacts)
+        assert all(a["source"].startswith(str(home)) for a in artifacts)
+        assert any(
+            f"{backend} transcript" in rec.message and "not preserved" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_sandbox_mode_records_files_staged_by_helper(self, worktree: Path):
+        sid = "thr_123"
+        staged = worktree / ".helix_artifacts/backend_transcripts/codex" / f"{sid}.jsonl"
+        staged.parent.mkdir(parents=True)
+        staged.write_text("x\n")
+
+        artifacts = _collect(worktree, "codex", sid, SandboxConfig(enabled=True))
+
+        assert artifacts == [
+            {
+                "backend": "codex",
+                "session_id": sid,
+                "path": f".helix_artifacts/backend_transcripts/codex/{sid}.jsonl",
+                "source": "sandbox_auth_volume",
+                "available": True,
+            }
+        ]
+
+    def test_sandbox_mode_miss_never_touches_host_home(self, home: Path, worktree: Path):
+        src = home / ".codex/sessions/2026/09/10/rollout-x-thr_123.jsonl"
+        src.parent.mkdir(parents=True)
+        src.write_text("host\n")
+
+        artifacts = _collect(worktree, "codex", "thr_123", SandboxConfig(enabled=True))
+
+        assert artifacts[0]["available"] is False
+        assert artifacts[0]["source"] == "sandbox_auth_volume"
+        assert artifacts[0]["reason"] == "transcript_not_found"
+
+    def test_sandbox_mode_opencode_exports_staged_db(self, worktree: Path):
+        sid = "ses_abc"
+        out = worktree / ".helix_artifacts/backend_transcripts/opencode"
+        _make_opencode_db(out / f".{sid}.opencode.db", [sid])
+        (out / f".{sid}.opencode.db-wal").write_bytes(b"")
+
+        artifacts = _collect(worktree, "opencode", sid, SandboxConfig(enabled=True))
+
+        assert artifacts[0]["available"] is True
+        assert sorted(p.name for p in out.iterdir()) == [f"{sid}.jsonl"]
+
+    def test_disabled_option_collects_nothing(self, home: Path, worktree: Path):
+        src = home / ".codex/sessions/2026/09/10/rollout-x-thr_123.jsonl"
+        src.parent.mkdir(parents=True)
+        src.write_text("host\n")
+
+        assert (
+            _collect(
+                worktree,
+                "codex",
+                "thr_123",
+                SandboxConfig(preserve_backend_transcripts=False),
+            )
+            == []
+        )
+
+    def test_unsafe_session_id_is_skipped(self, home: Path, worktree: Path, caplog):
+        caplog.set_level("DEBUG", logger="helix.mutator")
+        assert _collect(worktree, "codex", "../../etc/passwd") == []
+        assert _collect(worktree, "codex", "a b; rm -rf /") == []
+        assert any("unexpected session id" in rec.message for rec in caplog.records)
+
+    @pytest.mark.parametrize(
+        ("backend", "stdout"),
+        [
+            ("codex", '{"type":"thread.started","thread_id":"thr_9"}\n'),
+            ("cursor", '{"type":"system","session_id":"thr_9"}\n'),
+            ("opencode", '{"type":"step_start","sessionID":"thr_9"}\n'),
+            ("agy", '{"conversation_id":"thr_9","status":"ok","response":"x"}'),
+        ],
+    )
+    def test_write_backend_artifacts_derives_id_from_stdout(
+        self, home: Path, worktree: Path, backend: str, stdout: str
+    ):
+        from helix.mutator import _write_backend_artifacts
+
+        _write_backend_artifacts(
+            str(worktree),
+            backend=backend,
+            command=backend,
+            result=subprocess.CompletedProcess([backend], 0, stdout=stdout, stderr=""),
+            parsed={"events": [json.loads(line) for line in stdout.splitlines()]},
+        )
+
+        payload = json.loads((worktree / BACKEND_RESULT_ARTIFACT_NAME).read_text())
+        assert payload["transcript_artifacts"]
+        assert all(a["session_id"] == "thr_9" for a in payload["transcript_artifacts"])
+        assert all(a["backend"] == backend for a in payload["transcript_artifacts"])

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -2239,6 +2239,30 @@ class TestBackendTranscriptCollection:
         assert (out / f"{sid}.jsonl").read_text() == "short\n"
         assert (out / f"{sid}.full.jsonl").read_text() == "full\n"
 
+    def test_opencode_staged_database_is_removed_even_when_interrupted(
+        self, home: Path, worktree: Path, mocker
+    ):
+        """An interrupt must not strand the raw database in the worktree.
+
+        The staged copy is the whole ``opencode.db``: its ``account`` table
+        carries the OAuth access/refresh tokens and its rows cover every
+        candidate, not just this one.  Cleanup therefore has to survive a
+        ``BaseException`` (Ctrl-C, SIGTERM) raised between the copy and the
+        export, not only the sqlite errors the export itself catches.
+        """
+        sid = "ses_000000000000TestSession01"
+        _make_opencode_db(home / ".local/share/opencode/opencode.db", [sid])
+        mocker.patch(
+            "helix.mutator._export_sqlite_session_rows",
+            side_effect=KeyboardInterrupt,
+        )
+
+        with pytest.raises(KeyboardInterrupt):
+            _collect(worktree, "opencode", sid)
+
+        out = worktree / ".helix_artifacts/backend_transcripts/opencode"
+        assert sorted(p.name for p in out.glob("*")) == []
+
     def test_opencode_exports_only_this_sessions_rows(self, home: Path, worktree: Path):
         sid = "ses_000000000000TestSession01"
         db = home / ".local/share/opencode/opencode.db"

--- a/tests/unit/test_mutator.py
+++ b/tests/unit/test_mutator.py
@@ -2122,7 +2122,7 @@ class TestSalvageBackendUsage:
 
 
 # ---------------------------------------------------------------------------
-# preserve_backend_transcripts for non-Claude backends
+# Native transcript collection for non-Claude backends
 # ---------------------------------------------------------------------------
 
 
@@ -2327,21 +2327,6 @@ class TestBackendTranscriptCollection:
         assert artifacts[0]["available"] is True
         assert sorted(p.name for p in out.iterdir()) == [f"{sid}.jsonl"]
 
-    def test_disabled_option_collects_nothing(self, home: Path, worktree: Path):
-        src = home / ".codex/sessions/2026/09/10/rollout-x-thr_123.jsonl"
-        src.parent.mkdir(parents=True)
-        src.write_text("host\n")
-
-        assert (
-            _collect(
-                worktree,
-                "codex",
-                "thr_123",
-                SandboxConfig(preserve_backend_transcripts=False),
-            )
-            == []
-        )
-
     def test_unsafe_session_id_is_skipped(self, home: Path, worktree: Path, caplog):
         caplog.set_level("DEBUG", logger="helix.mutator")
         assert _collect(worktree, "codex", "../../etc/passwd") == []
@@ -2374,3 +2359,153 @@ class TestBackendTranscriptCollection:
         assert payload["transcript_artifacts"]
         assert all(a["session_id"] == "thr_9" for a in payload["transcript_artifacts"])
         assert all(a["backend"] == backend for a in payload["transcript_artifacts"])
+
+
+# ---------------------------------------------------------------------------
+# Tool-event counting from the kept native transcript
+# ---------------------------------------------------------------------------
+
+
+_CLAUDE_TOOL_TRANSCRIPT = "".join(
+    json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "tool_use", "name": name, "input": {}}]
+            },
+        }
+    )
+    + "\n"
+    for name in ("Read", "Edit", "Bash")
+)
+
+
+class TestToolCountsFromNativeTranscript:
+    def test_claude_counts_come_from_kept_transcript(self, tmp_path: Path, mocker):
+        root = tmp_path / "claude-root"
+        root.mkdir()
+        (root / "sess_tool.jsonl").write_text(_CLAUDE_TOOL_TRANSCRIPT)
+        mock_run = mocker.patch("helix.mutator.subprocess.run")
+        mock_run.return_value = MagicMock(
+            stdout='{"type":"result","session_id":"sess_tool","num_turns":2}\n',
+            stderr="",
+            returncode=0,
+        )
+        wt = tmp_path / "g1-s1"
+        wt.mkdir()
+
+        invoke_claude_code(
+            str(wt),
+            "prompt",
+            AgentConfig(backend="claude"),
+            sandbox=SandboxConfig(claude_transcript_root=str(root)),
+        )
+
+        payload = json.loads((wt / BACKEND_RESULT_ARTIFACT_NAME).read_text())
+        assert payload["usage"]["tool_event_count"] == 3
+        assert payload["usage"]["tool_names"] == ["Read", "Edit", "Bash"]
+        copied = wt / ".helix_artifacts" / "backend_transcripts"
+        assert (copied / "claude" / "sess_tool.jsonl").is_file()
+        assert payload["transcript_artifacts"][0]["available"] is True
+        assert (wt / BACKEND_STDOUT_ARTIFACT_NAME).read_text().startswith('{"type"')
+
+    def test_agy_counter_reads_native_transcript(self, tmp_path: Path):
+        from helix.mutator import _count_agy_transcript_tool_events
+
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(
+            json.dumps({"type": "USER_INPUT", "content": "go"})
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "PLANNER_RESPONSE",
+                    "tool_calls": [
+                        {"name": "view_file", "args": "{}"},
+                        {"name": "run_command", "args": "{}"},
+                    ],
+                }
+            )
+            + "\nnot json\n"
+            + json.dumps({"type": "PLANNER_RESPONSE", "tool_calls": [{"name": 3}]})
+            + "\n"
+            + json.dumps({"type": "PLANNER_RESPONSE", "tool_calls": [{"name": "grep_search"}]})
+            + "\n"
+        )
+
+        assert _count_agy_transcript_tool_events(transcript) == (
+            3,
+            ["view_file", "run_command", "grep_search"],
+        )
+
+    def test_agy_counts_patched_from_kept_transcript(self, tmp_path: Path, monkeypatch):
+        from helix.mutator import _collect_backend_transcript_artifacts
+
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        sid = "conv-1"
+        logs = home / ".gemini/antigravity-cli/brain" / sid / ".system_generated/logs"
+        logs.mkdir(parents=True)
+        (logs / "transcript.jsonl").write_text(
+            json.dumps({"type": "PLANNER_RESPONSE", "tool_calls": [{"name": "list_dir"}]})
+            + "\n"
+        )
+        (logs / "transcript_full.jsonl").write_text("full\n")
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        usage = UsageStats(session_id=sid)
+
+        artifacts = _collect_backend_transcript_artifacts(
+            str(wt),
+            backend="agy",
+            usage=usage,
+            sandbox=SandboxConfig(),
+        )
+
+        assert usage.tool_event_count == 1
+        assert usage.tool_names == ["list_dir"]
+        assert len(artifacts) == 2
+        assert (
+            wt / ".helix_artifacts/backend_transcripts/agy" / f"{sid}.full.jsonl"
+        ).is_file()
+
+    def test_stdout_artifacts_written_even_when_transcript_missing(
+        self, tmp_path: Path, monkeypatch
+    ):
+        from helix.mutator import _write_backend_artifacts
+
+        monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+        stdout = '{"type":"thread.started","thread_id":"thr_1"}\n'
+        _write_backend_artifacts(
+            str(tmp_path),
+            backend="codex",
+            command="codex",
+            result=subprocess.CompletedProcess(["codex"], 0, stdout=stdout, stderr="e"),
+            parsed={"events": [json.loads(stdout)]},
+            sandbox=SandboxConfig(),
+        )
+
+        assert (tmp_path / BACKEND_STDOUT_ARTIFACT_NAME).read_text() == stdout
+        assert (tmp_path / BACKEND_STDERR_ARTIFACT_NAME).read_text() == "e"
+        payload = json.loads((tmp_path / BACKEND_RESULT_ARTIFACT_NAME).read_text())
+        assert payload["transcript_artifacts"][0]["available"] is False
+
+    def test_sandboxed_miss_logs_warning_with_candidate_and_path(
+        self, tmp_path: Path, caplog
+    ):
+        from helix.mutator import _collect_backend_transcript_artifacts
+
+        wt = tmp_path / "g3-s7"
+        wt.mkdir()
+        caplog.set_level("WARNING", logger="helix.mutator")
+
+        _collect_backend_transcript_artifacts(
+            str(wt),
+            backend="codex",
+            usage=UsageStats(session_id="thr_missing"),
+            sandbox=SandboxConfig(enabled=True),
+        )
+
+        [rec] = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert "codex transcript for candidate g3-s7 not preserved" in rec.message
+        assert "transcript_not_found" in rec.message
+        assert "backend_transcripts/codex/thr_missing.jsonl" in rec.message

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1120,7 +1120,7 @@ class TestDockerEnvRedaction:
 
 
 # ---------------------------------------------------------------------------
-# preserve_backend_transcripts for non-Claude backends (auth-volume side)
+# Native transcript collection for non-Claude backends (auth-volume side)
 # ---------------------------------------------------------------------------
 
 
@@ -1262,3 +1262,132 @@ def test_agent_skips_transcript_helper_for_unsafe_session_id(tmp_path: Path, moc
     )
 
     assert not any("helix-auth-codex:/home/node:ro" in call for call in calls)
+
+
+# ---------------------------------------------------------------------------
+# Per-generation sandbox agent state reset
+# ---------------------------------------------------------------------------
+
+# Fixed, independent of the code under test: paths that must never be wiped.
+_CREDENTIAL_PATHS = (
+    ".claude/.credentials.json",
+    ".claude/settings.json",
+    ".claude.json",
+    ".codex/auth.json",
+    ".codex/config.toml",
+    ".codex/AGENTS.md",
+    ".codex/installation_id",
+    ".config/cursor/auth.json",
+    ".cursor/cli-config.json",
+    ".cursor/mcp.json",
+    ".gemini/antigravity-cli/antigravity-oauth-token",
+    ".gemini/antigravity-cli/settings.json",
+    ".gemini/antigravity-cli/installation_id",
+    ".local/share/opencode/auth.json",
+    ".local/share/opencode/account.json",
+    ".local/share/opencode/opencode.db",
+    ".local/state/opencode/locks",
+    ".local/state/opencode/locks/auth.lock",
+)
+
+
+def test_sandbox_state_paths_never_match_credentials():
+    from fnmatch import fnmatchcase
+    from pathlib import PurePosixPath
+
+    from helix.backends import BACKEND_STATE_PATHS, BACKENDS
+
+    assert set(BACKEND_STATE_PATHS) == set(BACKENDS)
+    for backend, patterns in BACKEND_STATE_PATHS.items():
+        assert patterns, backend
+        for pattern in patterns:
+            assert not pattern.startswith(("/", "~", "..")), pattern
+            assert "$" not in pattern, pattern
+            for cred in _CREDENTIAL_PATHS:
+                cred_path = PurePosixPath(cred)
+                targets = [cred, *(str(p) for p in cred_path.parents if str(p) != ".")]
+                hits = [t for t in targets if fnmatchcase(t, pattern)]
+                assert not hits, f"{backend}: {pattern!r} would remove {cred!r}"
+
+
+def test_reset_sandbox_agent_state_runs_single_writer_container(mocker, caplog):
+    from helix.backends import BACKEND_STATE_PATHS
+
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    caplog.set_level("INFO", logger="helix.sandbox")
+
+    count = sandbox_module.reset_sandbox_agent_state(
+        "codex", image="helix-test:latest", generation=3
+    )
+
+    assert count == len(BACKEND_STATE_PATHS["codex"])
+    [args] = calls
+    assert args[:2] == ["docker", "run"]
+    assert "helix-auth-codex:/home/node:rw" in args
+    assert args[args.index("--network") + 1] == "none"
+    assert args[args.index("--user") + 1] == "node"
+    assert args[-3:-1] == ["sh", "-c"]
+    script = args[-1]
+    assert script.startswith("set -u; rm -rf ")
+    for path in BACKEND_STATE_PATHS["codex"]:
+        assert '"$HOME"/' + path.replace("*", "*") in script or path in script
+    assert "auth.json" not in script and "config.toml" not in script
+    assert any(
+        rec.levelname == "INFO"
+        and rec.message
+        == f"reset codex agent state in helix-auth-codex before generation 3 ({count} paths)"
+        for rec in caplog.records
+    )
+
+
+def test_reset_sandbox_agent_state_opencode_deletes_rows_not_db(mocker):
+    calls: list[list[str]] = []
+    mocker.patch(
+        "helix.sandbox.subprocess.run",
+        side_effect=lambda args, **kw: (
+            calls.append(args),
+            subprocess.CompletedProcess(args, 0, stdout="", stderr=""),
+        )[1],
+    )
+
+    sandbox_module.reset_sandbox_agent_state("opencode", image="img")
+
+    script = calls[0][-1]
+    rm_part, _, py_part = script.partition("; python3 -c ")
+    assert "opencode.db" not in rm_part
+    assert "auth.json" not in rm_part
+    assert "opencode.db" in py_part
+    for table in ("part", "message", "session"):
+        assert table in py_part
+    assert "account" not in py_part
+
+
+def test_reset_sandbox_agent_state_failure_is_a_warning(mocker, caplog):
+    caplog.set_level("WARNING", logger="helix.sandbox")
+    mocker.patch(
+        "helix.sandbox.subprocess.run",
+        return_value=subprocess.CompletedProcess([], 1, stdout="", stderr="rm: boom"),
+    )
+    assert sandbox_module.reset_sandbox_agent_state("claude", image="img") == 0
+    assert any(
+        "failed to reset claude agent state in helix-auth-claude" in rec.message
+        and "rm: boom" in rec.message
+        for rec in caplog.records
+    )
+
+    caplog.clear()
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=OSError("no docker"))
+    assert sandbox_module.reset_sandbox_agent_state("claude", image="img") == 0
+    assert any("no docker" in rec.message for rec in caplog.records)
+
+
+def test_reset_sandbox_agent_state_unknown_backend_is_noop(mocker):
+    run = mocker.patch("helix.sandbox.subprocess.run")
+    assert sandbox_module.reset_sandbox_agent_state("nope", image="img") == 0
+    run.assert_not_called()

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1117,3 +1117,148 @@ class TestDockerEnvRedaction:
         result = sandbox_module._run_docker(args, check=False)
 
         assert result.stderr == traceback_text
+
+
+# ---------------------------------------------------------------------------
+# preserve_backend_transcripts for non-Claude backends (auth-volume side)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("backend", "stdout", "expected"),
+    [
+        ("codex", '{"type":"thread.started","thread_id":"thr_1"}\n{"type":"x"}', "thr_1"),
+        ("agy", '{"conversation_id":"conv_1","response":"hi"}', "conv_1"),
+        ("opencode", '{"type":"step_start","sessionID":"ses_1"}\n', "ses_1"),
+        ("cursor", '{"type":"system","sessionId":"cur_1"}\n', "cur_1"),
+        ("claude", '{"type":"result","session_id":"cl_1"}', "cl_1"),
+        # A codex-shaped id inside claude output is not a claude session id.
+        ("claude", '{"type":"thread.started","thread_id":"thr_1"}', None),
+    ],
+)
+def test_extract_session_id_uses_backend_keys(backend, stdout, expected):
+    from helix.backends import transcript_session_id_keys
+
+    assert (
+        sandbox_module._extract_session_id_from_json_output(
+            stdout, transcript_session_id_keys(backend)
+        )
+        == expected
+    )
+
+
+def test_shell_glob_word_quotes_literals_but_not_globs():
+    word = sandbox_module._shell_glob_word(".codex/sessions/*/*/*/rollout-*-a b.jsonl")
+    assert word == ".codex/sessions/*/*/*/rollout-*'-a b.jsonl'"
+
+
+def test_backend_transcript_copy_script_per_backend():
+    build = sandbox_module._backend_transcript_copy_script
+    cfg = SandboxConfig(enabled=True)
+
+    claude = build(agent_backend="claude", sandbox=cfg, session_id="sess_1")
+    assert claude is not None
+    assert "/home/node/.claude/projects/-workspace/sess_1.jsonl" in claude
+    assert "/workspace/.helix_artifacts/backend_transcripts/claude/sess_1.jsonl" in claude
+
+    codex = build(agent_backend="codex", sandbox=cfg, session_id="thr_1")
+    assert codex is not None
+    assert '"$HOME"/.codex/sessions/*/*/*/rollout-*-thr_1.jsonl' in codex
+    assert "/workspace/.helix_artifacts/backend_transcripts/codex/thr_1.jsonl" in codex
+
+    agy = build(agent_backend="agy", sandbox=cfg, session_id="conv_1")
+    assert agy is not None
+    assert agy.count("cp ") == 2
+    assert "backend_transcripts/agy/conv_1.full.jsonl" in agy
+
+    opencode = build(agent_backend="opencode", sandbox=cfg, session_id="ses_1")
+    assert opencode is not None
+    assert '"$HOME"/.local/share/opencode/opencode.db-wal' in opencode
+    assert "backend_transcripts/opencode/.ses_1.opencode.db-wal" in opencode
+
+    assert build(agent_backend="unknown", sandbox=cfg, session_id="x") is None
+
+
+def test_agent_copies_codex_transcript_from_auth_volume(tmp_path: Path, mocker):
+    source = tmp_path / "candidate"
+    source.mkdir()
+    (source / "main.py").write_text("old\n")
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if args[:2] == ["docker", "run"] and not _is_workspace_chown(args):
+            workspace = Path(args[args.index("-v") + 1].split(":", 1)[0])
+            if args[-3] == "sh" and "thr_123" in args[-1]:
+                transcript = (
+                    workspace
+                    / ".helix_artifacts"
+                    / "backend_transcripts"
+                    / "codex"
+                    / "thr_123.jsonl"
+                )
+                transcript.parent.mkdir(parents=True)
+                transcript.write_text('{"type":"session_meta"}\n')
+            else:
+                (workspace / "main.py").write_text("new\n")
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout='{"type":"thread.started","thread_id":"thr_123"}\n',
+            stderr="",
+        )
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+
+    run_sandboxed_command(
+        ["codex", "exec", "prompt"],
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True),
+        scope="agent",
+        sync_back=True,
+        image="helix-test:latest",
+        agent_backend="codex",
+    )
+
+    assert (source / "main.py").read_text() == "new\n"
+    transcript = (
+        source / ".helix_artifacts" / "backend_transcripts" / "codex" / "thr_123.jsonl"
+    )
+    assert transcript.read_text() == '{"type":"session_meta"}\n'
+    copy_call = next(
+        call
+        for call in calls
+        if call[:2] == ["docker", "run"] and "thr_123" in " ".join(call)
+    )
+    assert "helix-auth-codex:/home/node:ro" in copy_call
+    assert "--network" in copy_call and copy_call[copy_call.index("--network") + 1] == "none"
+
+
+def test_agent_skips_transcript_helper_for_unsafe_session_id(tmp_path: Path, mocker):
+    source = tmp_path / "candidate"
+    source.mkdir()
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return subprocess.CompletedProcess(
+            args, 0, stdout='{"thread_id":"../x; rm -rf /"}\n', stderr=""
+        )
+
+    mocker.patch("helix.sandbox.subprocess.run", side_effect=fake_run)
+    mocker.patch("helix.sandbox._host_owner", return_value=None)
+
+    run_sandboxed_command(
+        ["codex", "exec", "prompt"],
+        cwd=source,
+        env={},
+        sandbox=SandboxConfig(enabled=True),
+        scope="agent",
+        sync_back=True,
+        image="helix-test:latest",
+        agent_backend="codex",
+    )
+
+    assert not any("helix-auth-codex:/home/node:ro" in call for call in calls)


### PR DESCRIPTION
> **BREAKING**: `sandbox.preserve_backend_transcripts` is removed. Every backend's native transcript is now always copied out of the auth volume at the end of each invocation, always kept as a run artifact, and always used for tool-call accounting. Configs that still set the field are rejected by Pydantic's `extra="forbid"` (same precedent as the removed `evaluator.score_parser`). Sandboxed runs additionally reset the backend's session state every generation; there is no option for either behaviour.

## The bug

`sandbox.preserve_backend_transcripts` promised to keep each agent invocation's native CLI transcript, but both `_copy_claude_transcript_from_auth_volume` (sandbox.py) and `_collect_backend_transcript_artifacts` (mutator.py) returned early for anything but `claude`. `codex`, `opencode`, `agy` and `cursor` runs silently preserved nothing, and the docs called Codex "an extension point". Turning the option off also lost Claude's tool-call counts, which only the transcript carries.

## What each backend's transcript is and where it lands

One table, `helix.backends.BACKEND_TRANSCRIPT_SOURCES`, maps a session id to the `$HOME`-relative files the CLI writes plus the stdout keys that carry the id. Both the sandbox helper container (mounts `helix-auth-<backend>` read-only, copies into the workspace before sync-back) and the mutator's unsandboxed `$HOME` path are driven from it. Everything lands under `.helix_artifacts/backend_transcripts/<backend>/`, matching claude's existing convention, and is reported in `.helix_backend_result.json` `transcript_artifacts` with `available: false` plus a `reason` on a miss.

| backend | id key in stdout | native source (`$HOME`-relative) | artifact |
| --- | --- | --- | --- |
| claude | `session_id` | `claude_transcript_root/<id>.jsonl` (unchanged) | `claude/<id>.jsonl` |
| codex | `thread_id` (`thread.started`) | `.codex/sessions/YYYY/MM/DD/rollout-<local-ts>-<thread_id>.jsonl` (verified: `session_meta.payload.id` == filename suffix) | `codex/<id>.jsonl` |
| cursor | `session_id`/`sessionId` | `.cursor/projects/<cwd-slug>/agent-transcripts/<id>/<id>.jsonl` (plain JSONL; the `~/.cursor/chats/<hash>/<id>/store.db` blob store is why an earlier grep found nothing) | `cursor/<id>.jsonl` |
| agy | `conversation_id` | `.gemini/antigravity-cli/brain/<id>/.system_generated/logs/transcript.jsonl` + `transcript_full.jsonl` (the `conversations/<id>.db/.pb` are the same data in binary form, not copied) | `agy/<id>.jsonl`, `agy/<id>.full.jsonl` |
| opencode | `sessionID` | this session's rows of `.local/share/opencode/opencode.db` (see below) | `opencode/<id>.jsonl` |

The JSONL backends' stdout stream is still kept verbatim in `.helix_backend_stdout.txt` regardless; the native transcript is copied in addition because it carries the full per-turn record (tool payloads, reasoning items) the streamed events elide. Session ids are validated (`TRANSCRIPT_SESSION_ID_RE`) before being interpolated into file names or shell globs.

### The sqlite decision (OpenCode)

OpenCode 1.18 persists sessions only in one `opencode.db` shared by every session; the `storage/` JSON tree on this machine was last written by 1.1.65 and is legacy. Copying the whole ~15 MB file per candidate would be wasteful and would leak other sessions, so the db + WAL are staged under a dot-prefixed name, this session's `session`/`message`/`part` rows are exported to `<id>.jsonl` (one `{"table", "row"}` object per line, `rowid` order) with host-side stdlib `sqlite3`, and the staged copy is deleted. Same code path sandboxed and unsandboxed.

## Per-generation sandbox state reset

`reset_sandbox_agent_state` (sandbox.py) runs from a small self-contained hook at the top of `run_evolution`'s generation loop, above the merge/mutate split, sandboxed runs only. It starts one single-writer container (`helix-auth-<backend>` mounted rw, `--network none`, user `node`) and `rm -rf`s the `$HOME`-relative globs in `helix.backends.BACKEND_STATE_PATHS`, verified read-only against the local CLI state dirs:

- **claude**: `.claude/{projects,sessions,telemetry,backups,history.jsonl,shell-snapshots,file-history,session-env,debug,paste-cache}` — kept: `.credentials.json`, `settings.json`, `~/.claude.json`, plugins, skills, cache
- **codex**: `.codex/{sessions,archived_sessions,session_index.jsonl,history.jsonl,memories,memories_*.sqlite*,shell_snapshots,state_*.sqlite*,thread_history*.sqlite*,logs_*.sqlite*,models_cache.json,log}` — kept: `auth.json`, `config.toml`, `AGENTS.md`, `installation_id`, skills, rules, plugins
- **agy**: `.gemini/antigravity-cli/{conversations,brain,cache,log,cli.log,crashes,presence,knowledge,history.jsonl,conversation_summaries.db}` — kept: `antigravity-oauth-token`, `settings.json`, `installation_id`, keybindings, mcp, plugins
- **cursor**: `.cursor/{projects,chats,ai-tracking,browser-logs,prompt_history.json,snapshots,worktrees}` — kept: `cli-config.json`, `mcp.json`, `agent-cli-state.json`, extensions, `~/.config/cursor/auth.json`
- **opencode**: `.local/share/opencode/{storage,snapshot,tool-output,log}`, `.local/state/opencode/prompt-history.jsonl`, plus an in-place `DELETE` of the `part`/`message`/`session` rows via `python3` (present in the base image). **`opencode.db` itself is never deleted**: its `account` table holds `access_token`/`refresh_token` for the OpenCode account (provider keys live in `auth.json`), so the file is a credential store.

A failed wipe is a WARNING, never fatal; one INFO line per generation: `reset <backend> agent state in <volume> before generation N (K paths)`. Because the wipe deletes the source, a transcript that could not be copied in sandbox mode is logged at WARNING with the candidate id and the path looked for. `test_sandbox_state_paths_never_match_credentials` asserts no wipe glob matches a fixed list of credential/config paths or any of their ancestors.

## Tool-call counting

Counting never depended on retention in the new code; with the option gone it is simply: claude and agy count from the copied native transcript (agy's `PLANNER_RESPONSE` steps carry `tool_calls: [{"name", "args"}]`, a stable shape in local files, so it gains a counter), codex/cursor/opencode keep counting from the stdout artifact, which is written before any transcript work.

## Tests

- mutator: per-backend copy/derive/miss for codex, cursor, agy, opencode (unsandboxed `$HOME` and sandboxed staged files), sqlite export isolates one session and removes the staged db, unsafe ids skipped, id derivation through `_write_backend_artifacts`, claude/agy tool counts from the kept transcript, stdout artifacts written on a miss, WARNING on sandboxed miss.
- sandbox: per-backend id keys, glob quoting, per-backend copy scripts, codex end-to-end copy through `run_sandboxed_command` with sync-back, unsafe-id guard, reset container args/script/INFO line, opencode rows-not-file, failure-is-warning, unknown backend no-op, credential guard.
- evolution: reset runs before each generation, copy-before-next-reset ordering, no reset when unsandboxed.

## Gates

- `uv run python -m pytest -q` — 1047 passed
- `uv run ruff check src/ tests/` — All checks passed
- `uv run mypy --strict src/helix/` — Success: no issues found in 28 source files

## Merge note

PR #72 (open) touches the same mutator region and adds a per-generation credential warm hook at the same spot in `run_evolution`; this PR's hook is a separate one-line call (`_reset_sandbox_agent_state_for_generation`) so they should merge cleanly, but whichever merges second needs a merge from main. Wipe-then-warm is the intended order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126UoDvKj2BN5SHLH81aqnW
